### PR TITLE
[Documents] Image Editable - Fix version preview with non-nullable properties assigned null

### DIFF
--- a/models/Document/Editable/Image.php
+++ b/models/Document/Editable/Image.php
@@ -723,4 +723,20 @@ class Image extends Model\Document\Editable implements IdRewriterInterface, Edit
 
         return $finalVars;
     }
+
+    /**
+     * @internal
+     *
+     * https://github.com/pimcore/pimcore/issues/15932
+     * used for non-nullable properties stored with null
+     * @TODO: Remove in Pimcore 12
+     *
+     * @return void
+     */
+    public function __unserialize(array $data): void
+    {
+        foreach (get_object_vars($this) as $property => $value) {
+            $this->$property = $data["\0*\0".$property] ?? $value;
+        }
+    }
 }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #15932

## Additional info
Regression of https://github.com/pimcore/pimcore/pull/13725/files

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c96592a</samp>

Fix unserialization errors for image editables with null properties. Add a temporary `__unserialize` method to `Image` class to handle null values and assign defaults.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c96592a</samp>

> _`Image` unserializes_
> _Nulls in data cause trouble_
> _Workaround for now_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c96592a</samp>

*  Add a new method `__unserialize` to the `Image` class to handle null values in some properties ([link](https://github.com/pimcore/pimcore/pull/16009/files?diff=unified&w=0#diff-a4253070399493532b7da5f2e33e4a3ebc4be35de25ce3f6b6811dda3b9dd0edR726-R741))
