### PR TITLE
Fix: RgbaColor::getDataForEditmode(): Argument #2 ($object) must be of type ?Concrete, Localizedfield given

### DIFF
--- a/models/DataObject/ClassDefinition/Data/RgbaColor.php
+++ b/models/DataObject/ClassDefinition/Data/RgbaColor.php
@@ -273,11 +273,7 @@ class RgbaColor extends Data implements
     {
         $data = $this->getDataFromObjectParam($object, $params);
 
-        if ($data instanceof Model\DataObject\Data\RgbaColor) {
-            return sprintf('#%02x%02x%02x%02x', $data->getR(), $data->getG(), $data->getB(), $data->getA());
-        }
-
-        return '';
+        return $this->getDataForEditmode($data) ?? '';
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/RgbaColor.php
+++ b/models/DataObject/ClassDefinition/Data/RgbaColor.php
@@ -273,7 +273,11 @@ class RgbaColor extends Data implements
     {
         $data = $this->getDataFromObjectParam($object, $params);
 
-        return $this->getDataForEditmode($data, $object, $params) ?? '';
+        if ($data instanceof Model\DataObject\Data\RgbaColor) {
+            return sprintf('#%02x%02x%02x%02x', $data->getR(), $data->getG(), $data->getB(), $data->getA());
+        }
+
+        return '';
     }
 
     /**


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15756

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1a1485c</samp>

Changed the CSV export format for `RgbaColor` fields to use hexadecimal notation. This improves the consistency and readability of the CSV output for color values.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1a1485c</samp>

> _`getForCsvExport`_
> _Hex colors for clarity_
> _Autumn leaves falling_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1a1485c</samp>

* Changed the CSV export format for color fields to use hexadecimal values instead of editmode values ([link](https://github.com/pimcore/pimcore/pull/15763/files?diff=unified&w=0#diff-e261c422370e96abb413f918096e7a1d21d79f369c232e9a3d03ca2669cfa50bL276-R280),                            
