### PR TITLE
[DOC] Fix links to admin bundle

### DIFF
--- a/doc/18_Tools_and_Features/35_GDPR_Data_Extractor.md
+++ b/doc/18_Tools_and_Features/35_GDPR_Data_Extractor.md
@@ -61,7 +61,7 @@ exports can be attached or external data sources can be included.
 To do so, following steps are necessary: 
 
 1) Create a custom implementation of 
-[`Pimcore\Bundle\AdminBundle\GDPR\DataProvider\DataProviderInterface`](https://github.com/pimcore/pimcore/blob/11.x/bundles/AdminBundle/src/GDPR/DataProvider/DataProviderInterface.php#L20). 
+[`Pimcore\Bundle\AdminBundle\GDPR\DataProvider\DataProviderInterface`](https://github.com/pimcore/admin-ui-classic-bundle/blob/1.x/src/GDPR/DataProvider/DataProviderInterface.php#L20). 
 The following functions need to be implemented:
 
     * `getSortPriority()` - Returns sort priority for the tabs - higher is sorted first.

--- a/doc/20_Extending_Pimcore/11_Event_API_and_Event_Manager.md
+++ b/doc/20_Extending_Pimcore/11_Event_API_and_Event_Manager.md
@@ -44,7 +44,7 @@ All Pimcore events are defined and documented as a constant on component specifi
 - [Targeting](https://github.com/pimcore/pimcore/blob/11.x/lib/Event/TargetingEvents.php)
 - [Tests](https://github.com/pimcore/pimcore/blob/11.x/lib/Event/TestEvents.php)
 - [Translation](https://github.com/pimcore/pimcore/blob/11.x/lib/Event/TranslationEvents.php)
-- [Bundle Manager for injecting js/css files to Pimcore backend or editmode](https://github.com/pimcore/pimcore/blob/11.x/bundles/AdminBundle/src/Event/BundleManagerEvents.php)
+- [Bundle Manager for injecting js/css files to Pimcore backend or editmode](https://github.com/pimcore/admin-ui-classic-bundle/blob/1.x/src/Event/BundleManagerEvents.php)
 
 ## Examples
 
@@ -161,4 +161,3 @@ into the /news/in-enim-justo_2/image_1 asset folder.
                 }
         });
 ```  
-

--- a/doc/20_Extending_Pimcore/11_Event_API_and_Event_Manager.md
+++ b/doc/20_Extending_Pimcore/11_Event_API_and_Event_Manager.md
@@ -44,7 +44,7 @@ All Pimcore events are defined and documented as a constant on component specifi
 - [Targeting](https://github.com/pimcore/pimcore/blob/11.x/lib/Event/TargetingEvents.php)
 - [Tests](https://github.com/pimcore/pimcore/blob/11.x/lib/Event/TestEvents.php)
 - [Translation](https://github.com/pimcore/pimcore/blob/11.x/lib/Event/TranslationEvents.php)
-- [Bundle Manager for injecting js/css files to Pimcore backend or editmode](https://github.com/pimcore/admin-ui-classic-bundle/blob/1.x/src/Event/BundleManagerEvents.php)
+- [Bundle Manager for injecting js/css files to Pimcore backend or editmode](https://github.com/pimcore/pimcore/blob/11.x/lib/Event/BundleManagerEvents.php)
 
 ## Examples
 

--- a/doc/20_Extending_Pimcore/13_Bundle_Developers_Guide/07_Adding_Asset_Types.md
+++ b/doc/20_Extending_Pimcore/13_Bundle_Developers_Guide/07_Adding_Asset_Types.md
@@ -30,7 +30,7 @@ It needs to extend `pimcore.asset.asset`, be located in the namespace `pimcore.a
 `$type` property of the corresponding PHP class.
 
 For examples have a look at the Pimcore core asset types at
-[github](https://github.com/pimcore/pimcore/tree/11.x/bundles/AdminBundle/public/js/pimcore/asset)
+[github](https://github.com/pimcore/admin-ui-classic-bundle/tree/1.x/public/js/pimcore/asset)
 
 ## 3) Register the asset on the asset type map
 

--- a/doc/20_Extending_Pimcore/13_Bundle_Developers_Guide/11_Adding_Object_Datatypes.md
+++ b/doc/20_Extending_Pimcore/13_Bundle_Developers_Guide/11_Adding_Object_Datatypes.md
@@ -19,7 +19,7 @@ options in class editor.
    `$fieldtype` property of the corresponding PHP class.
      
    For examples have a look at the Pimcore core datatypes at 
-   [github](https://github.com/pimcore/pimcore/tree/11.5/bundles/AdminBundle/public/js/pimcore/object/classes/data)
+   [github](https://github.com/pimcore/admin-ui-classic-bundle/tree/1.x/public/js/pimcore/object/classes/data)
 
 
 3) Create JavaScript class for object editor (object tag):
@@ -30,7 +30,7 @@ is presented and an can be entered within Pimcore objects.
    `$fieldtype` property of the corresponding PHP class.
      
    For examples have a look at the Pimcore core datatypes at
-   [github](https://github.com/pimcore/pimcore/tree/11.5/bundles/AdminBundle/public/js/pimcore/object/tags)
+   [github](https://github.com/pimcore/admin-ui-classic-bundle/tree/1.x/public/js/pimcore/object/tags)
    
    
 4) Register a datatype in Pimcore
@@ -50,4 +50,3 @@ pimcore:
                 map:
                   myDataType: \App\Model\DataObject\Data\MyDataType
 ```
-

--- a/doc/20_Extending_Pimcore/13_Bundle_Developers_Guide/12_Adding_Object_ Layout_types.md
+++ b/doc/20_Extending_Pimcore/13_Bundle_Developers_Guide/12_Adding_Object_ Layout_types.md
@@ -18,7 +18,7 @@ Following steps are necessary to do so:
    `$fieldtype` property of the corresponding PHP class.
      
    For examples have a look at the Pimcore core layout types at  
-   [github](https://github.com/pimcore/pimcore/tree/11.x/bundles/AdminBundle/public/js/pimcore/object/classes/layout)
+   [github](https://github.com/pimcore/admin-ui-classic-bundle/tree/1.x/public/js/pimcore/object/classes/layout)
 
 3) Create JavaScript class for object editor:
    This JavaScript class defines the representation of the layout type in the *object editor*. You can use very simple ExtJS elements here.
@@ -27,7 +27,7 @@ Following steps are necessary to do so:
    `$fieldtype` property of the corresponding PHP class.
      
    For examples have a look at the Pimcore core layout types at  
-   [github](https://github.com/pimcore/pimcore/tree/11.x/bundles/AdminBundle/public/js/pimcore/object/layout)
+   [github](https://github.com/pimcore/admin-ui-classic-bundle/tree/1.x/public/js/pimcore/object/layout)
     
 4) Register a layout type in Pimcore by extending the `pimcore.objects.class_definitions.data.layout` configuration. 
    This can be done in any config file which is loaded (e.g. `config/config.yaml`), but if you provide the layout type 

--- a/doc/20_Extending_Pimcore/25_Implement_Your_Own_Search.md
+++ b/doc/20_Extending_Pimcore/25_Implement_Your_Own_Search.md
@@ -36,7 +36,7 @@ pimcore.helpers.hasSearchImplementation()
 If you want to create your own search implementation you have to provide some predefined methods. 
 These methods are: `openItemSelector`, `showQuickSearch`, `hideQuickSearch` and `getObjectRelationInlineSearchRoute`.
 - The `openItemSelector` method will be triggered by certain data object fields and editables through the 
-  [helper.js](https://github.com/pimcore/pimcore/blob/11.x/bundles/AdminBundle/public/js/pimcore/helpers.js#L814).
+  [helper.js](https://github.com/pimcore/admin-ui-classic-bundle/blob/1.x/public/js/pimcore/helpers.js#L814).
 - The `showQuickSearch` and `hideQuickSearch` is responsible for managing the quickSearch.
 - The `getObjectRelationInlineSearchRoute` has to return the route to `DataObjectController::optionsAction`.
 

--- a/doc/20_Extending_Pimcore/25_Implement_Your_Own_Search.md
+++ b/doc/20_Extending_Pimcore/25_Implement_Your_Own_Search.md
@@ -36,7 +36,7 @@ pimcore.helpers.hasSearchImplementation()
 If you want to create your own search implementation you have to provide some predefined methods. 
 These methods are: `openItemSelector`, `showQuickSearch`, `hideQuickSearch` and `getObjectRelationInlineSearchRoute`.
 - The `openItemSelector` method will be triggered by certain data object fields and editables through the 
-  [helper.js](https://github.com/pimcore/admin-ui-classic-bundle/blob/1.x/public/js/pimcore/helpers.js#L814).
+  [helper.js](https://github.com/pimcore/admin-ui-classic-bundle/blob/1.x/public/js/pimcore/helpers.js#L822).
 - The `showQuickSearch` and `hideQuickSearch` is responsible for managing the quickSearch.
 - The `getObjectRelationInlineSearchRoute` has to return the route to `DataObjectController::optionsAction`.
 


### PR DESCRIPTION
## Changes in this pull request  
Fix links to admin bundle.
See https://github.com/pimcore/pimcore/discussions/15890

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1cba47b</samp>

This pull request updates various documentation files for bundle developers and users of the Event API and the GDPR Data Extractor. It fixes broken links, typos, and formatting issues caused by the migration of the admin UI code to the `admin-ui-classic-bundle` repository.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1cba47b</samp>

> _Oh we're the bundle developers of Pimcore_
> _We keep the docs and links up to date_
> _We heave and haul on the `admin-ui-classic-bundle`_
> _And we sing this shanty while we wait_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1cba47b</samp>

* Update links to point to the admin-ui-classic-bundle repository instead of the pimcore repository, reflecting the migration of the admin UI code to a separate bundle ([link](https://github.com/pimcore/pimcore/pull/15907/files?diff=unified&w=0#diff-d5b1b9a9ecef55935c2de8d247749b4d04e42997c51cc91a2d7f54dfac8488a5L64-R64), [link](https://github.com/pimcore/pimcore/pull/15907/files?diff=unified&w=0#diff-dcbe6cffa4559327402262ee36d350273c9256c9c5a4a8184b2cffcaa05d95f7L47-R47), [link](https://github.com/pimcore/pimcore/pull/15907/files?diff=unified&w=0#diff-c5a1750dcbf10054d6ae610d3178b1bc4c330eb09f10ac36962b0a64f0a9c943L33-R33), [link](https://github.com/pimcore/pimcore/pull/15907/files?diff=unified&w=0#diff-3e63c444934902c278575df584cc740a30f2a415eef2febd42dbe44ca7663a72L22-R22), [link](https://github.com/pimcore/pimcore/pull/15907/files?diff=unified&w=0#diff-3e63c444934902c278575df584cc740a30f2a415eef2febd42dbe44ca7663a72L33-R33), [link](https://github.com/pimcore/pimcore/pull/15907/files?diff=unified&w=0#diff-28f5b025e506afa6e69b452f6c3039b3e950b78f2ec7d817390e5ef68707c3bfL21-R21), [link](https://github.com/pimcore/pimcore/pull/15907/files?diff=unified&w=0#diff-28f5b025e506afa6e69b452f6c3039b3e950b78f2ec7d817390e5ef68707c3bfL30-R30), [link](https://github.com/pimcore/pimcore/pull/15907/files?diff=unified&w=0#diff-e55f2f1a726f9c8a54548f81a0de8bdb810dee7175894e16929e43b74243260aL39-R39))
* Remove empty and unnecessary code blocks from the documentation ([link](https://github.com/pimcore/pimcore/pull/15907/files?diff=unified&w=0#diff-dcbe6cffa4559327402262ee36d350273c9256c9c5a4a8184b2cffcaa05d95f7L164), [link](https://github.com/pimcore/pimcore/pull/15907/files?diff=unified&w=0#diff-3e63c444934902c278575df584cc740a30f2a415eef2febd42dbe44ca7663a72L53))
* Fix the syntax of a markdown code block in the documentation ([link](https://github.com/pimcore/pimcore/pull/15907/files?diff=unified&w=0#diff-c5a1750dcbf10054d6ae610d3178b1bc4c330eb09f10ac36962b0a64f0a9c943L50-R50))
* Fix a typo in the name of the `SimpleBackendSearchBundle` in the documentation ([link](https://github.com/pimcore/pimcore/pull/15907/files?diff=unified&w=0#diff-e55f2f1a726f9c8a54548f81a0de8bdb810dee7175894e16929e43b74243260aL66-R66))
