### PR TITLE
Allow userOwner to be null in search-backend-reindex command

### DIFF
--- a/bundles/SimpleBackendSearchBundle/src/Model/Search/Backend/Data.php
+++ b/bundles/SimpleBackendSearchBundle/src/Model/Search/Backend/Data.php
@@ -95,7 +95,7 @@ class Data extends AbstractModel
     /**
      * User-ID of the owner
      *
-     * @var int
+     * @var int|null
      */
     protected ?int $userOwner = null;
 

--- a/bundles/SimpleBackendSearchBundle/src/Model/Search/Backend/Data.php
+++ b/bundles/SimpleBackendSearchBundle/src/Model/Search/Backend/Data.php
@@ -97,7 +97,7 @@ class Data extends AbstractModel
      *
      * @var int
      */
-    protected int $userOwner;
+    protected ?int $userOwner = null;
 
     /**
      * User-ID of the user last modified the element
@@ -255,7 +255,7 @@ class Data extends AbstractModel
         return $this;
     }
 
-    public function getUserOwner(): int
+    public function getUserOwner(): ?int
     {
         return $this->userOwner;
     }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  

Fixes another case where `userOwner` could be null causing broken functionality.

During `pimcore:search-backend-reindex` following exception occurs when the indexed element has `userOwner` set to null, causing the whole reindex command to crash.

```
[2023-09-07T13:37:00.134630+02:00] console.CRITICAL: Error thrown while running command "pimcore:search-backend-reindex". Message: "Cannot assign null to property Pimcore\Bundle\SimpleBackendSearchBundle\Model\Search\Backend\Data::$userOwner of type int" {"exception":"[object] (TypeError(code: 0): Cannot assign null to property Pimcore\\Bundle\\SimpleBackendSearchBundle\\Model\\Search\\Backend\\Data::$userOwner of type int at /home/zitmaxx/domains/pim-zitmaxx.emico.nl/application/releases/601/vendor/pimcore/pimcore/bundles/SimpleBackendSearchBundle/src/Model/Search/Backend/Data.php:336)","command":"pimcore:search-backend-reindex","message":"Cannot assign null to property Pimcore\\Bundle\\SimpleBackendSearchBundle\\Model\\Search\\Backend\\Data::$userOwner of type int"} []
[2023-09-07T13:37:00.149121+02:00] php.CRITICAL: Uncaught Error: Cannot assign null to property Pimcore\Bundle\SimpleBackendSearchBundle\Model\Search\Backend\Data::$userOwner of type int {"exception":"[object] (TypeError(code: 0): Cannot assign null to property Pimcore\\Bundle\\SimpleBackendSearchBundle\\Model\\Search\\Backend\\Data::$userOwner of type int at /vendor/pimcore/pimcore/bundles/SimpleBackendSearchBundle/src/Model/Search/Backend/Data.php:336)"}
```

Also this field is nullable in the DB `search_backend_data`, so the model also reflects this correctly now.

## Remarks

Btw I branched from 11.x because this is only an issue introduced in pimcore 11, and the separate SimpleBackendSearchBundle didn't exist before.
