### PR TITLE
[Docs] Add upgrade notes about removal of executeMigrationsUp

### DIFF
--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -246,7 +246,9 @@ pimcore:
 
 #### [Migrations] :
 
--  Pimcore does not run core migrations after `composer` update automatically anymore. Make sure that migrations are executed. You can run `bin/console doctrine:migrations:migrate`.
+-  Removed `executeMigrationsUp` from `Pimcore\Composer`.
+-  Pimcore does not run core migrations after `composer` update automatically anymore.
+   Make sure that migrations are executed by running the command `bin/console doctrine:migrations:migrate --prefix=Pimcore\\Bundle\\CoreBundle`.
 
 #### [Naming] :
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #15737

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 70a2216</samp>

Removed `executeMigrationsUp` method from `Pimcore\Composer` and updated documentation. This change simplifies the migration process and prevents conflicts with other bundles.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 70a2216</samp>

> _`executeMigrationsUp` gone_
> _No more conflicts with bundles_
> _Winter of clean code_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 70a2216</samp>

* Remove `executeMigrationsUp` method from `Pimcore\Composer` class to avoid conflicts with other bundles that use migrations ([link](https://github.com/pimcore/pimcore/pull/15909/files?diff=unified&w=0#diff-375aded12dfb868b84d5b8c27d1aed2358680a27b683e8a985f1b85193dd79aaL249-R251),                           F27L3
