### PR TITLE
PhpStan: Bump version and fix new error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -139,7 +139,7 @@
     "codeception/codeception": "^5.0.3",
     "codeception/module-symfony": "^3.1.0",
     "codeception/phpunit-wrapper": "^9",
-    "phpstan/phpstan": "1.10.26",
+    "phpstan/phpstan": "1.10.28",
     "phpstan/phpstan-symfony": "^1.3.2",
     "phpunit/phpunit": "^9.3",
     "gotenberg/gotenberg-php": "^1.1",

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -428,10 +428,6 @@ class Asset extends Element\AbstractElement
      */
     public static function getList(array $config = []): Listing
     {
-        if (!is_array($config)) {
-            throw new \RuntimeException('Unable to initiate list class - please provide valid configuration array');
-        }
-
         $listClass = Listing::class;
 
         /** @var Listing $list */


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15659
```
 ------ ---------------------------------------------------------------------- 
  Line   models/Asset.php                                                      
 ------ ---------------------------------------------------------------------- 
  408    Call to function is_array() with array will always evaluate to true.  
 ------ ---------------------------------------------------------------------- 
```

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b95e020</samp>

This pull request updates the `phpstan/phpstan` dependency to the latest version and removes a redundant check in the `Asset::getList` method. These changes improve the PHP 8.1 compatibility and the code quality of the project.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b95e020</samp>

> _`phpstan` updated_
> _Fixing bugs, adding features_
> _Winter of improvement_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b95e020</samp>

*  Update phpstan/phpstan dependency to 1.10.28 for PHP 8.1 compatibility and bug fixes ([link](https://github.com/pimcore/pimcore/pull/15785/files?diff=unified&w=0#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L142-R142))
*  Remove redundant check for `$config` being an array in `Asset::getList` method, as it is already type-declared ([link](https://github.com/pimcore/pimcore/pull/15785/files?diff=unified&w=0#diff-867a334e4cc9a097b215afcb2b1f4949910cb2f2103a2cd997d8699d4d414fc9L431-L434))
