### PR TITLE
Deactivate "Generate docs" and "POEditor Export" workflow on forks

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,6 +25,7 @@ jobs:
     docs:
         name: "Generate docs Pimcore Docs Generator"
         runs-on: "ubuntu-latest"
+        if: ${{ github.repository == 'pimcore/pimcore' }}
         steps:
             - name: "Checkout code"
               uses: "actions/checkout@v3"
@@ -63,4 +64,3 @@ jobs:
               run: |
                   npm install
                   npm run build
-                  

--- a/.github/workflows/poeditor-export.yaml
+++ b/.github/workflows/poeditor-export.yaml
@@ -17,6 +17,7 @@ permissions:
 jobs:
     poeditor:
         runs-on: ubuntu-latest
+        if: ${{ github.repository == 'pimcore/pimcore' }}
         steps:
             - name: Trigger workflow in pimcore/poeditor-export-action
               env:


### PR DESCRIPTION
## Changes in this pull request  
In forks we get following error:
`Error: Input required and not supplied: token`

See https://github.com/blankse/pimcore/actions/runs/6046217407/job/16407421935

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 59adc48</samp>

Improved the workflow for deploying documentation. Prevented `deploy-docs` job from running on forks of the main repository.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 59adc48</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A clever condition for the `deploy-docs` job,_
> _That only the main repository, source of truth,_
> _Might publish the glorious documentation._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 59adc48</samp>

* Add a condition to the `deploy-docs` job to restrict it to the main repository ([link](https://github.com/pimcore/pimcore/pull/15876/files?diff=unified&w=0#diff-d54d69dbb27e75dae25cb4b2384310cb57707e419377cf572d5cb0ecc1f16877R28))
* Remove an empty line from the YAML file for better readability ([link](https://github.com/pimcore/pimcore/pull/15876/files?diff=unified&w=0#diff-d54d69dbb27e75dae25cb4b2384310cb57707e419377cf572d5cb0ecc1f16877L66))
