### PR TITLE
[CoreBundle] Fix down migrations by removing IF EXISTS, not a valid MySQL 8 statements

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20220119082511.php
+++ b/bundles/CoreBundle/Migrations/Version20220119082511.php
@@ -66,22 +66,22 @@ final class Version20220119082511 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        if ($schema->getTable('gridconfig_favourites')->hasIndex('grid_config_id')) {
-            $this->addSql('ALTER TABLE `gridconfig_favourites` DROP INDEX IF EXISTS `grid_config_id`;');
-        }
-
         if ($schema->getTable('gridconfig_favourites')->hasForeignKey('fk_gridconfig_favourites_gridconfigs')) {
-            $this->addSql('ALTER TABLE `gridconfig_favourites` DROP FOREIGN KEY IF EXISTS `fk_gridconfig_favourites_gridconfigs`;');
+            $this->addSql('ALTER TABLE `gridconfig_favourites` DROP FOREIGN KEY `fk_gridconfig_favourites_gridconfigs`;');
         }
 
         $this->addSql('ALTER TABLE `gridconfig_favourites` CHANGE `gridConfigId` `gridConfigId` int(11) NULL;');
 
-        if ($schema->getTable('gridconfig_shares')->hasIndex('grid_config_id')) {
-            $this->addSql('ALTER TABLE `gridconfig_shares` DROP INDEX IF EXISTS `grid_config_id`;');
+        if ($schema->getTable('gridconfig_shares')->hasForeignKey('fk_gridconfig_favourites_gridconfigs')) {
+            $this->addSql('ALTER TABLE `gridconfig_shares` DROP FOREIGN KEY `fk_gridconfig_shares_gridconfigs`;');
         }
 
-        if ($schema->getTable('gridconfig_shares')->hasForeignKey('fk_gridconfig_favourites_gridconfigs')) {
-            $this->addSql('ALTER TABLE `gridconfig_shares` DROP FOREIGN KEY IF EXISTS `fk_gridconfig_shares_gridconfigs`;');
+        if ($schema->getTable('gridconfig_favourites')->hasIndex('grid_config_id')) {
+            $this->addSql('ALTER TABLE `gridconfig_favourites` DROP INDEX `grid_config_id`;');
+        }
+
+        if ($schema->getTable('gridconfig_shares')->hasIndex('grid_config_id')) {
+            $this->addSql('ALTER TABLE `gridconfig_shares` DROP INDEX `grid_config_id`;');
         }
     }
 }

--- a/bundles/CoreBundle/Migrations/Version20220120121803.php
+++ b/bundles/CoreBundle/Migrations/Version20220120121803.php
@@ -87,12 +87,12 @@ final class Version20220120121803 extends AbstractMigration
     {
         foreach (['documents_hardlink', 'documents_link', 'documents_page', 'documents_snippet', 'documents_printpage', 'documents_email', 'email_log', 'documents_newsletter', 'documents_editables', 'documents_translations'] as $table) {
             if ($schema->getTable($table)->hasForeignKey('fk_'.$table.'_documents')) {
-                $this->addSql('ALTER TABLE `'.$table.'` DROP FOREIGN KEY IF EXISTS `fk_'.$table.'_documents`;');
+                $this->addSql('ALTER TABLE `'.$table.'` DROP FOREIGN KEY `fk_'.$table.'_documents`;');
             }
         }
 
         if ($schema->getTable('sites')->hasForeignKey('fk_sites_documents')) {
-            $this->addSql('ALTER TABLE `sites` DROP FOREIGN KEY IF EXISTS `fk_sites_documents`;');
+            $this->addSql('ALTER TABLE `sites` DROP FOREIGN KEY `fk_sites_documents`;');
         }
     }
 }

--- a/bundles/CoreBundle/Migrations/Version20220120162621.php
+++ b/bundles/CoreBundle/Migrations/Version20220120162621.php
@@ -121,11 +121,11 @@ final class Version20220120162621 extends AbstractMigration
     {
         foreach (['asset', 'document', 'object'] as $elementType) {
             if ($schema->getTable('users_workspaces_'.$elementType)->hasForeignKey('fk_users_workspaces_'.$elementType.'_'.$elementType.'s')) {
-                $this->addSql('ALTER TABLE `users_workspaces_'.$elementType.'` DROP FOREIGN KEY IF EXISTS `fk_users_workspaces_'.$elementType.'_'.$elementType.'s`');
+                $this->addSql('ALTER TABLE `users_workspaces_'.$elementType.'` DROP FOREIGN KEY `fk_users_workspaces_'.$elementType.'_'.$elementType.'s`');
             }
 
             if ($schema->getTable('users_workspaces_'.$elementType)->hasForeignKey('fk_users_workspaces_'.$elementType.'_users')) {
-                $this->addSql('ALTER TABLE `users_workspaces_'.$elementType.'` DROP FOREIGN KEY IF EXISTS `fk_users_workspaces_'.$elementType.'_users`');
+                $this->addSql('ALTER TABLE `users_workspaces_'.$elementType.'` DROP FOREIGN KEY `fk_users_workspaces_'.$elementType.'_users`');
             }
 
             $this->addSql('ALTER TABLE `users_workspaces_'.$elementType.'` CHANGE `userId` `userId` int(11) NOT NULL DEFAULT \'0\'');


### PR DESCRIPTION
## Changes in this pull request  
Related to #15787

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ed64f9</samp>

Fix SQL errors in migration `down` functions by reordering or removing `IF EXISTS` clauses. This resolves issue #10976.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6ed64f9</samp>

> _`down` function changed_
> _drop foreign keys before indexes_
> _MySQL bugfix done_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6ed64f9</samp>

*  Fix issue #10976 by dropping foreign keys before indexes in migration classes ([link](https://github.com/pimcore/pimcore/pull/15792/files?diff=unified&w=0#diff-ef6ae2f8db3e5ba72144a750d6251f958684b0accdc2c6a51dbce922a4d198a7L69-R85), [link](https://github.com/pimcore/pimcore/pull/15792/files?diff=unified&w=0#diff-16a66ecef029997901ca218419d1d956f02bad7ae4361808f4eee946aba41134L90-R95), [link](https://github.com/pimcore/pimcore/pull/15792/files?diff=unified&w=0#diff-0bc3fef907dcd2fc649ad1649d0b2c944f02a03fd602cf91d2fe86458f47876aL124-R128))
*  Remove unsupported `IF EXISTS` clause from SQL statements to drop foreign keys in migration classes `Version20220120121803.php` and `Version20220120162621.php` ([link](https://github.com/pimcore/pimcore/pull/15792/files?diff=unified&w=0#diff-16a66ecef029997901ca218419d1d956f02bad7ae4361808f4eee946aba41134L90-R95), [link](https://github.com/pimcore/pimcore/pull/15792/files?diff=unified&w=0#diff-0bc3fef907dcd2fc649ad1649d0b2c944f02a03fd602cf91d2fe86458f47876aL124-R128))
