### PR TITLE
[Bug]: Fix sanitized text being encoded before persisting to db

### DIFF
--- a/.github/ci/files/config/packages/html_sanitizer.yaml
+++ b/.github/ci/files/config/packages/html_sanitizer.yaml
@@ -2,5 +2,55 @@ framework:
     html_sanitizer:
         sanitizers:
             pimcore.wysiwyg_sanitizer:
+                allow_attributes:
+                    pimcore_type: '*'
+                    pimcore_id: '*'
+                allow_relative_links: true
+                allow_relative_medias: true
                 allow_elements:
+                    span: [ 'class', 'style', 'id' ]
+                    div: [ 'class', 'style', 'id' ]
+                    p: [ 'class', 'style', 'id' ]
+                    strong: 'class'
+                    em: 'class'
+                    h1: [ 'class', 'id' ]
+                    table: [ 'class', 'style', 'cellspacing', 'cellpadding', 'border', 'width', 'height', 'id' ]
+                    colgroup: 'class'
+                    col: [ 'class', 'style', 'id' ]
+                    thead: [ 'class', 'id' ]
+                    tbody: [ 'class', 'id' ]
+                    tr: [ 'class', 'id' ]
+                    td: [ 'class', 'id' ]
+                    th: [ 'class', 'id', 'scope' ]
+                    ul: [ 'class', 'style', 'id' ]
+                    li: [ 'class', 'style', 'id' ]
+                    ol: [ 'class', 'style', 'id' ]
+                    u: [ 'class', 'id' ]
+                    i: [ 'class', 'id' ]
+                    b: [ 'class', 'id' ]
+                    caption: [ 'class', 'id' ]
+                    sub: [ 'class', 'id' ]
+                    sup: [ 'class', 'id' ]
+                    blockquote: [ 'class', 'id' ]
+                    s: [ 'class', 'id' ]
+                    iframe: [ 'frameborder', 'height', 'longdesc', 'name', 'sandbox', 'scrolling', 'src', 'title', 'width' ]
+                    br: ''
+                    img: [ 'alt', 'style', 'src' ]
+            pimcore.translation_sanitizer:
+                allow_attributes:
+                    pimcore_type: '*'
+                    pimcore_id: '*'
+                allow_relative_links: true
+                allow_elements:
+                    span: [ 'class', 'style', 'id' ]
+                    p: [ 'class', 'style', 'id' ]
+                    strong: 'class'
+                    em: 'class'
+                    h1: [ 'class', 'id' ]
+                    h2: [ 'class', 'id' ]
+                    h3: [ 'class', 'id' ]
+                    h4: [ 'class', 'id' ]
+                    h5: [ 'class', 'id' ]
+                    h6: [ 'class', 'id' ]
+                    a: [ 'class', 'id', 'href', 'target', 'title', 'rel' ]
                     br: ''

