### PR TITLE
feat: support using editables in dialog box

### DIFF
--- a/doc/03_Documents/01_Editables/02_Areablock/02_Bricks.md
+++ b/doc/03_Documents/01_Editables/02_Areablock/02_Bricks.md
@@ -295,15 +295,13 @@ class WysiwygWithImages extends AbstractAreabrick implements EditableDialogBoxIn
             [
                 (new Editable\Input())
                     ->setName('myDialogInput')
-                    ->setLabel('Some additional Text') // labels are optional
-            ],
-            [
+                    ->setLabel('Some additional Text'), // labels are optional
+                    
                 (new Editable\Checkbox())
                     ->setName('myDialogCheckbox')
                     ->setLabel('This is the checkbox label')
-                    ->setDialogDescription('This is a description for myDialogCheckbox')  // descriptions are optional
-            ],
-            [
+                    ->setDialogDescription('This is a description for myDialogCheckbox'),  // descriptions are optional
+                    
                 (new Editable\Date())
                     ->setName('myDialogDate')
             ]

--- a/doc/03_Documents/01_Editables/02_Areablock/02_Bricks.md
+++ b/doc/03_Documents/01_Editables/02_Areablock/02_Bricks.md
@@ -254,6 +254,18 @@ structured layout in the context of the current brick.
 The editing interface is configured by implementing the `EditableDialogBoxInterface` on your brick class and by providing 
 a simple config array.
 
