### PR TITLE
Fix Data\Link setter errors: argument must be of type string, null given

### DIFF
--- a/models/DataObject/Data/Link.php
+++ b/models/DataObject/Data/Link.php
@@ -163,7 +163,7 @@ class Link implements OwnerAwareFieldInterface
     /**
      * @return $this
      */
-    public function setParameters(string $parameters): static
+    public function setParameters(?string $parameters): static
     {
         $this->parameters = $parameters;
         $this->markMeDirty();
@@ -179,7 +179,7 @@ class Link implements OwnerAwareFieldInterface
     /**
      * @return $this
      */
-    public function setAnchor(string $anchor): static
+    public function setAnchor(?string $anchor): static
     {
         $this->anchor = $anchor;
         $this->markMeDirty();
@@ -195,7 +195,7 @@ class Link implements OwnerAwareFieldInterface
     /**
      * @return $this
      */
-    public function setTitle(string $title): static
+    public function setTitle(?string $title): static
     {
         $this->title = $title;
         $this->markMeDirty();
@@ -211,7 +211,7 @@ class Link implements OwnerAwareFieldInterface
     /**
      * @return $this
      */
-    public function setAccesskey(string $accesskey): static
+    public function setAccesskey(?string $accesskey): static
     {
         $this->accesskey = $accesskey;
         $this->markMeDirty();
@@ -227,7 +227,7 @@ class Link implements OwnerAwareFieldInterface
     /**
      * @return $this
      */
-    public function setRel(string $rel): static
+    public function setRel(?string $rel): static
     {
         $this->rel = $rel;
         $this->markMeDirty();
@@ -243,7 +243,7 @@ class Link implements OwnerAwareFieldInterface
     /**
      * @return $this
      */
-    public function setTabindex(string $tabindex): static
+    public function setTabindex(?string $tabindex): static
     {
         $this->tabindex = $tabindex;
         $this->markMeDirty();
@@ -254,7 +254,7 @@ class Link implements OwnerAwareFieldInterface
     /**
      * @return $this
      */
-    public function setAttributes(string $attributes): static
+    public function setAttributes(?string $attributes): static
     {
         $this->attributes = $attributes;
         $this->markMeDirty();
@@ -270,7 +270,7 @@ class Link implements OwnerAwareFieldInterface
     /**
      * @return $this
      */
-    public function setClass(string $class): static
+    public function setClass(?string $class): static
     {
         $this->class = $class;
         $this->markMeDirty();


### PR DESCRIPTION

<img width="1601" alt="Screenshot 2023-09-12 at 14 24 52" src="https://github.com/pimcore/pimcore/assets/6807023/7502e7c7-7411-4e81-aa53-a00dc4030e56">

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Fixes:  Data\Link setter errors: argument must be of type string, null given

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 90377ab</samp>

Allow nullable strings for link properties in `Link` class. This enhances the handling of links with optional or empty attributes in data objects.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 90377ab</samp>

> _Sing, O Muse, of the skillful Link, the builder of bridges_
> _Who with cunning mind and nimble fingers fashioned the paths_
> _That connect the scattered realms of the web, the vast domain of Zeus_
> _And who, in his wisdom, granted his methods the power to accept_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 90377ab</samp>

*  Allow nullable strings as arguments for various setter methods of the `Link` class to handle empty or unset link attributes ([link](https://github.com/pimcore/pimcore/pull/15926/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL166-R166), [link](https://github.com/pimcore/pimcore/pull/15926/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL182-R182), [link](https://github.com/pimcore/pimcore/pull/15926/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL198-R198), [link](https://github.com/pimcore/pimcore/pull/15926/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL214-R214), [link](https://github.com/pimcore/pimcore/pull/15926/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL230-R230), [link](https://github.com/pimcore/pimcore/pull/15926/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL246-R246), [link](https://github.com/pimcore/pimcore/pull/15926/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL257-R257), [link](https://github.com/pimcore/pimcore/pull/15926/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL273-R273)) in file `models/DataObject/Data/Link.php`
