### PR TITLE
[Data objects] ManyToOneRelation::checkValidity("") returns true

### DIFF
--- a/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
@@ -312,7 +312,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
      */
     public function checkValidity(mixed $data, bool $omitMandatoryCheck = false, array $params = []): void
     {
-        if (!$omitMandatoryCheck && $this->getMandatory() && empty($data)) {
+        if (!$omitMandatoryCheck && $this->getMandatory() && $data === null) {
             throw new Element\ValidationException('Empty mandatory field [ '.$this->getName().' ]');
         }
 

--- a/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
@@ -322,7 +322,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
             $allow = $this->allowAssetRelation($data);
         } elseif ($data instanceof DataObject\AbstractObject) {
             $allow = $this->allowObjectRelation($data);
-        } elseif (empty($data)) {
+        } elseif ($data === null) {
             $allow = true;
         } else {
             Logger::error(sprintf('Invalid data in field `%s` [type: %s]', $this->getName(), $this->getFieldtype()));


### PR DESCRIPTION
Currently `checkValidity()` for a ManyToOneRelation returns `true` for an empty string. But when calling the setter, it fails with error
`TypeError: Pimcore\Model\DataObject\DataObjectClass::setManyToOneRelation(): Argument #1 ($ManyToOneRelation) must be of type ?Pimcore\Model\Element\AbstractElement, string given`