### PR TITLE
[Draft]: Make Element Dependencies optional

### DIFF
--- a/bundles/ElementDependenciesBundle/config/event_listeners.yaml
+++ b/bundles/ElementDependenciesBundle/config/event_listeners.yaml
@@ -1,0 +1,6 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    Pimcore\Bundle\ElementDependenciesBundle\EventListener\SavingDependenciesListener: ~

--- a/bundles/ElementDependenciesBundle/config/pimcore/routing.yaml
+++ b/bundles/ElementDependenciesBundle/config/pimcore/routing.yaml
@@ -1,0 +1,6 @@
+_pimcore_dependencies:
+    resource: "@PimcoreElementDependenciesBundle/src/Controller/"
+    type: annotation
+    prefix: /admin
+    options:
+        expose: true

--- a/bundles/ElementDependenciesBundle/config/services.yaml
+++ b/bundles/ElementDependenciesBundle/config/services.yaml
@@ -1,0 +1,9 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    Pimcore\Bundle\ElementDependenciesBundle\Controller\:
+        resource: '../src/Controller'
+        public: true
+        tags: ['controller.service_arguments']

--- a/bundles/ElementDependenciesBundle/src/Controller/ElementController.php
+++ b/bundles/ElementDependenciesBundle/src/Controller/ElementController.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\ElementDependenciesBundle\Controller;
+
+use Pimcore\Bundle\AdminBundle\Controller\AdminAbstractController;
+use Pimcore\Model;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ *
+ * @internal
+ */
+class ElementController extends AdminAbstractController
+{
+    /**
+     * @Route("/element/get-requires-dependencies", name="pimcore_admin_element_getrequiresdependencies", methods={"GET"})
+     *
+     * @param Request $request
+     *
+     * @return JsonResponse
+     */
+    public function getRequiresDependenciesAction(Request $request): JsonResponse
+    {
+        $id = $request->query->getInt('id');
+        $type = $request->query->get('elementType');
+        $allowedTypes = ['asset', 'document', 'object'];
+        $offset = (int)$request->get('start', 0);
+        $limit = (int)$request->get('limit', 25);
+
+        if ($id && in_array($type, $allowedTypes)) {
+            $element = Model\Element\Service::getElementById($type, $id);
+            $dependencies = $element->getDependencies();
+
+            if ($element instanceof Model\Element\ElementInterface) {
+                $dependenciesResult = Model\Element\Service::getRequiresDependenciesForFrontend($dependencies, $offset, $limit);
+
+                $dependenciesResult['start'] = $offset;
+                $dependenciesResult['limit'] = $limit;
+                $dependenciesResult['total'] = $dependencies->getRequiresTotalCount();
+
+                return $this->adminJson($dependenciesResult);
+            }
+        }
+
+        return $this->adminJson(false);
+    }
+
+    /**
+     * @Route("/element/get-required-by-dependencies", name="pimcore_admin_element_getrequiredbydependencies", methods={"GET"})
+     *
+     * @param Request $request
+     *
+     * @return JsonResponse
+     */
+    public function getRequiredByDependenciesAction(Request $request): JsonResponse
+    {
+        $id = $request->query->getInt('id');
+        $type = $request->query->get('elementType');
+        $allowedTypes = ['asset', 'document', 'object'];
+        $offset = (int)$request->get('start', 0);
+        $limit = (int)$request->get('limit', 25);
+
+        if ($id && in_array($type, $allowedTypes)) {
+            $element = Model\Element\Service::getElementById($type, $id);
+            $dependencies = $element->getDependencies();
+
+            if ($element instanceof Model\Element\ElementInterface) {
+                $dependenciesResult = Model\Element\Service::getRequiredByDependenciesForFrontend($dependencies, $offset, $limit);
+
+                $dependenciesResult['start'] = $offset;
+                $dependenciesResult['limit'] = $limit;
+                $dependenciesResult['total'] = $dependencies->getRequiredByTotalCount();
+
+                return $this->adminJson($dependenciesResult);
+            }
+        }
+
+        return $this->adminJson(false);
+    }
+}

