### PR TITLE
Deprecate CsvFormulaFormatter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "guzzlehttp/guzzle": "^7.2",
     "http-interop/http-factory-guzzle": "^1.0.0",
     "knplabs/knp-paginator-bundle": "^6.0.0",
-    "league/csv": "^9.7",
+    "league/csv": "^9.11",
     "league/flysystem": "^3.12.0",
     "league/flysystem-bundle": "^3.1",
     "league/html-to-markdown": "^5.1",

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -11,6 +11,7 @@
     - `isMaintenanceModeScheduledForLogin`, `scheduleMaintenanceModeOnLogin`, `unscheduleMaintenanceModeOnLogin` will be removed in Pimcore 12
 - [CoreCacheHandler] Remove redundant cache item tagging with own key
 - [Auth] The tokens for password reset are now stored in the DB and are one time use only (gets expired whenever a new one is generated or when consumed).
+- `Pimcore\Helper\CsvFormulaFormatter` has been deprecated. Use `League\Csv\EscapeFormula` instead.
 
 ## Pimcore 11.0.7
 - Putting `null` to the `Pimcore\Model\DataObject\Data::setIndex()` method is deprecated now. Only booleans are allowed.

--- a/lib/Helper/CsvFormulaFormatter.php
+++ b/lib/Helper/CsvFormulaFormatter.php
@@ -17,10 +17,21 @@ declare(strict_types=1);
 
 namespace Pimcore\Helper;
 
