### PR TITLE
Fix Symfony deprecations

### DIFF
--- a/.github/ci/files/config/packages/security.yaml
+++ b/.github/ci/files/config/packages/security.yaml
@@ -1,6 +1,4 @@
 security:
-    enable_authenticator_manager: true
-
     providers:
         pimcore_admin:
             id: Pimcore\Security\User\UserProvider

--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -23,6 +23,7 @@ framework:
     php_errors:
         log: true
     assets: ~
+    http_method_override: false
     mailer:
         enabled: true
         transports:
@@ -48,7 +49,6 @@ framework:
         default_bus: messenger.bus.pimcore-core
         buses:
             messenger.bus.pimcore-core:
-        reset_on_message: true
     rate_limiter:
         reset_password:
             policy: 'fixed_window'

--- a/bundles/CoreBundle/src/DependencyInjection/Compiler/WorkflowPass.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Compiler/WorkflowPass.php
@@ -18,6 +18,7 @@ namespace Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler;
 
 use Pimcore\Workflow\Manager;
 use Pimcore\Workflow\Transition;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -27,7 +28,6 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Security\Core\Authorization\ExpressionLanguage;
-use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Workflow;
 use Symfony\Component\Workflow\Exception\LogicException;
 

--- a/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php
+++ b/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php
@@ -50,8 +50,8 @@ final class PimcoreCoreExtension extends ConfigurableExtension implements Prepen
         \Pimcore::disableShutdown();
 
         // performance improvement, see https://github.com/symfony/symfony/pull/26276/files
-        if (!$container->hasParameter('container.dumper.inline_class_loader')) {
-            $container->setParameter('container.dumper.inline_class_loader', true);
+        if (!$container->hasParameter('.container.dumper.inline_class_loader')) {
+            $container->setParameter('.container.dumper.inline_class_loader', true);
         }
 
         // bundle manager/locator config

--- a/composer.json
+++ b/composer.json
@@ -96,7 +96,7 @@
     "symfony/framework-bundle": "^6.2",
     "symfony/html-sanitizer": "^6.2",
     "symfony/http-foundation": "^6.2",
-    "symfony/http-kernel": "^6.2",
+    "symfony/http-kernel": "^6.3",
     "symfony/lock": "^6.2",
     "symfony/mailer": "^6.2",
     "symfony/messenger": "^6.2",

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -82,7 +82,7 @@
 
 #### [Authentication] :
 
--  Removed support old authentication system
+- Removed support old authentication system
 - Removed BruteforceProtection, use Symfony defaults now
 - Removed PreAuthenticatedAdminToken
 - Admin Login Events

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -82,7 +82,7 @@
 
 #### [Authentication] :
 
--  Removed support old authentication system (not setting `security.enable_authenticator_manager: true` in `security.yaml`).
+-  Removed support old authentication system
 - Removed BruteforceProtection, use Symfony defaults now
 - Removed PreAuthenticatedAdminToken
 - Admin Login Events

--- a/lib/Controller/ArgumentValueResolver/DocumentValueResolver.php
+++ b/lib/Controller/ArgumentValueResolver/DocumentValueResolver.php
@@ -19,7 +19,7 @@ namespace Pimcore\Controller\ArgumentValueResolver;
 use Pimcore\Http\Request\Resolver\DocumentResolver;
 use Pimcore\Model\Document;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 
 /**
@@ -27,7 +27,7 @@ use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
  *
  * @internal
  */
-final class DocumentValueResolver implements ArgumentValueResolverInterface
+final class DocumentValueResolver implements ValueResolverInterface
 {
     protected DocumentResolver $documentResolver;
 
@@ -36,23 +36,20 @@ final class DocumentValueResolver implements ArgumentValueResolverInterface
         $this->documentResolver = $documentResolver;
     }
 
-    public function supports(Request $request, ArgumentMetadata $argument): bool
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
         if ($argument->getType() !== Document::class) {
-            return false;
+            return [];
         }
 
         if ($argument->getName() !== 'document') {
-            return false;
+            return [];
         }
 
-        $document = $this->documentResolver->getDocument($request);
+        if ($document = $this->documentResolver->getDocument($request)) {
+            return [$document];
+        }
 
-        return $document && $document instanceof Document;
-    }
-
-    public function resolve(Request $request, ArgumentMetadata $argument): iterable
-    {
-        yield $this->documentResolver->getDocument($request);
+        return [];
     }
 }

--- a/lib/Controller/ArgumentValueResolver/EditmodeValueResolver.php
+++ b/lib/Controller/ArgumentValueResolver/EditmodeValueResolver.php
@@ -18,13 +18,13 @@ namespace Pimcore\Controller\ArgumentValueResolver;
 
 use Pimcore\Http\Request\Resolver\EditmodeResolver;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 
 /**
  * @internal
  */
-final class EditmodeValueResolver implements ArgumentValueResolverInterface
+final class EditmodeValueResolver implements ValueResolverInterface
 {
     private EditmodeResolver $editmodeResolver;
 
@@ -33,13 +33,16 @@ final class EditmodeValueResolver implements ArgumentValueResolverInterface
         $this->editmodeResolver = $editmodeResolver;
     }
 