--- a/bundles/ElementDependenciesBundle/src/DependencyInjection/PimcoreElementDependenciesExtension.php
+++ b/bundles/ElementDependenciesBundle/src/DependencyInjection/PimcoreElementDependenciesExtension.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\ElementDependenciesBundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
+
+class PimcoreElementDependenciesExtension extends ConfigurableExtension implements PrependExtensionInterface
+{
+
+    public function loadInternal(array $config, ContainerBuilder $container): void
+    {
+        $loader = new YamlFileLoader(
+            $container,
+            new FileLocator(__DIR__ . '/../../config')
+        );
+
+        $loader->load('services.yaml');
+    }
+
+    public function prepend(ContainerBuilder $container)
+    {
+        // TODO: Implement prepend() method.
+    }
+}

--- a/bundles/ElementDependenciesBundle/src/EventListener/SavingDependenciesListener.php
+++ b/bundles/ElementDependenciesBundle/src/EventListener/SavingDependenciesListener.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\ElementDependenciesBundle\EventListener;
+
+use Pimcore\Event\AssetEvents;
+use Pimcore\Event\DataObjectEvents;
+use Pimcore\Event\DocumentEvents;
+use Pimcore\Event\Model\ElementEventInterface;
+use Pimcore\Model;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @internal
+ */
+class SavingDependenciesListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            DataObjectEvents::POST_ADD => 'onElementPostAdd',
+            DocumentEvents::POST_ADD => 'onElementPostAdd',
+            AssetEvents::POST_ADD => 'onElementPostAdd',
+
+            DataObjectEvents::POST_UPDATE => 'onElementPostUpdate',
+            DocumentEvents::POST_UPDATE => 'onElementPostUpdate',
+            AssetEvents::POST_UPDATE => 'onElementPostUpdate',
+        ];
+    }
+
+    /**
+     * Save Dependencies
+     */
+    public function onElementPostUpdate(ElementEventInterface $e): void
+    {
+        $object = $e->getObject();
+
+        $d = new Model\Dependency();
+        $d->setSourceType('object');
+        $d->setSourceId($object->getId());
+
+        foreach ($object->resolveDependencies() as $requirement) {
+            if ($requirement['id'] == $object->getId() && $requirement['type'] === 'object') {
+                // dont't add a reference to yourself
+                continue;
+            }
+
+            $d->addRequirement($requirement['id'], $requirement['type']);
+        }
+
+        $d->save();
+    }
+}

--- a/bundles/ElementDependenciesBundle/src/EventListener/SavingDependenciesListener.php
+++ b/bundles/ElementDependenciesBundle/src/EventListener/SavingDependenciesListener.php
@@ -20,7 +20,7 @@ use Pimcore\Event\AssetEvents;
 use Pimcore\Event\DataObjectEvents;
 use Pimcore\Event\DocumentEvents;
 use Pimcore\Event\Model\ElementEventInterface;