--- a/models/DataObject/ClassDefinition/Data/Wysiwyg.php
+++ b/models/DataObject/ClassDefinition/Data/Wysiwyg.php
@@ -114,6 +114,7 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
     public function getDataFromResource(mixed $data, DataObject\Concrete $object = null, array $params = []): ?string
     {
         if (is_string($data)) {
+            $data = htmlentities($data);
             $data = html_entity_decode(self::getWysiwygSanitizer()->sanitizeFor('body', $data));
         }
 

--- a/models/DataObject/ClassDefinition/Data/Wysiwyg.php
+++ b/models/DataObject/ClassDefinition/Data/Wysiwyg.php
@@ -114,7 +114,8 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
     public function getDataFromResource(mixed $data, DataObject\Concrete $object = null, array $params = []): ?string
     {
         if (is_string($data)) {
-            $data = htmlentities($data);
+            //fix for https://github.com/pimcore/pimcore/issues/15740
+            $data = preg_replace('/(?!<[a-zA-Z=\"\':; ]*[^ ]>|<\\/[a-zA-Z="\':; ]*>)(<)/', "&lt;", $data);
             $data = html_entity_decode(self::getWysiwygSanitizer()->sanitizeFor('body', $data));
         }
 

--- a/models/DataObject/ClassDefinition/Data/Wysiwyg.php
+++ b/models/DataObject/ClassDefinition/Data/Wysiwyg.php
@@ -114,7 +114,7 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
     public function getDataFromResource(mixed $data, DataObject\Concrete $object = null, array $params = []): ?string
     {
         if (is_string($data)) {
-            $data = self::getWysiwygSanitizer()->sanitize($data);
+            $data = html_entity_decode(self::getWysiwygSanitizer()->sanitize($data));
         }
 
         return Text::wysiwygText($data);

--- a/models/DataObject/ClassDefinition/Data/Wysiwyg.php
+++ b/models/DataObject/ClassDefinition/Data/Wysiwyg.php
@@ -114,7 +114,7 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
     public function getDataFromResource(mixed $data, DataObject\Concrete $object = null, array $params = []): ?string
     {
         if (is_string($data)) {
-            $data = html_entity_decode(self::getWysiwygSanitizer()->sanitize($data));
+            $data = html_entity_decode(self::getWysiwygSanitizer()->sanitizeFor('textarea', $data));
         }
 
         return Text::wysiwygText($data);

--- a/models/DataObject/ClassDefinition/Data/Wysiwyg.php
+++ b/models/DataObject/ClassDefinition/Data/Wysiwyg.php
@@ -114,7 +114,7 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
     public function getDataFromResource(mixed $data, DataObject\Concrete $object = null, array $params = []): ?string
     {
         if (is_string($data)) {
-            $data = html_entity_decode(self::getWysiwygSanitizer()->sanitizeFor('textarea', $data));
+            $data = html_entity_decode(self::getWysiwygSanitizer()->sanitizeFor('body', $data));
         }
 
         return Text::wysiwygText($data);

--- a/models/Document/Editable/Wysiwyg.php
+++ b/models/Document/Editable/Wysiwyg.php
@@ -101,7 +101,7 @@ class Wysiwyg extends Model\Document\Editable implements IdRewriterInterface, Ed
     public function setDataFromEditmode(mixed $data): static
     {
         $helper = self::getWysiwygSanitizer();
-        $this->text = $helper->sanitize($data);
+        $this->text = html_entity_decode($helper->sanitize($data));
 
         return $this;
     }

--- a/models/Document/Editable/Wysiwyg.php
+++ b/models/Document/Editable/Wysiwyg.php
@@ -90,7 +90,7 @@ class Wysiwyg extends Model\Document\Editable implements IdRewriterInterface, Ed
     public function setDataFromResource(mixed $data): static
     {
         $helper = self::getWysiwygSanitizer();
-        $this->text = html_entity_decode($helper->sanitizeFor('textarea', $data));
+        $this->text = html_entity_decode($helper->sanitizeFor('body', $data));
 
         return $this;
     }

--- a/models/Document/Editable/Wysiwyg.php
+++ b/models/Document/Editable/Wysiwyg.php
@@ -90,7 +90,7 @@ class Wysiwyg extends Model\Document\Editable implements IdRewriterInterface, Ed
     public function setDataFromResource(mixed $data): static
     {
         $helper = self::getWysiwygSanitizer();
-        $this->text = $helper->sanitize($data);
+        $this->text = html_entity_decode($helper->sanitize($data));
 
         return $this;
     }

--- a/models/Document/Editable/Wysiwyg.php
+++ b/models/Document/Editable/Wysiwyg.php
@@ -101,7 +101,7 @@ class Wysiwyg extends Model\Document\Editable implements IdRewriterInterface, Ed
     public function setDataFromEditmode(mixed $data): static
     {
         $helper = self::getWysiwygSanitizer();
-        $this->text = html_entity_decode($helper->sanitizeFor('textarea', $data));
+        $this->text = html_entity_decode($helper->sanitizeFor('body', $data));
 
         return $this;
     }

--- a/models/Document/Editable/Wysiwyg.php
+++ b/models/Document/Editable/Wysiwyg.php
@@ -90,7 +90,8 @@ class Wysiwyg extends Model\Document\Editable implements IdRewriterInterface, Ed
     public function setDataFromResource(mixed $data): static
     {
         $helper = self::getWysiwygSanitizer();
-        $data = htmlentities($data);
+        //fix for https://github.com/pimcore/pimcore/issues/15740
+        $data = preg_replace('/(?!<[a-zA-Z=\"\':; ]*[^ ]>|<\\/[a-zA-Z="\':; ]*>)(<)/', "&lt;", $data);
         $this->text = html_entity_decode($helper->sanitizeFor('body', $data));
 
         return $this;
@@ -102,7 +103,8 @@ class Wysiwyg extends Model\Document\Editable implements IdRewriterInterface, Ed
     public function setDataFromEditmode(mixed $data): static
     {
         $helper = self::getWysiwygSanitizer();
-        $data = htmlentities($data);
+        //fix for https://github.com/pimcore/pimcore/issues/15740
+        $data = preg_replace('/(?!<[a-zA-Z=\"\':; ]*[^ ]>|<\\/[a-zA-Z="\':; ]*>)(<)/', "&lt;", $data);
         $this->text = html_entity_decode($helper->sanitizeFor('body', $data));
 
         return $this;

--- a/models/Document/Editable/Wysiwyg.php
+++ b/models/Document/Editable/Wysiwyg.php
@@ -90,7 +90,7 @@ class Wysiwyg extends Model\Document\Editable implements IdRewriterInterface, Ed
     public function setDataFromResource(mixed $data): static
     {
         $helper = self::getWysiwygSanitizer();
-        $this->text = html_entity_decode($helper->sanitize($data));
+        $this->text = html_entity_decode($helper->sanitizeFor('textarea', $data));
 
         return $this;
     }
@@ -101,7 +101,7 @@ class Wysiwyg extends Model\Document\Editable implements IdRewriterInterface, Ed
     public function setDataFromEditmode(mixed $data): static
     {
         $helper = self::getWysiwygSanitizer();
-        $this->text = html_entity_decode($helper->sanitize($data));
+        $this->text = html_entity_decode($helper->sanitizeFor('textarea', $data));
 
         return $this;
     }

--- a/models/Document/Editable/Wysiwyg.php
+++ b/models/Document/Editable/Wysiwyg.php
@@ -90,6 +90,7 @@ class Wysiwyg extends Model\Document\Editable implements IdRewriterInterface, Ed
     public function setDataFromResource(mixed $data): static
     {
         $helper = self::getWysiwygSanitizer();
+        $data = htmlentities($data);
         $this->text = html_entity_decode($helper->sanitizeFor('body', $data));
 
         return $this;
@@ -101,6 +102,7 @@ class Wysiwyg extends Model\Document\Editable implements IdRewriterInterface, Ed
     public function setDataFromEditmode(mixed $data): static
     {
         $helper = self::getWysiwygSanitizer();
+        $data = htmlentities($data);
         $this->text = html_entity_decode($helper->sanitizeFor('body', $data));
 
         return $this;

--- a/models/Translation/Dao.php
+++ b/models/Translation/Dao.php
@@ -105,7 +105,7 @@ class Dao extends Model\Dao\AbstractDao
                         'key' => $this->model->getKey(),
                         'type' => $this->model->getType(),
                         'language' => $language,
-                        'text' => $sanitizer->sanitize($text),
+                        'text' => html_entity_decode($sanitizer->sanitize($text)),
                         'modificationDate' => $this->model->getModificationDate(),
                         'creationDate' => $this->model->getCreationDate(),
                         'userOwner' => $this->model->getUserOwner(),

--- a/models/Translation/Dao.php
+++ b/models/Translation/Dao.php
@@ -105,7 +105,7 @@ class Dao extends Model\Dao\AbstractDao
                         'key' => $this->model->getKey(),
                         'type' => $this->model->getType(),
                         'language' => $language,
-                        'text' => html_entity_decode($sanitizer->sanitizeFor('textarea', $text)),
+                        'text' => html_entity_decode($sanitizer->sanitizeFor('body', $text)),
                         'modificationDate' => $this->model->getModificationDate(),
                         'creationDate' => $this->model->getCreationDate(),
                         'userOwner' => $this->model->getUserOwner(),

--- a/models/Translation/Dao.php
+++ b/models/Translation/Dao.php
@@ -101,6 +101,8 @@ class Dao extends Model\Dao\AbstractDao
                         continue;
                     }
 
+                    //fix for https://github.com/pimcore/pimcore/issues/15740
+                    $text = preg_replace('/(?!<[a-zA-Z=\"\':; ]*[^ ]>|<\\/[a-zA-Z="\':; ]*>)(<)/', "&lt;", $text);
                     $data = [
                         'key' => $this->model->getKey(),
                         'type' => $this->model->getType(),

--- a/models/Translation/Dao.php
+++ b/models/Translation/Dao.php
@@ -105,7 +105,7 @@ class Dao extends Model\Dao\AbstractDao
                         'key' => $this->model->getKey(),
                         'type' => $this->model->getType(),
                         'language' => $language,
-                        'text' => html_entity_decode($sanitizer->sanitize($text)),
+                        'text' => html_entity_decode($sanitizer->sanitizeFor('textarea', $text)),
                         'modificationDate' => $this->model->getModificationDate(),
                         'creationDate' => $this->model->getCreationDate(),
                         'userOwner' => $this->model->getUserOwner(),

--- a/models/Translation/Dao.php
+++ b/models/Translation/Dao.php
@@ -101,6 +101,9 @@ class Dao extends Model\Dao\AbstractDao
                         continue;
                     }
 
+                    //fix for https://github.com/pimcore/pimcore/issues/15740
+                    $text = preg_replace('/(?!<[a-zA-Z=\"\':; ]*[^ ]>|<\\/[a-zA-Z="\':; ]*>)(<)/', "&lt;", $text);
+
                     $data = [
                         'key' => $this->model->getKey(),
                         'type' => $this->model->getType(),

--- a/models/Translation/Dao.php
+++ b/models/Translation/Dao.php
@@ -101,9 +101,6 @@ class Dao extends Model\Dao\AbstractDao
                         continue;
                     }
 
-                    //fix for https://github.com/pimcore/pimcore/issues/15740
-                    $text = preg_replace('/(?!<[a-zA-Z=\"\':; ]*[^ ]>|<\\/[a-zA-Z="\':; ]*>)(<)/', "&lt;", $text);
-
                     $data = [
                         'key' => $this->model->getKey(),
                         'type' => $this->model->getType(),

--- a/tests/Model/DataObject/ObjectTest.php
+++ b/tests/Model/DataObject/ObjectTest.php
@@ -359,10 +359,10 @@ class ObjectTest extends ModelTestCase
         $db = Db::get();
 
         $object = TestHelper::createEmptyObject();
-        $object->setWysiwyg('!@#$%^abc\'"<script>console.log("ops");</script> 测试');
+        $object->setWysiwyg('!@#$%^abc\'"<script>console.log("ops");</script> 测试< edf > "');
         $object->save();
 
-        $this->assertEquals('!@#$%^abc\'" 测试', $object->getWysiwyg(),'Asseting setter/getter value is sanitized');
+        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', $object->getWysiwyg(),'Asseting setter/getter value is sanitized');
 
         $dbQueryValue = $db->fetchOne(
             sprintf(
@@ -371,7 +371,7 @@ class ObjectTest extends ModelTestCase
                 $object->getId()
             )
         );
-        $this->assertEquals('!@#$%^abc\'" 测试', $dbQueryValue, 'Asserting object_query table value is persisted as sanitized');
+        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', $dbQueryValue, 'Asserting object_query table value is persisted as sanitized');
 
         $dbStoreValue = $db->fetchOne(
             sprintf(
@@ -380,6 +380,6 @@ class ObjectTest extends ModelTestCase
                 $object->getId()
             )
         );
-        $this->assertEquals('!@#$%^abc\'" 测试', $dbStoreValue, 'Asserting object_store table value is persisted as sanitized');
+        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', $dbStoreValue, 'Asserting object_store table value is persisted as sanitized');
     }
 }

--- a/tests/Model/DataObject/ObjectTest.php
+++ b/tests/Model/DataObject/ObjectTest.php
@@ -362,6 +362,9 @@ class ObjectTest extends ModelTestCase
         $object->setWysiwyg('!@#$%^abc\'"<script>console.log("ops");</script> 测试< edf > "');
         $object->save();
 
+        //reload from db
+        $object = DataObject::getById($object->getId(), ['force' => true]);
+
         $this->assertEquals('!@#$%^abc\'" 测试< edf > "', $object->getWysiwyg(),'Asseting setter/getter value is sanitized');
 
         $dbQueryValue = $db->fetchOne(
@@ -372,14 +375,5 @@ class ObjectTest extends ModelTestCase
             )
         );
         $this->assertEquals('!@#$%^abc\'" 测试< edf > "', $dbQueryValue, 'Asserting object_query table value is persisted as sanitized');
-
-        $dbStoreValue = $db->fetchOne(
-            sprintf(
-                'SELECT `wysiwyg` FROM object_store_%s WHERE oo_id = %d',
-                $object->getClassName(),
-                $object->getId()
-            )
-        );
-        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', $dbStoreValue, 'Asserting object_store table value is persisted as sanitized');
     }
 }

--- a/tests/Model/DataObject/ObjectTest.php
+++ b/tests/Model/DataObject/ObjectTest.php
@@ -362,6 +362,8 @@ class ObjectTest extends ModelTestCase
         $object->setWysiwyg('!@#$%^abc\'"<script>console.log("ops");</script> 测试');
         $object->save();
 
+        $this->assertEquals('!@#$%^abc\'" 测试', $object->getWysiwyg(),'Asseting setter/getter value is sanitized');
+
         $dbQueryValue = $db->fetchOne(
             sprintf(
                 'SELECT `wysiwyg` FROM object_query_%s WHERE oo_id = %d',
@@ -369,6 +371,7 @@ class ObjectTest extends ModelTestCase
                 $object->getId()
             )
         );
+        $this->assertEquals('!@#$%^abc\'" 测试', $dbQueryValue, 'Asserting object_query table value is persisted as sanitized');
 
         $dbStoreValue = $db->fetchOne(
             sprintf(
@@ -377,9 +380,6 @@ class ObjectTest extends ModelTestCase
                 $object->getId()
             )
         );
-
-        $this->assertEquals('!@#$%^abc\'" 测试', $object->getWysiwyg());
-        $this->assertEquals('!@#$%^abc\'" 测试', $dbQueryValue);
-        $this->assertEquals('!@#$%^abc\'" 测试', $dbStoreValue);
+        $this->assertEquals('!@#$%^abc\'" 测试', $dbStoreValue, 'Asserting object_store table value is persisted as sanitized');
     }
 }

--- a/tests/Unit/Translation/TranslatorTest.php
+++ b/tests/Unit/Translation/TranslatorTest.php
@@ -263,7 +263,7 @@ class TranslatorTest extends TestCase
         $db = Db::get();
         $dbValue = $db->fetchOne(
             sprintf(
-                'SELECT `text` FROM translations_messages WHERE key = %s AND language = %s',
+                'SELECT `text` FROM translations_messages WHERE `key` = %s AND `language` = %s',
                 $db->quote($key),
                 $db->quote('en')
             )

--- a/tests/Unit/Translation/TranslatorTest.php
+++ b/tests/Unit/Translation/TranslatorTest.php
@@ -256,9 +256,8 @@ class TranslatorTest extends TestCase
         $translation->setTranslations(['en' => '@#$%^abc\'"<script>console.log("ops");</script> 测试']);
         $translation->save();
 
-        $translationGet = new Translation();
-        $translationGet->getKey($key);
-        $getter = $translationGet->getTranslation('en');
+        $translation = Translation::getByKey($key);
+        $getter = $translation->getTranslation('en');
         $this->assertEquals('!@#$%^abc\'" 测试', $getter, 'Asserting translation is properly sanitized');
 
         $db = Db::get();

--- a/tests/Unit/Translation/TranslatorTest.php
+++ b/tests/Unit/Translation/TranslatorTest.php
@@ -253,12 +253,12 @@ class TranslatorTest extends TestCase
         $key = 'sanitizerTest';
         $translation->setDomain('messages');
         $translation->setKey($key);
-        $translation->setTranslations(['en' => '@#$%^abc\'"<script>console.log("ops");</script> 测试']);
+        $translation->setTranslations(['en' => '!@#$%^abc\'"<script>console.log("ops");</script> 测试< edf > "']);
         $translation->save();
 
         $translation = Translation::getByKey($key);
         $getter = $translation->getTranslation('en');
-        $this->assertEquals('!@#$%^abc\'" 测试', $getter, 'Asserting translation is properly sanitized');
+        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', $getter, 'Asserting translation is properly sanitized');
 
         $db = Db::get();
         $dbValue = $db->fetchOne(
@@ -268,6 +268,6 @@ class TranslatorTest extends TestCase
                 $db->quote('en')
             )
         );
-        $this->assertEquals('!@#$%^abc\'" 测试', $dbValue, 'Asserting translation is persisted as sanitized');
+        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', $dbValue, 'Asserting translation is persisted as sanitized');
     }
 }

