### PR TITLE
[DataObjects] Fix classification store data loss on adding new group

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -319,7 +319,11 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
      *
      * @see Data::getDataFromEditmode
      */
-    public function getDataFromEditmode(mixed $data, DataObject\Concrete $object = null, array $params = []): DataObject\Classificationstore
+    public function getDataFromEditmode(
+        mixed $data,
+        DataObject\Concrete $object = null,
+        array $params = []
+    ): DataObject\Classificationstore
     {
         $classificationStore = $this->getDataFromObjectParam($object);
 
@@ -327,9 +331,9 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
             $classificationStore = new DataObject\Classificationstore();
         }
 
+        $activeGroups = $data['activeGroups'];
+        $groupCollectionMapping = $data['groupCollectionMapping'];
         $data = $data['data'];
-        $activeGroups = $data['activeGroups'] ?? [];
-        $groupCollectionMapping = $data['groupCollectionMapping'] ?? [];
 
         $correctedMapping = [];
 
@@ -347,7 +351,9 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
                     foreach ($keys as $keyId => $value) {
                         $keyConfig = $this->getKeyConfiguration($keyId);
 
-                        $dataDefinition = DataObject\Classificationstore\Service::getFieldDefinitionFromKeyConfig($keyConfig);
+                        $dataDefinition = DataObject\Classificationstore\Service::getFieldDefinitionFromKeyConfig(
+                            $keyConfig
+                        );
 
                         $dataFromEditMode = $dataDefinition->getDataFromEditmode($value);
                         $activeGroups[$groupId] = true;


### PR DESCRIPTION
## Changes in this pull request  
Resolves #15751

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d67ab26</samp>

Improved code style and compatibility of `Classificationstore.php` with PSR-12 and PHP 8.1.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d67ab26</samp>

> _Oh we're the coders of the stormy sea_
> _And we like our code to be tidy_
> _So we reformat the function calls_
> _To comply with PSR and avoid the squalls_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d67ab26</samp>

* Reformat function signature of `getDataFromEditmode` to follow PSR-12 coding standard ([link](https://github.com/pimcore/pimcore/pull/15757/files?diff=unified&w=0#diff-d5e2db6cf7e1d7b788bc054ec65949fa41b9524e600aff4655231db843024f89L322-R326))
* Change order of assignments and avoid null coalescing operator on undefined array keys in `getDataFromEditmode` ([link](https://github.com/pimcore/pimcore/pull/15757/files?diff=unified&w=0#diff-d5e2db6cf7e1d7b788bc054ec65949fa41b9524e600aff4655231db843024f89L330-R336))
* Reformat function call to `getFieldDefinitionFromKeyConfig` to follow PSR-12 coding standard in `models/DataObject/ClassDefinition/Data/Classificationstore.php` ([link](https://github.com/pimcore/pimcore/pull/15757/files?diff=unified&w=0#diff-d5e2db6cf7e1d7b788bc054ec65949fa41b9524e600aff4655231db843024f89L350-R356))
