### PR TITLE
Fix CsvFormulaFormatter breaks with league/csv:9.11

### DIFF
--- a/lib/Helper/CsvFormulaFormatter.php
+++ b/lib/Helper/CsvFormulaFormatter.php
@@ -19,15 +19,8 @@ namespace Pimcore\Helper;
 
 class CsvFormulaFormatter extends \League\Csv\EscapeFormula
 {
-    public function unEscapeField(string $field): string
+    public function unEscapeField(mixed $field): string
     {
-        if (isset($field[0], $field[1])
-            && $field[0] === $this->getEscape()
-            && in_array($field[1], $this->getSpecialCharacters())
-        ) {
-            return ltrim($field, $field[0]);
-        }
-
-        return $field;
+        return parent::unescapeField($field);
     }
 }

--- a/lib/Helper/CsvFormulaFormatter.php
+++ b/lib/Helper/CsvFormulaFormatter.php
@@ -21,6 +21,13 @@ class CsvFormulaFormatter extends \League\Csv\EscapeFormula
 {
     public function unEscapeField(mixed $field): string
     {
-        return parent::unescapeField($field);
+        if (isset($field[0], $field[1])
+            && $field[0] === $this->getEscape()
+            && in_array($field[1], $this->getSpecialCharacters())
+        ) {
+            return ltrim($field, $field[0]);
+        }
+
+        return $field;
     }
 }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #15998

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dac19b9</samp>

Simplified and fixed CSV export of data objects with formulas. Used parent class method for `unEscapeField` in `CsvFormulaFormatter.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at dac19b9</samp>

> _`unEscapeField` changed_
> _uses parent class method_
> _bug fixed in autumn_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dac19b9</samp>

*  Simplify the `unEscapeField` method in the `CsvFormulaFormatter` class to use the parent class method and fix a bug with CSV export of data objects with formulas ([link](https://github.com/pimcore/pimcore/pull/15999/files?diff=unified&w=0#diff-cbd1d9c0567d80b312e5c5685b32f87fea4a3566d4df159f6ecda2b558e5f438L22-R24))
* Update the type hint of the `$field` parameter in the `unEscapeField` method to `mixed` to match the parent class signature ([link](https://github.com/pimcore/pimcore/pull/15999/files?diff=unified&w=0#diff-cbd1d9c0567d80b312e5c5685b32f87fea4a3566d4df159f6ecda2b558e5f438L22-R24))
