### PR TITLE
[Bug]: Omit Mandatory Check on field with Default Value when creating a new DataObject

### DIFF
--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -143,8 +143,7 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
 
                     $omitMandatoryCheck = $this->getOmitMandatoryCheck();
                     // when adding a new object, skip check on mandatory fields with default value
-                    if (empty($value) && !$isUpdate && $fd->getMandatory()
-                        && method_exists($fd, 'getDefaultValue') && !empty($fd->getDefaultValue())
+                    if (empty($value) && !$isUpdate && method_exists($fd, 'getDefaultValue') && !empty($fd->getDefaultValue())
                     ){
                         $omitMandatoryCheck = true;
                     }

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -140,13 +140,13 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
 
                 if (method_exists($this, $getter)) {
                     $value = $this->$getter();
-                    
+
                     $omitMandatoryCheck = $this->getOmitMandatoryCheck();
                     // when adding a new object, skip check on mandatory fields with default value
-                    if (empty($value) && !$isUpdate && $fd->getMandatory() 
+                    if (empty($value) && !$isUpdate && $fd->getMandatory()
                         && method_exists($fd, 'getDefaultValue') && !empty($fd->getDefaultValue())
                     ){
-                        $omitMandatoryCheck = true;
+                        //$omitMandatoryCheck = true;
                     }
 
                     //check throws Exception

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -146,7 +146,7 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
                     if (empty($value) && !$isUpdate && $fd->getMandatory()
                         && method_exists($fd, 'getDefaultValue') && !empty($fd->getDefaultValue())
                     ){
-                        //$omitMandatoryCheck = true;
+                        $omitMandatoryCheck = true;
                     }
 
                     //check throws Exception

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -140,7 +140,14 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
 
                 if (method_exists($this, $getter)) {
                     $value = $this->$getter();
+                    
                     $omitMandatoryCheck = $this->getOmitMandatoryCheck();
+                    // when adding a new object, skip check on mandatory fields with default value
+                    if (empty($value) && !$isUpdate && $fd->getMandatory() 
+                        && method_exists($fd, 'getDefaultValue') && !empty($fd->getDefaultValue())
+                    ){
+                        $omitMandatoryCheck = true;
+                    }
 
                     //check throws Exception
                     try {

--- a/tests/Model/DataObject/ObjectTest.php
+++ b/tests/Model/DataObject/ObjectTest.php
@@ -207,6 +207,25 @@ class ObjectTest extends ModelTestCase
     }
 
     /**
+     * Verifies a newly published object gets the default values of mandatory fields
+     */
+    public function testDefaultValueAndMandatorySavedToVersion(): void
+    {
+        $object = TestHelper::createEmptyObject('', false, true);
+        $object->setOmitMandatoryCheck(false);
+        try {
+            $object->save();
+        } catch (\Exception $e) {
+            $this->assertStringContainsString( 'Empty mandatory field', $e->getMessage());
+        }
+
+        $versions = $object->getVersions();
+        $latestVersion = end($versions);
+
+        $this->assertEquals('default', $latestVersion->getData()->getMandatoryInputWithDefault(), 'Expected default value saved to version');
+    }
+
+    /**
      * Verifies that when an object gets cloned, the fields get copied properly
      */
     public function testCloning(): void

--- a/tests/Model/DataObject/ObjectTest.php
+++ b/tests/Model/DataObject/ObjectTest.php
@@ -213,11 +213,7 @@ class ObjectTest extends ModelTestCase
     {
         $object = TestHelper::createEmptyObject('', false, true);
         $object->setOmitMandatoryCheck(false);
-        try {
-            $object->save();
-        } catch (\Exception $e) {
-            $this->assertStringContainsString( 'Empty mandatory field', $e->getMessage());
-        }
+        $object->save();
 
         $versions = $object->getVersions();
         $latestVersion = end($versions);

--- a/tests/Support/Helper/Model.php
+++ b/tests/Support/Helper/Model.php
@@ -451,6 +451,10 @@ class Model extends AbstractDefinitionHelper
             $inputWithDefault = $this->createDataChild('input', 'inputWithDefault');
             $inputWithDefault->setDefaultValue('default');
             $panel->addChild($inputWithDefault);
+            /** @var ClassDefinition\Data\Input $mandatoryInputWithDefault */
+            $mandatoryInputWithDefault = $this->createDataChild('input', 'mandatoryInputWithDefault', true);
+            $mandatoryInputWithDefault->setDefaultValue('default');
+            $panel->addChild($mandatoryInputWithDefault);
 
             $panel->addChild($this->createDataChild('manyToOneRelation', 'lazyHref')
                 ->setDocumentTypes([])->setAssetTypes([])->setClasses([])


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15311

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5c02d95</samp>

Fix mandatory check for fields with default values in `DataObject/Concrete.php`. This allows saving new objects with empty mandatory fields that have a default value set in the class definition.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5c02d95</samp>

> _`default` values_
> _skip the mandatory check_
> _autumn leaves falling_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5c02d95</samp>

*  Skip mandatory check on fields with default value when adding new object ([link](https://github.com/pimcore/pimcore/pull/15812/files?diff=unified&w=0#diff-8ff96247c8a26d5a3ecbf9b79e38c31b8fc8a638bd145a46b9cdb7ee27d4869bL143-R150))
