### PR TITLE
CacheClearCommand/WorkflowDumpCommand: Don't override $defaultName property

### DIFF
--- a/bundles/CoreBundle/src/Command/CacheClearCommand.php
+++ b/bundles/CoreBundle/src/Command/CacheClearCommand.php
@@ -19,6 +19,7 @@ namespace Pimcore\Bundle\CoreBundle\Command;
 use Pimcore\Cache;
 use Pimcore\Console\AbstractCommand;
 use Pimcore\Event\SystemEvents;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -29,6 +30,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 /**
  * @internal
  */
+#[AsCommand('pimcore:cache:clear')]
 class CacheClearCommand extends AbstractCommand
 {
     public function __construct(private EventDispatcherInterface $eventDispatcher)
@@ -39,7 +41,6 @@ class CacheClearCommand extends AbstractCommand
     protected function configure(): void
     {
         $this
-            ->setName('pimcore:cache:clear')
             ->setDescription('Clear caches')
             ->addOption(
                 'tags',

--- a/bundles/CoreBundle/src/Command/CacheClearCommand.php
+++ b/bundles/CoreBundle/src/Command/CacheClearCommand.php
@@ -31,8 +31,6 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  */
 class CacheClearCommand extends AbstractCommand
 {
-    protected static $defaultName = 'pimcore:cache:clear';
-
     public function __construct(private EventDispatcherInterface $eventDispatcher)
     {
         parent::__construct();
@@ -41,6 +39,7 @@ class CacheClearCommand extends AbstractCommand
     protected function configure(): void
     {
         $this
+            ->setName('pimcore:cache:clear')
             ->setDescription('Clear caches')
             ->addOption(
                 'tags',
@@ -89,6 +88,11 @@ class CacheClearCommand extends AbstractCommand
         return 0;
     }
 
+    /**
+     * @param string[] $tags
+     *
+     * @return string[]
+     */
     private function prepareTags(array $tags): array
     {
         // previous implementations didn't use VALUE_IS_ARRAY and just supported csv strings, so we not iterate

--- a/bundles/CoreBundle/src/Command/WorkflowDumpCommand.php
+++ b/bundles/CoreBundle/src/Command/WorkflowDumpCommand.php
@@ -19,6 +19,7 @@ namespace Pimcore\Bundle\CoreBundle\Command;
 use Pimcore\Console\AbstractCommand;
 use Pimcore\Workflow\Dumper\GraphvizDumper;
 use Pimcore\Workflow\Dumper\StateMachineGraphvizDumper;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -28,6 +29,7 @@ use Symfony\Component\Workflow\Marking;
 /**
  * @internal
  */
+#[AsCommand('pimcore:workflow:dump')]
 class WorkflowDumpCommand extends AbstractCommand
 {
     /**
@@ -36,7 +38,6 @@ class WorkflowDumpCommand extends AbstractCommand
     protected function configure(): void
     {
         $this
-            ->setName('pimcore:workflow:dump')
             ->setDefinition([
                 new InputArgument('name', InputArgument::REQUIRED, 'A workflow name'),
                 new InputArgument('marking', InputArgument::IS_ARRAY, 'A marking (a list of places)'),

--- a/bundles/CoreBundle/src/Command/WorkflowDumpCommand.php
+++ b/bundles/CoreBundle/src/Command/WorkflowDumpCommand.php
@@ -30,14 +30,13 @@ use Symfony\Component\Workflow\Marking;
  */
 class WorkflowDumpCommand extends AbstractCommand
 {
-    protected static $defaultName = 'pimcore:workflow:dump';
-
     /**
      * {@inheritdoc}
      */
     protected function configure(): void
     {
         $this
+            ->setName('pimcore:workflow:dump')
             ->setDefinition([
                 new InputArgument('name', InputArgument::REQUIRED, 'A workflow name'),
                 new InputArgument('marking', InputArgument::IS_ARRAY, 'A marking (a list of places)'),


### PR DESCRIPTION
## Changes in this pull request  
Resolves
```
The "Symfony\Component\Console\Command\Command::$defaultName" property is considered final. You should not override it in "Pimcore\Bundle\CoreBundle\Command\CacheClearCommand".
The "Symfony\Component\Console\Command\Command::$defaultName" property is considered final. You should not override it in "Pimcore\Bundle\CoreBundle\Command\WorkflowDumpCommand".
```

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8058d8a</samp>

Updated two console command classes to work with Symfony 5.4 and higher. Removed deprecated static properties and added required methods to `CacheClearCommand` and `WorkflowDumpCommand` in `bundles/CoreBundle/src/Command`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8058d8a</samp>

> _Sing, O Muse, of the valiant deeds of the coders_
> _Who, with skill and wisdom, updated their commands_
> _To match the new requirements of the mighty Symfony_
> _The framework of frameworks, the best of all the lands_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8058d8a</samp>

*  Remove the static property `$defaultName` from the `CacheClearCommand` and `WorkflowDumpCommand` classes, as it is no longer needed in Symfony 5.4 and higher ([link](https://github.com/pimcore/pimcore/pull/15784/files?diff=unified&w=0#diff-444d8f77bcdacf16f4452b8af516bac7152421a170c3f008e8e7641e6285eb2cL34-L35), [link](https://github.com/pimcore/pimcore/pull/15784/files?diff=unified&w=0#diff-b58fcff3ca0196d06c6dab8e93d950d6cfdc0c162b694d95af6b637b07ea5b25L33-L34))
* Add the `setName` method to the `CacheClearCommand` and `WorkflowDumpCommand` classes, to explicitly define the command name as `pimcore:cache:clear` and `pimcore:workflow:dump` respectively, as required for Symfony 5.4 and higher ([link](https://github.com/pimcore/pimcore/pull/15784/files?diff=unified&w=0#diff-444d8f77bcdacf16f4452b8af516bac7152421a170c3f008e8e7641e6285eb2cR42), [link](https://github.com/pimcore/pimcore/pull/15784/files?diff=unified&w=0#diff-b58fcff3ca0196d06c6dab8e93d950d6cfdc0c162b694d95af6b637b07ea5b25R39))
* Add the PHPDoc comment to the `clearDataCache` method of the `CacheClearCommand` class, to document the type and description of the `$tags` parameter and the return value ([link](https://github.com/pimcore/pimcore/pull/15784/files?diff=unified&w=0#diff-444d8f77bcdacf16f4452b8af516bac7152421a170c3f008e8e7641e6285eb2cR91-R95))
