### PR TITLE
Adding PruningCacheItemsTask

### DIFF
--- a/bundles/CoreBundle/config/maintenance.yaml
+++ b/bundles/CoreBundle/config/maintenance.yaml
@@ -76,6 +76,10 @@ services:
         tags:
             - { name: pimcore.maintenance.task, type: low_quality_image_preview }
 
+    Pimcore\Maintenance\Tasks\PruningCacheItemsTask:
+        tags:
+            - { name: pimcore.maintenance.task, type: pruning_cache_items }
+
     Pimcore\Maintenance\Tasks\StaticPagesGenerationTask:
         arguments:
             - '@Pimcore\Document\StaticPageGenerator'

--- a/lib/Maintenance/Tasks/PruningCacheItemsTask.php
+++ b/lib/Maintenance/Tasks/PruningCacheItemsTask.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Maintenance\Tasks;
+
+use Pimcore\Maintenance\TaskInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\PruneableInterface;
+
+final class PruningCacheItemsTask implements TaskInterface
+{
+    public function __construct(private CacheItemPoolInterface $pool)
+    {
+    }
+
+    public function execute(): void
+    {
+        if ($this->pool instanceof PruneableInterface) {
+            $this->pool->prune();
+        }
+    }
+}


### PR DESCRIPTION
## Changes in this pull request  
Pimcore doesn't cleanup the cache_items db table. It should be a maintenance task to prune the outdated cache items.
See https://symfony.com/doc/current/components/cache/cache_pools.html#pruning-cache-items

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f72734</samp>

This pull request introduces a new maintenance task for pruning expired cache items from cache pools that support it. It adds a new class `PruningCacheItemsTask` and a configuration entry in `maintenance.yaml`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3f72734</samp>

> _`PruningCacheItemsTask`_
> _cleans up the cache pool_
> _a spring cleaning_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3f72734</samp>

* Register a new maintenance task for pruning expired cache items from the cache pool ([link](https://github.com/pimcore/pimcore/pull/15950/files?diff=unified&w=0#diff-b1b003e4f080d8b97400340c8e2ccb22e0dd42c70878de7c1622784469d3c254R79-R82))
* Implement the `PruningCacheItemsTask` class in `PruningCacheItemsTask.php` ([link](https://github.com/pimcore/pimcore/pull/15950/files?diff=unified&w=0#diff-38349a67ed553980e889633effeb2c8ecf0a582f1a66a54ce865deb130ed4d50R1-R35))
* Fix a typo in the indentation of the `tags` key in `maintenance.yaml` ([link](https://github.com/pimcore/pimcore/pull/15950/files?diff=unified&w=0#diff-b1b003e4f080d8b97400340c8e2ccb22e0dd42c70878de7c1622784469d3c254L84-R88))
