### PR TITLE
Allow more elements to fit CKEditor Content

### DIFF
--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -77,6 +77,7 @@ framework:
                     tbody: [ 'class', 'id' ]
                     tr: [ 'class', 'id' ]
                     td: [ 'class', 'id' ]
+                    th: [ 'class', 'id', 'scope' ]
                     ul: [ 'class', 'style', 'id' ]
                     li: [ 'class', 'style', 'id' ]
                     ol: [ 'class', 'style', 'id' ]

--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -84,6 +84,12 @@ framework:
                     u: [ 'class', 'id' ]
                     i: [ 'class', 'id' ]
                     b: [ 'class', 'id' ]
+                    caption: [ 'class', 'id' ]
+                    sub: [ 'class', 'id' ]
+                    sup: [ 'class', 'id' ]
+                    blockquote: [ 'class', 'id' ]
+                    s: [ 'class', 'id' ]
+                    iframe: [ 'frameborder', 'height', 'longdesc', 'name', 'sandbox', 'scrolling', 'src', 'title', 'width' ]
                     br: ''
                     img: [ 'alt', 'style', 'src' ]
             pimcore.translation_sanitizer:

--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -63,24 +63,28 @@ framework:
                 allow_relative_links: true
                 allow_relative_medias: true
                 allow_elements:
-                    span : [ 'class', 'style', 'id' ]
-                    div : [ 'class', 'style', 'id' ]
+                    span: [ 'class', 'style', 'id' ]
+                    div: [ 'class', 'style', 'id' ]
                     p: [ 'class', 'style', 'id' ]
                     strong: 'class'
                     em: 'class'
-                    h1: ['class', 'id']
-                    a: ['class', 'id', 'href', 'target', 'title', 'rel']
-                    table: ['class', 'style', 'cellspacing', 'cellpadding', 'border', 'width', 'height', 'id']
+                    h1: [ 'class', 'id' ]
+                    a: [ 'class', 'id', 'href', 'target', 'title', 'rel', 'style' ]
+                    table: [ 'class', 'style', 'cellspacing', 'cellpadding', 'border', 'width', 'height', 'id' ]
                     colgroup: 'class'
-                    col: ['class', 'style', 'id']
-                    tbody: ['class', 'id']
-                    tr: ['class', 'id']
-                    td: ['class', 'id']
-                    ul: ['class', 'style', 'id']
-                    li: ['class', 'style', 'id']
-                    ol: ['class', 'style', 'id']
+                    col: [ 'class', 'style', 'id' ]
+                    thead: [ 'class', 'id' ]
+                    tbody: [ 'class', 'id' ]
+                    tr: [ 'class', 'id' ]
+                    td: [ 'class', 'id' ]
+                    ul: [ 'class', 'style', 'id' ]
+                    li: [ 'class', 'style', 'id' ]
+                    ol: [ 'class', 'style', 'id' ]
+                    u: [ 'class', 'id' ]
+                    i: [ 'class', 'id' ]
+                    b: [ 'class', 'id' ]
                     br: ''
-                    img: ['alt', 'style', 'src']
+                    img: [ 'alt', 'style', 'src' ]
             pimcore.translation_sanitizer:
                 allow_attributes:
                     pimcore_type: '*'


### PR DESCRIPTION
## Changes in this pull request 

CKEditor used elements like `<u>`, `<i>` or `<b>` and allowed use of properties like style on tags like a.
If you update pimcore 10 to pimcore 11 this content will be gone. All `<u>Text</u>` will simply be removed!
This does add the elements back. In the future we should probably have a replacement from `<u>` to `<span style="text-decoration: underline;">` but we can not loose so much content during update.

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ecb6526</samp>

Allow more HTML tags and attributes in rich text editor. This change modifies the `pimcore.richtext` configuration in `bundles/CoreBundle/config/pimcore/default.yaml` to enhance the content editing experience.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ecb6526</samp>

> _`pimcore.richtext`_
> _More HTML tags allowed_
> _Cutting edge content_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ecb6526</samp>

*  Allow more HTML tags and attributes in the rich text editor by modifying the `allow_elements` section of the `pimcore.richtext` configuration ([link](https://github.com/pimcore/pimcore/pull/15807/files?diff=unified&w=0#diff-34d259c58a9001df91ca2ccc5f41ab960a307d1566cffceb88262d679cfc6c70L66-R87))
