### PR TITLE
improvement: add deeplink and element id to Symfony profiler

### DIFF
--- a/bundles/CoreBundle/templates/Profiler/data_collector.html.twig
+++ b/bundles/CoreBundle/templates/Profiler/data_collector.html.twig
@@ -22,6 +22,22 @@
             <b>Context</b>
             <span>{{ collector.context }}</span>
         </div>
+
+        {% if collector.deeplink is iterable %}
+            <div class="sf-toolbar-info-piece">
+                <b>Deeplink</b>
+                <span>
+                    <a href="{{ collector.deeplink.href }}" target="_blank">{{ collector.deeplink.label }}</a>
+                </span>
+            </div>
+        {% endif %}
+
+        {% if collector.elementId %}
+            <div class="sf-toolbar-info-piece">
+                <b>Element ID</b>
+                <span>{{ collector.elementId }}</span>
+            </div>
+        {% endif %}
     {% endset %}
 
     {# the 'link' value set to 'false' means that this panel doesn't
@@ -58,5 +74,21 @@
             <span class="value">{{ collector.context }}</span>
             <span class="label">Request Context</span>
         </div>
+
+        {% if collector.deeplink is iterable %}
+            <div class="metric">
+                <span>
+                    <a href="{{ collector.deeplink.href }}" class="value" target="_blank">{{ collector.deeplink.label }}</a>
+                </span>
+                <span class="label">Deeplink</span>
+            </div>
+        {% endif %}
+
+        {% if collector.elementId %}
+            <div class="metric">
+                <span class="value">{{ collector.elementId }}</span>
+                <span class="label">Element ID</span>
+            </div>
+        {% endif %}
     </div>
 {% endblock %}


### PR DESCRIPTION
## Changes in this pull request  
Adds both the deeplink and element ID of the element that is currently being viewed. This will make it easier to open elements from the frontend directly in the backend.

## Additional info
- Supports both objects and documents.
- Not available in Pimcore backend.

![image](https://github.com/pimcore/pimcore/assets/57256630/5870067b-32fb-42a1-9aa6-d1df0bb9f7a6)


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b6cf1d8</samp>

This pull request adds a deeplink feature to the Pimcore data collector, which enables users to open the Pimcore element of the current request in the admin interface. It modifies the `PimcoreDataCollector` class and the `data_collector.html.twig` template to display the deeplink and element ID in the Symfony profiler. This improves the developer experience and productivity.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b6cf1d8</samp>

> _`PimcoreDataCollector`_
> _Adds deeplink feature for elements_
> _Spring of easy access_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b6cf1d8</samp>

*  Add deeplink and element ID information to the Pimcore data collector ([link](https://github.com/pimcore/pimcore/pull/15837/files?diff=unified&w=0#diff-77d2091550be5824ed019bc4a16bbaec945a573f9e71bbc89bb4e3aaf774a8bbL20-R28), [link](https://github.com/pimcore/pimcore/pull/15837/files?diff=unified&w=0#diff-77d2091550be5824ed019bc4a16bbaec945a573f9e71bbc89bb4e3aaf774a8bbL32-R38), [link](https://github.com/pimcore/pimcore/pull/15837/files?diff=unified&w=0#diff-77d2091550be5824ed019bc4a16bbaec945a573f9e71bbc89bb4e3aaf774a8bbR49-R63), [link](https://github.com/pimcore/pimcore/pull/15837/files?diff=unified&w=0#diff-77d2091550be5824ed019bc4a16bbaec945a573f9e71bbc89bb4e3aaf774a8bbR90-R99), [link](https://github.com/pimcore/pimcore/pull/15837/files?diff=unified&w=0#diff-d011d0d88c845a20ca38f4abe20ed3bde0b9731a87f3163662bc1e70266e9bbfR25-R40), [link](https://github.com/pimcore/pimcore/pull/15837/files?diff=unified&w=0#diff-d011d0d88c845a20ca38f4abe20ed3bde0b9731a87f3163662bc1e70266e9bbfR77-R92))
  * Inject the `RouterInterface` service to the `PimcoreDataCollector` constructor ([link](https://github.com/pimcore/pimcore/pull/15837/files?diff=unified&w=0#diff-77d2091550be5824ed019bc4a16bbaec945a573f9e71bbc89bb4e3aaf774a8bbL32-R38))
  * Add missing use statements for classes used in the `PimcoreDataCollector` class ([link](https://github.com/pimcore/pimcore/pull/15837/files?diff=unified&w=0#diff-77d2091550be5824ed019bc4a16bbaec945a573f9e71bbc89bb4e3aaf774a8bbL20-R28))
  * Check if the current request has an element attribute and create a deeplink array with the label and href of the element ([link](https://github.com/pimcore/pimcore/pull/15837/files?diff=unified&w=0#diff-77d2091550be5824ed019bc4a16bbaec945a573f9e71bbc89bb4e3aaf774a8bbR49-R63))
  * Store the element ID and the deeplink array in the data array of the collector ([link](https://github.com/pimcore/pimcore/pull/15837/files?diff=unified&w=0#diff-77d2091550be5824ed019bc4a16bbaec945a573f9e71bbc89bb4e3aaf774a8bbR49-R63))
  * Add getter methods for the element ID and the deeplink array ([link](https://github.com/pimcore/pimcore/pull/15837/files?diff=unified&w=0#diff-77d2091550be5824ed019bc4a16bbaec945a573f9e71bbc89bb4e3aaf774a8bbR90-R99))
  * Render the deeplink and element ID information in the profiler toolbar and panel using the `data_collector.html.twig` template ([link](https://github.com/pimcore/pimcore/pull/15837/files?diff=unified&w=0#diff-d011d0d88c845a20ca38f4abe20ed3bde0b9731a87f3163662bc1e70266e9bbfR25-R40), [link](https://github.com/pimcore/pimcore/pull/15837/files?diff=unified&w=0#diff-d011d0d88c845a20ca38f4abe20ed3bde0b9731a87f3163662bc1e70266e9bbfR77-R92))
    * Use conditional checks to display the information only if available ([link](https://github.com/pimcore/pimcore/pull/15837/files?diff=unified&w=0#diff-d011d0d88c845a20ca38f4abe20ed3bde0b9731a87f3163662bc1e70266e9bbfR25-R40), [link](https://github.com/pimcore/pimcore/pull/15837/files?diff=unified&w=0#diff-d011d0d88c845a20ca38f4abe20ed3bde0b9731a87f3163662bc1e70266e9bbfR77-R92))
    * Use anchor and span tags for the toolbar and div tags with a class of `metric` for the panel ([link](https://github.com/pimcore/pimcore/pull/15837/files?diff=unified&w=0#diff-d011d0d88c845a20ca38f4abe20ed3bde0b9731a87f3163662bc1e70266e9bbfR25-R40), [link](https://github.com/pimcore/pimcore/pull/15837/files?diff=unified&w=0#diff-d011d0d88c845a20ca38f4abe20ed3bde0b9731a87f3163662bc1e70266e9bbfR77-R92))
