### PR TITLE
[Properties] Set cpath when using AbstractElement::setProperty()

### DIFF
--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -243,7 +243,7 @@ class Dao extends Model\Element\Dao
 
         // because this should be faster than mysql
         usort($propertiesRaw, function ($left, $right) {
-            return strcmp($left['cpath'], $right['cpath']);
+            return strcmp((string)$left['cpath'], (string)$right['cpath']);
         });
 
         foreach ($propertiesRaw as $propertyRaw) {

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -274,6 +274,7 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
         }
         $property->setName($name);
         $property->setCtype(Service::getElementType($this));
+        $property->setCpath($this->getRealFullPath());
         $property->setData($data);
         $property->setInherited($inherited);
         $property->setInheritable($inheritable);

--- a/models/Property/Dao.php
+++ b/models/Property/Dao.php
@@ -44,6 +44,14 @@ class Dao extends Model\Dao\AbstractDao
             $data = \Pimcore\Tool\Serialize::serialize($data);
         }
 
+        $cpath = $this->model->getCpath();
+        if(empty($cpath)) {
+            $element = Model\Element\Service::getElementById($this->model->getCtype(), $this->model->getCid());
+            if($element instanceof Model\Element\ElementInterface) {
+                $cpath = $element->getRealFullPath();
+            }
+        }
+
         $saveData = [
             'cid' => $this->model->getCid(),
             'ctype' => $this->model->getCtype(),


### PR DESCRIPTION
When calling `$element->setProperty('test', 'text', 'value')` the field `cpath` does not get set. Thus you will get the error
`E_DEPRECATED: strcmp(): Passing null to parameter #1 ($string1) of type string is deprecated in /var/www/html/vendor/pimcore/pimcore/models/DataObject/AbstractObject/Dao.php, line 254`
in https://github.com/pimcore/pimcore/blob/e22a8209fde57c953a5caba13292d60ae3b06979/models/DataObject/AbstractObject/Dao.php#L237

This PR on the one hand sets the `cpath` when using `setProperty()` and on the other hand prevents above deprecation message if it is not set.