### PR TITLE
Update Dao.php

### DIFF
--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -634,7 +634,7 @@ class Dao extends Model\Element\Dao
             $orderByType = $type ? ', `' . $type . '` DESC' : '';
             $permissions = $this->db->fetchAssociative('SELECT ' . $queryType . ' FROM users_workspaces_object WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $user->getId() . ') DESC' . $orderByType . ' LIMIT 1');
 
-            return $permissions;
+            return $permissions != false ? $permissions : null;
         } catch (\Exception $e) {
             Logger::warn('Unable to get permission ' . $type . ' for object ' . $this->model->getId());
         }


### PR DESCRIPTION
When the user has limited grants there is error when trying to search some elements in gridview. Pimcore\Model\DataObject\AbstractObject\Dao::getPermissions(): Return value must be of type ?array, bool returned. This commit fix it.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e2998f7</samp>

Fix a bug in `getPermissions` method of data objects that caused an error when no row was found. Add a null check to the `fetchAssociative` method in `models/DataObject/AbstractObject/Dao.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e2998f7</samp>

> _`fetchAssociative`_
> _may return false; check it_
> _autumn bug hunting_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e2998f7</samp>

*  Add null check to prevent error when fetching permissions for non-existing object ([link](https://github.com/pimcore/pimcore/pull/15778/files?diff=unified&w=0#diff-51d8f734290cf822c76411e21fe077c9d01d38fc6d49648dea6b6e10ce5269d7L637-R637))
