### PR TITLE
Fix uncaught error "Argument #1 ($id) must be of type int, null given" when userOwner of userModification is null

### DIFF
--- a/models/User/AbstractUser.php
+++ b/models/User/AbstractUser.php
@@ -38,7 +38,7 @@ abstract class AbstractUser extends Model\AbstractModel implements AbstractUserI
 
     protected string $type = '';
 
-    public static function getById(int $id): static|null
+    public static function getById(?int $id = null): static|null
     {
         if ($id < 0) {
             return null;


### PR DESCRIPTION
When userOwner and userModification are not set that time search by id is throwing error.

php.CRITICAL: Uncaught Error: Pimcore\Model\User\AbstractUser::getById(): Argument #1 ($id) must be of type int, null given, called in {project_root}/var/cache/acceptance/twig/ac/ac4a382cb38374880f7892b33abdbe63.php on line 174 {"exception":"[object] (TypeError(code: 0): Pimcore\\Model\\User\\AbstractUser::getById(): Argument #1 ($id) must be of type int, null given, called in {project_root}/var/cache/acceptance/twig/ac/ac4a382cb38374880f7892b33abdbe63.php on line 174 at {project_root}/vendor/pimcore/pimcore/models/User/AbstractUser.php:41)"} []

File - templates/searchadmin/search/quicksearch/info_table.html.twig
Line number - 52 - 66

 {% set owner = pimcore_user(element.getUserOwner()) %}
      {% if owner is instanceof('\\Pimcore\\Model\\User') %}
          <tr>
              <th>{{ 'owner'|trans([],'admin') }}</th>
              <td>{{ owner.name }}</td>
          </tr>
      {% endif %}

      {% set editor = pimcore_user(element.getUserModification()) %}
      {% if editor is instanceof('\\Pimcore\\Model\\User') %}
          <tr>
              <th>{{ 'usermodification'|trans([],'admin') }}</th>
              <td>{{ editor.name }}</td>
          </tr>
      {% endif %}
        
        
There is no condition set.