### PR TITLE
Fix deprecation in TestDataHelper

### DIFF
--- a/tests/Support/Helper/DataType/TestDataHelper.php
+++ b/tests/Support/Helper/DataType/TestDataHelper.php
@@ -850,7 +850,10 @@ class TestDataHelper extends AbstractTestDataHelper
         $this->assertEquals($expected, $value);
     }
 
-    public function assertVideo(Concrete $object, string $field, mixed $returnParams, int $seed = 1): void
+    /**
+     * @param array<string, mixed> $returnParams
+     */
+    public function assertVideo(Concrete $object, string $field, array $returnParams, int $seed = 1): void
     {
         $getter = 'get' . ucfirst($field);
 

--- a/tests/Support/Helper/DataType/TestDataHelper.php
+++ b/tests/Support/Helper/DataType/TestDataHelper.php
@@ -850,7 +850,7 @@ class TestDataHelper extends AbstractTestDataHelper
         $this->assertEquals($expected, $value);
     }
 
-    public function assertVideo(Concrete $object, string $field, int $seed = 1, mixed $returnParams): void
+    public function assertVideo(Concrete $object, string $field, int $seed, mixed $returnParams): void
     {
         $getter = 'get' . ucfirst($field);
 

--- a/tests/Support/Helper/DataType/TestDataHelper.php
+++ b/tests/Support/Helper/DataType/TestDataHelper.php
@@ -850,7 +850,7 @@ class TestDataHelper extends AbstractTestDataHelper
         $this->assertEquals($expected, $value);
     }
 
-    public function assertVideo(Concrete $object, string $field, int $seed, mixed $returnParams): void
+    public function assertVideo(Concrete $object, string $field, mixed $returnParams, int $seed = 1): void
     {
         $getter = 'get' . ucfirst($field);
 

--- a/tests/Support/Test/DataType/AbstractDataTypeTestCase.php
+++ b/tests/Support/Test/DataType/AbstractDataTypeTestCase.php
@@ -806,7 +806,7 @@ abstract class AbstractDataTypeTestCase extends TestCase
         $this->refreshObject();
         $this->assertNotNull($this->testObject->getVideo());
 
-        $this->testDataHelper->assertVideo($this->testObject, 'video', $this->seed, $returnData);
+        $this->testDataHelper->assertVideo($this->testObject, 'video', $returnData, $this->seed);
     }
 
     public function testWysiwyg(): void


### PR DESCRIPTION
```
PHP Deprecated:  Optional parameter $seed declared before required parameter $returnParams is implicitly treated as a required parameter in /var/www/html/vendor/pimcore/pimcore/tests/Support/Helper/DataType/TestDataHelper.php on line 853
```