### PR TITLE
fix: error in migration CoreBundle, IF EXISTS is not a valid MySQL 8 statement

### DIFF
--- a/bundles/CoreBundle/src/Migrations/Version20230616085142.php
+++ b/bundles/CoreBundle/src/Migrations/Version20230616085142.php
@@ -54,7 +54,7 @@ final class Version20230616085142 extends AbstractMigration
 
             if (!$metaDataTable->hasColumn(self::AUTO_ID)) {
                 if ($recreateForeignKey = $metaDataTable->hasForeignKey($foreignKeyName)) {
-                    $this->addSql('ALTER TABLE `' . $tableName . '` DROP FOREIGN KEY IF EXISTS `'.$foreignKeyName.'`');
+                    $this->addSql('ALTER TABLE `' . $tableName . '` DROP FOREIGN KEY `' . $foreignKeyName . '`');
                 }
 
                 if ($metaDataTable->hasPrimaryKey()) {
@@ -105,16 +105,19 @@ final class Version20230616085142 extends AbstractMigration
 
             if ($metaDataTable->hasColumn(self::AUTO_ID)) {
                 if ($recreateForeignKey = $metaDataTable->hasForeignKey($foreignKeyName)) {
-                    $this->addSql('ALTER TABLE `' . $tableName . '` DROP FOREIGN KEY IF EXISTS `'.$foreignKeyName.'`');
+                    $this->addSql('ALTER TABLE `' . $tableName . '` DROP FOREIGN KEY `' . $foreignKeyName . '`');
                 }
 
                 $this->addSql('ALTER TABLE `' . $tableName . '` DROP COLUMN `' . self::AUTO_ID . '`');
                 $this->addSql(
                     'ALTER TABLE `' . $tableName . '` ADD PRIMARY KEY (' . self::PK_COLUMNS  . ')'
                 );
-                $this->addSql(
-                    'ALTER TABLE `' . $tableName . '` DROP INDEX IF EXISTS `' . self::UNIQUE_KEY_NAME  . '`'
-                );
+
+                if ($metaDataTable->hasIndex(self::UNIQUE_KEY_NAME)) {
+                    $this->addSql(
+                        'ALTER TABLE `' . $tableName . '` DROP INDEX `' . self::UNIQUE_KEY_NAME . '`'
+                    );
+                }
 
                 if ($recreateForeignKey) {
                     $this->addSql(


### PR DESCRIPTION
Error: An exception occurred while executing 'ALTER TABLE `object_metadata_14` DROP FOREIGN KEY IF EXISTS `fk_object_metadata_14__o_id`':
   SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax;
   check the manual that corresponds to your MySQL server version for the right syntax to use near '
   IF EXISTS `fk_object_metadata_14__o_id`' at line 1
Caused by: "IF EXISTS" is valid in MariaDB but not in MySQL 8 Resolved with: checking existence via metadata