### PR TITLE
Fix: User password reset does not work with user id

### DIFF
--- a/bundles/CoreBundle/src/Command/ResetPasswordCommand.php
+++ b/bundles/CoreBundle/src/Command/ResetPasswordCommand.php
@@ -57,10 +57,11 @@ class ResetPasswordCommand extends AbstractCommand
     {
         $userArgument = $input->getArgument('user');
 
-        $method = is_numeric($userArgument) ? 'getById' : 'getByName';
-
-        /** @var User|null $user */
-        $user = User::$method($userArgument);
+        if (is_numeric($userArgument)) {
+            $user = User::getById((int) $userArgument);
+        } else {
+            $user = User::getByName($userArgument);
+        }
 
         if (!$user) {
             $this->writeError('User with name/ID ' . $userArgument . ' could not be found. Exiting');


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15883

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 54662bd</samp>

Refactor `ResetPasswordCommand.php` to use a fixed method name and an integer user ID. This enhances code quality and fixes some bugs with the command.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 54662bd</samp>

> _`reset_password`_
> _No more variable name_
> _Cast user ID too_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 54662bd</samp>

* Refactor reset password command to use explicit method names and integer user ID ([link](https://github.com/pimcore/pimcore/pull/15884/files?diff=unified&w=0#diff-607135d32f871ceee0fe0e9dd3fc40f91391a1b6e364af1f5486cf83d0bbd84eL60-R65))
