### PR TITLE
Fix issue with setting the read target to settings-store after pimcore 11 install

### DIFF
--- a/lib/SystemSettingsConfig.php
+++ b/lib/SystemSettingsConfig.php
@@ -48,7 +48,7 @@ class SystemSettingsConfig
     private static function getRepository(): LocationAwareConfigRepository
     {
         if (!self::$locationAwareConfigRepository) {
-            $containerConfigSettings = self::getValuesFromContainerConfig();
+            $containerConfigSettings = self::getConfigValuesFromContainer();
             $config[self::CONFIG_ID] = $containerConfigSettings['config'];
 
             $storageConfig = $containerConfigSettings['containerConfig']['config_location'][self::CONFIG_ID];
@@ -72,8 +72,9 @@ class SystemSettingsConfig
 
         // If the read target is settings-store and no data is found there,
         // load the data from the container config
+        // Please see https://github.com/pimcore/pimcore/issues/15596 for more information
         if(!$data && $loadType === $repository::LOCATION_SETTINGS_STORE) {
-            $data = self::getValuesFromContainerConfig()['config'];
+            $data = self::getConfigValuesFromContainer()['config'];
             $data['writeable'] = $repository->isWriteable();
         }
         return $data;
@@ -240,7 +241,7 @@ class SystemSettingsConfig
         }
     }
 
-    private static function getValuesFromContainerConfig():array {
+    private static function getConfigValuesFromContainer():array {
         $containerConfig = \Pimcore\Config::getSystemConfiguration();
         $data = [
             'general' => $containerConfig['general'],

--- a/lib/SystemSettingsConfig.php
+++ b/lib/SystemSettingsConfig.php
@@ -241,7 +241,7 @@ class SystemSettingsConfig
     }
 
     private static function getValuesFromContainerConfig():array {
-        $containerConfig = \Pimcore::getContainer()->getParameter('pimcore.config');
+        $containerConfig = \Pimcore\Config::getSystemConfiguration();
         $data = [
             'general' => $containerConfig['general'],
             'documents' => $containerConfig['documents'],


### PR DESCRIPTION


<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15596

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e3d32ff</samp>

Refactor system settings loading and add backward compatibility features. This change simplifies the `SystemSettingsConfig` class and allows it to load settings from the container config or a fallback file, as well as to check if the settings are writeable.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e3d32ff</samp>

> _Sing, O Muse, of the skillful refactorer_
> _Who improved the system settings loading_
> _From the container config, that great store_
> _Of parameters for the software molding._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e3d32ff</samp>

*  Refactor the code to extract the system settings data from the container config into a separate private method `getValuesFromContainerConfig` ([link](https://github.com/pimcore/pimcore/pull/15822/files?diff=unified&w=0#diff-77818c024321d17e303f2ee1d8b37c0127a1d7ef7725c3e344be835c32748ed9L51-R54), [link](https://github.com/pimcore/pimcore/pull/15822/files?diff=unified&w=0#diff-77818c024321d17e303f2ee1d8b37c0127a1d7ef7725c3e344be835c32748ed9R242-R253))
* Add a fallback mechanism to load the system settings data from the container config if the data is not found in the settings store, and add a `writeable` flag to the data ([link](https://github.com/pimcore/pimcore/pull/15822/files?diff=unified&w=0#diff-77818c024321d17e303f2ee1d8b37c0127a1d7ef7725c3e344be835c32748ed9L71-R79))
* Update the `get` method in `lib/SystemSettingsConfig.php` to use the `getValuesFromContainerConfig` method and the `writeable` flag ([link](https://github.com/pimcore/pimcore/pull/15822/files?diff=unified&w=0#diff-77818c024321d17e303f2ee1d8b37c0127a1d7ef7725c3e344be835c32748ed9L71-R79))
