### PR TITLE
[Bug]: Asset Helper Controller: get-batch-jobs action - Method not allowed

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetHelperController.php
@@ -992,7 +992,7 @@ class AssetHelperController extends AdminAbstractController
     }
 
     /**
-     * @Route("/get-batch-jobs", name="pimcore_admin_asset_assethelper_getbatchjobs", methods={"GET"})
+     * @Route("/get-batch-jobs", name="pimcore_admin_asset_assethelper_getbatchjobs", methods={"POST"})
      *
      * @param Request $request
      *


### PR DESCRIPTION
- AssetHelperController: Change allowed method to POST

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request 
When trying to edit assets metadata via the batch edit all function, the system throws a "Method not allowed" Exception, because the Controller only allow Method GET. 
https://github.com/pimcore/pimcore/blob/10.6/bundles/AdminBundle/Controller/Admin/Asset/AssetHelperController.php#L995
Data is being sent via POST. Changing the allowed Method to POST fix the problem. 

## Additional info
Same functionality for the batch edit in the data objects as reference, as here is the allowed method POST
https://github.com/pimcore/pimcore/blob/10.6/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php#L1533

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4081d0d</samp>

Changed the HTTP method for the `get-batch-jobs` action in `AssetHelperController.php` from GET to POST to fix a URL length bug. This improved the reliability of asset metadata batch editing.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4081d0d</samp>

> _`get-batch-jobs` changed_
> _from GET to POST request_
> _autumn bug fixing_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4081d0d</samp>

* Change the request method for the `get-batch-jobs` action to POST to avoid URL length limit errors ([link](https://github.com/pimcore/pimcore/pull/15754/files?diff=unified&w=0#diff-3b9fa3c50831357d3ba9e73ba21b2f1fabc55e04b3a414ed6da773f809077c1dL995-R995))
