### PR TITLE
Fix: Use the `getFieldType()` method instead of the fieldtype attribute

### DIFF
--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -1108,7 +1108,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         $diffdata['disabled'] = !($this->isDiffChangeAllowed($object));
         $diffdata['field'] = $this->getName();
         $diffdata['key'] = $this->getName();
-        $diffdata['type'] = $this->fieldtype;
+        $diffdata['type'] = $this->getFieldType();
 
         if (method_exists($this, 'getDiffVersionPreview')) {
             $value = $this->getDiffVersionPreview($data, $object, $params);

--- a/models/DataObject/ClassDefinition/Data/BooleanSelect.php
+++ b/models/DataObject/ClassDefinition/Data/BooleanSelect.php
@@ -214,7 +214,7 @@ class BooleanSelect extends Data implements
         $diffdata['disabled'] = false;
         $diffdata['field'] = $this->getName();
         $diffdata['key'] = $this->getName();
-        $diffdata['type'] = $this->fieldtype;
+        $diffdata['type'] = $this->getFieldType();
 
         $value = '';
         foreach ($this->options as $option) {

--- a/models/DataObject/ClassDefinition/Data/Date.php
+++ b/models/DataObject/ClassDefinition/Data/Date.php
@@ -301,7 +301,7 @@ class Date extends Data implements ResourcePersistenceAwareInterface, QueryResou
         $diffdata = [];
         $diffdata['field'] = $this->getName();
         $diffdata['key'] = $this->getName();
-        $diffdata['type'] = $this->fieldtype;
+        $diffdata['type'] = $this->getFieldType();
         $diffdata['value'] = $this->getVersionPreview($data, $object, $params);
         $diffdata['data'] = $thedata;
         $diffdata['title'] = !empty($this->title) ? $this->title : $this->name;

--- a/models/DataObject/ClassDefinition/Data/Datetime.php
+++ b/models/DataObject/ClassDefinition/Data/Datetime.php
@@ -301,7 +301,7 @@ class Datetime extends Data implements ResourcePersistenceAwareInterface, QueryR
         $diffdata = [];
         $diffdata['field'] = $this->getName();
         $diffdata['key'] = $this->getName();
-        $diffdata['type'] = $this->fieldtype;
+        $diffdata['type'] = $this->getFieldType();
         $diffdata['value'] = $this->getVersionPreview($data, $object, $params);
         $diffdata['data'] = $thedata;
         $diffdata['title'] = !empty($this->title) ? $this->title : $this->name;

--- a/models/DataObject/ClassDefinition/Data/Password.php
+++ b/models/DataObject/ClassDefinition/Data/Password.php
@@ -334,7 +334,7 @@ class Password extends Data implements ResourcePersistenceAwareInterface, QueryR
         $diffdata['disabled'] = !($this->isDiffChangeAllowed($object, $params));
         $diffdata['field'] = $this->getName();
         $diffdata['key'] = $this->getName();
-        $diffdata['type'] = $this->fieldtype;
+        $diffdata['type'] = $this->getFieldType();
 
         if ($data) {
             $diffdata['value'] = $this->getVersionPreview($data, $object, $params);

--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -250,7 +250,7 @@ class Select extends Data implements
         $diffdata['disabled'] = false;
         $diffdata['field'] = $this->getName();
         $diffdata['key'] = $this->getName();
-        $diffdata['type'] = $this->fieldtype;
+        $diffdata['type'] = $this->getFieldType();
 
         $value = '';
         foreach ($this->options as $option) {


### PR DESCRIPTION
## Changes in this pull request  
Splitted from #15770

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 47d1c32</samp>

This pull request fixes a typo in the `Data` class and its subclasses that use the `getDiffDataForEditMode` method. It replaces the direct access to the `fieldtype` property with the `getFieldType` getter method, which allows for proper inheritance and overriding.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 47d1c32</samp>

> _`fieldtype` typo_
> _fixed in `Data` subclasses_
> _autumn of errors_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 47d1c32</samp>

* Fix typo in `fieldtype` property usage by replacing it with `getFieldType` method in subclasses of `Data` class ([link](https://github.com/pimcore/pimcore/pull/15899/files?diff=unified&w=0#diff-b5f1d85f837f86e84cd4a1a905d034c9c71bf3124bf03e6fcbf6de61919b47e7L1111-R1111), [link](https://github.com/pimcore/pimcore/pull/15899/files?diff=unified&w=0#diff-488d3d97be8bace849bb91f5c99a0cb970a187670af9f33aab308be11d26c132L217-R217), [link](https://github.com/pimcore/pimcore/pull/15899/files?diff=unified&w=0#diff-f9e8614c6fe54e4873af1506ee66172b2c8aad0ee906e85e93b07c8905382c53L304-R304), [link](https://github.com/pimcore/pimcore/pull/15899/files?diff=unified&w=0#diff-576184ea3bf05f2cb1af45b7536d8d3ca10bf05775ef3ad1686bb7dab560abe3L304-R304), [link](https://github.com/pimcore/pimcore/pull/15899/files?diff=unified&w=0#diff-dd280011afe4eae89c01d5b7dcb849fb9b5b26509fc1f3569e236179f749a805L337-R337), [link](https://github.com/pimcore/pimcore/pull/15899/files?diff=unified&w=0#diff-c622407049f7baa79f2520f1745ee112b447b41efff4f19ff50b8a7df44bd521L253-R253))
