### PR TITLE
Fix error Search\Backend\Data:: must not be accessed before initializ…

### DIFF
--- a/bundles/SimpleBackendSearchBundle/src/Model/Search/Backend/Data.php
+++ b/bundles/SimpleBackendSearchBundle/src/Model/Search/Backend/Data.php
@@ -76,7 +76,7 @@ class Data extends AbstractModel
      *
      * @var bool
      */
-    protected bool $published;
+    protected bool $published = false;
 
     /**
      * timestamp of creation date


### PR DESCRIPTION
On adding a hard link to a document / document folder
<img width="297" alt="Screenshot 2023-09-12 at 11 12 35" src="https://github.com/pimcore/pimcore/assets/6807023/7d7debc2-5328-47dd-a2b6-9e5d835a4a97">

It throws this error:
<img width="1320" alt="Screenshot 2023-09-12 at 11 37 27" src="https://github.com/pimcore/pimcore/assets/6807023/dffdb277-5303-45d3-8d21-462952593bd6">

<!--



Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves error:
```
Typed property Pimcore\Bundle\SimpleBackendSearchBundle\Model\Search\Backend\Data::$published must not be accessed before initialization
```

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6e518e1</samp>

Fixed a bug in `Data` class where `published` property was not initialized properly. Improved the handling of `Data` objects and subclasses in the Simple Backend Search Bundle.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6e518e1</samp>

> _`Data` published_
> _false by default, bug fixed_
> _autumn leaves falling_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6e518e1</samp>

* Initialize `published` property to `false` in `Data` class constructor to avoid unset values when creating from array ([link](https://github.com/pimcore/pimcore/pull/15925/files?diff=unified&w=0#diff-b79507fb7b3335c72020ff443717e08af41e7cdc057b44cbef5b096ea0343f84L79-R79))
