### PR TITLE
Fixed "Database Model" doc text formatting

### DIFF
--- a/doc/Development_Documentation/19_Development_Tools_and_Details/05_Database_Model.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/05_Database_Model.md
@@ -84,11 +84,11 @@ added to the database. The tables have a numerical suffix, denoting the number
  
 | Table / View | Description |
 |-------|-------------|
-| object_(id) View | Database view joining object_query_(id) and objects table |
-| object_query_(id) Table | Use this table to retrieve data incl. inherited data. Data types with relations are usually stored in a serialized form here, too. Pimcore Object-Lists work with this table. |
-| object_relations_(id) Table | Contains data of fields with relations to objects, assets, etc. |
-| object_store_(id) Table | This is the main data storage table of an object class. It contains all "flat" data without any relations or external dependencies. |
-| objects Table | Contains an entry for each and every object in the system. The id field is an auto_increment and the source of the primary key for an object. Metadata about an object is stored in this table, too. |
+| `object_(id)` View | Database view joining object_query_(id) and objects table |
+| `object_query_(id)` Table | Use this table to retrieve data incl. inherited data. Data types with relations are usually stored in a serialized form here, too. Pimcore Object-Lists work with this table. |
+| `object_relations_(id)` Table | Contains data of fields with relations to objects, assets, etc. |
+| `object_store_(id)` Table | This is the main data storage table of an object class. It contains all "flat" data without any relations or external dependencies. |
+| `objects` Table | Contains an entry for each and every object in the system. The id field is an auto_increment and the source of the primary key for an object. Metadata about an object is stored in this table, too. |
 
 > When restore of query tables is necessary (for what ever reason) calling `DataObject\Concrete::disableDirtyDetection();` and 
 > saving all data objects of class will do the trick. When not disabling dirty detection, there might be data missing in query table. 


### PR DESCRIPTION
## Changes in this pull request  
The "Table / View" col in the "Objects" section table had a formatting issue with the underscore in the table names. The text was displayed italic. It is now formatted as code to solve this.

![Screenshot 2023-09-21 at 16 17 39](https://github.com/pimcore/pimcore/assets/2734232/b6774c70-75e9-479a-adfa-163acab769f8)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 76cc4d7</samp>

Improved the formatting of table and view names in `Database_Model.md` by using code literals. This is part of a documentation update for the Pimcore database model.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 76cc4d7</samp>

> _Backticks for code names_
> _Document the database_
> _Winter of Pimcore_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 76cc4d7</samp>

*  Wrap table and view names in code literals in `Database_Model.md` ([link](https://github.com/pimcore/pimcore/pull/15986/files?diff=unified&w=0#diff-7a668880eafd21643b8543f3a535c01c6f530ac681432c9e30a373bd2da44698L87-R91))
