### PR TITLE
[TinyMCE]: Align the order of pimcore element html attributes to match regex

### DIFF
--- a/bundles/TinymceBundle/public/js/editor.js
+++ b/bundles/TinymceBundle/public/js/editor.js
@@ -185,19 +185,19 @@ pimcore.bundle.tinymce.editor = Class.create({
 
                 additionalAttributes = mergeObject(additionalAttributes, {
                     src: uri,
-                    pimcore_type: 'asset',
-                    pimcore_id: id,
                     target: '_blank',
-                    alt: 'asset_image'
+                    alt: 'asset_image',
+                    pimcore_id: id,
+                    pimcore_type: 'asset'
                 });
                 tinymce.activeEditor.selection.setContent(tinymce.activeEditor.dom.createHTML('img', additionalAttributes));
                 return true;
             } else {
                 tinymce.activeEditor.selection.setContent(tinymce.activeEditor.dom.createHTML('a', {
                     href: uri,
-                    pimcore_type: 'asset',
+                    target: '_blank',
                     pimcore_id: id,
-                    target: '_blank'
+                    pimcore_type: 'asset'
                 }, wrappedText));
                 return true;
             }
@@ -207,8 +207,8 @@ pimcore.bundle.tinymce.editor = Class.create({
             || data.type === "hardlink" || data.type === "link")) {
             tinymce.activeEditor.selection.setContent(tinymce.activeEditor.dom.createHTML('a', {
                 href: uri,
-                pimcore_type: 'document',
-                pimcore_id: id
+                pimcore_id: id,
+                pimcore_type: 'document'
             }, wrappedText));
             return true;
         }
@@ -216,8 +216,8 @@ pimcore.bundle.tinymce.editor = Class.create({
         if (data.elementType === "object") {
             tinymce.activeEditor.selection.setContent(tinymce.activeEditor.dom.createHTML('a', {
                 href: uri,
-                pimcore_type: 'object',
-                pimcore_id: id
+                pimcore_id: id,
+                pimcore_type: 'object'
             }, wrappedText));
             return true;
         }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15878, https://github.com/pimcore/pimcore/issues/15874

## Additional info
By looking at https://github.com/pimcore/pimcore/blob/8378d7506654cb5c8bbade9c98ef18e40e3e25a7/lib/Tool/Text.php#L194 it seems that is meant to be first `pimcore_id` and then `pimcore_type`, while in the JS they were inverted making this regex preg not working 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 49174d1</samp>

Harmonized attribute order for `img` and `a` tags in `editor.js`. This improves code quality and consistency in the TinymceBundle.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 49174d1</samp>

> _We're the crew of the editor ship, we code with skill and pride_
> _We harmonize our attributes, we keep them neat and tidy_
> _Heave away, me hearties, heave away with me_
> _We'll raise the sail of quality with `img` and `a`_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 49174d1</samp>

*  Reordered the attributes for the `img` and `a` tags in `editor.js` to improve consistency and readability ([link](https://github.com/pimcore/pimcore/pull/15940/files?diff=unified&w=0#diff-8a2dc43663bb99540091e249b44189b63f7f4ba73bf2a3b7d470a998eeabd19cL188-R191), [link](https://github.com/pimcore/pimcore/pull/15940/files?diff=unified&w=0#diff-8a2dc43663bb99540091e249b44189b63f7f4ba73bf2a3b7d470a998eeabd19cL198-R200), [link](https://github.com/pimcore/pimcore/pull/15940/files?diff=unified&w=0#diff-8a2dc43663bb99540091e249b44189b63f7f4ba73bf2a3b7d470a998eeabd19cL210-R211), [link](https://github.com/pimcore/pimcore/pull/15940/files?diff=unified&w=0#diff-8a2dc43663bb99540091e249b44189b63f7f4ba73bf2a3b7d470a998eeabd19cL219-R220))
