### PR TITLE
[Docs]: Add garbage helper information inside External System Interaction

### DIFF
--- a/doc/05_Objects/05_External_System_Interaction.md
+++ b/doc/05_Objects/05_External_System_Interaction.md
@@ -94,6 +94,7 @@ If you're using / creating very much objects you should call the Pimcore garbage
 ```
 
 **WARNING:** This will flush the entire internal registry!
+**NOTICE:** This helper only works in `prod` environments!
 
 To avoid this, you can pass an array with keys (indexes) which should stay in the registry eg. 
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  

Added garbage helper information inside External System Interaction docs

## Additional info
Related https://github.com/pimcore/pimcore/issues/15866#issuecomment-1701309533

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 26a59c4</samp>

Added a notice to the documentation of `Pimcore\Cache\Runtime` to clarify its limitations in non-production environments. This is part of a bug fix for the helper class not working as expected in some cases.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 26a59c4</samp>

> _`Runtime` cache class_
> _Warns of memory issues_
> _Only for production_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 26a59c4</samp>

* Fix a bug related to the `Pimcore\Cache\Runtime` helper class not working as expected in non-production environments ([link](https://github.com/pimcore/pimcore/pull/15895/files?diff=unified&w=0#diff-41bda9974f78f1664ab277cc67f440a48d0171a76fe65a03e9e52699098c2e4eR97),                           
