### PR TITLE
SitemapGeneratorListener: Fix deprecation

### DIFF
--- a/bundles/SeoBundle/src/EventListener/SitemapGeneratorListener.php
+++ b/bundles/SeoBundle/src/EventListener/SitemapGeneratorListener.php
@@ -40,7 +40,7 @@ class SitemapGeneratorListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            SitemapPopulateEvent::ON_SITEMAP_POPULATE => 'onPopulateSitemap',
+            SitemapPopulateEvent::class => 'onPopulateSitemap',
         ];
     }
 

--- a/doc/18_Tools_and_Features/39_Sitemaps.md
+++ b/doc/18_Tools_and_Features/39_Sitemaps.md
@@ -76,7 +76,7 @@ interface GeneratorInterface
 }
 ```
 
-When the sitemap bundle fires its `SitemapPopulateEvent::ON_SITEMAP_POPULATE` event, Pimcore will iterate through every
+When the sitemap bundle fires its `SitemapPopulateEvent::class` event, Pimcore will iterate through every
 registered generator and call the `populate()` method. To make a generator available to the event handler, it needs to be
 registered via config. `generator_id` in the config below references a generator which was previously registered
 as service. As you can see, generators can be enabled/disabled and ordered by priority.


### PR DESCRIPTION
## Changes in this pull request  
Resolves:
Don't use SitemapPopulateEvent::ON_SITEMAP_POPULATE:
Deprecated since presta/sitemap-bundle 3.3, use `SitemapPopulateEvent::class` instead.

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ce72e00</samp>

Refactored the event system to use class constants instead of string literals for event names. Updated `SitemapGeneratorListener.php` to follow this convention.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ce72e00</samp>

> _`Event` constant_
> _Refactoring for robustness_
> _Autumn leaves no trace_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ce72e00</samp>

* Refactor event system to use class constants instead of string literals for event names ([link](https://github.com/pimcore/pimcore/pull/15842/files?diff=unified&w=0#diff-c61f2d4f85194e83f608130eab5c737d4b894d7eb273975b0c67c6ede0557af6L43-R43),                             F
