### PR TITLE
[Data objects] Create localized query table fields as UTF8

### DIFF
--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -702,7 +702,7 @@ class Dao extends Model\Dao\AbstractDao
 
             // create query
             $sql = sprintf(
-                'IF(`%s`.`%s` IS NULL OR STRCMP(`%s`.`%s`, "") = 0, %s, `%s`.`%s`)',
+                'CONVERT(IF(`%s`.`%s` IS NULL OR STRCMP(`%s`.`%s`, "") = 0, %s, `%s`.`%s`) USING utf8)',
                 $lang,
                 $field,
                 $lang,


### PR DESCRIPTION
I wondered about errors like
`General error: 1267 Illegal mix of collations (utf8mb4_bin,NONE) and (utf8mb4_general_ci,COERCIBLE) for operation '=' ` for simple SQL queries like 
```sql
SELECT object_localized_Produkt_de_DE.o_id as o_id, object_localized_Produkt_de_DE.o_type as o_type 
FROM object_localized_Produkt_de_DE 
WHERE `name` = 'abc' AND object_localized_Produkt_de_DE.o_type IN ('object','folder')
```

The field `name` is a localized input field. There are languages `de` and `de_DE`. `de_DE` has `de` as fallback language.

With fallback languages the view `object_localized_Produkt_de_DE` gets created with the column `name` via
```if(`de_DE`.`Name` is null or strcmp(`de_DE`.`Name`,'') = 0,`de`.`Name`,`de_DE`.`Name`)```
in https://github.com/pimcore/pimcore/blob/6dcaccdbc09ed5c9215944695c000581c9460bfa/models/DataObject/Localizedfield/Dao.php#L689-L713

And this leads to the problem that all columns in the view have collation utf8_bin:
<img width="582" alt="Bildschirmfoto 2023-09-06 um 08 26 54" src="https://github.com/pimcore/pimcore/assets/8749138/c274e379-c789-453c-aa8d-98526b4253a9">

Problem happened with `10.3.35-MariaDB`. I could not reproduce this error locally with `10.8.3-MariaDB` but I do not know if this caused the problem. 