### PR TITLE
[Improvement]: Make Password Recovery Token to be one time use only

### DIFF
--- a/bundles/CoreBundle/src/Migrations/Version20230913173812.php
+++ b/bundles/CoreBundle/src/Migrations/Version20230913173812.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Pimcore\Model\Dao\AbstractDao;
+
+final class Version20230913173812 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Adds passwordRecoveryToken column to users table';
+    }
+    public function up(Schema $schema): void
+    {
+        if (!$schema->getTable('users')->hasColumn('passwordRecoveryToken')) {
+            $this->addSql('ALTER TABLE `users` ADD COLUMN `passwordRecoveryToken` varchar(255) DEFAULT NULL AFTER `password`;');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if ($schema->getTable('users')->hasColumn('passwordRecoveryToken')) {
+            $this->addSql('ALTER TABLE `users` DROP COLUMN `passwordRecoveryToken`;');
+        }
+    }
+}

--- a/bundles/CoreBundle/src/Migrations/Version20230913173812.php
+++ b/bundles/CoreBundle/src/Migrations/Version20230913173812.php
@@ -30,7 +30,9 @@ final class Version20230913173812 extends AbstractMigration
     public function up(Schema $schema): void
     {
         if (!$schema->getTable('users')->hasColumn('passwordRecoveryToken')) {
-            $this->addSql('ALTER TABLE `users` ADD COLUMN `passwordRecoveryToken` varchar(255) DEFAULT NULL AFTER `password`;');
+            $this->addSql(
+            'ALTER TABLE `users` ADD COLUMN `passwordRecoveryToken` varchar(255) DEFAULT NULL AFTER `password`;'
+            );
         }
     }
 

--- a/bundles/InstallBundle/dump/install.sql
+++ b/bundles/InstallBundle/dump/install.sql
@@ -479,6 +479,7 @@ CREATE TABLE `users` (
   `websiteTranslationLanguagesView` LONGTEXT NULL DEFAULT NULL,
   `lastLogin` int(11) unsigned DEFAULT NULL,
   `keyBindings` json NULL,
+  `passwordRecoveryToken` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `type_name` (`type`,`name`),
   KEY `parentId` (`parentId`),

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -3,6 +3,7 @@
 ## Pimcore 11.1.0
 - Property `$fieldtype` of the `Pimcore\Model\DataObject\Data` class is deprecated now. Use the `getFieldType()` method instead.
 - [DataObject] Method `getSiblings()` output is now sorted based on the parent sorting parameters (same as `getChildren`) instead of alphabetical.
+- [Auth] The tokens for password reset are now stored in the DB and are one time use only (gets expired whenever a new one is generated or when consumed).
 
 ## Pimcore 11.0.7
 - Putting `null` to the `Pimcore\Model\DataObject\Data::setIndex()` method is deprecated now. Only booleans are allowed.

--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -205,21 +205,27 @@ class Authentication
     }
 
     /**
-     *
+     * passing $user as a string is dis-recommended since 11.1.0, please pass a User object instead.
      *
      * @internal
      */
-    public static function generateToken(User $user): string
+    public static function generateToken(string|User $user): string
     {
         $secret = \Pimcore::getContainer()->getParameter('secret');
 
-        $data = time() - 1 . '|' . $user->getName();
-        $token = Crypto::encryptWithPassword($data, $secret);
+        if (is_string($user)) {
+            $user = User::getByName($user);
+        }
 
-        $user->setPasswordRecoveryToken($token);
-        $user->save();
+        if ($user instanceof User) {
+            $data = time() - 1 . '|' . $user->getName();
+            $token = Crypto::encryptWithPassword($data, $secret);
 
-        return $token;
+            $user->setPasswordRecoveryToken($token);
+            $user->save();
+
+            return $token;
+        }
     }
 
     /**

--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -224,6 +224,7 @@ class Authentication
 
     /**
      * @throws NotFoundException if token does not belong to any user
+     * @throws CryptoException
      */
     private static function tokenDecrypt(string $token): array
     {

--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -20,6 +20,7 @@ use Defuse\Crypto\Crypto;
 use Defuse\Crypto\Exception\CryptoException;
 use Pimcore\Config;
 use Pimcore\Logger;
+use Pimcore\Model\Exception\NotFoundException;
 use Pimcore\Model\User;
 use Pimcore\Security\User\UserProvider;
 use Symfony\Component\HttpFoundation\Request;

--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -205,19 +205,17 @@ class Authentication
     }
 
     /**
-     * Use tokenGenerate() instead, this will be removed once dropping support for admin-ui-bundle 1.*
-     *
      * @internal
      */
     public static function generateToken(string $username): string
     {
         $user = User::getByName($username);
-        return self::tokenGenerate($user);
+        return self::generateTokenByUser($user);
     }
     /**
      * @internal
      */
