### PR TITLE
Fix: Version error when using a Calculated Value in Objects Bricks

### DIFF
--- a/models/DataObject/Objectbrick/Data/AbstractData.php
+++ b/models/DataObject/Objectbrick/Data/AbstractData.php
@@ -171,7 +171,7 @@ abstract class AbstractData extends Model\AbstractModel implements Model\DataObj
             return $this->$key;
         }
 
-        return false;
+        return null;
     }
 
     /**

--- a/models/DataObject/Objectbrick/Data/AbstractData.php
+++ b/models/DataObject/Objectbrick/Data/AbstractData.php
@@ -23,6 +23,7 @@ use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\Exception\InheritanceParentNotFoundException;
 use Pimcore\Model\DataObject\Localizedfield;
 use Pimcore\Model\DataObject\ObjectAwareFieldInterface;
+use Pimcore\Model\DataObject\Service;
 
 /**
  * @method Dao getDao()
@@ -169,6 +170,15 @@ abstract class AbstractData extends Model\AbstractModel implements Model\DataObj
     {
         if ($this->$key) {
             return $this->$key;
+        }
+
+        $definition = $this->getDefinition();
+        $fd = $definition->getFieldDefinition($key);
+        if ($fd instanceof Model\DataObject\ClassDefinition\Data\CalculatedValue) {
+            $value = new Model\DataObject\Data\CalculatedValue($key);
+            $value->setContextualData('objectbrick', $this->getFieldname(), $definition->getKey(), $fd->getName(), null, null, $fd);
+
+            return Service::getCalculatedFieldValue($this, $value);
         }
 
         return null;


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15846
Alternative to https://github.com/pimcore/pimcore/pull/15847

The getValueForFieldName() method should return null like the getValueForFieldName() method of the Concrete:
https://github.com/pimcore/pimcore/blob/a8d0258495aa3d5b6a25f95ae2b4f3b0d0abc66d/models/DataObject/Concrete.php#L344-L358

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d449f00</samp>

Fixed return type of `getValueForFieldName` in object bricks to match PHPDoc and interface. This improved the code quality and analysis in the DataObject namespace.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d449f00</samp>

> _`getValueForFieldName`_
> _Returns null, not false - kireji_
> _PHPStan issues fixed_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d449f00</samp>

*  Make return type of `getValueForFieldName` consistent with PHPDoc and interface ([link](https://github.com/pimcore/pimcore/pull/15850/files?diff=unified&w=0#diff-54f0e49023130d49845477fa706977e8619d3b66f52e4f7bc107383965b4f7eeL174-R174))
