### PR TITLE
[Improvement] - Extract metadata from AdvancedManyToManyRelation when they exist

### DIFF
--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
@@ -483,7 +483,18 @@ class AdvancedManyToManyRelation extends ManyToManyRelation implements IdRewrite
             $paths = [];
             foreach ($data as $metaObject) {
                 $eo = $metaObject->getElement();
-                if ($eo instanceof Element\ElementInterface) {
+                $metadata = $metaObject->getData();
+                $colmuns = $metaObject->getColumns();
+
+                if (!empty($metadata) || !empty($colmuns)) {
+                    $paths[] = $eo->getKey();
+
+                    // We use this loop to keep the metadata order the same as in the grid
+                    foreach ($colmuns as $column) {
+                        $paths[] = $metadata[$column] ?? '';
+                    }
+
+                } elseif ($eo instanceof Element\ElementInterface) {
                     $paths[] = Element\Service::getElementType($eo) . ':' . $eo->getRealFullPath();
                 }
             }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Allow extraction of metadata contained in AdvancedManyToManyRelation in grid export.

Currently, when exporting an AdvancedManyToManyRelation, only the type of the related object and their fullpath is exported. But most of the time, the important information is stored in the metadata. 

Minimalist exemple here : 
![image](https://github.com/pimcore/pimcore/assets/35225430/3ea56ad9-bf73-47f8-b15d-3a7755ca25f1)

![image](https://github.com/pimcore/pimcore/assets/35225430/1769d91c-1342-410c-948a-5aba9ffd880a)

This PR chnages export from this : 
```csv
"ID";"Test"
"81";"object:/Product Data/Cars/alfa romeo/1900,object:/Product Data/Cars/alfa romeo/2000"
"82";"object:/Product Data/Cars/alfa romeo/1900,object:/Product Data/Cars/alfa romeo/2000"
```

To this : 
```csv
"ID";"Test"
"81";"1900,Key1,,2000,Key2,Data here !"
"82";"1900,Key1,,2000,Key2,Data here !"
```

I am open to discuss the definitive form of the export if you think it needs adjustments. 
