### PR TITLE
CoreCacheHandler: Don't set key as tag

### DIFF
--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -3,6 +3,7 @@
 ## Pimcore 11.1.0
 - Property `$fieldtype` of the `Pimcore\Model\DataObject\Data` class is deprecated now. Use the `getFieldType()` method instead.
 - [DataObject] Method `getSiblings()` output is now sorted based on the parent sorting parameters (same as `getChildren`) instead of alphabetical.
+- [CoreCacheHandler] Remove redundant cache item tagging with own key
 
 ## Pimcore 11.0.7
 - Putting `null` to the `Pimcore\Model\DataObject\Data::setIndex()` method is deprecated now. Only booleans are allowed.

--- a/lib/Cache/Core/CoreCacheHandler.php
+++ b/lib/Cache/Core/CoreCacheHandler.php
@@ -501,7 +501,6 @@ class CoreCacheHandler implements LoggerAwareInterface
         $item->set($data);
         $item->expiresAfter($lifetime);
         $item->tag($tags);
-        $item->tag($key);
         $result = $this->pool->save($item);
 
         if ($result) {


### PR DESCRIPTION
## Changes in this pull request  
At the moment the cache saves a additional tag with the key.
I think this makes no sense and increase the cache size.

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3da8c03</samp>

Remove redundant cache item tagging in `CoreCacheHandler.php`. This improves the cache performance and avoids potential bugs.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3da8c03</samp>

> _`tag` method removed_
> _cache items no longer self-tagged_
> _a spring cleaning_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3da8c03</samp>

* Remove redundant cache item tagging with own key ([link](https://github.com/pimcore/pimcore/pull/15948/files?diff=unified&w=0#diff-cc4f4d6b07b1520be4f1763eddc77036da47c488a52a366cd943ead918976ab4L546),                              F
