### PR TITLE
Fallback to url if text is disabled

### DIFF
--- a/models/Document/Editable/Link.php
+++ b/models/Document/Editable/Link.php
@@ -171,7 +171,12 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
 
             $attribs = array_unique($attribs);
 
-            return '<a href="'.$url.'" '.implode(' ', $attribs).'>' . $prefix . ($noText ? '' : htmlspecialchars($disabledText ? $url : ($this->data['text'] ?? $url))) . $suffix . '</a>';
+            $text = '';
+            if (!$noText) {
+                $text = htmlspecialchars($disabledText ? $url : ($this->data['text'] ?? $url));
+            }
+            
+            return '<a href="'.$url.'" '.implode(' ', $attribs).'>' . $prefix . $text . $suffix . '</a>';
         }
 
         return '';

--- a/models/Document/Editable/Link.php
+++ b/models/Document/Editable/Link.php
@@ -171,7 +171,7 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
 
             $attribs = array_unique($attribs);
 
-            return '<a href="'.$url.'" '.implode(' ', $attribs).'>' . $prefix . ($noText ? '' : htmlspecialchars($disabledText ? $url : $this->data['text'])) . $suffix . '</a>';
+            return '<a href="'.$url.'" '.implode(' ', $attribs).'>' . $prefix . ($noText ? '' : htmlspecialchars($disabledText ? $url : ($this->data['text'] ?? $url))) . $suffix . '</a>';
         }
 
         return '';


### PR DESCRIPTION
Fix `htmlspecialchars(): Argument #1 ($string) must be of type string, null given` at  [Link.php](https://github.com/pimcore/pimcore/blob/639e865d449587cd6f30f11eed6095c60483362f/models/Document/Editable/Link.php#L174), when the text is disabled (`disabledField: ['text']` in twig) or noText (`noText: true` in twig) is set for the link, but the Link is rendered by SimpleBackendSearchBundle.
In this case there is no config for the editable, thus neither `$noText` nor `$disabledText` variable is `true`, so the `htmlspecialchars` is called with null. This throws TypeError in strict mode.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Fallback to url if no text is set for the link when creating indexable data for backend search.


## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b06dbd4</samp>

Fix empty link text bug in `Link` editable. Use null coalescing operator to fallback to `$url` if `text` attribute is missing in link data.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b06dbd4</samp>

> _`frontend` renders_
> _link text with coalescing_
> _fixes winter bug_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b06dbd4</samp>

*  Add null coalescing operator to link text in `frontend` function of `Link` class to avoid empty output if `text` attribute is not defined ([link](https://github.com/pimcore/pimcore/pull/15830/files?diff=unified&w=0#diff-c35541d0aea564c845ae03c018bb61018c369cb36ca7b405c9d1183be3a5e043L174-R174))
