### PR TITLE
Fix/improve dataobject block behaviour

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Block.php
+++ b/models/DataObject/ClassDefinition/Data/Block.php
@@ -347,6 +347,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
     {
         $result = [];
         $count = 0;
+        $context = $params['context'] ?? [];
 
         foreach ($data as $rawBlockElement) {
             $resultElement = [];
@@ -360,7 +361,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
                 $invisible = $fd->getInvisible();
                 if ($invisible && !is_null($oIndex)) {
                     $blockGetter = 'get' . ucfirst($this->getname());
-                    if (method_exists($object, $blockGetter)) {
+                    if (empty($context['containerType']) && method_exists($object, $blockGetter)) {
                         $language = $params['language'] ?? null;
                         $items = $object->$blockGetter($language);
                         if (isset($items[$oIndex])) {

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -1513,7 +1513,7 @@ class Service extends Model\Element\Service
         if (method_exists($layout, 'getChildren')) {
             $children = $layout->getChildren();
             if (is_array($children)) {
-                // Send information when we have block or simmilar element
+                // Send information when we have block or similar element
                 if ($layout instanceof \Pimcore\Model\DataObject\ClassDefinition\Data && empty($context['subContainerType'])) {
                     $context['subContainerKey'] = $layout->getName();
                     $context['subContainerType'] = $layout->getFieldtype();

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -1513,6 +1513,12 @@ class Service extends Model\Element\Service
         if (method_exists($layout, 'getChildren')) {
             $children = $layout->getChildren();
             if (is_array($children)) {
+                // Send information when we have block or simmilar element
+                if ($layout instanceof \Pimcore\Model\DataObject\ClassDefinition\Data && empty($context['subContainerType'])) {
+                    $context['subContainerKey'] = $layout->getName();
+                    $context['subContainerType'] = $layout->getFieldtype();
+                }
+
                 foreach ($children as $child) {
                     self::enrichLayoutDefinition($child, $object, $context);
                 }


### PR DESCRIPTION
### WHAT
I notice few issues with dataobject block
- If block is nested into brick, than on the end we do not have information about that block inside context var (_for example, if you use OptionProvider for selectoption in that block, you will have information about object, object key, brick name, and final input name, but you would not know what is between brick and that input_)
- Same case, when you have block inside brick, and you have input filed on object with same name; pimcore made wrong assumption and take data from object instead from objectbrick

