### PR TITLE
Deprecate legacy method Image::getThumbnailConfig()

### DIFF
--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -159,6 +159,28 @@ EOT;
     }
 
     /**
+     * Legacy method for backwards compatibility. Use getThumbnail($config)->getConfig() instead.
+     *
+     * @internal
+     *
+     * @deprecated Will be removed in Pimcore 12
+     */
+    public function getThumbnailConfig(array|string|Image\Thumbnail\Config|null $config): ?Image\Thumbnail\Config
+    {
+        trigger_deprecation(
+            'pimcore/pimcore',
+            '11.1',
+            'Using "%s" is deprecated and will be removed in Pimcore 12, use "%s" instead.',
+            __METHOD__,
+            'getThumbnail($config)->getConfig()'
+        );
+
+        $thumbnail = $this->getThumbnail($config);
+
+        return $thumbnail->getConfig();
+    }
+
+    /**
      * Returns a path to a given thumbnail or a thumbnail configuration.
      */
     public function getThumbnail(array|string|Image\Thumbnail\Config|null $config = null, bool $deferred = true): Image\ThumbnailInterface

--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -159,19 +159,6 @@ EOT;
     }
 
     /**
-     * Legacy method for backwards compatibility. Use getThumbnail($config)->getConfig() instead.
-     *
-     * @internal
-     *
-     */
-    public function getThumbnailConfig(array|string|Image\Thumbnail\Config|null $config): ?Image\Thumbnail\Config
-    {
-        $thumbnail = $this->getThumbnail($config);
-
-        return $thumbnail->getConfig();
-    }
-
-    /**
      * Returns a path to a given thumbnail or a thumbnail configuration.
      */
     public function getThumbnail(array|string|Image\Thumbnail\Config|null $config = null, bool $deferred = true): Image\ThumbnailInterface

--- a/models/DataObject/Data/Hotspotimage.php
+++ b/models/DataObject/Data/Hotspotimage.php
@@ -148,7 +148,7 @@ class Hotspotimage implements OwnerAwareFieldInterface
             $crop = $this->getCrop();
         }
 
-        $thumbConfig = $this->getImage()->getThumbnailConfig($thumbnailName);
+        $thumbConfig = $this->getImage()->getThumbnail($thumbnailName)->getConfig();
         if (!$thumbConfig && $crop) {
             $thumbConfig = new Asset\Image\Thumbnail\Config();
         }

--- a/models/Document/Editable/Image.php
+++ b/models/Document/Editable/Image.php
@@ -219,7 +219,7 @@ class Image extends Model\Document\Editable implements IdRewriterInterface, Edit
                 // create a thumbnail first
                 $autoName = false;
 
-                $thumbConfig = $image->getThumbnailConfig($thumbnailName);
+                $thumbConfig = $image->getThumbnail($thumbnailName)->getConfig();
                 if (!$thumbConfig && $this->cropPercent) {
                     $thumbConfig = new Asset\Image\Thumbnail\Config();
                 }
@@ -425,7 +425,7 @@ class Image extends Model\Document\Editable implements IdRewriterInterface, Edit
     {
         $image = $this->getImage();
         if ($image instanceof Asset\Image) {
-            $thumbConfig = $image->getThumbnailConfig($conf);
+            $thumbConfig = $image->getThumbnail($conf)->getConfig();
             if ($thumbConfig && $this->cropPercent) {
                 $this->applyCustomCropping($thumbConfig);
                 $thumbConfig->generateAutoName();


### PR DESCRIPTION
## Changes in this pull request  
The php doc says it shouldn't use and is legacy. It is also internal so we don't need to deprecate it first.

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bfa5e0a</samp>

This pull request refactors the image thumbnail generation logic in various classes to use the new `Asset\Image` API and avoid deprecated methods. This improves performance, simplifies the code, and ensures compatibility.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bfa5e0a</samp>

> _To simplify the `Asset\Image` class_
> _We removed a method that was a mess_
> _The `getThumbnailConfig` was old_
> _And the `getThumbnail` was gold_
> _So we used it in `Hotspotimage` and `Editable\Image` no less_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bfa5e0a</samp>

*  Remove deprecated `getThumbnailConfig` method from `Asset\Image` class and use `getThumbnail` method instead ([link](https://github.com/pimcore/pimcore/pull/15869/files?diff=unified&w=0#diff-5cc2bbd78fc2da7dfcf976d8120a6bbec2deab1b113c1f0c7a8b17840a191720L162-L174))
*  Update `getThumbnail` method of `Hotspotimage` data object to use `Asset\Image::getThumbnail` method ([link](https://github.com/pimcore/pimcore/pull/15869/files?diff=unified&w=0#diff-207f66ed07eeb3e613efff3ba46b2141b9fae9a12bb6a18980ad67a5e7629395L151-R151))
*  Update `frontend` and `getThumbnail` methods of `Document\Editable\Image` document element to use `Asset\Image::getThumbnail` method ([link](https://github.com/pimcore/pimcore/pull/15869/files?diff=unified&w=0#diff-a4253070399493532b7da5f2e33e4a3ebc4be35de25ce3f6b6811dda3b9dd0edL222-R222), [link](https://github.com/pimcore/pimcore/pull/15869/files?diff=unified&w=0#diff-a4253070399493532b7da5f2e33e4a3ebc4be35de25ce3f6b6811dda3b9dd0edL428-R428))
