### PR TITLE
Fixed saving localized advanced many to many relation

### DIFF
--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
@@ -560,6 +560,9 @@ class AdvancedManyToManyRelation extends ManyToManyRelation implements IdRewrite
 
                 if (!DataObject::isDirtyDetectionDisabled() && $object instanceof Element\DirtyIndicatorInterface) {
                     if ($context['containerType']) {
+                        if ($object instanceof Localizedfield) {
+                            $context['containerType'] = 'localizedfield';
+                        }
                         $sql .= ' AND ' . Db\Helper::quoteInto($db, 'ownertype = ?', $context['containerType']);
                     }
                 }


### PR DESCRIPTION
## Pimcore version
11.x

## Steps to reproduce
- Create an Object Class
- Add localized field container
- Add advanced many to many relation to localized field
- Create new object with class just made 
- Save object
- Make changes to object
- Save again

## Actual behavior
Saving an object with an Advanced Many to Many Relation inside a localized fields container multiple times causing the error: `Message: Key "`auto_id`" passed for upsert not found in data`

## Expected behavior
Save the relations including metadata without error.

## Changes in this pull request  
When relations are updated in de UI, they are deleted in de database and added again. In this specific case the owner of data datafield is 'object' but should be 'localizedfield'. 

This PR solves this issue.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e0548ff</samp>

Fix missing hooks for localized fields in advanced many-to-many relations. Add a `containerType` key to the context array to indicate if the relation item is part of a `Localizedfield` or not.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e0548ff</samp>

> _`Localizedfield` check_
> _Passes context to hooks_
> _Autumn bug is fixed_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e0548ff</samp>

* Fix a bug where preSave and postSave hooks were not called for relation items in localized fields ([link](https://github.com/pimcore/pimcore/pull/15956/files?diff=unified&w=0#diff-1d0bb2ae86274681b1012717ccb5958660cfdaf177d0c2a3e5f6b1cf039dbf98R563-R565))

Co-authored with @rubanooo 
