### PR TITLE
[DataObject] Link - Do not mark non-nullable properties as null

### DIFF
--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -3,9 +3,6 @@
 ## Pimcore 11.0.7
 - Putting `null` to the `Pimcore\Model\DataObject\Data::setIndex()` method is deprecated now. Only booleans are allowed.
 
-## Pimcore 11.0.6
-- Properties of `Pimcore\Model\DataObject\Data\Link` are nullable now. 
-
 ## Pimcore 11.0.0
 ### API
 #### [General] :

--- a/models/DataObject/Data/Link.php
+++ b/models/DataObject/Data/Link.php
@@ -31,7 +31,7 @@ class Link implements OwnerAwareFieldInterface
     use OwnerAwareFieldTrait;
     use ObjectVarTrait;
 
-    protected ?string $text = '';
+    protected string $text = '';
 
     protected ?string $internalType = null;
 
@@ -43,25 +43,25 @@ class Link implements OwnerAwareFieldInterface
 
     protected ?string $target = null;
 
-    protected ?string $parameters = '';
+    protected string $parameters = '';
 
-    protected ?string $anchor = '';
+    protected string $anchor = '';
 
-    protected ?string $title = '';
+    protected string $title = '';
 
-    protected ?string $accesskey = '';
+    protected string $accesskey = '';
 
-    protected ?string $rel = '';
+    protected string $rel = '';
 
-    protected ?string $tabindex = '';
+    protected string $tabindex = '';
 
-    protected ?string $class = '';
+    protected string $class = '';
 
-    protected ?string $attributes = '';
+    protected string $attributes = '';
 
     public function getText(): string
     {
-        return $this->text ?? '';
+        return $this->text;
     }
 
     /**
@@ -157,13 +157,13 @@ class Link implements OwnerAwareFieldInterface
 
     public function getParameters(): string
     {
-        return $this->parameters ?? '';
+        return $this->parameters;
     }
 
     /**
      * @return $this
      */
