### PR TITLE
Update documentation for OBJECT_GET_PRE_SEND_DATA

### DIFF
--- a/doc/26_Best_Practice/60_Modifying_Permissions_based_on_Object_Data.md
+++ b/doc/26_Best_Practice/60_Modifying_Permissions_based_on_Object_Data.md
@@ -36,7 +36,7 @@ services:
         arguments:
             - '@Pimcore\Security\User\UserLoader'
         tags:
-            - { name: kernel.event_listener, event: pimcore.admin.object.get.preSendData, method: checkPermissions }
+            - { name: kernel.event_listener, event: pimcore.admin.dataobject.get.preSendData, method: checkPermissions }
 ```
 
 `src/EventListener/MyEventListener`


### PR DESCRIPTION
## Changes in this pull request  
Rebased  https://github.com/pimcore/pimcore/pull/15964#discussion_r1329685815

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ea363ac</samp>

Updated the event name for customizing data object permissions in the best practice documentation. This fixes a compatibility issue with Pimcore 6.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ea363ac</samp>

> _`Object` renamed_
> _`DataObject` reflects change_
> _Autumn leaves fall fast_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ea363ac</samp>

* Update the event name for custom permission logic on data objects ([link](https://github.com/pimcore/pimcore/pull/15985/files?diff=unified&w=0#diff-e50345a4546478eb74b7791e42ec83db0ac8a022557f07041e69d96dde25e0a8L39-R39))
