### PR TITLE
Make sure unserialized is array

### DIFF
--- a/bundles/CoreBundle/src/Migrations/Version20230424084415.php
+++ b/bundles/CoreBundle/src/Migrations/Version20230424084415.php
@@ -37,19 +37,17 @@ class Version20230424084415 extends AbstractMigration
 
             foreach ($editables as $editable) {
                 $unserialized = unserialize($editable['data']);
-                if(is_array($unserialized)) {
-                    if (array_key_exists('attributes', $unserialized)) {
-                        unset($unserialized['attributes']);
-
-                        $editable['data'] = serialize($unserialized);
-
-                        Db\Helper::upsert(
-                            $db,
-                            'documents_editables',
-                            $editable,
-                            $primaryKey
-                        );
-                    }
+                if (is_array($unserialized) && array_key_exists('attributes', $unserialized)) {
+                    unset($unserialized['attributes']);
+    
+                    $editable['data'] = serialize($unserialized);
+    
+                    Db\Helper::upsert(
+                        $db,
+                        'documents_editables',
+                        $editable,
+                        $primaryKey
+                    );
                 }
             }
             $db->executeStatement('SET foreign_key_checks = 1');

--- a/bundles/CoreBundle/src/Migrations/Version20230424084415.php
+++ b/bundles/CoreBundle/src/Migrations/Version20230424084415.php
@@ -37,17 +37,19 @@ class Version20230424084415 extends AbstractMigration
 
             foreach ($editables as $editable) {
                 $unserialized = unserialize($editable['data']);
-                if(array_key_exists('attributes', $unserialized)) {
-                    unset($unserialized['attributes']);
+                if(is_array($unserialized)) {
+                    if (array_key_exists('attributes', $unserialized)) {
+                        unset($unserialized['attributes']);
 
-                    $editable['data'] = serialize($unserialized);
+                        $editable['data'] = serialize($unserialized);
 
-                    Db\Helper::upsert(
-                        $db,
-                        'documents_editables',
-                        $editable,
-                        $primaryKey
-                    );
+                        Db\Helper::upsert(
+                            $db,
+                            'documents_editables',
+                            $editable,
+                            $primaryKey
+                        );
+                    }
                 }
             }
             $db->executeStatement('SET foreign_key_checks = 1');


### PR DESCRIPTION
## Changes in this pull request  
Unserialized may be false sometimes which will cause the following error when running the migration:

> [error] Migration Pimcore\Bundle\CoreBundle\Migrations\Version20230424084415 failed during Execution. Error: "array_key_exists(): Argument #2 ($array) must be of type array, bool given"
17:29:18 CRITICAL  [console] Error thrown while running command "doctrine:migrations:migrate". Message: "array_key_exists(): Argument #2 ($array) must be of type array, bool given" ["exception" => TypeError { …},"command" => "doctrine:migrations:migrate","message" => "array_key_exists(): Argument #2 ($array) must be of type array, bool given"]
In Version20230424084415.php line 40:
array_key_exists(): Argument #2 ($array) must be of type array, bool given

Make sure that unserialized is an array and skip otherwise or Pimcore 10 > 11 updates might fail.

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9f802ac</samp>

Fix migration of document editables from Pimcore 5 to Pimcore 10. Add array check to `unserialize` result in `Version20230424084415.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9f802ac</samp>

> _`unserialize` /_
> _check if array or not /_
> _fall migration fix_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9f802ac</samp>

*  Add a check for array type before accessing keys of `$unserialized` variable in `Version20230424084415.php` ([link](https://github.com/pimcore/pimcore/pull/15823/files?diff=unified&w=0#diff-4492c287cba77cb97fbd796ce563017733864d7357e2c22ab5b036f4131dfb92L40-R52))