-    public function setParameters(?string $parameters): static
+    public function setParameters(string $parameters): static
     {
         $this->parameters = $parameters;
         $this->markMeDirty();
@@ -173,13 +173,13 @@ class Link implements OwnerAwareFieldInterface
 
     public function getAnchor(): string
     {
-        return $this->anchor ?? '';
+        return $this->anchor;
     }
 
     /**
      * @return $this
      */
-    public function setAnchor(?string $anchor): static
+    public function setAnchor(string $anchor): static
     {
         $this->anchor = $anchor;
         $this->markMeDirty();
@@ -189,13 +189,13 @@ class Link implements OwnerAwareFieldInterface
 
     public function getTitle(): string
     {
-        return $this->title ?? '';
+        return $this->title;
     }
 
     /**
      * @return $this
      */
-    public function setTitle(?string $title): static
+    public function setTitle(string $title): static
     {
         $this->title = $title;
         $this->markMeDirty();
@@ -205,13 +205,13 @@ class Link implements OwnerAwareFieldInterface
 
     public function getAccesskey(): string
     {
-        return $this->accesskey ?? '';
+        return $this->accesskey;
     }
 
     /**
      * @return $this
      */
-    public function setAccesskey(?string $accesskey): static
+    public function setAccesskey(string $accesskey): static
     {
         $this->accesskey = $accesskey;
         $this->markMeDirty();
@@ -221,13 +221,13 @@ class Link implements OwnerAwareFieldInterface
 
     public function getRel(): string
     {
-        return $this->rel ?? '';
+        return $this->rel;
     }
 
     /**
      * @return $this
      */
-    public function setRel(?string $rel): static
+    public function setRel(string $rel): static
     {
         $this->rel = $rel;
         $this->markMeDirty();
@@ -237,13 +237,13 @@ class Link implements OwnerAwareFieldInterface
 
     public function getTabindex(): string
     {
-        return $this->tabindex ?? '';
+        return $this->tabindex;
     }
 
     /**
      * @return $this
      */
-    public function setTabindex(?string $tabindex): static
+    public function setTabindex(string $tabindex): static
     {
         $this->tabindex = $tabindex;
         $this->markMeDirty();
@@ -254,7 +254,7 @@ class Link implements OwnerAwareFieldInterface
     /**
      * @return $this
      */
-    public function setAttributes(?string $attributes): static
+    public function setAttributes(string $attributes): static
     {
         $this->attributes = $attributes;
         $this->markMeDirty();
@@ -264,13 +264,13 @@ class Link implements OwnerAwareFieldInterface
 
     public function getAttributes(): string
     {
-        return $this->attributes ?? '';
+        return $this->attributes;
     }
 
     /**
      * @return $this
      */
-    public function setClass(?string $class): static
+    public function setClass(string $class): static
     {
         $this->class = $class;
         $this->markMeDirty();
@@ -280,7 +280,7 @@ class Link implements OwnerAwareFieldInterface
 
     public function getClass(): string
     {
-        return $this->class ?? '';
+        return $this->class;
     }
 
     /**
@@ -437,9 +437,12 @@ class Link implements OwnerAwareFieldInterface
      */
     public function setValues(array $data = []): static
     {
+        $reflectionClass = new \ReflectionClass(static::class);
         foreach ($data as $key => $value) {
             $method = 'set' . ucfirst($key);
             if (method_exists($this, $method)) {
+                //used for non-nullable properties stored with null, todo: Remove in Pimcore 12
+                $value = $value ?: $reflectionClass->getProperty($key)->getDefaultValue();
                 $this->$method($value);
             }
         }

--- a/models/DataObject/Data/Link.php
+++ b/models/DataObject/Data/Link.php
@@ -43,7 +43,7 @@ class Link implements OwnerAwareFieldInterface
 
     protected ?string $target = null;
 
-    protected string $parameters = '123';
+    protected string $parameters = '';
 
     protected string $anchor = '';
 

--- a/models/DataObject/Data/Link.php
+++ b/models/DataObject/Data/Link.php
@@ -454,6 +454,8 @@ class Link implements OwnerAwareFieldInterface
     }
 
     /**
+     * @internal
+     *
      * https://github.com/pimcore/pimcore/pull/15926
      * used for non-nullable properties stored with null
      * @TODO: Remove in Pimcore 12

--- a/models/DataObject/Data/Link.php
+++ b/models/DataObject/Data/Link.php
@@ -43,7 +43,7 @@ class Link implements OwnerAwareFieldInterface
 
     protected ?string $target = null;
 
-    protected string $parameters = '';
+    protected string $parameters = '123';
 
     protected string $anchor = '';
 
@@ -437,12 +437,9 @@ class Link implements OwnerAwareFieldInterface
      */
     public function setValues(array $data = []): static
     {
-        $reflectionClass = new \ReflectionClass(static::class);
         foreach ($data as $key => $value) {
             $method = 'set' . ucfirst($key);
             if (method_exists($this, $method)) {
-                //used for non-nullable properties stored with null, todo: Remove in Pimcore 12
-                $value = $value ?: $reflectionClass->getProperty($key)->getDefaultValue();
                 $this->$method($value);
             }
         }
@@ -454,5 +451,19 @@ class Link implements OwnerAwareFieldInterface
     public function __toString(): string
     {
         return $this->getHtml();
+    }
+
+    /**
+     * https://github.com/pimcore/pimcore/pull/15926
+     * used for non-nullable properties stored with null
+     * @TODO: Remove in Pimcore 12
+     *
+     * @return void
+     */
+    public function __unserialize(array $data): void
+    {
+        foreach (get_object_vars($this) as $property => $value) {
+            $this->$property = $data["\0*\0".$property] ?? $value;
+        }
     }
 }


### PR DESCRIPTION
## Changes in this pull request  
Follow up to #15926

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ada913f</samp>

Improve `Link` class by making string properties non-null and using reflection for database compatibility.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ada913f</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _The `Link` class, and made its strings more defined._
> _He shunned the nulls that lurked in the database,_
> _And used reflection, like a mirror of his grace._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ada913f</samp>

*  Simplify getter methods and change setter methods to accept non-nullable strings for the `text`, `parameters`, `anchor`, `title`, `accesskey`, `rel`, `tabindex`, `attributes`, and `class` properties of the `Link` class in `models/DataObject/Data/Link.php` ([link](https://github.com/pimcore/pimcore/pull/15949/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL34-R34), [link](https://github.com/pimcore/pimcore/pull/15949/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL46-R64), [link](https://github.com/pimcore/pimcore/pull/15949/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL160-R160), [link](https://github.com/pimcore/pimcore/pull/15949/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL166-R166), [link](https://github.com/pimcore/pimcore/pull/15949/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL176-R176), [link](https://github.com/pimcore/pimcore/pull/15949/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL182-R182), [link](https://github.com/pimcore/pimcore/pull/15949/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL192-R192), [link](https://github.com/pimcore/pimcore/pull/15949/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL198-R198), [link](https://github.com/pimcore/pimcore/pull/15949/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL208-R208), [link](https://github.com/pimcore/pimcore/pull/15949/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL214-R214), [link](https://github.com/pimcore/pimcore/pull/15949/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL224-R224), [link](https://github.com/pimcore/pimcore/pull/15949/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL230-R230), [link](https://github.com/pimcore/pimcore/pull/15949/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL240-R240), [link](https://github.com/pimcore/pimcore/pull/15949/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL246-R246), [link](https://github.com/pimcore/pimcore/pull/15949/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL257-R257), [link](https://github.com/pimcore/pimcore/pull/15949/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL267-R267), [link](https://github.com/pimcore/pimcore/pull/15949/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL273-R273), [link](https://github.com/pimcore/pimcore/pull/15949/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL283-R283))
*  Use reflection to assign default values to non-nullable properties that are stored with null in the database in the `setValues` method of the `Link` class in `models/DataObject/Data/Link.php` as a temporary workaround to avoid breaking changes in the database schema ([link](https://github.com/pimcore/pimcore/pull/15949/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL440-R445))