-    public function supports(Request $request, ArgumentMetadata $argument): bool
-    {
-        return $argument->getType() === 'bool' && $argument->getName() === 'editmode';
-    }
-
     public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
-        yield $this->editmodeResolver->isEditmode($request);
+        if ($argument->getType() !== 'bool') {
+            return [];
+        }
+
+        if ($argument->getName() !== 'editmode') {
+            return [];
+        }
+
+        return [$this->editmodeResolver->isEditmode($request)];
     }
 }

--- a/lib/Controller/ArgumentValueResolver/WebsiteConfigValueResolver.php
+++ b/lib/Controller/ArgumentValueResolver/WebsiteConfigValueResolver.php
@@ -18,22 +18,24 @@ namespace Pimcore\Controller\ArgumentValueResolver;
 
 use Pimcore\Config;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 
 /**
  * Adds support for type hinting controller actions and getting the current website config.
- *
  */
-final class WebsiteConfigValueResolver implements ArgumentValueResolverInterface
+final class WebsiteConfigValueResolver implements ValueResolverInterface
 {
-    public function supports(Request $request, ArgumentMetadata $argument): bool
-    {
-        return $argument->getType() === 'array' && $argument->getName() === 'websiteConfig';
-    }
-
     public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
-        yield Config::getWebsiteConfig();
+        if ($argument->getType() !== 'array') {
+            return [];
+        }
+
+        if ($argument->getName() !== 'websiteConfig') {
+            return [];
+        }
+
+        return [Config::getWebsiteConfig()];
     }
 }

--- a/lib/Controller/ArgumentValueResolver/WebsiteConfigValueResolver.php
+++ b/lib/Controller/ArgumentValueResolver/WebsiteConfigValueResolver.php
@@ -23,6 +23,8 @@ use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 
 /**
  * Adds support for type hinting controller actions and getting the current website config.
+ *
+ * @internal
  */
 final class WebsiteConfigValueResolver implements ValueResolverInterface
 {

--- a/lib/Serializer/Normalizer/ReferenceLoopNormalizer.php
+++ b/lib/Serializer/Normalizer/ReferenceLoopNormalizer.php
@@ -46,7 +46,7 @@ class ReferenceLoopNormalizer implements NormalizerInterface
         return $object;
     }
 
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
     {
         return $format === JsonEncoder::FORMAT;
     }


### PR DESCRIPTION
## Changes in this pull request  
Resolves
```
Since symfony/framework-bundle 6.1: Option "reset_on_message" at "framework.messenger" is deprecated. It does nothing and will be removed in version 7.0.
Since symfony/framework-bundle 6.1: Not setting the "framework.http_method_override" config option is deprecated. It will default to "false" in 7.0.
Since symfony/security-bundle 6.2: The "enable_authenticator_manager" option at "security" is deprecated.
User Deprecated: Since symfony/http-kernel 6.3: Parameter "container.dumper.inline_class_loader" is deprecated, use ".container.dumper.inline_class_loader" instead.
The "Pimcore\Serializer\Normalizer\ReferenceLoopNormalizer::supportsNormalization()" method will require a new "array $context" argument in the next major version of its interface "Symfony\Component\Serializer\Normalizer\NormalizerInterface", not defining it is deprecated.
```

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 643af7f</samp>

This pull request improves security and performance of the pimcore application by disabling the HTTP method override feature, removing obsolete options from the configuration files, and refactoring the authentication system. It also updates the upgrade notes to document the breaking changes and the migration steps.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 643af7f</samp>

> _No more old authentication, no more override_
> _We purge the obsolete, we refactor and rewrite_
> _Breaking changes in the code, we document and advise_
> _We secure and optimize, we pimcore with pride_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 643af7f</samp>

*  Refactor and clean up the authentication system in pimcore ([link](https://github.com/pimcore/pimcore/pull/15796/files?diff=unified&w=0#diff-ee8ff688fded8943af83197fb3b0953bf27ea9ff986d6754f5c4d1a5b5767a3eL2-L3))
   - Update the upgrade notes in `README.md` to inform the users of the breaking change and the migration steps ([link](https://github.com/pimcore/pimcore/pull/15796/files?diff=unified&w=0#diff-375aded12dfb868b84d5b8c27d1aed2358680a27b683e8a985f1b85193dd79aaL85-R85))
* Disable the HTTP method override feature in Symfony for security and compatibility reasons ([link](https://github.com/pimcore/pimcore/pull/15796/files?diff=unified&w=0#diff-34d259c58a9001df91ca2ccc5f41ab960a307d1566cffceb88262d679cfc6c70R26))
* Remove the `reset_on_message` option from `default.yaml`, as it is not needed anymore ([link](https://github.com/pimcore/pimcore/pull/15796/files?diff=unified&w=0#diff-34d259c58a9001df91ca2ccc5f41ab960a307d1566cffceb88262d679cfc6c70L51))
