### PR TITLE
fix: add null coalescing check for getTranslations

### DIFF
--- a/models/Translation.php
+++ b/models/Translation.php
@@ -279,7 +279,7 @@ final class Translation extends AbstractModel
      */
     public function getTranslation($language)
     {
-        return $this->translations[$language];
+        return $this->translations[$language] ?? '';
     }
 
     /**


### PR DESCRIPTION
## Changes in this pull request  
Added null coalescing check for `getTranslation` method to avoid null pointer exception

## Additional info
sure this could be checked with `hasTranslation` but I think the method should still not crash if a translation not exists

### HOW
```php
$currentTranslation = Translation::getByKey('my-custom-key', 'shared', true);
$currentTranslation->getTranslation('fr');
```