-use Pimcore\Model;
+use Pimcore\Bundle\ElementDependenciesBundle\Model\Dependency;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -48,7 +48,7 @@ class SavingDependenciesListener implements EventSubscriberInterface
     {
         $object = $e->getObject();
 
-        $d = new Model\Dependency();
+        $d = new Dependency();
         $d->setSourceType('object');
         $d->setSourceId($object->getId());
 

--- a/bundles/ElementDependenciesBundle/src/Model/Dependency.php
+++ b/bundles/ElementDependenciesBundle/src/Model/Dependency.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  *  @license    http://www.pimcore.org/license     GPLv3 and PCL
  */
 
-namespace Pimcore\Model;
+namespace Pimcore\Bundle\ElementDependenciesBundle\Model;
 
 /**
  * @internal

--- a/bundles/ElementDependenciesBundle/src/Model/Dependency/Dao.php
+++ b/bundles/ElementDependenciesBundle/src/Model/Dependency/Dao.php
@@ -13,7 +13,7 @@
  *  @license    http://www.pimcore.org/license     GPLv3 and PCL
  */
 
-namespace Pimcore\Model\Dependency;
+namespace Pimcore\Bundle\ElementDependenciesBundle\Model\Dependency;
 
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Pimcore\Db\Helper;

--- a/bundles/ElementDependenciesBundle/src/Resources/install/install.sql
+++ b/bundles/ElementDependenciesBundle/src/Resources/install/install.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS `dependencies` ;
+CREATE TABLE `dependencies` (
+                                `id` BIGINT(20) NOT NULL AUTO_INCREMENT,
+                                `sourcetype` ENUM('document','asset','object') NOT NULL DEFAULT 'document',
+                                `sourceid` INT(11) UNSIGNED NOT NULL DEFAULT '0',
+                                `targettype` ENUM('document','asset','object') NOT NULL DEFAULT 'document',
+                                `targetid` INT(11) UNSIGNED NOT NULL DEFAULT '0',
+                                PRIMARY KEY (`id`),
+                                UNIQUE INDEX `combi` (`sourcetype`, `sourceid`, `targettype`, `targetid`),
+                                INDEX `targettype_targetid` (`targettype`, `targetid`)
+) DEFAULT CHARSET=utf8mb4;

--- a/bundles/ElementDependenciesBundle/src/Tool/ResolveDependecies.php
+++ b/bundles/ElementDependenciesBundle/src/Tool/ResolveDependecies.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\ElementDependenciesBundle\Tool;
+
+use Pimcore\Logger;
+use Pimcore\Model\DataObject;
+use Pimcore\Model\DataObject\ClassDefinition\Data;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Hotspotimage;
+
+class ResolveDependecies
+{
+    public static function resolveDependencies(object $cd, mixed $data, array $params = []) :array
+    {
+        if ($cd instanceof Data\Block){
+            return self::resolveBlock($cd, $data);
+        }
+        if ($cd instanceof Data\ImageGallery){
+            return self::resolveImageGallery($data);
+        }
+    }
+
+    protected static function resolveBlock($class, array $data) :array
+    {
+        $dependencies = [];
+
+        if (!is_array($data)) {
+            return [];
+        }
+
+        foreach ($data as $blockElements) {
+            foreach ($blockElements as $elementName => $blockElement) {
+                $fd = $class->getFieldDefinition($elementName);
+                if (!$fd) {
+                    // class definition seems to have changed
+                    Logger::warn('class definition seems to have changed, element name: ' . $elementName);
+
+                    continue;
+                }
+                $elementData = $blockElement->getData();
+
+                $dependencies = array_merge($dependencies, $fd->resolveDependencies($elementData));
+            }
+        }
+
+        return $dependencies;
+    }
+
+    protected static function resolveImageGallery(DataObject\Data\ImageGallery $data) :array
+    {
+        $dependencies = [];
+
+        $fd = new Hotspotimage();
+        foreach ($data as $item) {
+            $itemDependencies = $fd->resolveDependencies($item);
+            $dependencies = array_merge($dependencies, $itemDependencies);
+        }
+
+        return $dependencies;
+    }
+}

--- a/bundles/InstallBundle/dump/install.sql
+++ b/bundles/InstallBundle/dump/install.sql
@@ -58,18 +58,6 @@ CREATE TABLE `classes` (
 	UNIQUE INDEX `name` (`name`)
 ) DEFAULT CHARSET=utf8mb4;
 
-DROP TABLE IF EXISTS `dependencies` ;
-CREATE TABLE `dependencies` (
-	`id` BIGINT(20) NOT NULL AUTO_INCREMENT,
-	`sourcetype` ENUM('document','asset','object') NOT NULL DEFAULT 'document',
-	`sourceid` INT(11) UNSIGNED NOT NULL DEFAULT '0',
-	`targettype` ENUM('document','asset','object') NOT NULL DEFAULT 'document',
-	`targetid` INT(11) UNSIGNED NOT NULL DEFAULT '0',
-	PRIMARY KEY (`id`),
-	UNIQUE INDEX `combi` (`sourcetype`, `sourceid`, `targettype`, `targetid`),
-	INDEX `targettype_targetid` (`targettype`, `targetid`)
-) DEFAULT CHARSET=utf8mb4;
-
 DROP TABLE IF EXISTS `documents` ;
 CREATE TABLE `documents` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,

--- a/bundles/SimpleBackendSearchBundle/config/services.yaml
+++ b/bundles/SimpleBackendSearchBundle/config/services.yaml
@@ -37,7 +37,7 @@ services:
     # EventListener
     #
     Pimcore\Bundle\SimpleBackendSearchBundle\EventListener\SearchBackendListener: ~
-
+    Pimcore\Bundle\ElementDependenciesBundle\EventListener\SavingDependenciesListener: ~
     #
     # Message Handler
     #

--- a/composer.json
+++ b/composer.json
@@ -178,7 +178,8 @@
       "Pimcore\\Bundle\\CustomReportsBundle\\": "bundles/CustomReportsBundle/src/",
       "Pimcore\\Bundle\\StaticRoutesBundle\\": "bundles/StaticRoutesBundle/src/",
       "Pimcore\\Bundle\\WordExportBundle\\": "bundles/WordExportBundle/src/",
-      "Pimcore\\Bundle\\TinymceBundle\\": "bundles/TinymceBundle/src/"
+      "Pimcore\\Bundle\\TinymceBundle\\": "bundles/TinymceBundle/src/",
+      "Pimcore\\Bundle\\ElementDependenciesBundle\\": "bundles/ElementDependenciesBundle/src/"
     },
     "classmap": [
       "lib/Pimcore.php"

--- a/config/dao-classmap.php
+++ b/config/dao-classmap.php
@@ -61,7 +61,7 @@ return [
     'Pimcore\\Model\\DataObject\\QuantityValue\\Unit' => 'Pimcore\\Model\\DataObject\\QuantityValue\\Unit\\Dao',
     'Pimcore\\Model\\DataObject\\QuantityValue\\Unit\\Listing' => 'Pimcore\\Model\\DataObject\\QuantityValue\\Unit\\Listing\\Dao',
     'Pimcore\\Model\\DataObject\\Service' => 'Pimcore\\Model\\Element\\Dao',
-    'Pimcore\\Model\\Dependency' => 'Pimcore\\Model\\Dependency\\Dao',
+    'Pimcore\\Model\\Dependency' => 'Pimcore\\Bundle\\ElementDependenciesBundle\\Model\\Dependency\\Dao',
     'Pimcore\\Model\\Document' => 'Pimcore\\Model\\Document\\Dao',
     'Pimcore\\Model\\Document\\DocType' => 'Pimcore\\Model\\Document\\DocType\\Dao',
     'Pimcore\\Model\\Document\\DocType\\Listing' => 'Pimcore\\Model\\Document\\DocType\\Listing\\Dao',

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1550,7 +1550,7 @@ class Asset extends Element\AbstractElement
         $this->closeStream();
     }
 
-    protected function resolveDependencies(): array
+    public function resolveDependencies(): array
     {
         $dependencies = [parent::resolveDependencies()];
 

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -718,22 +718,6 @@ abstract class AbstractObject extends Model\Element\AbstractElement
             }
         }
 
