### PR TITLE
Fix the issue with the '<' in the wysiwg editor

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Wysiwyg.php
+++ b/models/DataObject/ClassDefinition/Data/Wysiwyg.php
@@ -114,7 +114,7 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
     public function getDataFromResource(mixed $data, DataObject\Concrete $object = null, array $params = []): ?string
     {
         if (is_string($data)) {
-            $data = self::getWysiwygSanitizer()->sanitize(html_entity_decode($data));
+            $data = self::getWysiwygSanitizer()->sanitize($data);
         }
 
         return Text::wysiwygText($data);

--- a/models/Document/Editable/Wysiwyg.php
+++ b/models/Document/Editable/Wysiwyg.php
@@ -90,7 +90,7 @@ class Wysiwyg extends Model\Document\Editable implements IdRewriterInterface, Ed
     public function setDataFromResource(mixed $data): static
     {
         $helper = self::getWysiwygSanitizer();
-        $this->text = $helper->sanitize(html_entity_decode($data));
+        $this->text = $helper->sanitize($data);
 
         return $this;
     }
@@ -101,7 +101,7 @@ class Wysiwyg extends Model\Document\Editable implements IdRewriterInterface, Ed
     public function setDataFromEditmode(mixed $data): static
     {
         $helper = self::getWysiwygSanitizer();
-        $this->text = $helper->sanitize(html_entity_decode($data));
+        $this->text = $helper->sanitize($data);
 
         return $this;
     }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15740

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d112925</samp>

The pull request fixes a bug in the `Wysiwyg` classes for documents and data objects that could cause data loss or corruption due to double decoding of HTML entities in rich text data. It removes unnecessary `html_entity_decode` calls from several methods that set or get the data from different sources.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d112925</samp>

> _`Wysiwyg` class changed_
> _No more `html_entity_decode`_
> _Data stays intact_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d112925</samp>

* Remove `html_entity_decode` function calls from `Wysiwyg` class methods to prevent double decoding of HTML entities ([link](https://github.com/pimcore/pimcore/pull/15811/files?diff=unified&w=0#diff-2ba4202bada58b975309826f8fc4a99d465b9ef1a6c7227bc49487f7541f44edL117-R117), [link](https://github.com/pimcore/pimcore/pull/15811/files?diff=unified&w=0#diff-0c6c24fc188205dba44a894fc6eb75aa6959974d07e633a0fc92d12e179f25e0L93-R93), [link](https://github.com/pimcore/pimcore/pull/15811/files?diff=unified&w=0#diff-0c6c24fc188205dba44a894fc6eb75aa6959974d07e633a0fc92d12e179f25e0L104-R104))
