### PR TITLE
Fix allowed brick types are out-of-date for versions

### DIFF
--- a/models/DataObject/Objectbrick.php
+++ b/models/DataObject/Objectbrick.php
@@ -224,7 +224,7 @@ class Objectbrick extends Model\AbstractModel implements DirtyIndicatorInterface
     public function __sleep(): array
     {
         $finalVars = [];
-        $blockedVars = ['object'];
+        $blockedVars = ['object', 'brickGetters'];
         $vars = parent::__sleep();
 
         foreach ($vars as $value) {


### PR DESCRIPTION
## Changes in this pull request  
Resolves #15251

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5dba9ea</samp>

Prevent serialization of brick getters in `Objectbrick` class. This fixes a cache invalidation bug for object bricks.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5dba9ea</samp>

> _`brickGetters` blocked_
> _in `__sleep` function_
> _cache bug fixed now_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5dba9ea</samp>

*  Prevent serialization of brick getters in object bricks ([link](https://github.com/pimcore/pimcore/pull/15963/files?diff=unified&w=0#diff-0a5b70799b5caaa32011d78d907e4156d1b627d54d9411f5c58e0e6c3fb257c2L227-R227))