-class CsvFormulaFormatter extends \League\Csv\EscapeFormula
+use League\Csv\EscapeFormula;
+
+/**
+ * @deprecated and will be removed in Pimcore 12. Use \League\Csv\EscapeFormula instead.
+ */
+class CsvFormulaFormatter extends EscapeFormula
 {
     public function unEscapeField(mixed $field): string
     {
+        trigger_deprecation(
+            'pimcore/pimcore',
+            '11.1.0',
+            sprintf('The "%s" class is deprecated, use "%s" instead.', __CLASS__, EscapeFormula::class)
+        );
+
         if (isset($field[0], $field[1])
             && $field[0] === $this->getEscape()
             && in_array($field[1], $this->getSpecialCharacters())

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -26,7 +26,7 @@ use Doctrine\DBAL\Query\QueryBuilder as DoctrineQueryBuilder;
 use Pimcore;
 use Pimcore\Db;
 use Pimcore\Event\SystemEvents;
-use Pimcore\Helper\CsvFormulaFormatter;
+use League\Csv\EscapeFormula;
 use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\Asset;
@@ -53,7 +53,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class Service extends Model\AbstractModel
 {
-    private static ?CsvFormulaFormatter $formatter = null;
+    private static ?EscapeFormula $formatter = null;
 
     /**
      * @internal
@@ -1442,24 +1442,22 @@ class Service extends Model\AbstractModel
     public static function escapeCsvRecord(array $rowData): array
     {
         if (self::$formatter === null) {
-            self::$formatter = new CsvFormulaFormatter("'", ['=', '-', '+', '@']);
+            self::$formatter = new EscapeFormula("'", ['=', '-', '+', '@']);
         }
-        $rowData = self::$formatter->escapeRecord($rowData);
 
-        return $rowData;
+        return self::$formatter->escapeRecord($rowData);
     }
 
     /**
      * @internal
      */
-    public static function unEscapeCsvField(string $value): string
+    public static function unEscapeCsvRecord(array $rowData): array
     {
         if (self::$formatter === null) {
-            self::$formatter = new CsvFormulaFormatter("'", ['=', '-', '+', '@']);
+            self::$formatter = new EscapeFormula("'", ['=', '-', '+', '@']);
         }
-        $value = self::$formatter->unEscapeField($value);
 
-        return $value;
+        return self::$formatter->unescapeRecord($rowData);
     }
 
     /**

--- a/models/Translation.php
+++ b/models/Translation.php
@@ -428,6 +428,7 @@ final class Translation extends AbstractModel
                 $data = array_slice($data, 1);
                 foreach ($data as $row) {
                     $keyValueArray = [];
+                    $row = Service::unEscapeCsvRecord($row);
                     for ($counter = 0; $counter < count($row); $counter++) {
                         $rd = str_replace('&quot;', '"', $row[$counter]);
                         $keyValueArray[$keys[$counter]] = $rd;
@@ -438,7 +439,6 @@ final class Translation extends AbstractModel
                         $t = static::getByKey($textKey, $domain, true);
                         $dirty = false;
                         foreach ($keyValueArray as $key => $value) {
-                            $value = Service::unEscapeCsvField($value);
                             if (in_array($key, $languages)) {
                                 $currentTranslation = $t->getTranslation($key);
                                 if ($replaceExistingTranslations) {

--- a/tests/Unit/Helper/CsvFormulaTest.php
+++ b/tests/Unit/Helper/CsvFormulaTest.php
@@ -17,44 +17,44 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Unit\Helper;
 
-use Pimcore\Helper\CsvFormulaFormatter;
+use League\Csv\EscapeFormula;
 use Pimcore\Tests\Support\Test\TestCase;
 
 class CsvFormulaTest extends TestCase
 {
     public function testUnEscapeFormula(): void
     {
-        $formatter = new CsvFormulaFormatter("'", ['=', '-', '+', '@']);
+        $formatter = new EscapeFormula("'", ['=', '-', '+', '@']);
 
         $escapedRow = $formatter->escapeRecord(['=1+1']);
         $this->assertEquals("'=1+1", $escapedRow[0]);
-        $this->assertEquals('=1+1', $formatter->unEscapeField($escapedRow[0]));
+        $this->assertEquals('=1+1', $formatter->unescapeRecord($escapedRow)[0]);
 
         $escapedRow = $formatter->escapeRecord(['-1+1']);
         $this->assertEquals("'-1+1", $escapedRow[0]);
-        $this->assertEquals('-1+1', $formatter->unEscapeField($escapedRow[0]));
+        $this->assertEquals('-1+1', $formatter->unescapeRecord($escapedRow)[0]);
 
         $escapedRow = $formatter->escapeRecord(['+1+1']);
         $this->assertEquals("'+1+1", $escapedRow[0]);
-        $this->assertEquals('+1+1', $formatter->unEscapeField($escapedRow[0]));
+        $this->assertEquals('+1+1', $formatter->unescapeRecord($escapedRow)[0]);
 
         $escapedRow = $formatter->escapeRecord(['@1+1']);
         $this->assertEquals("'@1+1", $escapedRow[0]);
-        $this->assertEquals('@1+1', $formatter->unEscapeField($escapedRow[0]));
+        $this->assertEquals('@1+1', $formatter->unescapeRecord($escapedRow)[0]);
 
         // There should be no escape. So the string should be returned as is.
         $escapedRow = $formatter->escapeRecord(['test']);
         $this->assertEquals('test', $escapedRow[0]);
-        $this->assertEquals('test', $formatter->unEscapeField($escapedRow[0]));
+        $this->assertEquals('test', $formatter->unescapeRecord($escapedRow)[0]);
 
         $testString = 'test=test';
         $escapedRow = $formatter->escapeRecord([$testString]);
         $this->assertEquals($testString, $escapedRow[0]);
-        $this->assertEquals($testString, $formatter->unEscapeField($escapedRow[0]));
+        $this->assertEquals($testString, $formatter->unescapeRecord($escapedRow)[0]);
 
         $testString = 'test+test';
         $escapedRow = $formatter->escapeRecord([$testString]);
         $this->assertEquals($testString, $escapedRow[0]);
-        $this->assertEquals($testString, $formatter->unEscapeField($escapedRow[0]));
+        $this->assertEquals($testString, $formatter->unescapeRecord($escapedRow)[0]);
     }
 }


### PR DESCRIPTION
## Changes in this pull request  
please see https://github.com/pimcore/pimcore/pull/15999#discussion_r1335626745

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a28126a</samp>

Refactored CSV escaping and unescaping logic to use `EscapeFormula` class from `League\Csv` library. Deprecated `CsvFormulaFormatter` class and updated `Service` and `CsvFormulaTest` classes accordingly. Improved security and performance of CSV export and import operations.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a28126a</samp>

> _`CsvFormulaFormatter`_
> _Deprecated, use `EscapeFormula` now_
> _Spring cleaning for code_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a28126a</samp>

*  Deprecate `CsvFormulaFormatter` class and replace it with `EscapeFormula` class from `League\Csv` library ([link](https://github.com/pimcore/pimcore/pull/16002/files?diff=unified&w=0#diff-cbd1d9c0567d80b312e5c5685b32f87fea4a3566d4df159f6ecda2b558e5f438L20-R34), [link](https://github.com/pimcore/pimcore/pull/16002/files?diff=unified&w=0#diff-f1c5d50aa07c3685f76a2947c0c3859e2582f8b683ebadf175679eb4aae78785L29-R29), [link](https://github.com/pimcore/pimcore/pull/16002/files?diff=unified&w=0#diff-f1c5d50aa07c3685f76a2947c0c3859e2582f8b683ebadf175679eb4aae78785L56-R56), [link](https://github.com/pimcore/pimcore/pull/16002/files?diff=unified&w=0#diff-3f4b453f98d8208d6cb0088f81c007c49e14252a636b44bfa35089432c78b514L20-R20))
* Simplify `escapeCsvRecord` method of `Service` class to use `escapeRecord` method of `formatter` property ([link](https://github.com/pimcore/pimcore/pull/16002/files?diff=unified&w=0#diff-f1c5d50aa07c3685f76a2947c0c3859e2582f8b683ebadf175679eb4aae78785L1445-R1448))
* Rename and modify `unEscapeCsvField` method of `Service` class to `unEscapeCsvRecord` and use `unescapeRecord` method of `formatter` property ([link](https://github.com/pimcore/pimcore/pull/16002/files?diff=unified&w=0#diff-f1c5d50aa07c3685f76a2947c0c3859e2582f8b683ebadf175679eb4aae78785L1455-R1460))
* Update `testUnEscapeFormula` method of `CsvFormulaTest` class to use `unescapeRecord` method of `formatter` property and check the whole row ([link](https://github.com/pimcore/pimcore/pull/16002/files?diff=unified&w=0#diff-3f4b453f98d8208d6cb0088f81c007c49e14252a636b44bfa35089432c78b514L27-R58))
