### PR TITLE
Fix: Editing the Classification values in grid view throws an error

### DIFF
--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -696,7 +696,7 @@ class Service extends Model\Element\Service
     /**
      * gets store value for given object and key
      */
-    private static function getStoreValueForObject(Concrete $object, string $key, ?string $requestedLanguage): ?string
+    private static function getStoreValueForObject(Concrete $object, string $key, ?string $requestedLanguage): mixed
     {
         $keyParts = explode('~', $key);
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15758
Alternative to https://github.com/pimcore/pimcore/pull/15768

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 35cf53c</samp>

Fixed a bug in `models/DataObject/Service.php` that caused an exception when returning array values from `getStoreValueForObject`. Changed the return type of the method to `mixed` to match `setStoreValueForObject`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 35cf53c</samp>

> _`getStoreValueForObject`_
> _Returns mixed values now_
> _A bug fix in spring_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 35cf53c</samp>

* Changed the return type of `getStoreValueForObject` from `?string` to `mixed` to allow returning different types of values ([link](https://github.com/pimcore/pimcore/pull/15773/files?diff=unified&w=0#diff-c47f0147cc6e364ce6b905a4b8c97bb43ff1bec60048d90d2a062abd165ae4e8L699-R699))
