### PR TITLE
QuantityValue: NumberFormatter::format(): Argument #1 ($num) must be …

### DIFF
--- a/models/DataObject/Data/QuantityValue.php
+++ b/models/DataObject/Data/QuantityValue.php
@@ -51,7 +51,7 @@ class QuantityValue extends AbstractQuantityValue
 
             if ($locale) {
                 $formatter = new \NumberFormatter($locale, \NumberFormatter::DECIMAL);
-                $value = $formatter->format($value);
+                $value = $formatter->format((float) $value);
             }
         }
 


### PR DESCRIPTION
…of type int|float, string given

Fix: https://github.com/pimcore/pimcore/issues/15618
Alternative to https://github.com/pimcore/pimcore/pull/15619 for target branch `11.0`