### PR TITLE
 [Version20230616085142] Recreate Foreign key checks for object_metadata_ table

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20230616085142.php
+++ b/bundles/CoreBundle/Migrations/Version20230616085142.php
@@ -71,7 +71,6 @@ final class Version20230616085142 extends AbstractMigration
                             UNIQUE (' . self::PK_COLUMNS . ')'
                     );
                 }
-#
                 if ($recreateForeignKey) {
                     $this->addSql(
                         'ALTER TABLE `' . $tableName . '`

--- a/bundles/CoreBundle/Migrations/Version20230616085142.php
+++ b/bundles/CoreBundle/Migrations/Version20230616085142.php
@@ -19,7 +19,7 @@ namespace Pimcore\Bundle\CoreBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
-use Pimcore\Model\DataObject\Data\ObjectMetadata\Dao;
+use Pimcore\Model\Dao\AbstractDao;
 
 final class Version20230616085142 extends AbstractMigration
 {
@@ -50,7 +50,7 @@ final class Version20230616085142 extends AbstractMigration
         foreach ($metaDataTables as $table) {
             $tableName = current($table);
             $metaDataTable = $schema->getTable($tableName);
-            $foreignKeyName = Dao::getForeignKeyName($tableName, 'o_id');
+            $foreignKeyName = AbstractDao::getForeignKeyName($tableName, 'o_id');
 
             if (!$metaDataTable->hasColumn(self::AUTO_ID)) {
                 if ($recreateForeignKey = $metaDataTable->hasForeignKey($foreignKeyName)) {
@@ -71,6 +71,7 @@ final class Version20230616085142 extends AbstractMigration
                             UNIQUE (' . self::PK_COLUMNS . ')'
                     );
                 }
+
                 if ($recreateForeignKey) {
                     $this->addSql(
                         'ALTER TABLE `' . $tableName . '`
@@ -100,7 +101,7 @@ final class Version20230616085142 extends AbstractMigration
         foreach ($metaDataTables as $table) {
             $tableName = current($table);
             $metaDataTable = $schema->getTable($tableName);
-            $foreignKeyName = Dao::getForeignKeyName($tableName, 'o_id');
+            $foreignKeyName = AbstractDao::getForeignKeyName($tableName, 'o_id');
 
             if ($metaDataTable->hasColumn(self::AUTO_ID)) {
                 if ($recreateForeignKey = $metaDataTable->hasForeignKey($foreignKeyName)) {

--- a/bundles/CoreBundle/Migrations/Version20230616085142.php
+++ b/bundles/CoreBundle/Migrations/Version20230616085142.php
@@ -101,7 +101,7 @@ final class Version20230616085142 extends AbstractMigration
         foreach ($metaDataTables as $table) {
             $tableName = current($table);
             $metaDataTable = $schema->getTable($tableName);
-            $foreignKeyName = AbstractDao::getForeignKeyName($tableName, 'o_id');
+            $foreignKeyName = AbstractDao::getForeignKeyName($tableName, self::ID_COLUMN);
 
             if ($metaDataTable->hasColumn(self::AUTO_ID)) {
                 if ($recreateForeignKey = $metaDataTable->hasForeignKey($foreignKeyName)) {

--- a/bundles/CoreBundle/Migrations/Version20230616085142.php
+++ b/bundles/CoreBundle/Migrations/Version20230616085142.php
@@ -50,7 +50,7 @@ final class Version20230616085142 extends AbstractMigration
         foreach ($metaDataTables as $table) {
             $tableName = current($table);
             $metaDataTable = $schema->getTable($tableName);
-            $foreignKeyName = AbstractDao::getForeignKeyName($tableName, 'o_id');
+            $foreignKeyName = AbstractDao::getForeignKeyName($tableName, self::ID_COLUMN);
 
             if (!$metaDataTable->hasColumn(self::AUTO_ID)) {
                 if ($recreateForeignKey = $metaDataTable->hasForeignKey($foreignKeyName)) {


### PR DESCRIPTION
## Changes in this pull request  
follow up to #15746

## Additional info
fixes problem with deleting objects 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a98e6ab</samp>

This pull request adds auto-increment and uniqueness features to the object metadata tables and fixes the foreign key constraint. It modifies the migration class in `Version20230616085142.php` to implement these changes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a98e6ab</samp>

> _To improve the object metadata_
> _We added a column called `id`_
> _It auto-increments_
> _And has a unique constraint_
> _And the foreign key constraint is now valid_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a98e6ab</samp>

*  Import `Dao` class to generate foreign key name for object metadata tables ([link](https://github.com/pimcore/pimcore/pull/15771/files?diff=unified&w=0#diff-1a5239629d336d186cb69c776ae06e99026fb8f5ca3d29f2636fc604b9abd498R22))
*  Drop foreign key constraint on object ID column before dropping primary key constraint on object metadata tables in `up` function ([link](https://github.com/pimcore/pimcore/pull/15771/files?diff=unified&w=0#diff-1a5239629d336d186cb69c776ae06e99026fb8f5ca3d29f2636fc604b9abd498L52-R59))
*  Add conditional statement to recreate foreign key constraint on object ID column with new column names and cascade options after adding unique constraint on object metadata tables in `up` function ([link](https://github.com/pimcore/pimcore/pull/15771/files?diff=unified&w=0#diff-1a5239629d336d186cb69c776ae06e99026fb8f5ca3d29f2636fc604b9abd498L63-R84))
*  Drop foreign key constraint on object ID column before dropping auto-increment column on object metadata tables in `down` function ([link](https://github.com/pimcore/pimcore/pull/15771/files?diff=unified&w=0#diff-1a5239629d336d186cb69c776ae06e99026fb8f5ca3d29f2636fc604b9abd498L86-R110))
*  Add conditional statement to recreate foreign key constraint on object ID column with original column names and restrict options after restoring original primary key constraint on object metadata tables in `down` function ([link](https://github.com/pimcore/pimcore/pull/15771/files?diff=unified&w=0#diff-1a5239629d336d186cb69c776ae06e99026fb8f5ca3d29f2636fc604b9abd498R118-R128))
