### PR TITLE
[Task][Docs]: Improve asset document thumbs messenger queue instructions

### DIFF
--- a/doc/04_Assets/03_Working_with_Thumbnails/05_Document_Thumbnails.md
+++ b/doc/04_Assets/03_Working_with_Thumbnails/05_Document_Thumbnails.md
@@ -6,7 +6,7 @@ odt, ods, odp and many others.
 You can of course use existing image-thumbnail configurations to create a thumbnail of your choice.
  
 > **Important**   
-> Please be aware that the processing of thumbnails for documents is done asynchronously as part of the maintenance job. 
+> Please be aware that the processing of thumbnails for documents is done asynchronously as part of the [maintenance job](../../01_Getting_Started/00_Installation/01_Webserver_Installation.md#5-maintenance-cron-job), under the `pimcore_asset_update` messenger queue
  
 ##### Examples
 ```php


### PR DESCRIPTION
# Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/discussions/15834#discussioncomment-6847921

## Additional info


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8e4179a</samp>

Updated the documentation for asset document thumbnails to include more information about the maintenance job and the messenger queue. This improves the user experience and helps avoid potential issues with thumbnail generation.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8e4179a</samp>

> _`Important note` changed_
> _Link and queue name added_
> _Winter of docs_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8e4179a</samp>

* Update the important note in the document thumbnails documentation to include a link and the queue name ([link](https://github.com/pimcore/pimcore/pull/15836/files?diff=unified&w=0#diff-ad13d87d65a09ba8d4ad4540989fff4e896a186054ab75c4ae0f3ae06d83959eL9-R9))
