### PR TITLE
Fix invalidating thumbnails on asset save

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20230814142319.php
+++ b/bundles/CoreBundle/Migrations/Version20230814142319.php
@@ -33,7 +33,9 @@ final class Version20230814142319 extends AbstractMigration
     public function up(Schema $schema): void
     {
         if ($schema->getTable('assets')->hasColumn('dataModificationDate') === false) {
-            $this->addSql('ALTER TABLE `assets` ADD COLUMN `dataModificationDate` INT(11) UNSIGNED DEFAULT NULL AFTER `modificationDate`;');
+            $this->addSql('ALTER TABLE `assets`
+                ADD COLUMN `dataModificationDate` INT(11) UNSIGNED DEFAULT NULL AFTER `modificationDate`;'
+            );
         }
     }
 

--- a/bundles/CoreBundle/Migrations/Version20230814142319.php
+++ b/bundles/CoreBundle/Migrations/Version20230814142319.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230814142319 extends AbstractMigration
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getDescription(): string
+    {
+        return 'Add `dataModificationDate` column to `assets` database table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ($schema->getTable('assets')->hasColumn('dataModificationDate') === false) {
+            $this->addSql('ALTER TABLE `assets` ADD COLUMN `dataModificationDate` INT(11) UNSIGNED DEFAULT NULL AFTER `modificationDate`;');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if ($schema->getTable('assets')->hasColumn('storageType')) {
+            $this->addSql('ALTER TABLE `assets` DROP COLUMN `dataModificationDate`;');
+        }
+    }
+}

