### PR TITLE
[Task]: Make `sanitycheck` table dropping migration idempotent

### DIFF
--- a/bundles/CoreBundle/src/Migrations/Version20210928135248.php
+++ b/bundles/CoreBundle/src/Migrations/Version20210928135248.php
@@ -29,7 +29,7 @@ final class Version20210928135248 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        if($schema->hasTable('sanitycheck')) {
+        if ($schema->hasTable('sanitycheck')) {
             $schema->dropTable('sanitycheck');
         }
     }

--- a/bundles/CoreBundle/src/Migrations/Version20210928135248.php
+++ b/bundles/CoreBundle/src/Migrations/Version20210928135248.php
@@ -29,7 +29,9 @@ final class Version20210928135248 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $schema->dropTable('sanitycheck');
+        if($schema->hasTable('sanitycheck')) {
+            $schema->dropTable('sanitycheck');
+        }
     }
 
     public function down(Schema $schema): void

--- a/bundles/CoreBundle/src/Migrations/Version20210928135248.php
+++ b/bundles/CoreBundle/src/Migrations/Version20210928135248.php
@@ -36,12 +36,10 @@ final class Version20210928135248 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        if (!$schema->hasTable('sanitycheck')) {
-            $this->addSql("CREATE TABLE IF NOT EXISTS `sanitycheck` (
-              `id` int(11) unsigned NOT NULL,
-              `type` enum('document','asset','object') NOT NULL,
-              PRIMARY KEY  (`id`,`type`)
-            ) DEFAULT CHARSET=utf8mb4;");
-        }
+        $this->addSql("CREATE TABLE IF NOT EXISTS `sanitycheck` (
+          `id` int(11) unsigned NOT NULL,
+          `type` enum('document','asset','object') NOT NULL,
+          PRIMARY KEY  (`id`,`type`)
+        ) DEFAULT CHARSET=utf8mb4;");
     }
 }


### PR DESCRIPTION
Same as in https://github.com/pimcore/pimcore/pull/9024 and https://github.com/pimcore/pimcore/pull/9024