### PR TITLE
Fix: Can't send email documents in maintenance tasks

### DIFF
--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -119,6 +119,8 @@ twig:
         # avoid fetching and using services from templates if possible
         # this is only here for compatibility/dev reasons and may be removed later
         container: '@service_container'
+        document: ~
+        editmode: false
     paths:
         '%kernel.project_dir%/templates': App
 

--- a/bundles/CoreBundle/src/EventListener/Frontend/GlobalTemplateVariablesListener.php
+++ b/bundles/CoreBundle/src/EventListener/Frontend/GlobalTemplateVariablesListener.php
@@ -54,20 +54,7 @@ class GlobalTemplateVariablesListener implements EventSubscriberInterface, Logge
         return [
             KernelEvents::CONTROLLER => ['onKernelController', 15], // has to be after DocumentFallbackListener
             KernelEvents::RESPONSE => 'onKernelResponse',
-            KernelEvents::REQUEST => ['onKernelRequest', 700],
         ];
-    }
-
-    public function onKernelRequest(RequestEvent $event): void
-    {
-        // set the variables as soon as possible, so that we're not getting troubles in
-        // onKernelController() if the twig environment was already initialized before
-        // defining global variables is only possible before the twig environment was initialized
-        // however you can change the value of the variable at any time later on
-        if ($event->isMainRequest()) {
-            $this->twig->addGlobal('document', null);
-            $this->twig->addGlobal('editmode', false);
-        }
     }
 
     public function onKernelController(ControllerEvent $event): void

--- a/bundles/CoreBundle/src/EventListener/Frontend/GlobalTemplateVariablesListener.php
+++ b/bundles/CoreBundle/src/EventListener/Frontend/GlobalTemplateVariablesListener.php
@@ -24,7 +24,6 @@ use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
-use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Twig\Environment;
@@ -71,9 +70,9 @@ class GlobalTemplateVariablesListener implements EventSubscriberInterface, Logge
             // then it's not possible anymore to add globals
             $this->twig->addGlobal('document', $this->documentResolver->getDocument($request));
             $this->twig->addGlobal('editmode', $this->editmodeResolver->isEditmode($request));
-            array_push($this->globalsStack, $globals);
-        } catch (\Exception $e) {
-            array_push($this->globalsStack, false);
+            $this->globalsStack[] = $globals;
+        } catch (\Exception) {
+            $this->globalsStack[] = false;
         }
     }
 
@@ -83,7 +82,7 @@ class GlobalTemplateVariablesListener implements EventSubscriberInterface, Logge
             $globals = array_pop($this->globalsStack);
             if ($globals !== false) {
                 $this->twig->addGlobal('document', $globals['document'] ?? null);
-                $this->twig->addGlobal('editmode', $globals['editmode'] ?? null);
+                $this->twig->addGlobal('editmode', $globals['editmode'] ?? false);
             }
         }
     }

--- a/lib/Twig/Extension/DocumentEditableExtension.php
+++ b/lib/Twig/Extension/DocumentEditableExtension.php
@@ -87,10 +87,10 @@ class DocumentEditableExtension extends AbstractExtension
     public function renderEditable(array $context, string $type, string $name, array $options = []): string|\Pimcore\Model\Document\Editable\EditableInterface
     {
         $document = $context['document'] ?? null;
-        $editmode = $context['editmode'] ?? false;
         if (!($document instanceof PageSnippet)) {
             return '';
         }
+        $editmode = $context['editmode'] ?? false;
 
         return $this->editableRenderer->render($document, $type, $name, $options, $editmode);
     }

--- a/lib/Twig/Extension/DocumentEditableExtension.php
+++ b/lib/Twig/Extension/DocumentEditableExtension.php
@@ -86,8 +86,8 @@ class DocumentEditableExtension extends AbstractExtension
      */
     public function renderEditable(array $context, string $type, string $name, array $options = []): string|\Pimcore\Model\Document\Editable\EditableInterface
     {
-        $document = $context['document'];
-        $editmode = $context['editmode'];
+        $document = $context['document'] ?? null;
+        $editmode = $context['editmode'] ?? false;
         if (!($document instanceof PageSnippet)) {
             return '';
         }


### PR DESCRIPTION
## Changes in this pull request  
If I want send a email document in a maintanance task, the document global isn't set before twig is init (because the maintanance task have no main request). So the global can't be set and the editables have errors (document key isn't set)

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fc56317</samp>

This pull request defines the `document` and `editmode` global twig variables in the configuration file and removes the redundant event listener that used to set them. It also adds null checks to the `renderEditable` function to handle the cases where these variables are not available.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fc56317</samp>

> _`document`, `editmode`_
> _set in config, not listener_
> _simpler and safer_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fc56317</samp>

*  Define default values for `document` and `editmode` twig variables in `default.yaml` ([link](https://github.com/pimcore/pimcore/pull/15908/files?diff=unified&w=0#diff-34d259c58a9001df91ca2ccc5f41ab960a307d1566cffceb88262d679cfc6c70R122-R123))
*  Remove unnecessary `onKernelRequest` listener from `GlobalTemplateVariablesListener` ([link](https://github.com/pimcore/pimcore/pull/15908/files?diff=unified&w=0#diff-11fa36d43466d831f348318e77b6a32e7a6b28f45872631421e99835f31901e7L57-R59))
*  Add null coalescing operators to `renderEditable` function in `DocumentEditableExtension` to handle unset variables ([link](https://github.com/pimcore/pimcore/pull/15908/files?diff=unified&w=0#diff-92ce8044624d88ca9f6b94acad1b39f64f8a6386884130998eb553ac5aeca29eL89-R90))