-        // save dependencies
-        $d = new Model\Dependency();
-        $d->setSourceType('object');
-        $d->setSourceId($this->getId());
-
-        foreach ($this->resolveDependencies() as $requirement) {
-            if ($requirement['id'] == $this->getId() && $requirement['type'] === 'object') {
-                // dont't add a reference to yourself
-                continue;
-            }
-
-            $d->addRequirement($requirement['id'], $requirement['type']);
-        }
-
-        $d->save();
-
         //set object to registry
         RuntimeCache::set(self::getCacheKey($this->getId()), $this);
     }

--- a/models/DataObject/ClassDefinition/Data/Block.php
+++ b/models/DataObject/ClassDefinition/Data/Block.php
@@ -593,28 +593,12 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
 
     public function resolveDependencies(mixed $data): array
     {
-        $dependencies = [];
-
-        if (!is_array($data)) {
-            return [];
-        }
-
-        foreach ($data as $blockElements) {
-            foreach ($blockElements as $elementName => $blockElement) {
-                $fd = $this->getFieldDefinition($elementName);
-                if (!$fd) {
-                    // class definition seems to have changed
-                    Logger::warn('class definition seems to have changed, element name: ' . $elementName);
-
-                    continue;
-                }
-                $elementData = $blockElement->getData();
-
-                $dependencies = array_merge($dependencies, $fd->resolveDependencies($elementData));
-            }
-        }
-
-        return $dependencies;
+        trigger_deprecation(
+            'pimcore/pimcore',
+            '11.1',
+            sprintf('resolveDependencies() method %s is deprecated, use ResolveDependecies::resolveDependencies instead', __METHOD__)
+        );
+        return ResolveDependecies::resolveDependencies($this, $data);
     }
 
     public function getCacheTags(mixed $data, array $tags = []): array

