### PR TITLE
fix: add null coalescing check for getTranslations

### DIFF
--- a/models/Translation.php
+++ b/models/Translation.php
@@ -203,9 +203,9 @@ final class Translation extends AbstractModel
         $this->translations[$language] = $text;
     }
 
-    public function getTranslation(string $language): string
+    public function getTranslation(string $language): ?string
     {
-        return $this->translations[$language];
+        return $this->translations[$language] ?? null;
     }
 
     public function hasTranslation(string $language): bool
@@ -446,7 +446,7 @@ final class Translation extends AbstractModel
                         foreach ($keyValueArray as $key => $value) {
                             $value = Service::unEscapeCsvField($value);
                             if (in_array($key, $languages)) {
-                                $currentTranslation = $t->hasTranslation($key) ? $t->getTranslation($key) : null;
+                                $currentTranslation = $t->getTranslation($key);
                                 if ($replaceExistingTranslations) {
                                     $t->addTranslation($key, $value);
                                     if ($currentTranslation != $value) {

--- a/models/Translation.php
+++ b/models/Translation.php
@@ -94,6 +94,9 @@ final class Translation extends AbstractModel
         return $this->key;
     }
 
+    /**
+     * @return $this
+     */
     public function setKey(string $key): static
     {
         $this->key = $key;
@@ -121,6 +124,9 @@ final class Translation extends AbstractModel
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function setDate(int $date): static
     {
         $this->setModificationDate($date);
@@ -133,6 +139,9 @@ final class Translation extends AbstractModel
         return $this->creationDate;
     }
 
+    /**
+     * @return $this
+     */
     public function setCreationDate(int $date): static
     {
         $this->creationDate = $date;
@@ -145,6 +154,9 @@ final class Translation extends AbstractModel
         return $this->modificationDate;
     }
 
+    /**
+     * @return $this
+     */
     public function setModificationDate(int $date): static
     {
         $this->modificationDate = $date;


### PR DESCRIPTION
## Changes in this pull request  
Alternative to https://github.com/pimcore/pimcore/pull/15797 for branch 11.0

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ea61709</samp>

Enhanced the `Translation` class to avoid errors and streamline the import of translations from files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ea61709</samp>

> _There once was a class called `Translation`_
> _That handled the language variation_
> _But it threw too many errors_
> _And caused lots of terrors_
> _So they changed it to use null instead of exception_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ea61709</samp>

*  Return null instead of throwing exception when language is not found in translations array ([link](https://github.com/pimcore/pimcore/pull/15838/files?diff=unified&w=0#diff-d0dc6d8e60e668f42bd2013951b548bf2c28f63b0a6a2cf0dd1a0d9ecb0a8425L206-R208))
*  Simplify importTranslationsFromFile method by removing redundant check for translation existence ([link](https://github.com/pimcore/pimcore/pull/15838/files?diff=unified&w=0#diff-d0dc6d8e60e668f42bd2013951b548bf2c28f63b0a6a2cf0dd1a0d9ecb0a8425L449-R449))
