### PR TITLE
feat: add SSI includes for maintenance job static page generation

### DIFF
--- a/bundles/CoreBundle/src/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Configuration.php
@@ -129,7 +129,6 @@ final class Configuration implements ConfigurationInterface
         $this->addTemplatingEngineNode($rootNode);
         $this->addGotenbergNode($rootNode);
         $this->addChromiumNode($rootNode);
-        $this->addStaticPageGeneratorNode($rootNode);
         $storageNode = ConfigurationHelper::addConfigLocationWithWriteTargetNodes($rootNode, [
             'image_thumbnails' => PIMCORE_CONFIGURATION_DIRECTORY . '/image_thumbnails',
             'video_thumbnails' => PIMCORE_CONFIGURATION_DIRECTORY . '/video_thumbnails',
@@ -858,6 +857,18 @@ final class Configuration implements ConfigurationInterface
                         ->scalarNode('route_pattern')
                             ->defaultNull()
                             ->info('Optionally define route patterns to lookup static pages. Regular Expressions like: /^\/en\/Magazine/')
+                        ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('static_page_generator')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('headers')
+                            ->normalizeKeys(false)
+                                ->prototype('array')
+                                    ->children()
+                                        ->scalarNode('name')->end()
+                                        ->scalarNode('value')->end()
                         ->end()
                     ->end()
                 ->end()
@@ -1908,25 +1919,6 @@ final class Configuration implements ConfigurationInterface
                     ->children()
                         ->scalarNode('uri')
                             ->defaultNull()
-                        ->end()
-                    ->end()
-                ->end()
-            ->end();
-    }
-
-    private function addStaticPageGeneratorNode(ArrayNodeDefinition $rootNode): void
-    {
-        $rootNode
-            ->children()
-                ->arrayNode('static_page_generator')
-                    ->addDefaultsIfNotSet()
-                    ->children()
-                        ->arrayNode('headers')
-                            ->normalizeKeys(false)
-                                ->prototype('array')
-                                    ->children()
-                                        ->scalarNode('name')->end()
-                                        ->scalarNode('value')->end()
                         ->end()
                     ->end()
                 ->end()

--- a/bundles/CoreBundle/src/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Configuration.php
@@ -129,6 +129,7 @@ final class Configuration implements ConfigurationInterface
         $this->addTemplatingEngineNode($rootNode);
         $this->addGotenbergNode($rootNode);
         $this->addChromiumNode($rootNode);
+        $this->addStaticPageGeneratorNode($rootNode);
         $storageNode = ConfigurationHelper::addConfigLocationWithWriteTargetNodes($rootNode, [
             'image_thumbnails' => PIMCORE_CONFIGURATION_DIRECTORY . '/image_thumbnails',
             'video_thumbnails' => PIMCORE_CONFIGURATION_DIRECTORY . '/video_thumbnails',
@@ -1907,6 +1908,25 @@ final class Configuration implements ConfigurationInterface
                     ->children()
                         ->scalarNode('uri')
                             ->defaultNull()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    private function addStaticPageGeneratorNode(ArrayNodeDefinition $rootNode): void
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('static_page_generator')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('headers')
+                            ->normalizeKeys(false)
+                                ->prototype('array')
+                                    ->children()
+                                        ->scalarNode('name')->end()
+                                        ->scalarNode('value')->end()
                         ->end()
                     ->end()
                 ->end()

--- a/doc/19_Development_Tools_and_Details/20_Static_Page_Generator.md
+++ b/doc/19_Development_Tools_and_Details/20_Static_Page_Generator.md
@@ -65,6 +65,17 @@ In background, maintenance job takes care of generating static pages for documen
  also, you can filter the documents by parent path, which should processed for static generation:
  `php bin/console pimcore:documents:generate-static-pages -p /en/Magazine`
  
+### SSI
+If you want to add NGINX SSI module for generating the static pages, you can add following config:
+```yaml
+pimcore:
+    static_page_generator:
+        headers:
+            - { name: "Surrogate-Capability", value: 'device="SSI/1.0"' }
+```
+Now the maintenance command can generate SSI includes in the static files like a normal page load.
+
+
 ## Storage
 By default, Pimcore stores the generated HTML pages on local path: `'document_root/public/var/tmp/pages'`.
 

--- a/doc/19_Development_Tools_and_Details/20_Static_Page_Generator.md
+++ b/doc/19_Development_Tools_and_Details/20_Static_Page_Generator.md
@@ -69,9 +69,10 @@ In background, maintenance job takes care of generating static pages for documen
 If you want to add NGINX SSI module for generating the static pages, you can add following config:
 ```yaml
 pimcore:
-    static_page_generator:
-        headers:
-            - { name: "Surrogate-Capability", value: 'device="SSI/1.0"' }
+    document:
+        static_page_generator:
+            headers:
+                - { name: "Surrogate-Capability", value: 'device="SSI/1.0"' }
 ```
 Now the maintenance command can generate SSI includes in the static files like a normal page load.
 

--- a/lib/Document/Renderer/DocumentRenderer.php
+++ b/lib/Document/Renderer/DocumentRenderer.php
@@ -97,7 +97,7 @@ class DocumentRenderer implements DocumentRendererInterface
                 $host = $systemMainDomain;
             }
 
-            $request = $this->requestHelper->createRequestWithContext();
+            $request = $this->requestHelper->createRequestWithContext(host: $host);
         }
 
         if( in_array('pimcore_static_page_generator', $attributes) && in_array('static_page_generator', \Pimcore::getContainer()->getParameter('pimcore.config')) ) {

--- a/lib/Document/Renderer/DocumentRenderer.php
+++ b/lib/Document/Renderer/DocumentRenderer.php
@@ -100,7 +100,7 @@ class DocumentRenderer implements DocumentRendererInterface
             $request = $this->requestHelper->createRequestWithContext(host: $host);
         }
 
-        if( $attributes['pimcore_static_page_generator']){
+        if ($attributes['pimcore_static_page_generator'] ?? false) {
             $config = \Pimcore::getContainer()->getParameter('pimcore.config');
             $headers = $config['static_page_generator']['headers'];
             foreach( $headers as $header ) {

--- a/lib/Document/Renderer/DocumentRenderer.php
+++ b/lib/Document/Renderer/DocumentRenderer.php
@@ -100,8 +100,9 @@ class DocumentRenderer implements DocumentRendererInterface
             $request = $this->requestHelper->createRequestWithContext(host: $host);
         }
 
-        if( in_array('pimcore_static_page_generator', $attributes) && in_array('static_page_generator', \Pimcore::getContainer()->getParameter('pimcore.config')) ) {
-            $headers = \Pimcore::getContainer()->getParameter('pimcore.config')['static_page_generator']['headers'];
+        if( $attributes['pimcore_static_page_generator']){
+            $config = \Pimcore::getContainer()->getParameter('pimcore.config');
+            $headers = $config['static_page_generator']['headers'];
             foreach( $headers as $header ) {
                 $request->headers->set($header['name'], $header['value']);
             }

--- a/lib/Document/Renderer/DocumentRenderer.php
+++ b/lib/Document/Renderer/DocumentRenderer.php
@@ -92,7 +92,7 @@ class DocumentRenderer implements DocumentRendererInterface
 
             $host = 'localhost';
             if( $site = Frontend::getSiteForDocument($document) ){
-                $host = $site->getMainDomain() ?? 'localhost';
+                $host = $site->getMainDomain();
             }elseif( $systemMainDomain = Tool::getHostUrl() ){
                 $host = $systemMainDomain;
             }

--- a/lib/Document/Renderer/DocumentRenderer.php
+++ b/lib/Document/Renderer/DocumentRenderer.php
@@ -100,7 +100,7 @@ class DocumentRenderer implements DocumentRendererInterface
             $request = $this->requestHelper->createRequestWithContext();
         }
 
-        if( in_array('pimcore_static_page_generator', $attributes) && isset(\Pimcore::getContainer()->getParameter('pimcore.config')['static_page_generator']) ) {
+        if( in_array('pimcore_static_page_generator', $attributes) && \Pimcore::getContainer()->getParameter('pimcore.config')['static_page_generator'] ) {
             $headers = \Pimcore::getContainer()->getParameter('pimcore.config')['static_page_generator']['headers'];
             foreach( $headers as $header ) {
                 $request->headers->set($header['name'], $header['value']);

--- a/lib/Document/Renderer/DocumentRenderer.php
+++ b/lib/Document/Renderer/DocumentRenderer.php
@@ -101,8 +101,7 @@ class DocumentRenderer implements DocumentRendererInterface
         }
 
         if ($attributes['pimcore_static_page_generator'] ?? false) {
-            $config = \Pimcore::getContainer()->getParameter('pimcore.config');
-            $headers = $config['static_page_generator']['headers'];
+            $headers = \Pimcore\Config::getSystemConfiguration('documents')['static_page_generator']['headers'];
             foreach( $headers as $header ) {
                 $request->headers->set($header['name'], $header['value']);
             }

--- a/lib/Document/Renderer/DocumentRenderer.php
+++ b/lib/Document/Renderer/DocumentRenderer.php
@@ -100,7 +100,7 @@ class DocumentRenderer implements DocumentRendererInterface
             $request = $this->requestHelper->createRequestWithContext();
         }
 
-        if( in_array('pimcore_static_page_generator', $attributes) && \Pimcore::getContainer()->getParameter('pimcore.config')['static_page_generator'] ) {
+        if( in_array('pimcore_static_page_generator', $attributes) && in_array('static_page_generator', \Pimcore::getContainer()->getParameter('pimcore.config')) ) {
             $headers = \Pimcore::getContainer()->getParameter('pimcore.config')['static_page_generator']['headers'];
             foreach( $headers as $header ) {
                 $request->headers->set($header['name'], $header['value']);

--- a/lib/Document/Renderer/DocumentRenderer.php
+++ b/lib/Document/Renderer/DocumentRenderer.php
@@ -90,7 +90,7 @@ class DocumentRenderer implements DocumentRendererInterface
             $request = $this->requestHelper->getCurrentRequest();
         } catch (\Exception $e) {
 
-            $host = 'localhost';
+            $host = null;
             if( $site = Frontend::getSiteForDocument($document) ){
                 $host = $site->getMainDomain();
             }elseif( $systemMainDomain = Tool::getHostUrl() ){

--- a/lib/Http/RequestHelper.php
+++ b/lib/Http/RequestHelper.php
@@ -180,11 +180,13 @@ class RequestHelper
      *
      * @internal
      */
-    public function createRequestWithContext(string $uri = '/', string $host = 'localhost'): Request
+    public function createRequestWithContext(string $uri = '/', ?string $host): Request
     {
         $port = '';
         $scheme = $this->requestContext->getScheme();
-        $this->requestContext->setHost($host);
+        if ($host){
+            $this->requestContext->setHost($host);
+        }
 
         if ('http' === $scheme && 80 !== $this->requestContext->getHttpPort()) {
             $port = ':'.$this->requestContext->getHttpPort();

--- a/lib/Http/RequestHelper.php
+++ b/lib/Http/RequestHelper.php
@@ -180,7 +180,7 @@ class RequestHelper
      *
      * @internal
      */
-    public function createRequestWithContext(string $uri = '/', ?string $host): Request
+    public function createRequestWithContext(string $uri = '/', ?string $host = null): Request
     {
         $port = '';
         $scheme = $this->requestContext->getScheme();

--- a/lib/Http/RequestHelper.php
+++ b/lib/Http/RequestHelper.php
@@ -180,10 +180,11 @@ class RequestHelper
      *
      * @internal
      */
-    public function createRequestWithContext(string $uri = '/'): Request
+    public function createRequestWithContext(string $uri = '/', string $host = 'localhost'): Request
     {
         $port = '';
         $scheme = $this->requestContext->getScheme();
+        $this->requestContext->setHost($host);
 
         if ('http' === $scheme && 80 !== $this->requestContext->getHttpPort()) {
             $port = ':'.$this->requestContext->getHttpPort();


### PR DESCRIPTION
Static Pages Generation over CLI always without SSI includes.

In this Pull request you can find a possibility to add custom headers (like the surrogated) and now we can generate a ssi included static page in commands.

 