### PR TITLE
Fix: Converting Page to Email or Snippet

### DIFF
--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -302,6 +302,9 @@ abstract class PageSnippet extends Model\Document
         return $this->template;
     }
 
+    /**
+     * @return $this
+     */
     public function setController(?string $controller): static
     {
         $this->controller = $controller;
@@ -309,6 +312,9 @@ abstract class PageSnippet extends Model\Document
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function setTemplate(?string $template): static
     {
         $this->template = $template;
@@ -363,6 +369,9 @@ abstract class PageSnippet extends Model\Document
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function removeEditable(string $name): static
     {
         $this->getEditables();
@@ -463,6 +472,9 @@ abstract class PageSnippet extends Model\Document
         return null;
     }
 
+    /**
+     * @return $this
+     */
     public function setContentMainDocument(?PageSnippet $document): static
     {
         if ($document instanceof self) {
@@ -499,6 +511,9 @@ abstract class PageSnippet extends Model\Document
         return $this->editables;
     }
 
+    /**
+     * @return $this
+     */
     public function setEditables(?array $editables): static
     {
         $this->editables = $editables;
@@ -518,7 +533,10 @@ abstract class PageSnippet extends Model\Document
         return $this->versions;
     }
 
-    public function setVersions(array $versions): static
+    /**
+     * @return $this
+     */
+    public function setVersions(?array $versions): static
     {
         $this->versions = $versions;
 
@@ -605,6 +623,9 @@ abstract class PageSnippet extends Model\Document
         return $this->missingRequiredEditable;
     }
 
+    /**
+     * @return $this
+     */
     public function setMissingRequiredEditable(?bool $missingRequiredEditable): static
     {
         $this->missingRequiredEditable = $missingRequiredEditable;


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/admin-ui-classic-bundle/issues/259

`Pimcore\Model\Document\PageSnippet::setVersions(): Argument #1 ($versions) must be of type array, null given, called in /var/www/html/vendor/pimcore/pimcore/lib/Model/AbstractModel.php on line 188`

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 51a13c6</samp>

This pull request improves the PHPDoc comments of the `PageSnippet` class to reflect fluent interface and nullable types. This enhances the code readability and fixes a null version bug.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 51a13c6</samp>

> _`PageSnippet` of doom, reveal your secrets_
> _Fluent interface, chain of darkness_
> _Nullable types, the void awaits_
> _PHPDoc comments, the only salvation_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 51a13c6</samp>

*  Add PHPDoc comments to several methods of the `PageSnippet` class to indicate fluent interface ([link](https://github.com/pimcore/pimcore/pull/15910/files?diff=unified&w=0#diff-af590f2e28178b47df6034df5b2fa8d9a2fdd93e2bd1ada546bdfc6598323269R305-R307), [link](https://github.com/pimcore/pimcore/pull/15910/files?diff=unified&w=0#diff-af590f2e28178b47df6034df5b2fa8d9a2fdd93e2bd1ada546bdfc6598323269R315-R317), [link](https://github.com/pimcore/pimcore/pull/15910/files?diff=unified&w=0#diff-af590f2e28178b47df6034df5b2fa8d9a2fdd93e2bd1ada546bdfc6598323269R372-R374), [link](https://github.com/pimcore/pimcore/pull/15910/files?diff=unified&w=0#diff-af590f2e28178b47df6034df5b2fa8d9a2fdd93e2bd1ada546bdfc6598323269R475-R477), [link](https://github.com/pimcore/pimcore/pull/15910/files?diff=unified&w=0#diff-af590f2e28178b47df6034df5b2fa8d9a2fdd93e2bd1ada546bdfc6598323269R514-R516), [link](https://github.com/pimcore/pimcore/pull/15910/files?diff=unified&w=0#diff-af590f2e28178b47df6034df5b2fa8d9a2fdd93e2bd1ada546bdfc6598323269R626-R628))
*  Add nullable type hint to the `$versions` parameter of the `setVersions` method of the `PageSnippet` class to fix a bug with null versions ([link](https://github.com/pimcore/pimcore/pull/15910/files?diff=unified&w=0#diff-af590f2e28178b47df6034df5b2fa8d9a2fdd93e2bd1ada546bdfc6598323269L521-R539))
