### PR TITLE
Fix: class method naming in document data extractor

### DIFF
--- a/bundles/XliffBundle/src/ExportDataExtractorService/DataExtractor/DocumentDataExtractor.php
+++ b/bundles/XliffBundle/src/ExportDataExtractorService/DataExtractor/DocumentDataExtractor.php
@@ -50,7 +50,7 @@ class DocumentDataExtractor extends AbstractElementDataExtractor
         }
 
         $this
-            ->addDoumentEditables($document, $result)
+            ->addDocumentEditables($document, $result)
             ->addSettings($document, $result);
 
         return $result;
@@ -61,7 +61,7 @@ class DocumentDataExtractor extends AbstractElementDataExtractor
      *
      * @throws \Exception
      */
-    protected function addDoumentEditables(Document $document, AttributeSet $result): DocumentDataExtractor
+    protected function addDocumentEditables(Document $document, AttributeSet $result): DocumentDataExtractor
     {
         $editables = [];
         $service = new Document\Service;

--- a/bundles/XliffBundle/src/ExportDataExtractorService/DataExtractor/DocumentDataExtractor.php
+++ b/bundles/XliffBundle/src/ExportDataExtractorService/DataExtractor/DocumentDataExtractor.php
@@ -63,7 +63,7 @@ class DocumentDataExtractor extends AbstractElementDataExtractor
     {
         trigger_deprecation(
             'pimcore/pimcore',
-            '11.2',
+            '11.1',
             'Using "%s" is deprecated and will be removed in Pimcore 12, use "%s" instead.',
             'addDoumentEditables',
             'addDocumentEditables'

--- a/bundles/XliffBundle/src/ExportDataExtractorService/DataExtractor/DocumentDataExtractor.php
+++ b/bundles/XliffBundle/src/ExportDataExtractorService/DataExtractor/DocumentDataExtractor.php
@@ -61,7 +61,13 @@ class DocumentDataExtractor extends AbstractElementDataExtractor
      */
     protected function addDoumentEditables(Document $document, AttributeSet $result): DocumentDataExtractor
     {
-        trigger_deprecation('pimcore/pimcore', '11.2', 'Using "%s" is deprecated and will be removed in Pimcore 12, use "%s" instead.', 'addDoumentEditables', 'addDocumentEditables');
+        trigger_deprecation(
+            'pimcore/pimcore',
+            '11.2',
+            'Using "%s" is deprecated and will be removed in Pimcore 12, use "%s" instead.',
+            'addDoumentEditables',
+            'addDocumentEditables'
+        );
 
         return $this->addDocumentEditables($document, $result);
     }

--- a/bundles/XliffBundle/src/ExportDataExtractorService/DataExtractor/DocumentDataExtractor.php
+++ b/bundles/XliffBundle/src/ExportDataExtractorService/DataExtractor/DocumentDataExtractor.php
@@ -57,10 +57,15 @@ class DocumentDataExtractor extends AbstractElementDataExtractor
     }
 
     /**
-     *
-     *
-     * @throws \Exception
+     * @deprecated
      */
+    protected function addDoumentEditables(Document $document, AttributeSet $result): DocumentDataExtractor
+    {
+        trigger_deprecation('pimcore/pimcore', '11.2', 'Using "%s" is deprecated and will be removed in Pimcore 12, use "%s" instead.', 'addDoumentEditables', 'addDocumentEditables');
+
+        return $this->addDocumentEditables($document, $result);
+    }
+
     protected function addDocumentEditables(Document $document, AttributeSet $result): DocumentDataExtractor
     {
         $editables = [];


### PR DESCRIPTION
## Changes in this pull request
Change method name from addDoumentEditables to addDocumentEditables

