### PR TITLE
Rename wrong migration name Version22020614115124

### DIFF
--- a/bundles/CoreBundle/src/Migrations/Version20220614115124.php
+++ b/bundles/CoreBundle/src/Migrations/Version20220614115124.php
@@ -20,7 +20,7 @@ namespace Pimcore\Bundle\CoreBundle\Migrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-final class Version22020614115124 extends AbstractMigration
+final class Version20220614115124 extends AbstractMigration
 {
     public function getDescription(): string
     {
@@ -29,6 +29,9 @@ final class Version22020614115124 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        // Delete old Version Name
+        $this->addSql('DELETE FROM `migration_versions` WHERE `migration_versions`.`version` = \'Pimcore\\\\Bundle\\\\CoreBundle\\\\Migrations\\\\Version22020614115124\'');
+
         if (!$schema->getTable('assets_image_thumbnail_cache')->hasColumn('filesize')) {
             $this->addSql(
                 'ALTER TABLE `assets_image_thumbnail_cache`

--- a/lib/Migrations/DirectoryAwareVersionComparator.php
+++ b/lib/Migrations/DirectoryAwareVersionComparator.php
@@ -37,13 +37,14 @@ final class DirectoryAwareVersionComparator implements Comparator
     {
         try {
             return $this->getOrder($a) <=> $this->getOrder($b);
-        } catch (\ReflectionException) {
+        } catch (\ReflectionException|\ErrorException) {
             return (string) $a <=> (string) $b;
         }
     }
 
     /**
      * @throws \ReflectionException
+     * @throws \ErrorException if the migration file is not found
      *
      * @return array{int, string}
      */


### PR DESCRIPTION
It's hard to see if someone execute all migration because the message is always:
` [OK] Already at the latest version ("Pimcore\Bundle\CoreBundle\Migrations\Version22020614115124") `

It should not harm to execute this migration again. The old name will be removed so it is no orphan migration warning after this.

## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3bdb796</samp>

Fixed a migration issue that caused conflicts and errors when upgrading from older versions of Pimcore. Renamed and improved a migration script and refactored a migration helper class.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3bdb796</samp>

> _Oh we're the coders of the sea, we fix the bugs and make it run_
> _We heave and ho and pull and push, we work until the job is done_
> _We renamed and updated `migration`, we refactored `compare`_
> _We handle missing files with grace, we document with care_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3bdb796</samp>

* Fix migration name conflict and delete old version from database ([link](https://github.com/pimcore/pimcore/pull/15882/files?diff=unified&w=0#diff-4dbe1d328353880af1f35845e8808f09d57b0cfbed90d458f76e3a1c1f0edfdaL23-R23), [link](https://github.com/pimcore/pimcore/pull/15882/files?diff=unified&w=0#diff-4dbe1d328353880af1f35845e8808f09d57b0cfbed90d458f76e3a1c1f0edfdaR32-R34))
* Refactor directory-aware version comparator to handle missing migration files ([link](https://github.com/pimcore/pimcore/pull/15882/files?diff=unified&w=0#diff-ccef5dd598e0649e6c8f9ed43f94320d0c186e75e2abd3327041ebe2418e4094L40-R40), [link](https://github.com/pimcore/pimcore/pull/15882/files?diff=unified&w=0#diff-ccef5dd598e0649e6c8f9ed43f94320d0c186e75e2abd3327041ebe2418e4094R47))
