### PR TITLE
Data: Allow null for setIndex() for BC reasons

### DIFF
--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,5 +1,8 @@
 # Upgrade Notes
 
+## Pimcore 11.0.7
+- Putting `null` to the `Pimcore\Model\DataObject\Data::setIndex()` method is deprecated now. Only booleans are allowed.
+
 ## Pimcore 11.0.6
 - Properties of `Pimcore\Model\DataObject\Data\Link` are nullable now. 
 

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -258,7 +258,15 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
      */
     public function setIndex(?bool $index): static
     {
-        $this->index = $index ?? false;
+        if (null === $index) {
+            trigger_deprecation(
+                'pimcore/pimcore',
+                '11.0.7',
+                sprintf('Passing null to method %s is deprecated', __METHOD__)
+            );
+            $index = false;
+        }
+        $this->index = $index;
 
         return $this;
     }

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -256,9 +256,9 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
     /**
      * @return $this
      */
-    public function setIndex(bool $index): static
+    public function setIndex(?bool $index): static
     {
-        $this->index = $index;
+        $this->index = $index ?? false;
 
         return $this;
     }


### PR DESCRIPTION
## Changes in this pull request  
Followup to https://github.com/pimcore/pimcore/pull/15638

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f76cea2</samp>

Allow passing `null` as a default value for the `index` parameter of the `Data::setIndex` method. This improves the data object class definition API by making it more consistent and flexible.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f76cea2</samp>

> _`setIndex` accepts_
> _nullable `$index` param_
> _autumn of nulls_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f76cea2</samp>

*  Allow passing `null` as a default value for the `index` parameter of the `setIndex` method of the `Data` class ([link](https://github.com/pimcore/pimcore/pull/15774/files?diff=unified&w=0#diff-b5f1d85f837f86e84cd4a1a905d034c9c71bf3124bf03e6fcbf6de61919b47e7L259-R261)). This improves the consistency and flexibility of the data object class definitions, as other methods also accept `null` as a default value for boolean parameters.
