### PR TITLE
[WebDAV] Fix assets are not accessible on webdav links 

### DIFF
--- a/doc/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
+++ b/doc/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
@@ -123,7 +123,7 @@ server {
     # Still use a allowlist approach to prevent each and every missing asset to go through the PHP Engine.
     # If you are using remote storages like S3 or Google Cloud Storage, this doesn't work. You either deactivate it and handle it in PHP
     # or redirect these suffixes directly to your CDN URL. Additionally you should configure the frontend url prefixes accordingly, see: https://pimcore.com/docs/pimcore/current/Development_Documentation/Installation_and_Upgrade/System_Setup_and_Hosting/File_Storage_Setup.html
-    location ~* ^(?!/admin)(.+?)\.((?:css|js)(?:\.map)?|jpe?g|gif|png|svgz?|eps|exe|gz|zip|mp\d|m4a|ogg|ogv|webp|webm|pdf|docx?|xlsx?|pptx?)$ {
+    location ~* ^(?!/admin|/asset/webdav)(.+?)\.((?:css|js)(?:\.map)?|jpe?g|gif|png|svgz?|eps|exe|gz|zip|mp\d|m4a|ogg|ogv|webp|webm|pdf|docx?|xlsx?|pptx?)$ {
         try_files /var/assets$uri $uri =404;
         expires 2w;
         access_log off;

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,5 +1,21 @@
 # Upgrade Notes
 
+## Pimcore 11.0.8
+- Nginx config has been updated to fix the webDAV [assets access issue](https://github.com/pimcore/pimcore/issues/15855). Please update your project config with below changes:
+
+Old: 
+```
+# Assets
+....
+location ~* ^(?!/admin)(.+?)....
+```
+New:
+```
+# Assets
+....
+location ~* ^(?!/admin|/asset/webdav)(.+?)....
+```
+
 ## Pimcore 11.0.7
 - Putting `null` to the `Pimcore\Model\DataObject\Data::setIndex()` method is deprecated now. Only booleans are allowed.
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #15855

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3ae379e</samp>

This pull request updates the nginx configuration documentation and the upgrade notes to fix the webDAV assets issue. It modifies the `location` rule for static files in `doc/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md` and adds a note in `doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md` to explain the change.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3ae379e</samp>

> _`webdav` unblocked_
> _nginx config needs update_
> _note for spring users_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3ae379e</samp>

*  Fix webDAV assets being blocked by nginx static file rule ([link](https://github.com/pimcore/pimcore/pull/15856/files?diff=unified&w=0#diff-3f22c379dc87175f4c078d69a84e2198de16178f28dc81900a192c3e145e4b61L126-R126))
*  Add upgrade note for nginx config change ([link](https://github.com/pimcore/pimcore/pull/15856/files?diff=unified&w=0#diff-375aded12dfb868b84d5b8c27d1aed2358680a27b683e8a985f1b85193dd79aaR3-R18))
