### PR TITLE
[Task]: Followp WebDav Nginx upgrade notes

### DIFF
--- a/doc/04_Assets/05_Accessing_Assets_via_WebDAV.md
+++ b/doc/04_Assets/05_Accessing_Assets_via_WebDAV.md
@@ -5,4 +5,9 @@ just open following URL via your browser or WebDAV client: https://YOUR-DOMAIN/a
 
 As user credentials use any Pimcore Backend user. Permissions for asset access are based on the users permissions.  
 
-There is no additional server configuration necessary to get WebDAV up and running.
+### Nginx configuration
+Please make sure to have the following changes in your project 
+[Nginx configuration](../23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md):
+```
+location ~* ^(?!/admin|/asset/webdav)(.+?)....
+```

--- a/doc/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
+++ b/doc/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
@@ -2,8 +2,6 @@
 
 Installation on Nginx is entirely possible, and in our experience quite a lot faster than apache. This section won't dive into how Nginx is installed etc, but will show a working Nginx configuration.
 
-_Note:_ At time of writing this config snippet doesn't care about WebDAV at all.
-
 ## Configuration
 
 Below is the configuration for a Nginx server (just the server part, the http etc. part can be kept default, as long as mime.types are included).
@@ -406,7 +404,7 @@ server {
     # Still use a allowlist approach to prevent each and every missing asset to go through the PHP Engine.
     # If you are using remote storages like S3 or Google Cloud Storage, this doesn't work. You either deactivate it and handle it in PHP
     # or redirect these suffixes directly to your CDN URL. Additionally you should configure the frontend url prefixes accordingly, see: https://pimcore.com/docs/pimcore/current/Development_Documentation/Installation_and_Upgrade/System_Setup_and_Hosting/File_Storage_Setup.html
-    location ~* ^(?!/admin)(.+?)\.((?:css|js)(?:\.map)?|jpe?g|gif|png|svgz?|eps|exe|gz|zip|mp\d|m4a|ogg|ogv|webp|webm|pdf|docx?|xlsx?|pptx?)$ {
+    location ~* ^(?!/admin|/asset/webdav)(.+?)\.((?:css|js)(?:\.map)?|jpe?g|gif|png|svgz?|eps|exe|gz|zip|mp\d|m4a|ogg|ogv|webp|webm|pdf|docx?|xlsx?|pptx?)$ {
         try_files /var/assets$uri $uri =404;
         expires 2w;
         access_log off;

--- a/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
+++ b/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
@@ -43,7 +43,7 @@ pimcore:
 ```
 
 ### Configuration Storage Settings
-As some features were moved to separate bundles, their configuration storage settings might need to be moved. This is a two steps process:
+As some features were moved to separate bundles, their configuration storage followup docssettings might need to be moved. This is a two steps process:
 1) Remove settings before the update.
 2) Re-Add settings after the extracted bundles installation.
 
@@ -204,7 +204,7 @@ bin/console doctrine:migration:exec 'Pimcore\Bundle\CoreBundle\Migrations\Versio
 - Remove `var/config/system.yaml` after migrating all settings. 
 
 ### Server Configuration
-- WebDav: please keep in mind that the nginx configuration has changed due the WebDav path being moved. Please adapt your configuration accordingly by following the instruction under the WebDav section under the upgrade notes page.
+- WebDav: please keep in mind that the nginx configuration has changed due the WebDav path being moved. Please adapt your configuration accordingly by following the instruction under the WebDav section in the upgrade notes page.
 
 ### Update Symfony Messenger Worker Configuration
 With Pimcore 11, certain Symfony Messenger tasks were moved to a separate receiver. Make sure you adapt your Symfony Messenger worker configuration (e.g. your supervisor configuration [here](https://github.com/pimcore/skeleton/blob/11.x/.docker/supervisord.conf#LL5C39-L5C90) so that all receivers are consumed. Newly added consumers are: 

--- a/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
+++ b/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
@@ -204,7 +204,7 @@ bin/console doctrine:migration:exec 'Pimcore\Bundle\CoreBundle\Migrations\Versio
 - Remove `var/config/system.yaml` after migrating all settings. 
 
 ### Server Configuration
-- WebDav: please keep in mind that the nginx configuration has changed due the WebDav path being moved. Please adapt your configuration accordingly by following the instruction under the WebDav section in the upgrade notes page.
+- WebDav: please keep in mind that the nginx configuration has changed due to the WebDav path being moved. Please adapt your configuration accordingly by following the instruction under the WebDav section in the upgrade notes page.
 
 ### Update Symfony Messenger Worker Configuration
 With Pimcore 11, certain Symfony Messenger tasks were moved to a separate receiver. Make sure you adapt your Symfony Messenger worker configuration (e.g. your supervisor configuration [here](https://github.com/pimcore/skeleton/blob/11.x/.docker/supervisord.conf#LL5C39-L5C90) so that all receivers are consumed. Newly added consumers are: 

--- a/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
+++ b/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
@@ -203,6 +203,8 @@ bin/console doctrine:migration:exec 'Pimcore\Bundle\CoreBundle\Migrations\Versio
 
 - Remove `var/config/system.yaml` after migrating all settings. 
 
+### Server Configuration
+- WebDav: please keep in mind that the nginx configuration has changed due the WebDav path being moved. Please adapt your configuration accordingly by following the instruction under the WebDav section under the upgrade notes page.
 
 ### Update Symfony Messenger Worker Configuration
 With Pimcore 11, certain Symfony Messenger tasks were moved to a separate receiver. Make sure you adapt your Symfony Messenger worker configuration (e.g. your supervisor configuration [here](https://github.com/pimcore/skeleton/blob/11.x/.docker/supervisord.conf#LL5C39-L5C90) so that all receivers are consumed. Newly added consumers are: 

--- a/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
+++ b/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
@@ -43,7 +43,7 @@ pimcore:
 ```
 
 ### Configuration Storage Settings
-As some features were moved to separate bundles, their configuration storage followup docssettings might need to be moved. This is a two steps process:
+As some features were moved to separate bundles, their configuration storage settings might need to be moved. This is a two steps process:
 1) Remove settings before the update.
 2) Re-Add settings after the extracted bundles installation.
 

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,20 +1,8 @@
 # Upgrade Notes
 
 ## Pimcore 11.0.8
-- Nginx config has been updated to fix the webDAV [assets access issue](https://github.com/pimcore/pimcore/issues/15855). Please update your project config with below changes:
+- Nginx config has been updated to fix the webDAV [assets access issue](https://github.com/pimcore/pimcore/issues/15855). Please update your project config with the changes described under the `Pimcore 11.0.0` `WebDav` section of this page, if you didn't do it already.
 
-Old: 
-```
-# Assets
-....
-location ~* ^(?!/admin)(.+?)....
-```
-New:
-```
-# Assets
-....
-location ~* ^(?!/admin|/asset/webdav)(.+?)....
-```
 
 ## Pimcore 11.0.7
 - Putting `null` to the `Pimcore\Model\DataObject\Data::setIndex()` method is deprecated now. Only booleans are allowed.
@@ -358,6 +346,19 @@ pimcore:
 #### [WebDAV] :
 
 -  WebDAV url has been changed from `https://YOUR-DOMAIN/admin/asset/webdav` to `https://YOUR-DOMAIN/asset/webdav`
+
+   As result of this change, the following changes are required in your nginx configuration:
+    ```
+    # Assets
+    ....
+    location ~* ^(?!/admin)(.+?)....
+    ```
+    New:
+    ```
+    # Assets
+    ....
+    location ~* ^(?!/admin|/asset/webdav)(.+?)....
+    ```
 
 -----------------
 

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,9 +1,5 @@
 # Upgrade Notes
 
-## Pimcore 11.0.8
-- Nginx config has been updated to fix the webDAV [assets access issue](https://github.com/pimcore/pimcore/issues/15855). Please update your project config with the changes described under the `Pimcore 11.0.0` `WebDav` section of this page, if you didn't do it already.
-
-
 ## Pimcore 11.0.7
 - Putting `null` to the `Pimcore\Model\DataObject\Data::setIndex()` method is deprecated now. Only booleans are allowed.
 


### PR DESCRIPTION
## Changes in this pull request  
Follow-up https://github.com/pimcore/pimcore/pull/15856#issuecomment-1699064013

## Additional info


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d37637d</samp>

Improve WebDAV documentation for Pimcore 11.0.8. Move and simplify nginx config changes in `doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d37637d</samp>

> _WebDAV is the way to access your files_
> _But you need to tweak your nginx config_
> _Don't despair, the docs are here to guide you_
> _Follow the steps and upgrade to Pimcore_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d37637d</samp>

*  Simplify the upgrade note for Pimcore 11.0.8 by referring to the WebDAV section instead of repeating the nginx config changes ([link](https://github.com/pimcore/pimcore/pull/15859/files?diff=unified&w=0#diff-375aded12dfb868b84d5b8c27d1aed2358680a27b683e8a985f1b85193dd79aaL4-R5))
*  Add the nginx config changes for WebDAV under the WebDAV section to provide clear and consistent guidance for enabling WebDAV for assets ([link](https://github.com/pimcore/pimcore/pull/15859/files?diff=unified&w=0#diff-375aded12dfb868b84d5b8c27d1aed2358680a27b683e8a985f1b85193dd79aaR350-R362))
