### PR TITLE
[Improvement] Add Enable\Disable methods for RuntimeCache

### DIFF
--- a/doc/05_Objects/05_External_System_Interaction.md
+++ b/doc/05_Objects/05_External_System_Interaction.md
@@ -92,6 +92,7 @@ If you're using / creating very much objects you should call the Pimcore garbage
 // just call this static method
 \Pimcore::collectGarbage();
 ```
+Or use `RuntimeCache::disable()` before iterate many objects to avoid excesive memory usage.
 
 **WARNING:** This will flush the entire internal registry!
 

--- a/lib/Cache/RuntimeCache.php
+++ b/lib/Cache/RuntimeCache.php
@@ -24,7 +24,7 @@ class RuntimeCache extends \ArrayObject
 
     protected static ?RuntimeCache $instance = null;
 
-    public static bool $disabled = false;
+    private static bool $disabled = false;
 
     /**
      * Retrieves the default registry instance.

--- a/lib/Cache/RuntimeCache.php
+++ b/lib/Cache/RuntimeCache.php
@@ -24,6 +24,8 @@ class RuntimeCache extends \ArrayObject
 
     protected static ?RuntimeCache $instance = null;
 
+    public static bool $disabled = false;
+
     /**
      * Retrieves the default registry instance.
      *
@@ -68,6 +70,33 @@ class RuntimeCache extends \ArrayObject
         }
 
         return self::$tempInstance;
+    }
+
+    /**
+     * disables the caching for the current process, this is useful for importers, ...
+     * There are no new objects will be cached after that
+     *
+     * @static
+     */
+    public static function disable(): void
+    {
+        self::$disabled = true;
+    }
+
+    /**
+     * see @ self::disable()
+     * just enabled the caching in the current process
+     *
+     * @static
+     */
+    public static function enable(): void
+    {
+        self::$disabled = false;
+    }
+
+    public static function isEnabled(): bool
+    {
+        return !self::$disabled;
     }
 
     /**
@@ -137,6 +166,11 @@ class RuntimeCache extends \ArrayObject
 
     public function offsetSet($index, $value): void
     {
+        // check if caching is disabled for this process
+        if (self::$disabled) {
+            return;
+        }
+        
         parent::offsetSet($index, $value);
     }
 


### PR DESCRIPTION
Before Export\Import big amount of objects to avoid huge memory usage we can disable runtime cache, similar to `Version::disable()`

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 05893cc</samp>

This pull request adds a feature to `RuntimeCache` to disable and enable caching for the current process, and updates the documentation to explain how to use it for memory optimization.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 05893cc</samp>

> _`RuntimeCache` tweak_
> _Boosts performance and memory_
> _A winter tip_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 05893cc</samp>

*  Add a feature to disable the runtime caching for the current process ([link](https://github.com/pimcore/pimcore/pull/15959/files?diff=unified&w=0#diff-9651f3078ceb2eb4fa13b617947c59200386c45f6dc7308a1a9482b60e77f0a0R27-R28), [link](https://github.com/pimcore/pimcore/pull/15959/files?diff=unified&w=0#diff-9651f3078ceb2eb4fa13b617947c59200386c45f6dc7308a1a9482b60e77f0a0R76-R102), [link](https://github.com/pimcore/pimcore/pull/15959/files?diff=unified&w=0#diff-9651f3078ceb2eb4fa13b617947c59200386c45f6dc7308a1a9482b60e77f0a0R169-R173))
*  Add a documentation tip to use the caching feature in `doc/05_Objects/05_External_System_Interaction.md` ([link](https://github.com/pimcore/pimcore/pull/15959/files?diff=unified&w=0#diff-41bda9974f78f1664ab277cc67f440a48d0171a76fe65a03e9e52699098c2e4eR95))
