### PR TITLE
[Documents] Prevent error/deprecation due to passing null to Asset::getById in video editable

### DIFF
--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -189,7 +189,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
     public function getData(): mixed
     {
         $path = $this->id;
-        if ($this->id && $this->type === self::TYPE_ASSET && ($video = Asset::getById($this->id))) {
+        if ($this->id && $this->type === self::TYPE_ASSET && ($video = Asset::getById((int)$this->id))) {
             $path = $video->getFullPath();
         }
 
@@ -229,7 +229,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
             $data['poster'] = $poster->getRealFullPath();
         }
 
-        if ($this->type === self::TYPE_ASSET && ($video = Asset::getById($this->id))) {
+        if ($this->type === self::TYPE_ASSET && ($video = Asset::getById((int)$this->id))) {
             $data['path'] = $video->getRealFullPath();
         }
 
@@ -290,7 +290,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
         if (
             $this->id &&
             $this->type === self::TYPE_ASSET &&
-            $asset = Asset::getById($this->id)) {
+            $asset = Asset::getById((int)$this->id)) {
                 $key = 'asset_' . $asset->getId();
                 $dependencies[$key] = [
                     'id' => $asset->getId(),
@@ -312,8 +312,8 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
     public function checkValidity(): bool
     {
         $valid = true;
-        if ($this->type === self::TYPE_ASSET && !empty($this->id)) {
-            $el = Asset::getById($this->id);
+        if ($this->type === self::TYPE_ASSET && $this->id) {
+            $el = Asset::getById((int)$this->id);
             if (!$el instanceof Asset) {
                 $valid = false;
                 Logger::notice(
@@ -441,7 +441,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
 
     private function getAssetCode(bool $inAdmin = false): string
     {
-        $asset = Asset::getById($this->id);
+        $asset = Asset::getById((int)$this->id);
         $config = $this->getConfig();
         $thumbnailConfig = $config['thumbnail'] ?? null;
 
@@ -1058,7 +1058,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
     public function getVideoAsset(): ?Asset\Video
     {
         if ($this->id && $this->getVideoType() === self::TYPE_ASSET) {
-            return Asset\Video::getById($this->id);
+            return Asset\Video::getById((int)$this->id);
         }
 
         return null;

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -21,6 +21,7 @@ use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\Asset;
 use Pimcore\Tool;
+use Pimcore\Tool\Serialize;
 
 /**
  * @method \Pimcore\Model\Document\Editable\Dao getDao()
@@ -223,7 +224,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
     {
         $data = $this->getData();
 
-        $poster = Asset::getById($this->poster);
+        $poster = $this->poster ? Asset::getById($this->poster) : null;
         if ($poster) {
             $data['poster'] = $poster->getRealFullPath();
         }
@@ -286,15 +287,15 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
     {
         $dependencies = [];
 
-        if ($this->type === self::TYPE_ASSET) {
-            $asset = Asset::getById($this->id);
-            if ($asset instanceof Asset) {
+        if (
+            $this->id &&
+            $this->type === self::TYPE_ASSET &&
+            $asset = Asset::getById($this->id)) {
                 $key = 'asset_' . $asset->getId();
                 $dependencies[$key] = [
                     'id' => $asset->getId(),
                     'type' => self::TYPE_ASSET,
                 ];
-            }
         }
 
         if ($this->poster && $poster = Asset::getById($this->poster)) {
@@ -315,15 +316,19 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
             $el = Asset::getById($this->id);
             if (!$el instanceof Asset) {
                 $valid = false;
-                Logger::notice('Detected invalid relation, removing reference to non existent asset with id ['.$this->id.']');
+                Logger::notice(
+                    'Detected invalid relation, removing reference to non existent asset with id ['.$this->id.']'
+                );
                 $this->id   = null;
                 $this->type = null;
             }
         }
 
-        if (!($poster = Asset::getById($this->poster))) {
+        if ($this->poster && !Asset::getById($this->poster)) {
             $valid = false;
-            Logger::notice('Detected invalid relation, removing reference to non existent asset with id ['.$this->id.']');
+            Logger::notice(
+                'Detected invalid relation, removing reference to non existent asset with id ['.$this->id.']'
+            );
             $this->poster = null;
         }
 
@@ -350,7 +355,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
     public function setDataFromResource(mixed $data): static
     {
         if (!empty($data)) {
-            $data = \Pimcore\Tool\Serialize::unserialize($data);
+            $data = Serialize::unserialize($data);
         }
 
         $this->id = $data['id'];
@@ -476,7 +481,9 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
                     return $this->getProgressCode((string)$image);
                 }
 
-                return $this->getErrorCode('The video conversion failed, please see the log files in /var/log for more details.');
+                return $this->getErrorCode(
+                    'The video conversion failed, please see the log files in /var/log for more details.'
+                );
             }
 
             return $this->getErrorCode("The given thumbnail doesn't exist: '" . $thumbnailConfig . "'");
@@ -627,7 +634,9 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
             $seriesPrefix = 'videoseries?list=';
         }
 
-        $valid_youtube_prams = [ 'autohide',
+        //todo: move this to symfony config
+        $validYoutubeParams = [
+            'autohide',
             'autoplay',
             'cc_load_policy',
             'color',
@@ -652,7 +661,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
             'start',
             'theme',
         ];
-        $additional_params = '';
+        $additionalParams = '';
 
         $clipConfig = [];
         if (isset($config['config']['clip']) && is_array($config['config']['clip'])) {
@@ -667,22 +676,22 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
 
         if (!empty($configurations)) {
             foreach ($configurations as $key => $value) {
-                if (in_array($key, $valid_youtube_prams)) {
+                if (in_array($key, $validYoutubeParams)) {
                     if (is_bool($value)) {
                         if ($value) {
-                            $additional_params .= '&'.$key.'=1';
+                            $additionalParams .= '&'.$key.'=1';
                         } else {
-                            $additional_params .= '&'.$key.'=0';
+                            $additionalParams .= '&'.$key.'=0';
                         }
                     } else {
-                        $additional_params .= '&'.$key.'='.$value;
+                        $additionalParams .= '&'.$key.'='.$value;
                     }
                 }
             }
         }
 
         $code .= '<div id="pimcore_video_' . $this->getName() . '" class="pimcore_editable_video '. ($config['class'] ?? '') .'">
-            <iframe width="' . $width . '" height="' . $height . '" src="https://www.youtube-nocookie.com/embed/' . $seriesPrefix . $youtubeId . $wmode . $additional_params . '" title="YouTube video" allow="fullscreen" data-type="pimcore_video_editable"></iframe>
+            <iframe width="' . $width . '" height="' . $height . '" src="https://www.youtube-nocookie.com/embed/' . $seriesPrefix . $youtubeId . $wmode . $additionalParams . '" title="YouTube video" allow="fullscreen" data-type="pimcore_video_editable"></iframe>
         </div>';
 
         return $code;
@@ -696,7 +705,6 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
 
         $config = $this->getConfig();
         $code = '';
-        $uid = $this->getUniqId();
 
         // get vimeo id
         if (preg_match("@vimeo.*/([\d]+)@i", $this->id, $matches)) {
@@ -723,14 +731,15 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
                 $height = $config['height'];
             }
 
-            $valid_vimeo_prams = [
+            //todo: move this to symfony config
+            $validVimeoParams = [
                 'autoplay',
                 'background',
                 'loop',
                 'muted',
             ];
 
-            $additional_params = '';
+            $additionalParams = '';
 
             $clipConfig = [];
             if (isset($config['config']['clip']) && is_array($config['config']['clip'])) {
@@ -745,22 +754,22 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
 
             if (!empty($configurations)) {
                 foreach ($configurations as $key => $value) {
-                    if (in_array($key, $valid_vimeo_prams)) {
+                    if (in_array($key, $validVimeoParams)) {
                         if (is_bool($value)) {
                             if ($value) {
-                                $additional_params .= '&'.$key.'=1';
+                                $additionalParams .= '&'.$key.'=1';
                             } else {
-                                $additional_params .= '&'.$key.'=0';
+                                $additionalParams .= '&'.$key.'=0';
                             }
                         } else {
-                            $additional_params .= '&'.$key.'='.$value;
+                            $additionalParams .= '&'.$key.'='.$value;
                         }
                     }
                 }
             }
 
             $code .= '<div id="pimcore_video_' . $this->getName() . '" class="pimcore_editable_video '. ($config['class'] ?? '') .'">
-                <iframe src="https://player.vimeo.com/video/' . $vimeoId . '?dnt=1&title=0&amp;byline=0&amp;portrait=0' . $additional_params . '" width="' . $width . '" height="' . $height . '" title="Vimeo video" allow="fullscreen" data-type="pimcore_video_editable"></iframe>
+                <iframe src="https://player.vimeo.com/video/' . $vimeoId . '?dnt=1&title=0&amp;byline=0&amp;portrait=0' . $additionalParams . '" width="' . $width . '" height="' . $height . '" title="Vimeo video" allow="fullscreen" data-type="pimcore_video_editable"></iframe>
             </div>';
 
             return $code;
@@ -778,7 +787,6 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
 
         $config = $this->getConfig();
         $code = '';
-        $uid = $this->getUniqId();
 
         // get dailymotion id
         if (preg_match('@dailymotion.*/video/([^_]+)@i', $this->id, $matches)) {
@@ -798,14 +806,17 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
 
             $height = $config['height'] ?? '300';
 
-            $valid_dailymotion_prams = [
+            //todo: move this to symfony config
+            $validDailymotionParams = [
                 'autoplay',
                 'loop',
                 'mute', ];
 
-            $additional_params = '';
+            $additionalParams = '';
 
-            $clipConfig = isset($config['config']['clip']) && is_array($config['config']['clip']) ? $config['config']['clip'] : [];
+            $clipConfig =
+                isset($config['config']['clip']) &&
+                is_array($config['config']['clip']) ? $config['config']['clip'] : [];
 
             // this is to be backward compatible to <= v 1.4.7
             $configurations = $clipConfig;
@@ -815,22 +826,22 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
 
             if (!empty($configurations)) {
                 foreach ($configurations as $key => $value) {
-                    if (in_array($key, $valid_dailymotion_prams)) {
+                    if (in_array($key, $validDailymotionParams)) {
                         if (is_bool($value)) {
                             if ($value) {
-                                $additional_params .= '&'.$key.'=1';
+                                $additionalParams .= '&'.$key.'=1';
                             } else {
-                                $additional_params .= '&'.$key.'=0';
+                                $additionalParams .= '&'.$key.'=0';
                             }
                         } else {
-                            $additional_params .= '&'.$key.'='.$value;
+                            $additionalParams .= '&'.$key.'='.$value;
                         }
                     }
                 }
             }
 
             $code .= '<div id="pimcore_video_' . $this->getName() . '" class="pimcore_editable_video '. ($config['class'] ?? '') .'">
-                <iframe src="https://www.dailymotion.com/embed/video/' . $dailymotionId . '?' . $additional_params . '" width="' . $width . '" height="' . $height . '" title="DailyMotion video" allow="fullscreen" data-type="pimcore_video_editable"></iframe>
+                <iframe src="https://www.dailymotion.com/embed/video/' . $dailymotionId . '?' . $additionalParams . '" width="' . $width . '" height="' . $height . '" title="DailyMotion video" allow="fullscreen" data-type="pimcore_video_editable"></iframe>
             </div>';
 
             return $code;
@@ -840,7 +851,10 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
         return $this->getEmptyCode();
     }
 
-    private function getHtml5Code(array $urls = [], Asset\Video\ImageThumbnail|Asset\Image\Thumbnail $thumbnail = null): string
+    private function getHtml5Code(
+        array $urls = [],
+        Asset\Video\ImageThumbnail|Asset\Image\Thumbnail $thumbnail = null
+    ): string
     {
         $code = '';
         $video = $this->getVideoAsset();
@@ -856,9 +870,6 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
                 'name' => $this->getTitle(),
                 'description' => $this->getDescription(),
                 'uploadDate' => $uploadDate->format('Y-m-d\TH:i:sO'),
-                //'contentUrl' => Tool::getHostUrl() . $urls['mp4'],
-                //"embedUrl" => "http://www.example.com/videoplayer.swf?video=123",
-                //"interactionCount" => "1234",
             ];
             $duration = $video->getDuration();
 
@@ -1046,7 +1057,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
 
     public function getVideoAsset(): ?Asset\Video
     {
-        if ($this->getVideoType() === self::TYPE_ASSET) {
+        if ($this->id && $this->getVideoType() === self::TYPE_ASSET) {
             return Asset\Video::getById($this->id);
         }
 
@@ -1055,7 +1066,11 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
 
     public function getPosterAsset(): ?Asset\Image
     {
-        return Asset\Image::getById($this->poster);
+        if ($this->poster) {
+            return Asset\Image::getById($this->poster);
+        }
+
+        return null;
     }
 
     /**
@@ -1092,8 +1107,11 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
      */
     public function rewriteIds(array $idMapping): void
     {
-        if ($this->type == self::TYPE_ASSET && array_key_exists(self::TYPE_ASSET, $idMapping) && array_key_exists($this->getId(), $idMapping[self::TYPE_ASSET])) {
-            $this->setId($idMapping[self::TYPE_ASSET][$this->getId()]);
+        if (
+            $this->type == self::TYPE_ASSET &&
+            array_key_exists(self::TYPE_ASSET, $idMapping) &&
+            array_key_exists($this->getId(), $idMapping[self::TYPE_ASSET])) {
+                $this->setId($idMapping[self::TYPE_ASSET][$this->getId()]);
         }
     }
 }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #15939

## Additional info
Steps to reproduce:
1. Add video editable document template:
```
{{ pimcore_video('video') }}

```
3. Create document with the same template
4. Open document in Admin UI
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4e9384e</samp>

This pull request improves the Video editable class by fixing bugs, removing unused code, and following coding standards. It also proposes some configuration changes for future development.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4e9384e</samp>

> _We're fixing up the Video class, me hearties, yo ho ho_
> _We're checking for the `id` and `poster`, or else it won't go_
> _We're trimming down the code and breaking lines, to make it neat and clear_
> _We're renaming vars and adding todos, to follow standards here_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4e9384e</samp>

*  Add a use statement for the `Serialize` class and replace the fully qualified class name with the imported alias ([link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007R24), [link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L353-R358))
*  Add null checks for the `poster` and `id` properties before calling `Asset::getById` in various methods, to avoid passing null arguments and throwing exceptions ([link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L226-R227), [link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L289-R293), [link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L324-R331), [link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L1049-R1060), [link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L1058-R1073))
*  Break long log and error messages into two lines, to improve readability and adhere to the coding standards ([link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L318-R321), [link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L324-R331), [link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L479-R486))
*  Remove an unnecessary closing bracket in the `getEditmodeConfig` method ([link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L297))
*  Add todo comments to move the valid parameters arrays for YouTube, Vimeo, and Dailymotion to the symfony config, to avoid hardcoding the parameters and make them configurable ([link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L630-R639), [link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L726-R735), [link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L801-R819))
*  Rename the variables from snake_case to camelCase, to follow the convention and match the rest of the code ([link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L630-R639), [link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L655-R664), [link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L670-R687), [link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L685-R694), [link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L726-R735), [link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L733-R742), [link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L748-R765), [link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L763-R772), [link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L801-R819), [link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L818-R837), [link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L833-R844))
*  Remove unused variable declarations in the `getHtml5Code` and `getDailymotionCode` methods, to avoid confusion and improve performance ([link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L699), [link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L781))
*  Break the function declaration of `getDailymotionCode` into multiple lines, to improve readability and adhere to the coding standards ([link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L843-R857))
*  Remove some commented out code in the `getDailymotionCode` method, to avoid confusion and improve readability ([link](https://github.com/pimcore/pimcore/pull/15941/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L859-L861))
