### PR TITLE
Trigger deprecation for maintenance mode schedule on login

### DIFF
--- a/lib/Tool/Admin.php
+++ b/lib/Tool/Admin.php
@@ -211,6 +211,13 @@ class Admin
         $file = self::getMaintenanceModeScheduleLoginFile();
 
         if (is_file($file)) {
+            trigger_deprecation(
+                'pimcore/pimcore',
+                '11.1',
+                sprintf(
+                    "Calling Admin::scheduleMaintenanceModeOnLogin or using maintenance mode file %s is deprecated.
+                    \tThe maintenance mode schedule on login will not work in Pimcore 12", $file)
+            );
             $conf = include($file);
             if (isset($conf['schedule']) && $conf['schedule']) {
                 return true;


### PR DESCRIPTION
## Changes in this pull request  
Follow up to #15954

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 20316d5</samp>

Deprecate `isMaintenanceModeScheduledForLogin` function in `lib/Tool/Admin.php`. This function relies on a maintenance mode file that will be removed in Pimcore 12. Use the database flag instead.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 20316d5</samp>

> _`isMaintenanceMode`_
> _Deprecated, use database_
> _File will not work soon_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 20316d5</samp>

* Deprecate the maintenance mode file feature and replace it with a database flag ([link](https://github.com/pimcore/pimcore/pull/15991/files?diff=unified&w=0#diff-d8b1f4ffbedfa132c950644f445ac215fb6adc74e16e35ae6f5c1a98de5a2aeaR214-R220),                             F
