### PR TITLE
[Object bricks] Fix "not editable" mode for object bricks 

### DIFF
--- a/bundles/AdminBundle/Resources/public/css/ext-modifications.css
+++ b/bundles/AdminBundle/Resources/public/css/ext-modifications.css
@@ -670,6 +670,10 @@ body > .x-mask {
     cursor: default;
     pointer-events: auto!important;
 }
+/* Ext override to allow click through not editable object-brick's mask eg. relation buttons*/
+.pimcore_objectbrick_item.x-masked .x-mask{
+    pointer-events: none;
+}
 
 /** ExtJS7 changes starting from here */
 /* base color is #5fa2dd */

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectbricks.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectbricks.js
@@ -303,10 +303,8 @@ pimcore.object.tags.objectbricks = Class.create(pimcore.object.tags.abstract, {
                                 ownerName: this.fieldConfig.name,
                                 applyDefaults: manuallyAdded
                             }, false, true, dataProvider);
-                            if (this.fieldConfig.noteditable && children) {
-                                children.forEach(function (record) {
-                                    record.disabled = true;
-                                });
+                            if (this.fieldConfig.noteditable){
+                                panel.mask();
                             }
 
                             if (children) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectbricks.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectbricks.js
@@ -297,7 +297,7 @@ pimcore.object.tags.objectbricks = Class.create(pimcore.object.tags.abstract, {
                     afterrender: function (childConfig, dataProvider, manuallyAdded, panel) {
                         if (!panel.__tabpanel_initialized) {
                             var copy = Ext.decode(Ext.encode(childConfig));
-                            var children = this.getRecursiveLayout(copy, null, {
+                            var children = this.getRecursiveLayout(copy, this.fieldConfig.noteditable, {
                                 containerType: "objectbrick",
                                 containerKey: type,
                                 ownerName: this.fieldConfig.name,


### PR DESCRIPTION
With this PR `not editable` object brick container fields support text selection and do not show search / remove buttons for relations. Backport of https://github.com/pimcore/admin-ui-classic-bundle/pull/191

Grey background as from disabled elements is being kept:
<img width="435" alt="Bildschirmfoto 2023-08-17 um 08 09 02" src="https://github.com/pimcore/pimcore/assets/8749138/8461c7bb-9939-4ce7-99d6-02402a1809c8">

@kingjia90 I cannot comment on https://github.com/pimcore/admin-ui-classic-bundle/pull/191 - think the github repository setting are somehow wrong there. 
<img width="992" alt="Bildschirmfoto 2023-08-17 um 08 14 39" src="https://github.com/pimcore/pimcore/assets/8749138/3c37f126-f755-429a-96e7-51ab48f298c6">
But in Pimcore 11 I would remove the grey background because all other `not editable` fields also do not have this. For BC in 10.6 I agree to keep it but in 11 the grey background does not make sense to me.