### PR TITLE
[Docs] Workflow Support strategy - remove reference to deprecated class

### DIFF
--- a/doc/07_Workflow_Management/03_Support_Strategies.md
+++ b/doc/07_Workflow_Management/03_Support_Strategies.md
@@ -39,7 +39,7 @@ In the following example the workflow applies to products where the attribute "p
 ## Custom Support Strategy
 
 If a very specific logic is needed it's possible to add a service which implements the 
-`Symfony\Component\Workflow\SupportStrategy\SupportStrategyInterface`.
+`Symfony\Component\Workflow\SupportStrategy\WorkflowSupportStrategyInterface`.
 
 ##### Configuration Example
 
@@ -54,12 +54,12 @@ If a very specific logic is needed it's possible to add a service which implemen
 <?php
 namespace App\Workflow;
 
-use Symfony\Component\Workflow\SupportStrategy\SupportStrategyInterface;
-use Symfony\Component\Workflow\Workflow;
+use Symfony\Component\Workflow\SupportStrategy\WorkflowSupportStrategyInterface;
+use Symfony\Component\Workflow\WorkflowInterface;
 
-class SupportStrategy implements SupportStrategyInterface
+class SupportStrategy implements WorkflowSupportStrategyInterface
 {
-    public function supports(Workflow $workflow, object $subject): bool
+    public function supports(WorkflowInterface $workflow, object $subject): bool
     {
         if ($subject instanceof \Pimcore\Model\DataObject\Test) {
             return true;


### PR DESCRIPTION
Fixed examples for Support strategy and removed reference to SupportStrategyInterface - it's deprecated since 4.1 :
https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Workflow/SupportStrategy/SupportStrategyInterface.php.

And it's removed in Symfony 5.0. So, updated example and used WorkflowSupportStrategyInterface instead - it's still actual for Symfony 5.0-6.4:
https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/Workflow/SupportStrategy/WorkflowSupportStrategyInterface.php

I think it's actual for Pimcore 10.x and it's needed  - I can add as additional PR.

Please review, 