### PR TITLE
[Bug]: Fix Element/Service::getSafeCopyName for Assets

### DIFF
--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -394,9 +394,11 @@ class Service extends Model\AbstractModel
         $type = self::getElementType($target);
         if (self::pathExists($target->getRealFullPath() . '/' . $sourceKey, $type)) {
             // only for assets: add the prefix _copy before the file extension (if exist) not after to that source.jpg will be source_copy.jpg and not source.jpg_copy
-            if ($type == 'asset' && $fileExtension = pathinfo($sourceKey, PATHINFO_EXTENSION)) {
-                $sourceKey = preg_replace('/\.' . $fileExtension . '$/i', '_copy.' . $fileExtension, $sourceKey);
-            } elseif (preg_match("/_copy(|_\d*)$/", $sourceKey) === 1) {
+            if ($type === 'asset' && $fileExtension = pathinfo($sourceKey, PATHINFO_EXTENSION)) {
+                // temporary remove file extension from sourceKey
+                $sourceKey = preg_replace('/\.' . $fileExtension . '$/i', '', $sourceKey);
+            }
+            if (preg_match("/_copy(|_\d*)$/", $sourceKey) === 1) {
                 // If key already ends with _copy or copy_N, append a digit to avoid _copy_copy_copy naming
                 $keyParts = explode('_', $sourceKey);
                 $counterKey = array_key_last($keyParts);
@@ -408,6 +410,11 @@ class Service extends Model\AbstractModel
                 $sourceKey = implode('_', $keyParts);
             } else {
                 $sourceKey .= '_copy';
+            }
+
+            // re-add file extension to sourceKey, that got previously removed
+            if ($fileExtension) {
+                $sourceKey .= '.' . $fileExtension;
             }
 
             return self::getSafeCopyName($sourceKey, $target);

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -413,7 +413,7 @@ class Service extends Model\AbstractModel
             }
 
             // re-add file extension to sourceKey, that got previously removed
-            if ($fileExtension) {
+            if ($fileExtension ?? false) {
                 $sourceKey .= '.' . $fileExtension;
             }
 

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -393,7 +393,8 @@ class Service extends Model\AbstractModel
     {
         $type = self::getElementType($target);
         if (self::pathExists($target->getRealFullPath() . '/' . $sourceKey, $type)) {
-            // only for assets: add the prefix _copy before the file extension (if exist) not after to that source.jpg will be source_copy.jpg and not source.jpg_copy
+            // only for assets: add the prefix _copy before the file extension (if exist)
+            // not after to that source.jpg will be source_copy.jpg and not source.jpg_copy
             if ($type === 'asset' && $fileExtension = pathinfo($sourceKey, PATHINFO_EXTENSION)) {
                 // temporary remove file extension from sourceKey
                 $sourceKey = preg_replace('/\.' . $fileExtension . '$/i', '', $sourceKey);
@@ -412,8 +413,8 @@ class Service extends Model\AbstractModel
                 $sourceKey .= '_copy';
             }
 
-            // re-add file extension to sourceKey, that got previously removed
-            if ($fileExtension ?? false) {
+            // restore file extension that got previously removed from sourceKey, if it was present
+            if ($fileExtension ?? '') {
                 $sourceKey .= '.' . $fileExtension;
             }
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15747

## Additional info
Basically gets and puts aside the file extension and let it run through the same code for docs/objects and re-add the file extensions after that, so that is always consistent among all element types
Could be behaviour change, because it was always like that (_copy_copy_copy...) since https://github.com/pimcore/pimcore/pull/6044

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d8409f2</samp>

This pull request fixes a bug in asset copying, enhances the error messages of editable elements, and improves the type safety of website settings. It modifies the files `Element/Service.php`, `Document/Editable.php`, and `WebsiteSetting.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d8409f2</samp>

> _Sing, O Muse, of the valiant coder who toiled_
> _To enhance the web app with features and fixes bold_
> _He wrapped the error messages in `pre` tags of grace_
> _Like Hephaestus who forged the shield of Achilles with skill and taste_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d8409f2</samp>

* Improve the readability and styling of error messages for editable elements by wrapping them in a `<pre>` tag with a CSS class ([link](https://github.com/pimcore/pimcore/pull/15851/files?diff=unified&w=0#diff-629c3ab163921129218936956cf2db0761d23c958f2b554ad5e5225acc699cd8L409-R409))
* Fix the copy functionality of asset elements by removing and re-adding the file extension from the source key before and after generating a safe copy name ([link](https://github.com/pimcore/pimcore/pull/15851/files?diff=unified&w=0#diff-f1c5d50aa07c3685f76a2947c0c3859e2582f8b683ebadf175679eb4aae78785L397-R401),[link](https://github.com/pimcore/pimcore/pull/15851/files?diff=unified&w=0#diff-f1c5d50aa07c3685f76a2947c0c3859e2582f8b683ebadf175679eb4aae78785R415-R419))
* Enforce type safety for the data value of website setting elements by casting it to an integer before passing it to the `getElementById` method in `models/Element/Service.php` ([link](https://github.com/pimcore/pimcore/pull/15851/files?diff=unified&w=0#diff-9dff0d944b4fab5155a5a49e0e5125cccb25a836e4f5f98f3ab069ca4f24c9a6L195-R195))