-    public static function tokenGenerate(User $user): string
+    public static function generateTokenByUser(User $user): string
     {
         $secret = \Pimcore::getContainer()->getParameter('secret');
 

--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -18,8 +18,6 @@ namespace Pimcore\Tool;
 
 use Defuse\Crypto\Crypto;
 use Defuse\Crypto\Exception\CryptoException;
-use Defuse\Crypto\Exception\EnvironmentIsBrokenException;
-use Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException;
 use Pimcore\Config;
 use Pimcore\Logger;
 use Pimcore\Model\User;
@@ -225,8 +223,6 @@ class Authentication
 
     /**
      * @throws NotFoundException if token does not belong to any user
-     * @throws EnvironmentIsBrokenException
-     * @throws WrongKeyOrModifiedCiphertextException
      */
     private static function tokenDecrypt(string $token): array
     {

--- a/models/User.php
+++ b/models/User.php
@@ -109,7 +109,9 @@ final class User extends User\UserRole implements UserInterface
 
         return $this;
     }
-
+    /**
+     * @internal
+     */
     public function getPasswordRecoveryToken(): ?string
     {
         return $this->passwordRecoveryToken;

--- a/models/User.php
+++ b/models/User.php
@@ -33,6 +33,8 @@ final class User extends User\UserRole implements UserInterface
 
     protected ?string $password = null;
 
+    protected ?string $passwordRecoveryToken = null;
+
     protected ?string $firstname = null;
 
     protected ?string $lastname = null;
@@ -104,6 +106,21 @@ final class User extends User\UserRole implements UserInterface
         if (strlen((string) $password) > 4) {
             $this->password = $password;
         }
+
+        return $this;
+    }
+
+    public function getPasswordRecoveryToken(): ?string
+    {
+        return $this->passwordRecoveryToken;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setPasswordRecoveryToken(?string $passwordRecoveryToken): static
+    {
+        $this->passwordRecoveryToken = $passwordRecoveryToken;
 
         return $this;
     }

--- a/models/User.php
+++ b/models/User.php
@@ -118,6 +118,8 @@ final class User extends User\UserRole implements UserInterface
     }
 
     /**
+     * @internal
+     *
      * @return $this
      */
     public function setPasswordRecoveryToken(?string $passwordRecoveryToken): static

--- a/models/User/AbstractUser/Dao.php
+++ b/models/User/AbstractUser/Dao.php
@@ -82,6 +82,10 @@ class Dao extends Model\Dao\AbstractDao
         if ($data) {
             $data['admin'] = (bool)$data['admin'];
             $data['active'] = (bool)$data['active'];
+            $data['welcomescreen'] = (bool)$data['welcomescreen'];
+            $data['closeWarning'] = (bool)$data['closeWarning'];
+            $data['memorizeTabs'] = (bool)$data['memorizeTabs'];
+            $data['allowDirtyClose'] = (bool)$data['allowDirtyClose'];
             $this->assignVariablesToModel($data);
         } else {
             throw new Model\Exception\NotFoundException(sprintf('Token "%s" does not match any user.', $token));

--- a/models/User/AbstractUser/Dao.php
+++ b/models/User/AbstractUser/Dao.php
@@ -38,12 +38,7 @@ class Dao extends Model\Dao\AbstractDao
         }
 
         if ($data) {
-            $data['admin'] = (bool)$data['admin'];
-            $data['active'] = (bool)$data['active'];
-            $data['welcomescreen'] = (bool)$data['welcomescreen'];
-            $data['closeWarning'] = (bool)$data['closeWarning'];
-            $data['memorizeTabs'] = (bool)$data['memorizeTabs'];
-            $data['allowDirtyClose'] = (bool)$data['allowDirtyClose'];
+            $data = $this->castUserDataToBoolean($data);
             $this->assignVariablesToModel($data);
         } else {
             throw new Model\Exception\NotFoundException("user doesn't exist");
@@ -59,12 +54,7 @@ class Dao extends Model\Dao\AbstractDao
         $data = $this->db->fetchAssociative('SELECT * FROM users WHERE `type` = ? AND `name` = ?', [$this->model->getType(), $name]);
 
         if ($data) {
-            $data['admin'] = (bool)$data['admin'];
-            $data['active'] = (bool)$data['active'];
-            $data['welcomescreen'] = (bool)$data['welcomescreen'];
-            $data['closeWarning'] = (bool)$data['closeWarning'];
-            $data['memorizeTabs'] = (bool)$data['memorizeTabs'];
-            $data['allowDirtyClose'] = (bool)$data['allowDirtyClose'];
+            $data = $this->castUserDataToBoolean($data);
             $this->assignVariablesToModel($data);
         } else {
             throw new Model\Exception\NotFoundException(sprintf('User with name "%s" does not exist', $name));
@@ -80,17 +70,26 @@ class Dao extends Model\Dao\AbstractDao
         $data = $this->db->fetchAssociative('SELECT * FROM users WHERE `passwordRecoveryToken` = ?', [$token]);
 
         if ($data) {
-            $data['admin'] = (bool)$data['admin'];
-            $data['active'] = (bool)$data['active'];
-            $data['welcomescreen'] = (bool)$data['welcomescreen'];
-            $data['closeWarning'] = (bool)$data['closeWarning'];
-            $data['memorizeTabs'] = (bool)$data['memorizeTabs'];
-            $data['allowDirtyClose'] = (bool)$data['allowDirtyClose'];
+            $data = $this->castUserDataToBoolean($data);
             $this->assignVariablesToModel($data);
         } else {
             throw new Model\Exception\NotFoundException(sprintf('Token "%s" does not match any user.', $token));
         }
     }
+
+    private function castUserDataToBoolean($data): array
+    {
+        $data['admin'] = (bool)$data['admin'];
+        $data['active'] = (bool)$data['active'];
+        $data['welcomescreen'] = (bool)$data['welcomescreen'];
+        $data['closeWarning'] = (bool)$data['closeWarning'];
+        $data['memorizeTabs'] = (bool)$data['memorizeTabs'];
+        $data['allowDirtyClose'] = (bool)$data['allowDirtyClose'];
+
+        return $data;
+    }
+
+
     public function create(): void
     {
         $this->db->insert('users', [

--- a/models/User/AbstractUser/Dao.php
+++ b/models/User/AbstractUser/Dao.php
@@ -73,7 +73,7 @@ class Dao extends Model\Dao\AbstractDao
             $data = $this->castUserDataToBoolean($data);
             $this->assignVariablesToModel($data);
         } else {
-            throw new Model\Exception\NotFoundException(sprintf('Token "%s" does not match any user.', $token));
+            throw new Model\Exception\NotFoundException(sprintf('Token does not match any user.'));
         }
     }
 

--- a/models/User/AbstractUser/Dao.php
+++ b/models/User/AbstractUser/Dao.php
@@ -77,7 +77,7 @@ class Dao extends Model\Dao\AbstractDao
         }
     }
 
-    private function castUserDataToBoolean($data): array
+    private function castUserDataToBoolean(array $data): array
     {
         $data['admin'] = (bool)$data['admin'];
         $data['active'] = (bool)$data['active'];

--- a/models/User/AbstractUser/Dao.php
+++ b/models/User/AbstractUser/Dao.php
@@ -71,6 +71,22 @@ class Dao extends Model\Dao\AbstractDao
         }
     }
 