--- a/models/DataObject/ClassDefinition/Data/ImageGallery.php
+++ b/models/DataObject/ClassDefinition/Data/ImageGallery.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
+use Pimcore\Bundle\ElementDependenciesBundle\Tool\ResolveDependecies;
 use Pimcore\Model;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
@@ -292,17 +293,12 @@ class ImageGallery extends Data implements ResourcePersistenceAwareInterface, Qu
 
     public function resolveDependencies(mixed $data): array
     {
-        $dependencies = [];
-
-        if ($data instanceof DataObject\Data\ImageGallery) {
-            $fd = new Hotspotimage();
-            foreach ($data as $item) {
-                $itemDependencies = $fd->resolveDependencies($item);
-                $dependencies = array_merge($dependencies, $itemDependencies);
-            }
-        }
-
-        return $dependencies;
+        trigger_deprecation(
+            'pimcore/pimcore',
+            '11.1',
+            sprintf('resolveDependencies() method %s is deprecated, use ResolveDependecies::resolveDependencies instead', __METHOD__)
+        );
+        return ResolveDependecies::resolveDependencies($this, $data);
     }
 
     public function getDataForGrid(?DataObject\Data\ImageGallery $data, DataObject\Concrete $object = null, array $params = []): array

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -355,7 +355,7 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
         return $tags;
     }
 
-    protected function resolveDependencies(): array
+    public function resolveDependencies(): array
     {
         $dependencies = [parent::resolveDependencies()];
 

--- a/models/Document/Hardlink.php
+++ b/models/Document/Hardlink.php
@@ -55,7 +55,7 @@ class Hardlink extends Document
         return null;
     }
 
-    protected function resolveDependencies(): array
+    public function resolveDependencies(): array
     {
         $dependencies = parent::resolveDependencies();
         $sourceDocument = $this->getSourceDocument();

--- a/models/Document/Link.php
+++ b/models/Document/Link.php
@@ -76,7 +76,7 @@ class Link extends Model\Document
      */
     protected string $href = '';
 
-    protected function resolveDependencies(): array
+    public function resolveDependencies(): array
     {
         $dependencies = parent::resolveDependencies();
 

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -240,7 +240,7 @@ abstract class PageSnippet extends Model\Document
         return $tags;
     }
 
-    protected function resolveDependencies(): array
+    public function resolveDependencies(): array
     {
         $dependencies = [parent::resolveDependencies()];
 

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -389,7 +389,7 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
      * @internal
      *
      */
-    protected function resolveDependencies(): array
+    public function resolveDependencies(): array
     {
         $dependencies = [[]];
 

--- a/models/Element/ElementInterface.php
+++ b/models/Element/ElementInterface.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Pimcore\Model\Element;
 
-use Pimcore\Model\Dependency;
 use Pimcore\Model\ModelInterface;
 use Pimcore\Model\Property;
 use Pimcore\Model\Schedule\Task;
@@ -174,8 +173,6 @@ interface ElementInterface extends ModelInterface
      * @return Version[]
      */
     public function getVersions(): array;
-
-    public function getDependencies(): Dependency;
 
     public function __toString(): string;
 }


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15426

## Additional info
quite dirty draft, part of feasibility checks

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 72b2fa4</samp>

This pull request introduces a new ElementDependenciesBundle that handles the element dependencies logic separately from the core models. It refactors the `resolveDependencies` methods of the data types and the elements to use a common `ResolveDependecies` class, and registers a `SavingDependenciesListener` service that saves the dependencies on element events. It also adds a new `ElementController` that provides endpoints for getting the requires and required by dependencies of an element. It updates the composer.json, the dao-classmap.php, the install.sql and the services.yaml files to reflect the new bundle configuration. It removes the redundant code for saving the dependencies from the core models, and modifies the visibility of some methods to public. It ensures the compatibility of the new bundle with the existing SimpleBackendSearchBundle.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 72b2fa4</samp>

> _`resolveDependencies`_
> _moved to new bundle, kireji_
> _autumn of methods_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 72b2fa4</samp>

*  Create a new ElementDependenciesBundle that handles the element dependencies logic separately from the core models (F0-F9)
