### PR TITLE
Remove case sensitivity to class definition files

### DIFF
--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -246,9 +246,9 @@ class Definition extends Model\AbstractModel
      */
     public function getDefinitionFile(string $key = null): string
     {
-        $lowerKey = $key ?? $this->getkey();
+        $key ??= $this->getkey();
 
-        return $this->locateDefinitionFile(strtolower($lowerKey), 'fieldcollections/%s.php');
+        return $this->locateDefinitionFile(strtolower($key), 'fieldcollections/%s.php');
     }
 
     /**

--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -246,7 +246,9 @@ class Definition extends Model\AbstractModel
      */
     public function getDefinitionFile(string $key = null): string
     {
-        return $this->locateDefinitionFile($key ?? $this->getKey(), 'fieldcollections/%s.php');
+        $lowerKey = $key ?? $this->getkey();
+
+        return $this->locateDefinitionFile(strtolower($lowerKey), 'fieldcollections/%s.php');
     }
 
     /**

--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -543,8 +543,9 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
      */
     public function getDefinitionFile(string $key = null): string
     {
-        $lowerkey = $key ?? $this->getKey();
-        return $this->locateDefinitionFile(strtolower($lowerKey), 'objectbricks/%s.php');
+        $key ??= $this->getKey();
+
+        return $this->locateDefinitionFile(strtolower($key), 'objectbricks/%s.php');
     }
 
     /**

--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -543,7 +543,8 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
      */
     public function getDefinitionFile(string $key = null): string
     {
-        return $this->locateDefinitionFile($key ?? $this->getKey(), 'objectbricks/%s.php');
+        $lowerkey = $key ?? $this->getKey();
+        return $this->locateDefinitionFile(strtolower($lowerKey), 'objectbricks/%s.php');
     }
 
     /**


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #15889

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 530ef5c</samp>

Fix case-sensitivity bug in fieldcollection and objectbrick definition file names. Ensure the keys are lowercase before calling `locateDefinitionFile` in both `models/DataObject/Fieldcollection/Definition.php` and `models/DataObject/Objectbrick/Definition.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 530ef5c</samp>

> _`key` to lowercase_
> _avoids file name errors_
> _autumn bug fixing_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 530ef5c</samp>

*  Fix case-sensitivity bug for fieldcollection and objectbrick definition file names ([link](https://github.com/pimcore/pimcore/pull/15923/files?diff=unified&w=0#diff-b84bb67037967bae90d946c6ba020b7a9d349b25fa0e924eb2e278b75fa96ec6L249-R251), [link](https://github.com/pimcore/pimcore/pull/15923/files?diff=unified&w=0#diff-5f6e2476922f452c6ec96a3363099e2236913f095fcd615ac49b06b39bb74362L546-R547))