+    /**
+     *
+     * @throws Model\Exception\NotFoundException
+     */
+    public function getByPasswordRecoveryToken(string $token): void
+    {
+        $data = $this->db->fetchAssociative('SELECT * FROM users WHERE `passwordRecoveryToken` = ?', [$token]);
+
+        if ($data) {
+            $data['admin'] = (bool)$data['admin'];
+            $data['active'] = (bool)$data['active'];
+            $this->assignVariablesToModel($data);
+        } else {
+            throw new Model\Exception\NotFoundException(sprintf('Token "%s" does not match any user.', $token));
+        }
+    }
     public function create(): void
     {
         $this->db->insert('users', [


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15244

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0a3651f</samp>

This pull request adds a new feature of password reset tokens to the User model and the authentication logic. It changes the way the tokens are stored and handled, using the database instead of the session and simplifying the encryption and decryption. It also updates the database schema, the installation script, and the documentation accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0a3651f</samp>

> _If you forget your password, don't fret_
> _You can request a token to reset_
> _It's stored in the `users` table_
> _With encryption that's stable_
> _And it's one time use, so don't forget_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0a3651f</samp>

*  Add a new feature to store password reset tokens in the database and make them one time use only ([link](https://github.com/pimcore/pimcore/pull/15942/files?diff=unified&w=0#diff-efabafaa6155103e98e1113e9f4b5a294174400145c3b8ffd4b26371d1dc4801R1-R43), [link](https://github.com/pimcore/pimcore/pull/15942/files?diff=unified&w=0#diff-810875477d4dfc724e1692e89be6c2cbbb7bca85deeec0889d4663fad523bf3dR482), [link](https://github.com/pimcore/pimcore/pull/15942/files?diff=unified&w=0#diff-375aded12dfb868b84d5b8c27d1aed2358680a27b683e8a985f1b85193dd79aaR6), [link](https://github.com/pimcore/pimcore/pull/15942/files?diff=unified&w=0#diff-d9a11a8fd30a1dadfdfc75fe070ecbfa8e8d590787ff38634143c67cc154d4beR21-R22), [link](https://github.com/pimcore/pimcore/pull/15942/files?diff=unified&w=0#diff-d9a11a8fd30a1dadfdfc75fe070ecbfa8e8d590787ff38634143c67cc154d4beL118-R132), [link](https://github.com/pimcore/pimcore/pull/15942/files?diff=unified&w=0#diff-d9a11a8fd30a1dadfdfc75fe070ecbfa8e8d590787ff38634143c67cc154d4beL209-R241), [link](https://github.com/pimcore/pimcore/pull/15942/files?diff=unified&w=0#diff-606c30f14301fee5176f53f2477b0ce0c3ecce17a5e99779f466f02e309d5038R36-R37), [link](https://github.com/pimcore/pimcore/pull/15942/files?diff=unified&w=0#diff-606c30f14301fee5176f53f2477b0ce0c3ecce17a5e99779f466f02e309d5038L111-R128), [link](https://github.com/pimcore/pimcore/pull/15942/files?diff=unified&w=0#diff-7a228af14a3cf49a9ff64668b33a1218444fb752a70e2fd2f38e60b12231687eR74-R89))
  * Create a new migration class `Version20230913173812` to add a `passwordRecoveryToken` column to the `users` table and define the up and down methods ([link](https://github.com/pimcore/pimcore/pull/15942/files?diff=unified&w=0#diff-efabafaa6155103e98e1113e9f4b5a294174400145c3b8ffd4b26371d1dc4801R1-R43))
  * Update the `install.sql` file to include the `passwordRecoveryToken` column definition for new installations ([link](https://github.com/pimcore/pimcore/pull/15942/files?diff=unified&w=0#diff-810875477d4dfc724e1692e89be6c2cbbb7bca85deeec0889d4663fad523bf3dR482))
  * Add a note to the `README.md` file in the upgrade documentation about the new feature and its implications ([link](https://github.com/pimcore/pimcore/pull/15942/files?diff=unified&w=0#diff-375aded12dfb868b84d5b8c27d1aed2358680a27b683e8a985f1b85193dd79aaR6))
  * Modify the `authenticateToken` method in the `Authentication` class to accept a user object and query the database by the token, and expire the token after a successful authentication ([link](https://github.com/pimcore/pimcore/pull/15942/files?diff=unified&w=0#diff-d9a11a8fd30a1dadfdfc75fe070ecbfa8e8d590787ff38634143c67cc154d4beR21-R22), [link](https://github.com/pimcore/pimcore/pull/15942/files?diff=unified&w=0#diff-d9a11a8fd30a1dadfdfc75fe070ecbfa8e8d590787ff38634143c67cc154d4beL118-R132))
  * Modify the `generateToken` method in the `Authentication` class to accept a user object and save the token to the database, and add a new `tokenDecrypt` method that throws an exception if the token is invalid and returns the user object and the timestamp ([link](https://github.com/pimcore/pimcore/pull/15942/files?diff=unified&w=0#diff-d9a11a8fd30a1dadfdfc75fe070ecbfa8e8d590787ff38634143c67cc154d4beL209-R241))
  * Add a new property `passwordRecoveryToken` and a getter and a setter to the `User` model ([link](https://github.com/pimcore/pimcore/pull/15942/files?diff=unified&w=0#diff-606c30f14301fee5176f53f2477b0ce0c3ecce17a5e99779f466f02e309d5038R36-R37), [link](https://github.com/pimcore/pimcore/pull/15942/files?diff=unified&w=0#diff-606c30f14301fee5176f53f2477b0ce0c3ecce17a5e99779f466f02e309d5038L111-R128))
  * Add a new method `getByPasswordRecoveryToken` to the `User` Dao class that fetches the user data by the token and assigns it to the model ([link](https://github.com/pimcore/pimcore/pull/15942/files?diff=unified&w=0#diff-7a228af14a3cf49a9ff64668b33a1218444fb752a70e2fd2f38e60b12231687eR74-R89))