+> This config array can either contain the editables themselves, or an array of the format (not recommended):
+> 
+> ````php
+> [
+>   'type' => 'input',   // The type of the editable
+>   'name' => 'myInput',   // The name of the editable
+>   'config' => [],   // An optional array of the documented configurations (see the respective editables)
+>   'label' => 'My Input Label',   // An optional label
+>   'description' => 'Additional Description',   // An optional description
+> ]
+> ````
+
 ### Simple Example Config
 ```php
 <?php
@@ -263,6 +275,7 @@ namespace App\Document\Areabrick;
 use Pimcore\Extension\Document\Areabrick\EditableDialogBoxConfiguration;
 use Pimcore\Extension\Document\Areabrick\EditableDialogBoxInterface;
 use Pimcore\Model\Document;
+use Pimcore\Model\Document\Editable;
 use Pimcore\Model\Document\Editable\Area\Info;
 
 class WysiwygWithImages extends AbstractAreabrick implements EditableDialogBoxInterface
@@ -277,24 +290,24 @@ class WysiwygWithImages extends AbstractAreabrick implements EditableDialogBoxIn
         $config = new EditableDialogBoxConfiguration();
         $config->setWidth(600);
         //$config->setReloadOnClose(true);
+        
         $config->setItems([
             [
-                'type' => 'input',
-                'label' => 'Some additional Text', // labels are optional
-                'name' => 'myDialogInput'
+                (new Editable\Input())
+                    ->setName('myDialogInput')
+                    ->setLabel('Some additional Text') // labels are optional
             ],
             [
-                'type' => 'checkbox',
-                'name' => 'myDialogCheckbox',
-                'label' => 'This is the checkbox label',
-                'description' => 'This is a description for myDialogCheckbox' // descriptions are optional
+                (new Editable\Checkbox())
+                    ->setName('myDialogCheckbox')
+                    ->setLabel('This is the checkbox label')
+                    ->setDialogDescription('This is a description for myDialogCheckbox')  // descriptions are optional
             ],
             [
-                'type' => 'date',
-                'name' => 'myDialogDate'
+                (new Editable\Date())
+                    ->setName('myDialogDate')
             ]
         ]);
-
 
         return $config;
     }
@@ -310,7 +323,7 @@ namespace App\Document\Areabrick;
 
 use Pimcore\Extension\Document\Areabrick\EditableDialogBoxConfiguration;
 use Pimcore\Extension\Document\Areabrick\EditableDialogBoxInterface;
-use Pimcore\Model\Document;
+use Pimcore\Model\Document\Editable;
 use Pimcore\Model\Document\Editable\Area\Info;
 
 class WysiwygWithImages extends AbstractAreabrick implements EditableDialogBoxInterface
@@ -320,10 +333,11 @@ class WysiwygWithImages extends AbstractAreabrick implements EditableDialogBoxIn
         return 'WYSIWYG w. Images';
     }
 
-    public function getEditableDialogBoxConfiguration(Document\Editable $area, ?Info $info): EditableDialogBoxConfiguration
+    public function getEditableDialogBoxConfiguration(Editable $area, ?Info $info): EditableDialogBoxConfiguration
     {
         $config = new EditableDialogBoxConfiguration();
         $config->setWidth(600);
+        
         $config->setItems([
             'type' => 'tabpanel',
             'items' => [
@@ -331,116 +345,93 @@ class WysiwygWithImages extends AbstractAreabrick implements EditableDialogBoxIn
                     'type' => 'panel',
                     'title' => 'Tab 1',
                     'items' => [
-                        [
-                            'type' => 'wysiwyg',
-                            'label' => 'Some additional Text',
-                            'name' => 'myDialogWysiwyg'
-                        ],
-                        [
-                            'type' => 'video',
-                            'name' => 'myDialogVideo'
-                        ],
-                        [
-                            'type' => 'textarea',
-                            'name' => 'myDialogTextarea'
-                        ],
-                        [
-                            'type' => 'table',
-                            'name' => 'myDialogTable'
-                        ],
-                        [
-                            'type' => 'snippet',
-                            'name' => 'myDialogSnippet'
-                        ],
-                        [
-                            'type' => 'select',
-                            'name' => 'myDialogSelect',
-                            'config' => [
+                        (new Editable\Wysiwyg())
+                            ->setName('myDialogWysiwyg')
+                            ->setLabel('Some additional Text'),
+                            
+                        (new Editable\Video())
+                            ->setName('myDialogVideo'),
+                            
+                        (new Editable\Textarea())
+                            ->setName('myDialogTextarea'),
+                            
+                        (new Editable\Table())
+                            ->setName('myDialogTable'),
+                            
+                        (new Editable\Snippet())
+                            ->setName('myDialogSnippet'),
+                            
+                        (new Editable\Select())
+                            ->setName('myDialogSelect')
+                            ->setConfig([
                                 'store' => [
                                     ['foo', 'Foo'],
                                     ['bar', 'Bar'],
                                     ['baz', 'Baz'],
                                 ]
-                            ]
-                        ],
-                        [
-                            'type' => 'numeric',
-                            'name' => 'myDialogNumber'
-                        ],
-                        [
-                            'type' => 'multiselect',
-                            'name' => 'myDialogMultiSelect',
-                            'config' => [
+                            ]),
+                            
+                        (new Editable\Numeric())
+                            ->setName('myDialogNumber'),
+                            
+                        (new Editable\Multiselect())
+                            ->setName('myDialogMultiSelect')
+                            ->setConfig([
                                 'store' => [
                                     ['foo', 'Foo'],
                                     ['bar', 'Bar'],
                                     ['baz', 'Baz'],
                                 ]
-                            ]
-                        ],
-                        [
-                            'type' => 'checkbox',
-                            'name' => 'myDialogCheckbox',
-                            'label' => 'This is the checkbox label 😸',
-                        ],
-                        [
-                            'type' => 'input',
-                            'name' => 'myDialogInput'
-                        ]
+                            ]),
+                        
+                        (new Editable\Checkbox())
+                            ->setName('myDialogCheckbox')
+                            ->setLabel('This is the checkbox label 😸'),
+                        
+                        (new Editable\Input())
+                            ->setName('myDialogInput'),
                     ]
                 ],
                 [
                     'type' => 'panel',
                     'title' => 'Tab 2',
                     'items' => [
-                        [
-                            'type' => 'input',
-                            'name' => 'myNumber3'
-                        ],
-                        [
-                            'type' => 'link',
-                            'name' => 'myDialogLink'
-                        ],
-                        [
-                            'type' => 'image',
-                            'name' => 'myDialogImage'
-                        ],
-                        [
-                            'type' => 'embed',
-                            'name' => 'myDialogEmbed'
-                        ],
-                        [
-                            'type' => 'date',
-                            'name' => 'myDialogDate'
-                        ]
+                        (new Editable\Input())
+                            ->setName('anotherInput'),
+                        
+                        (new Editable\Link())
+                            ->setName('myDialogLink'),
+                        
+                        (new Editable\Image())
+                            ->setName('myDialogImage'),
+                        
+                        (new Editable\Embed())
+                            ->setName('myEmbed'),
+                        
+                        (new Editable\Date())
+                            ->setName('myDialogDate'),
                     ]
                 ],
                 [
                     'type' => 'panel',
                     'title' => 'Tab 3',
                     'items' => [
-                        [
-                            'type' => 'renderlet',
-                            'name' => 'myDialogRenderlet'
-                        ],
-                        [
-                            'type' => 'relations',
-                            'name' => 'myDialogRelations'
-                        ],
-                        [
-                            'label' => 'Just a single relation 😹',
-                            'type' => 'relation',
-                            'name' => 'myDialogRelation'
-                        ],
-                        [
-                            'type' => 'pdf',
-                            'name' => 'myDialogPdf'
-                        ]
+                        (new Editable\Renderlet())
+                            ->setName('myDialogRenderlet'),
+                            
+                        (new Editable\Relations())
+                            ->setName('myDialogRelations'),
+                            
+                        (new Editable\Relation())
+                            ->setName('myDialogRelation')
+                            ->setLabel('Just a single relation 😹'),
+                            
+                        (new Editable\Pdf())
+                            ->setName('myDialogPdf'),
                     ]
                 ]
             ]
         ]);
-
 
         return $config;
     }

--- a/models/Document/Editable.php
+++ b/models/Document/Editable.php
@@ -43,6 +43,12 @@ abstract class Editable extends Model\AbstractModel implements Model\Document\Ed
     protected array $config = [];
 
     /**
+     * The label rendered for the editmode dialog.
+     * @internal
+     */
+    protected ?string $label = null;
+
+    /**
      * @internal
      *
      */
@@ -327,6 +333,17 @@ abstract class Editable extends Model\AbstractModel implements Model\Document\Ed
     {
         $this->config[$name] = $value;
 
+        return $this;
+    }
+
+    public function getLabel(): ?string
+    {
+        return $this->label ?? null;
+    }
+
+    public function setLabel(?string $label): self
+    {
+        $this->label = $label;
         return $this;
     }
 

--- a/models/Document/Editable.php
+++ b/models/Document/Editable.php
@@ -347,7 +347,10 @@ abstract class Editable extends Model\AbstractModel implements Model\Document\Ed
         return $this->label ?? null;
     }
 
-    public function setLabel(?string $label): self
+    /**
+     * @return $this
+     */
+    public function setLabel(?string $label): static
     {
         $this->label = $label;
         return $this;

--- a/models/Document/Editable.php
+++ b/models/Document/Editable.php
@@ -344,7 +344,7 @@ abstract class Editable extends Model\AbstractModel implements Model\Document\Ed
 
     public function getLabel(): ?string
     {
-        return $this->label ?? null;
+        return $this->label;
     }
 
     /**
@@ -358,7 +358,7 @@ abstract class Editable extends Model\AbstractModel implements Model\Document\Ed
 
     public function getDialogDescription(): ?string
     {
-        return $this->dialogDescription ?? null;
+        return $this->dialogDescription;
     }
 
     /**

--- a/models/Document/Editable.php
+++ b/models/Document/Editable.php
@@ -49,6 +49,12 @@ abstract class Editable extends Model\AbstractModel implements Model\Document\Ed
     protected ?string $label = null;
 
     /**
+     * The description rendered for the editmode dialog.
+     * @internal
+     */
+    protected ?string $dialogDescription = null;
+
+    /**
      * @internal
      *
      */
@@ -344,6 +350,17 @@ abstract class Editable extends Model\AbstractModel implements Model\Document\Ed
     public function setLabel(?string $label): self
     {
         $this->label = $label;
+        return $this;
+    }
+
+    public function getDialogDescription(): ?string
+    {
+        return $this->dialogDescription ?? null;
+    }
+
+    public function setDialogDescription(?string $dialogDescription): self
+    {
+        $this->dialogDescription = $dialogDescription;
         return $this;
     }
 

--- a/models/Document/Editable.php
+++ b/models/Document/Editable.php
@@ -361,7 +361,10 @@ abstract class Editable extends Model\AbstractModel implements Model\Document\Ed
         return $this->dialogDescription ?? null;
     }
 
-    public function setDialogDescription(?string $dialogDescription): self
+    /**
+     * @return $this
+     */
+    public function setDialogDescription(?string $dialogDescription): static
     {
         $this->dialogDescription = $dialogDescription;
         return $this;

--- a/models/Document/Editable/Area.php
+++ b/models/Document/Editable/Area.php
@@ -91,7 +91,8 @@ class Area extends Model\Document\Editable
                 'type' => $config->getType(),
                 'name' => $config->getName(),
                 'label' => $config->getLabel(),
-                'config' => $config->getConfig()
+                'config' => $config->getConfig(),
+                'description' => $config->getDialogDescription(),
             ];
         }
 

--- a/models/Document/Editable/Area.php
+++ b/models/Document/Editable/Area.php
@@ -79,12 +79,26 @@ class Area extends Model\Document\Editable
         $this->outputEditmode('</div>');
     }
 
-    private function renderDialogBoxEditables(array $config, EditableRenderer $editableRenderer, string $dialogId): void
+    private function renderDialogBoxEditables(array|Model\Document\Editable $config, EditableRenderer $editableRenderer, string $dialogId): array
     {
+        if ($config instanceof BlockInterface || $config instanceof Area) {
+            // Unsupported element was passed (e.g., Block, Areablock, ...)
+            // or an Areas was passed, which is not supported to avoid too long editable names
+            $config = [];
+        } elseif ($config instanceof Model\Document\Editable) {
+            // Map editable to array config
+            $config = [
+                'type' => $config->getType(),
+                'name' => $config->getName(),
+                'label' => $config->getLabel(),
+                'config' => $config->getConfig()
+            ];
+        }
+
         if (isset($config['items']) && is_array($config['items'])) {
             // layout component
-            foreach ($config['items'] as $child) {
-                $this->renderDialogBoxEditables($child, $editableRenderer, $dialogId);
+            foreach ($config['items'] as $index => $child) {
+                $config['items'][$index] = $this->renderDialogBoxEditables($child, $editableRenderer, $dialogId);
             }
         } elseif (isset($config['name']) && isset($config['type'])) {
             $editable = $editableRenderer->getEditable($this->getDocument(), $config['type'], $config['name'], $config['config'] ?? []);
@@ -96,10 +110,12 @@ class Area extends Model\Document\Editable
             $editable->addConfig('dialogBoxConfig', $config);
             $this->outputEditmode($editable->render());
         } else {
-            foreach ($config as $item) {
-                $this->renderDialogBoxEditables($item, $editableRenderer, $dialogId);
+            foreach ($config as $index => $item) {
+                $config['items'][$index] = $this->renderDialogBoxEditables($item, $editableRenderer, $dialogId);
             }
         }
+
+        return $config;
     }
 
     private function buildInfoObject(): Area\Info
@@ -177,8 +193,9 @@ class Area extends Model\Document\Editable
 
         if ($dialogConfig) {
             $editableRenderer = \Pimcore::getContainer()->get(EditableRenderer::class);
+            $items = $this->renderDialogBoxEditables($dialogConfig->getItems(), $editableRenderer, $dialogConfig->getId());
+            $dialogConfig->setItems($items);
             $this->outputEditmode('<template id="dialogBoxConfig-' . $dialogConfig->getId() . '">' . \json_encode($dialogConfig) . '</template>');
-            $this->renderDialogBoxEditables($dialogConfig->getItems(), $editableRenderer, $dialogConfig->getId());
         }
 
         echo $editableHandler->renderAreaFrontend($info);

--- a/models/Document/Editable/Area.php
+++ b/models/Document/Editable/Area.php
@@ -84,7 +84,7 @@ class Area extends Model\Document\Editable
         if ($config instanceof BlockInterface || $config instanceof Area) {
             // Unsupported element was passed (e.g., Block, Areablock, ...)
             // or an Areas was passed, which is not supported to avoid too long editable names
-            $config = [];
+            throw new \Exception(sprintf('Using editables of type "%s" for the editable dialog "%s" is not supported.',  get_debug_type($config), $dialogId));
         } elseif ($config instanceof Model\Document\Editable) {
             // Map editable to array config
             $config = [

--- a/models/Document/Editable/Areablock.php
+++ b/models/Document/Editable/Areablock.php
@@ -426,7 +426,7 @@ class Areablock extends Model\Document\Editable implements BlockInterface
         if ($config instanceof BlockInterface || $config instanceof Area) {
             // Unsupported element was passed (e.g., Block, Areablock, ...)
             // or an Areas was passed, which is not supported to avoid too long editable names
-            $config = [];
+            throw new \Exception(sprintf('Using editables of type "%s" for the editable dialog "%s" is not supported.',  get_debug_type($config), $dialogId));
         } elseif ($config instanceof Document\Editable) {
             // Map editable to array config
             $config = [

--- a/models/Document/Editable/Areablock.php
+++ b/models/Document/Editable/Areablock.php
@@ -400,7 +400,8 @@ class Areablock extends Model\Document\Editable implements BlockInterface
         $dialogHtml = '';
         if ($dialogConfig) {
             $editableRenderer = \Pimcore::getContainer()->get(EditableRenderer::class);
-            $this->renderDialogBoxEditables($dialogConfig->getItems(), $editableRenderer, $dialogConfig->getId(), $dialogHtml);
+            $items = $this->renderDialogBoxEditables($dialogConfig->getItems(), $editableRenderer, $dialogConfig->getId(), $dialogHtml);
+            $dialogConfig->setItems($items);
         }
 
         return [
@@ -420,12 +421,26 @@ class Areablock extends Model\Document\Editable implements BlockInterface
      *
      * @internal
      */
-    protected function renderDialogBoxEditables(array $config, EditableRenderer $editableRenderer, string $dialogId, string &$html): void
+    protected function renderDialogBoxEditables(array|Document\Editable $config, EditableRenderer $editableRenderer, string $dialogId, string &$html): array
     {
+        if ($config instanceof BlockInterface || $config instanceof Area) {
+            // Unsupported element was passed (e.g., Block, Areablock, ...)
+            // or an Areas was passed, which is not supported to avoid too long editable names
+            $config = [];
+        } elseif ($config instanceof Document\Editable) {
+            // Map editable to array config
+            $config = [
+                'type' => $config->getType(),
+                'name' => $config->getName(),
+                'label' => $config->getLabel(),
+                'config' => $config->getConfig()
+            ];
+        }
+
         if (isset($config['items']) && is_array($config['items'])) {
             // layout component
-            foreach ($config['items'] as $child) {
-                $this->renderDialogBoxEditables($child, $editableRenderer, $dialogId, $html);
+            foreach ($config['items'] as $index => $child) {
+                $config['items'][$index] = $this->renderDialogBoxEditables($child, $editableRenderer, $dialogId, $html);
             }
         } elseif (isset($config['name']) && isset($config['type'])) {
             $editable = $editableRenderer->getEditable($this->getDocument(), $config['type'], $config['name'], $config['config'] ?? []);
@@ -437,10 +452,12 @@ class Areablock extends Model\Document\Editable implements BlockInterface
             $editable->addConfig('dialogBoxConfig', $config);
             $html .= $editable->render();
         } else {
-            foreach ($config as $item) {
-                $this->renderDialogBoxEditables($item, $editableRenderer, $dialogId, $html);
+            foreach ($config as $index => $item) {
+                $config['items'][$index] = $this->renderDialogBoxEditables($item, $editableRenderer, $dialogId, $html);
             }
         }
+
+        return $config;
     }
 
     public function blockEnd(): void

--- a/models/Document/Editable/Areablock.php
+++ b/models/Document/Editable/Areablock.php
@@ -433,7 +433,8 @@ class Areablock extends Model\Document\Editable implements BlockInterface
                 'type' => $config->getType(),
                 'name' => $config->getName(),
                 'label' => $config->getLabel(),
-                'config' => $config->getConfig()
+                'config' => $config->getConfig(),
+                'description' => $config->getDialogDescription(),
             ];
         }
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #7672

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8aa0195</samp>

This pull request improves the Editable Dialog feature for the Areablock Editable by using the `Editable` class for defining and rendering the dialog box editables. It also updates the documentation and adds new properties to the `Editable` class to allow customizing the dialog labels and descriptions.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8aa0195</samp>

> _`Editable` class is the new way to go_
> _Define your dialog boxes with ease and flow_
> _No more arrays or deprecated stuff_
> _`Area` and `Areablock` classes are now tough_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8aa0195</samp>

*  Add label and dialogDescription properties and methods to the Editable class to store the optional label and description for the editmode dialog of the editable ([link](https://github.com/pimcore/pimcore/pull/15798/files?diff=unified&w=0#diff-629c3ab163921129218936956cf2db0761d23c958f2b554ad5e5225acc699cd8L46-R58), [link](https://github.com/pimcore/pimcore/pull/15798/files?diff=unified&w=0#diff-629c3ab163921129218936956cf2db0761d23c958f2b554ad5e5225acc699cd8R345-R366))
*  Update the renderDialogBoxEditables methods of the Area and Areablock classes to accept and return either an array or an Editable instance as the config parameter, and update the frontend and blockStart methods to set the modified config items after rendering ([link](https://github.com/pimcore/pimcore/pull/15798/files?diff=unified&w=0#diff-b511b88988f140188545381ff9b7e470ba1440d2fec538550b929017379e5771L82-R102), [link](https://github.com/pimcore/pimcore/pull/15798/files?diff=unified&w=0#diff-b511b88988f140188545381ff9b7e470ba1440d2fec538550b929017379e5771L99-R119), [link](https://github.com/pimcore/pimcore/pull/15798/files?diff=unified&w=0#diff-b511b88988f140188545381ff9b7e470ba1440d2fec538550b929017379e5771L180-R199), [link](https://github.com/pimcore/pimcore/pull/15798/files?diff=unified&w=0#diff-d80b7e0f085732af7646014b34c070e2908365436af54dc979d2af09cf0a9ae6L403-R404), [link](https://github.com/pimcore/pimcore/pull/15798/files?diff=unified&w=0#diff-d80b7e0f085732af7646014b34c070e2908365436af54dc979d2af09cf0a9ae6L423-R444), [link](https://github.com/pimcore/pimcore/pull/15798/files?diff=unified&w=0#diff-d80b7e0f085732af7646014b34c070e2908365436af54dc979d2af09cf0a9ae6L440-R461))
*  Update the documentation of the Editable Dialog feature in `doc/03_Documents/01_Editables/02_Areablock/02_Bricks.md` to use the Editable class instances instead of the array format for defining the dialog editables, and to clarify the usage and alternatives of the feature ([link](https://github.com/pimcore/pimcore/pull/15798/files?diff=unified&w=0#diff-88f9e769e57fa42fef09f83669a719375e1da9e686fcfa426b136202d4ca9c6aR257-R268), [link](https://github.com/pimcore/pimcore/pull/15798/files?diff=unified&w=0#diff-88f9e769e57fa42fef09f83669a719375e1da9e686fcfa426b136202d4ca9c6aR278), [link](https://github.com/pimcore/pimcore/pull/15798/files?diff=unified&w=0#diff-88f9e769e57fa42fef09f83669a719375e1da9e686fcfa426b136202d4ca9c6aL280-R311), [link](https://github.com/pimcore/pimcore/pull/15798/files?diff=unified&w=0#diff-88f9e769e57fa42fef09f83669a719375e1da9e686fcfa426b136202d4ca9c6aL313-R326), [link](https://github.com/pimcore/pimcore/pull/15798/files?diff=unified&w=0#diff-88f9e769e57fa42fef09f83669a719375e1da9e686fcfa426b136202d4ca9c6aL323-R340), [link](https://github.com/pimcore/pimcore/pull/15798/files?diff=unified&w=0#diff-88f9e769e57fa42fef09f83669a719375e1da9e686fcfa426b136202d4ca9c6aL334-R366), [link](https://github.com/pimcore/pimcore/pull/15798/files?diff=unified&w=0#diff-88f9e769e57fa42fef09f83669a719375e1da9e686fcfa426b136202d4ca9c6aL364-R379), [link](https://github.com/pimcore/pimcore/pull/15798/files?diff=unified&w=0#diff-88f9e769e57fa42fef09f83669a719375e1da9e686fcfa426b136202d4ca9c6aL379-R392), [link](https://github.com/pimcore/pimcore/pull/15798/files?diff=unified&w=0#diff-88f9e769e57fa42fef09f83669a719375e1da9e686fcfa426b136202d4ca9c6aL396-R412), [link](https://github.com/pimcore/pimcore/pull/15798/files?diff=unified&w=0#diff-88f9e769e57fa42fef09f83669a719375e1da9e686fcfa426b136202d4ca9c6aL422-R430), [link](https://github.com/pimcore/pimcore/pull/15798/files?diff=unified&w=0#diff-88f9e769e57fa42fef09f83669a719375e1da9e686fcfa426b136202d4ca9c6aL444))
