### PR TITLE
Replace deprecated strftime() function

### DIFF
--- a/bundles/ApplicationLoggerBundle/src/FileObject.php
+++ b/bundles/ApplicationLoggerBundle/src/FileObject.php
@@ -36,15 +36,14 @@ final class FileObject
         $this->data = $data;
         $this->filename = $filename;
 
-        if (empty($this->filename)) {
-            $folderpath = strftime('/%Y/%m/%d');
-            $this->filename = $folderpath.'/'.uniqid('fileobject_', true);
+        if (!$this->filename) {
+            $this->filename = date('/Y/m/d/') . uniqid('fileobject_', true);
         }
         $storage = Storage::get('application_log');
 
         try {
             $storage->write($this->filename, $this->data);
-        } catch (FilesystemException | UnableToWriteFile $exception) {
+        } catch (FilesystemException | UnableToWriteFile) {
             Logger::warn('Application Logger could not write File Object:'.$this->filename);
         }
     }


### PR DESCRIPTION
## Changes in this pull request  

Related to https://github.com/pimcore/pimcore/issues/14524

The function is deprecated since 8.1.0:
https://www.php.net/manual/en/function.strftime.php

```
Deprecated: Function strftime() is deprecated in /var/www/html/vendor/pimcore/pimcore/bundles/ApplicationLoggerBundle/src/FileObject.php on line 40
```

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 41ded99</samp>

This pull request enhances the application logger bundle by fixing a potential issue with folder path generation on Windows systems and by cleaning up some redundant code in `FileObject.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 41ded99</samp>

> _`date` replaces `strftime`_
> _logger bundle improved_
> _unused var is gone_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 41ded99</samp>

* Replaced `strftime` with `date` for folder path generation in `FileObject.php` ([link](https://github.com/pimcore/pimcore/pull/15841/files?diff=unified&w=0#diff-52edacabc561df0b2cef69f8aa5d04acf317868cbc0e8823dc783834527fb477L39-R40)). This improves the performance and reliability of the application logger bundle by avoiding locale issues and using a standard function.