--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -33,6 +33,7 @@ CREATE TABLE `assets` (
   `mimetype` varchar(190) DEFAULT NULL,
   `creationDate` INT(11) UNSIGNED DEFAULT NULL,
   `modificationDate` INT(11) UNSIGNED DEFAULT NULL,
+  `dataModificationDate` INT(11) UNSIGNED DEFAULT NULL,
   `userOwner` int(11) unsigned DEFAULT NULL,
   `userModification` int(11) unsigned DEFAULT NULL,
   `customSettings` longtext,

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -172,10 +172,14 @@ class Asset extends Element\AbstractElement
 
     /**
      * @param int|null $dataModificationDate
+     *
+     * @return $this
      */
-    public function setDataModificationDate(?int $dataModificationDate): void
+    public function setDataModificationDate(?int $dataModificationDate): static
     {
         $this->dataModificationDate = $dataModificationDate;
+        
+        return $this;
     }
 
     /**

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -160,7 +160,7 @@ class Asset extends Element\AbstractElement
      *
      * @var int|null
      */
-    protected $dataModificationDate = null;
+    protected ?int $dataModificationDate = null;
 
     /**
      * @return int|null
@@ -858,7 +858,7 @@ class Asset extends Element\AbstractElement
 
     /**
      * @param bool $setModificationDate
-     * @param bool $saveOnlyVersionn
+     * @param bool $saveOnlyVersion
      * @param string $versionNote version note
      *
      * @return null|Version

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -222,7 +222,10 @@ class Asset extends Element\AbstractElement
             $asset = new static();
             $asset->getDao()->getByPath($path);
 
-            return static::getById($asset->getId(), Service::prepareGetByIdParams($force, __METHOD__, func_num_args() > 1));
+            return static::getById(
+                $asset->getId(),
+                Service::prepareGetByIdParams($force, __METHOD__, func_num_args() > 1)
+            );
         } catch (NotFoundException $e) {
             return null;
         }
@@ -292,20 +295,18 @@ class Asset extends Element\AbstractElement
 
                 Cache::save($asset, $cacheKey);
             } catch (NotFoundException $e) {
-                return null;
+                $asset = null;
             }
         } else {
             RuntimeCache::set($cacheKey, $asset);
         }
 
-        if (!$asset || !static::typeMatch($asset)) {
-            return null;
+        if ($asset && static::typeMatch($asset)) {
+            \Pimcore::getEventDispatcher()->dispatch(
+                new AssetEvent($asset, ['params' => $params]),
+                AssetEvents::POST_LOAD
+            );
         }
-
-        \Pimcore::getEventDispatcher()->dispatch(
-            new AssetEvent($asset, ['params' => $params]),
-            AssetEvents::POST_LOAD
-        );
 
         return $asset;
     }
@@ -322,9 +323,22 @@ class Asset extends Element\AbstractElement
         // create already the real class for the asset type, this is especially for images, because a system-thumbnail
         // (tree) is generated immediately after creating an image
         $class = Asset::class;
-        if (array_key_exists('filename', $data) && (array_key_exists('data', $data) || array_key_exists('sourcePath', $data) || array_key_exists('stream', $data))) {
+        if (
+            array_key_exists('filename', $data) &&
+            (
+                array_key_exists('data', $data) ||
+                array_key_exists('sourcePath', $data) ||
+                array_key_exists('stream', $data)
+            )
+        ) {
             if (array_key_exists('data', $data) || array_key_exists('stream', $data)) {
-                $tmpFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/asset-create-tmp-file-' . uniqid() . '.' . File::getFileExtension($data['filename']);
+                $fileExtension = File::getFileExtension($data['filename']);
+                $tmpFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/asset-create-tmp-file-' . uniqid() . '.' . $fileExtension;
+
+                if (!str_starts_with($tmpFile,  PIMCORE_SYSTEM_TEMP_DIRECTORY)) {
+                    throw new \InvalidArgumentException('Invalid filename');
+                }
+
                 if (array_key_exists('data', $data)) {
                     File::put($tmpFile, $data['data']);
                     self::checkMaxPixels($tmpFile, $data);
@@ -422,7 +436,7 @@ class Asset extends Element\AbstractElement
     public static function getList($config = [])
     {
         if (!is_array($config)) {
-            throw new Exception('Unable to initiate list class - please provide valid configuration array');
+            throw new \RuntimeException('Unable to initiate list class - please provide valid configuration array');
         }
 
         $listClass = Listing::class;
@@ -467,7 +481,8 @@ class Asset extends Element\AbstractElement
 
         $mappings = [
             'unknown' => ["/\.stp$/"],
-            'image' => ['/image/', "/\.eps$/", "/\.ai$/", "/\.svgz$/", "/\.pcx$/", "/\.iff$/", "/\.pct$/", "/\.wmf$/", '/photoshop/'],
+            'image' => ['/image/', "/\.eps$/", "/\.ai$/", "/\.svgz$/", "/\.pcx$/", "/\.iff$/", "/\.pct$/",
+                "/\.wmf$/", '/photoshop/'],
             'text' => ['/text\//', '/xml$/', '/\.json$/'],
             'audio' => ['/audio/'],
             'video' => ['/video/'],
@@ -525,11 +540,11 @@ class Asset extends Element\AbstractElement
 
             $this->correctPath();
 
-            $params['isUpdate'] = $isUpdate; // we need that in $this->update() for certain types (image, video, document)
+            $params['isUpdate'] = $isUpdate;// need for $this->update() for certain types (image, video, document)
 
-            // we wrap the save actions in a loop here, so that we can restart the database transactions in the case it fails
+            // we wrap the save actions in a loop here, to restart the database transactions in the case it fails
             // if a transaction fails it gets restarted $maxRetries times, then the exception is thrown out
-            // this is especially useful to avoid problems with deadlocks in multi-threaded environments (forked workers, ...)
+            // especially useful to avoid problems with deadlocks in multi-threaded environments (forked workers, ...)
             $maxRetries = 5;
             for ($retries = 0; $retries < $maxRetries; $retries++) {
                 $this->beginTransaction();
@@ -665,8 +680,10 @@ class Asset extends Element\AbstractElement
 
             $parent = Asset::getById($this->getParentId());
             if ($parent) {
-                // use the parent's path from the database here (getCurrentFullPath), to ensure the path really exists and does not rely on the path
-                // that is currently in the parent asset (in memory), because this might have changed but wasn't not saved
+                // use the parent's path from the database here (getCurrentFullPath),
+                //to ensure the path really exists and does not rely on the path
+                // that is currently in the parent asset (in memory),
+                //because this might have changed but wasn't not saved
                 $this->setPath(str_replace('//', '/', $parent->getCurrentFullPath() . '/'));
             } else {
                 trigger_deprecation(
@@ -841,7 +858,7 @@ class Asset extends Element\AbstractElement
 
     /**
      * @param bool $setModificationDate
-     * @param bool $saveOnlyVersion
+     * @param bool $saveOnlyVersionn
      * @param string $versionNote version note
      *
      * @return null|Version
@@ -1585,12 +1602,14 @@ class Asset extends Element\AbstractElement
                 $instance = $loader->build($metaData['type']);
                 $transformedData = $instance->transformGetterData($metaData['data'], $metaData);
             } catch (UnsupportedException $e) {
+                Logger::error((string) $e);
             }
 
             return $transformedData;
         };
 
         if ($name) {
+            $result = null;
             if ($language === null) {
                 $language = Pimcore::getContainer()->get(LocaleServiceInterface::class)->findLocale();
             }
@@ -1598,31 +1617,18 @@ class Asset extends Element\AbstractElement
             $data = null;
             foreach ($this->metadata as $md) {
                 if ($md['name'] == $name) {
-                    if ($language == $md['language']) {
-                        if ($raw) {
-                            return $md;
-                        }
-
-                        return $convert($md);
-                    }
-                    if (empty($md['language']) && !$strictMatch) {
-                        if ($raw) {
-                            return $md;
-                        }
+                    if ($language == $md['language'] || (empty($md['language']) && !$strictMatch)) {
                         $data = $md;
+                        break;
                     }
                 }
             }
 
             if ($data) {
-                if ($raw) {
-                    return $data;
-                }
-
-                return $convert($data);
+                $result = $raw ? $data : $convert($data);
             }
 
-            return null;
+            return $result;
         }
 
         $metaData = $this->getObjectVar('metadata');

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -156,6 +156,29 @@ class Asset extends Element\AbstractElement
     protected $dataChanged = false;
 
     /**
+     * @internal
+     *
+     * @var int|null
+     */
+    protected $dataModificationDate = null;
+
+    /**
+     * @return int|null
+     */
+    public function getDataModificationDate(): ?int
+    {
+        return $this->dataModificationDate;
+    }
+
+    /**
+     * @param int|null $dataModificationDate
+     */
+    public function setDataModificationDate(?int $dataModificationDate): void
+    {
+        $this->dataModificationDate = $dataModificationDate;
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getBlockedVars(): array
@@ -1218,7 +1241,8 @@ class Asset extends Element\AbstractElement
         }
 
         if (is_resource($stream)) {
-            $this->setDataChanged(true);
+            $this->setDataChanged();
+            $this->setDataModificationDate(time());
             $this->stream = $stream;
 
             $isRewindable = @rewind($this->stream);

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -257,7 +257,7 @@ class Processor
                 $fileExists = true;
             }
         } catch (\Exception $e) {
-            Logger::warn($e->getMessage());
+            Logger::debug($e->getMessage());
         }
 
         if ($fileExists === false) {

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -194,7 +194,7 @@ class Processor
 
         if ($modificationDate) {
             try {
-                if ($modificationDate >= $asset->getModificationDate()) {
+                if ($modificationDate >= $asset->getDataModificationDate()) {
                     return [
                         'src' => $storagePath,
                         'type' => 'thumbnail',

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -408,7 +408,7 @@ class Processor
      *
      * @return void
      */
-    private static function applyTransformations(Adapter $image, Asset $asset, Config $config, ?array $transformations)
+    private static function applyTransformations(Adapter $image, Asset $asset, Config $config, ?array $transformations): void
     {
         if (is_array($transformations) && !empty($transformations)) {
             $sourceImageWidth = PHP_INT_MAX;

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -19,6 +19,7 @@ use League\Flysystem\FilesystemException;
 use Pimcore\Config as PimcoreConfig;
 use Pimcore\File;
 use Pimcore\Helper\TemporaryFileHelperTrait;
+use Pimcore\Image\Adapter;
 use Pimcore\Logger;
 use Pimcore\Messenger\OptimizeImageMessage;
 use Pimcore\Model\Asset;
@@ -99,7 +100,13 @@ class Processor
      *
      * @throws \Exception
      */
-    public static function process(Asset $asset, Config $config, $fileSystemPath = null, $deferred = false, &$generated = false)
+    public static function process(
+        Asset $asset,
+        Config $config,
+        $fileSystemPath = null,
+        $deferred = false,
+        &$generated = false
+    )
     {
         $generated = false;
         $format = strtolower($config->getFormat());
@@ -250,6 +257,7 @@ class Processor
                 $fileExists = true;
             }
         } catch (\Exception $e) {
+            Logger::warn($e->getMessage());
         }
 
         if ($fileExists === false) {
@@ -332,104 +340,7 @@ class Processor
                     }
                 }
 
-                if (is_array($transformations) && count($transformations) > 0) {
-                    $sourceImageWidth = PHP_INT_MAX;
-                    $sourceImageHeight = PHP_INT_MAX;
-                    if ($asset instanceof Asset\Image) {
-                        $sourceImageWidth = $asset->getWidth();
-                        $sourceImageHeight = $asset->getHeight();
-                    }
-
-                    $highResFactor = $config->getHighResolution();
-                    $imageCropped = false;
-
-                    $calculateMaxFactor = function ($factor, $original, $new) {
-                        $newFactor = $factor * $original / $new;
-                        if ($newFactor < 1) {
-                            // don't go below factor 1
-                            $newFactor = 1;
-                        }
-
-                        return $newFactor;
-                    };
-
-                    // sorry for the goto/label - but in this case it makes life really easier and the code more readable
-                    prepareTransformations:
-
-                    foreach ($transformations as &$transformation) {
-                        if (!empty($transformation) && !isset($transformation['isApplied'])) {
-                            $arguments = [];
-
-                            if (is_string($transformation['method'])) {
-                                $mapping = self::$argumentMapping[$transformation['method']];
-
-                                if (is_array($transformation['arguments'])) {
-                                    foreach ($transformation['arguments'] as $key => $value) {
-                                        $position = array_search($key, $mapping);
-                                        if ($position !== false) {
-                                            // high res calculations if enabled
-                                            if (!in_array($transformation['method'], ['cropPercent']) && in_array($key,
-                                                ['width', 'height', 'x', 'y'])) {
-                                                if ($highResFactor && $highResFactor > 1) {
-                                                    $value *= $highResFactor;
-                                                    $value = (int)ceil($value);
-
-                                                    if (!isset($transformation['arguments']['forceResize']) || !$transformation['arguments']['forceResize']) {
-                                                        // check if source image is big enough otherwise adjust the high-res factor
-                                                        if (in_array($key, ['width', 'x'])) {
-                                                            if ($sourceImageWidth < $value) {
-                                                                $highResFactor = $calculateMaxFactor(
-                                                                    $highResFactor,
-                                                                    $sourceImageWidth,
-                                                                    $value
-                                                                );
-                                                                goto prepareTransformations;
-                                                            }
-                                                        } elseif (in_array($key, ['height', 'y'])) {
-                                                            if ($sourceImageHeight < $value) {
-                                                                $highResFactor = $calculateMaxFactor(
-                                                                    $highResFactor,
-                                                                    $sourceImageHeight,
-                                                                    $value
-                                                                );
-                                                                goto prepareTransformations;
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-
-                                            // inject the focal point
-                                            if ($transformation['method'] == 'cover' && $key == 'positioning' && $asset->getCustomSetting('focalPointX')) {
-                                                $value = [
-                                                    'x' => $asset->getCustomSetting('focalPointX'),
-                                                    'y' => $asset->getCustomSetting('focalPointY'),
-                                                ];
-                                            }
-
-                                            $arguments[$position] = $value;
-                                        }
-                                    }
-                                }
-                            }
-
-                            ksort($arguments);
-                            if (!is_string($transformation['method']) && is_callable($transformation['method'])) {
-                                trigger_deprecation(
-                                    'pimcore/pimcore',
-                                    '10.6',
-                                    'Using Callable in thumbnail transformations is deprecated and will not work on Pimcore 11.'
-                                );
-
-                                $transformation['method']($image);
-                            } elseif (method_exists($image, $transformation['method'])) {
-                                call_user_func_array([$image, $transformation['method']], $arguments);
-                            }
-
-                            $transformation['isApplied'] = true;
-                        }
-                    }
-                }
+                self::applyTransformations($image, $asset, $config, $transformations);
 
                 if ($optimizedFormat) {
                     $format = $image->getContentOptimizedFormat();
@@ -450,23 +361,28 @@ class Processor
 
                 $generated = true;
 
-                $isImageOptimizersEnabled = PimcoreConfig::getSystemConfiguration('assets')['image']['thumbnails']['image_optimizers']['enabled'];
+                $pimcoreAssetsConfig = PimcoreConfig::getSystemConfiguration('assets');
+                $isImageOptimizersEnabled = $pimcoreAssetsConfig['image']['thumbnails']['image_optimizers']['enabled'];
                 if ($optimizedFormat && $optimizeContent && $isImageOptimizersEnabled) {
                     \Pimcore::getContainer()->get('messenger.bus.pimcore-core')->dispatch(
                         new OptimizeImageMessage($storagePath)
                     );
                 }
 
-                Logger::debug('Thumbnail ' . $storagePath . ' generated in ' . (microtime(true) - $startTime) . ' seconds');
+                Logger::debug('Thumbnail ' . $storagePath . ' generated in ' .
+                    (microtime(true) - $startTime) . ' seconds');
             } else {
-                Logger::debug('Thumbnail ' . $storagePath . ' already generated, waiting on lock for ' . (microtime(true) - $startTime) . ' seconds');
+                Logger::debug('Thumbnail ' . $storagePath . ' already generated, waiting on lock for ' .
+                    (microtime(true) - $startTime) . ' seconds');
             }
             $lock->release();
         }
 
-        // quick bugfix / workaround, it seems that imagemagick / image optimizers creates sometimes empty PNG chunks (total size 33 bytes)
+        // quick bugfix / workaround,
+        //it seems that imagemagick / image optimizers creates sometimes empty PNG chunks (total size 33 bytes)
         // no clue why it does so as this is not continuous reproducible, and this is the only fix we can do for now
-        // if the file is corrupted the file will be created on the fly when requested by the browser (because it's deleted here)
+        // if the file is corrupted the file will be created on the fly
+        //when requested by the browser (because it's deleted here)
         if ($storage->fileExists($storagePath) && $storage->fileSize($storagePath) < 50) {
             $storage->delete($storagePath);
             $asset->getDao()->deleteFromThumbnailCache($config->getName(), $filename);
@@ -482,6 +398,118 @@ class Processor
             'type' => 'thumbnail',
             'storagePath' => $storagePath,
         ];
+    }
+
+    /**
+     * @param Adapter $image
+     * @param Asset $asset
+     * @param Config $config
+     * @param array|null $transformations
+     *
+     * @return void
+     */
+    private static function applyTransformations(Adapter $image, Asset $asset, Config $config, ?array $transformations)
+    {
+        if (is_array($transformations) && !empty($transformations)) {
+            $sourceImageWidth = PHP_INT_MAX;
+            $sourceImageHeight = PHP_INT_MAX;
+            if ($asset instanceof Asset\Image) {
+                $sourceImageWidth = $asset->getWidth();
+                $sourceImageHeight = $asset->getHeight();
+            }
+
+            $highResFactor = $config->getHighResolution();
+
+            $calculateMaxFactor = function ($factor, $original, $new) {
+                $newFactor = $factor * $original / $new;
+                if ($newFactor < 1) {
+                    // don't go below factor 1
+                    $newFactor = 1;
+                }
+
+                return $newFactor;
+            };
+
+            // sorry for the goto/label - but in this case it makes life really easier and the code more readable
+            prepareTransformations:
+
+            foreach ($transformations as &$transformation) {
+                if (!empty($transformation) && !isset($transformation['isApplied'])) {
+                    $arguments = [];
+
+                    if (is_string($transformation['method'])) {
+                        $mapping = self::$argumentMapping[$transformation['method']];
+
+                        if (is_array($transformation['arguments'])) {
+                            foreach ($transformation['arguments'] as $key => $value) {
+                                $position = array_search($key, $mapping);
+                                if ($position !== false) {
+                                    // high res calculations if enabled
+                                    if (!in_array($transformation['method'], ['cropPercent']) && in_array($key,
+                                            ['width', 'height', 'x', 'y'])) {
+                                        if ($highResFactor && $highResFactor > 1) {
+                                            $value *= $highResFactor;
+                                            $value = (int)ceil($value);
+
+                                            if (!isset($transformation['arguments']['forceResize']) ||
+                                                !$transformation['arguments']['forceResize']) {
+                                                // check if source image is big enough otherwise adjust high-res factor
+                                                if (in_array($key, ['width', 'x'])) {
+                                                    if ($sourceImageWidth < $value) {
+                                                        $highResFactor = $calculateMaxFactor(
+                                                            $highResFactor,
+                                                            $sourceImageWidth,
+                                                            $value
+                                                        );
+                                                        goto prepareTransformations;
+                                                    }
+                                                } elseif (in_array($key, ['height', 'y'])) {
+                                                    if ($sourceImageHeight < $value) {
+                                                        $highResFactor = $calculateMaxFactor(
+                                                            $highResFactor,
+                                                            $sourceImageHeight,
+                                                            $value
+                                                        );
+                                                        goto prepareTransformations;
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    // inject the focal point
+                                    if ($transformation['method'] == 'cover' &&
+                                        $key == 'positioning' &&
+                                        $asset->getCustomSetting('focalPointX')) {
+                                        $value = [
+                                            'x' => $asset->getCustomSetting('focalPointX'),
+                                            'y' => $asset->getCustomSetting('focalPointY'),
+                                        ];
+                                    }
+
+                                    $arguments[$position] = $value;
+                                }
+                            }
+                        }
+                    }
+
+                    ksort($arguments);
+                    if (!is_string($transformation['method']) && is_callable($transformation['method'])) {
+                        trigger_deprecation(
+                            'pimcore/pimcore',
+                            '10.6',
+                            'Using Callable in thumbnail transformations is deprecated and will not work on Pimcore 11.'
+                        );
+
+                        $transformation['method']($image);
+                    } elseif (method_exists($image, $transformation['method'])) {
+                        call_user_func_array([$image, $transformation['method']], $arguments);
+                    }
+
+                    $transformation['isApplied'] = true;
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## Changes in this pull request  
Resolves #15273

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5a39246</samp>

This pull request adds a new `dataModificationDate` property and column to the `Asset` class and table, respectively, to track the last change to the asset data. It also updates the thumbnail processor to use this property for cache validation. The purpose of this pull request is to improve the performance and accuracy of the image thumbnail generation and caching.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5a39246</samp>

> _Oh, we are the coders of Pimcore_
> _And we work on the assets galore_
> _We added `dataModificationDate`_
> _To make the thumbnails update at a faster rate_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5a39246</samp>

*  Add a new column `dataModificationDate` to the `assets` table to store the timestamp of the last change to the asset data ([link](https://github.com/pimcore/pimcore/pull/15748/files?diff=unified&w=0#diff-30df47f9d518790f988ef83ee87bf7e0fa978c7c93cee0097e44a215d20cc7c6R1-R46), [link](https://github.com/pimcore/pimcore/pull/15748/files?diff=unified&w=0#diff-c624477d3d2ae554e390ee2b45c5f4c48c160471609aee1e4df2478ab395c4a8R36))
*  Add a new property `dataModificationDate` and its getter and setter methods to the `Asset` class to access and update the new column ([link](https://github.com/pimcore/pimcore/pull/15748/files?diff=unified&w=0#diff-867a334e4cc9a097b215afcb2b1f4949910cb2f2103a2cd997d8699d4d414fc9R159-R181))
*  Update the `setStream` method of the `Asset` class to set the `dataModificationDate` property and column whenever a new stream of data is set for the asset ([link](https://github.com/pimcore/pimcore/pull/15748/files?diff=unified&w=0#diff-867a334e4cc9a097b215afcb2b1f4949910cb2f2103a2cd997d8699d4d414fc9L1221-R1245))
*  Use the `dataModificationDate` property of the asset instead of the `modificationDate` property when checking the thumbnail cache validity in the `process` method of the `Processor` class ([link](https://github.com/pimcore/pimcore/pull/15748/files?diff=unified&w=0#diff-16840b1fd40929e8fda46a67eae733c84fc71dc91da6a38097ba58b5da0c321cL197-R197))