--- a/tests/Unit/Translation/TranslatorTest.php
+++ b/tests/Unit/Translation/TranslatorTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Unit\Translation;
 
+use Pimcore\Db;
 use Pimcore\Model\Translation;
 use Pimcore\Tests\Support\Test\TestCase;
 use Pimcore\Translation\Translator;
@@ -244,5 +245,30 @@ class TranslatorTest extends TestCase
         $afterAdd = $translationsListing->load();
 
         $this->assertCount(count($beforeAdd) + 1, $afterAdd);
+    }
+
+    public function testSanitizedTranslation(): void
+    {
+        $translation = new Translation();
+        $key = 'sanitizerTest';
+        $translation->setDomain('messages');
+        $translation->setKey($key);
+        $translation->setTranslations(['en' => '@#$%^abc\'"<script>console.log("ops");</script> 测试']);
+        $translation->save();
+
+        $translationGet = new Translation();
+        $translationGet->getKey($key);
+        $getter = $translationGet->getTranslation('en');
+        $this->assertEquals('!@#$%^abc\'" 测试', $getter, 'Asserting translation is properly sanitized');
+
+        $db = Db::get();
+        $dbValue = $db->fetchOne(
+            sprintf(
+                'SELECT `text` FROM translations_messages WHERE key = %s AND language = %s',
+                $db->quote($key),
+                $db->quote('en')
+            )
+        );
+        $this->assertEquals('!@#$%^abc\'" 测试', $dbValue, 'Asserting translation is persisted as sanitized');
     }
 }


### PR DESCRIPTION
Resolves https://github.com/pimcore/admin-ui-classic-bundle/issues/234

## Additional info
Basically symfony sanitizer always returns an [encoded html entities text ](https://github.com/symfony/html-sanitizer/blob/947492c7351d6b01a7b38e515c98fb1107dc357d/Visitor/Node/TextNode.php#L37) which works fine for usual html output, but is not ideal for db persistion because it would require the decodification on every read.

Related https://github.com/pimcore/admin-ui-classic-bundle/issues/275 

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e39ca3e</samp>

Fix HTML entity decoding bug in translations. Use `html_entity_decode` on the text field in `models/Translation/Dao.php` before saving it to the database.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e39ca3e</samp>

> _`sanitizer` escapes_
> _HTML entities in text_
> _decode them in spring_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e39ca3e</samp>

* Decode HTML entities in text field before saving to database ([link](https://github.com/pimcore/pimcore/pull/15960/files?diff=unified&w=0#diff-d12fd3a68bfb8f0df7e549fa424f0d074eacc51fece6e6cb0c48ebaa952aee1eL108-R108)). This fixes a bug where translated text was not displayed correctly in the admin interface due to the `sanitizer` object escaping HTML characters. The change affects the `models/Translation/Dao.php` file.
