### PR TITLE
Reverts #15960 partially to fix anchor tag closing regression

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Wysiwyg.php
+++ b/models/DataObject/ClassDefinition/Data/Wysiwyg.php
@@ -114,8 +114,6 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
     public function getDataFromResource(mixed $data, DataObject\Concrete $object = null, array $params = []): ?string
     {
         if (is_string($data)) {
-            //fix for https://github.com/pimcore/pimcore/issues/15740
-            $data = preg_replace('/(?!<[a-zA-Z=\"\':; ]*[^ ]>|<\\/[a-zA-Z="\':; ]*>)(<)/', '&lt;', $data);
             $data = html_entity_decode(self::getWysiwygSanitizer()->sanitizeFor('body', $data));
         }
 

--- a/models/Document/Editable/Wysiwyg.php
+++ b/models/Document/Editable/Wysiwyg.php
@@ -90,8 +90,6 @@ class Wysiwyg extends Model\Document\Editable implements IdRewriterInterface, Ed
     public function setDataFromResource(mixed $data): static
     {
         $helper = self::getWysiwygSanitizer();
-        //fix for https://github.com/pimcore/pimcore/issues/15740
-        $data = preg_replace('/(?!<[a-zA-Z=\"\':; ]*[^ ]>|<\\/[a-zA-Z="\':; ]*>)(<)/', '&lt;', $data);
         $this->text = html_entity_decode($helper->sanitizeFor('body', $data));
 
         return $this;
@@ -103,8 +101,6 @@ class Wysiwyg extends Model\Document\Editable implements IdRewriterInterface, Ed
     public function setDataFromEditmode(mixed $data): static
     {
         $helper = self::getWysiwygSanitizer();
-        //fix for https://github.com/pimcore/pimcore/issues/15740
-        $data = preg_replace('/(?!<[a-zA-Z=\"\':; ]*[^ ]>|<\\/[a-zA-Z="\':; ]*>)(<)/', '&lt;', $data);
         $this->text = html_entity_decode($helper->sanitizeFor('body', $data));
 
         return $this;

--- a/models/Translation/Dao.php
+++ b/models/Translation/Dao.php
@@ -101,8 +101,6 @@ class Dao extends Model\Dao\AbstractDao
                         continue;
                     }
 
-                    //fix for https://github.com/pimcore/pimcore/issues/15740
-                    $text = preg_replace('/(?!<[a-zA-Z=\"\':; ]*[^ ]>|<\\/[a-zA-Z="\':; ]*>)(<)/', '&lt;', $text);
                     $data = [
                         'key' => $this->model->getKey(),
                         'type' => $this->model->getType(),

--- a/tests/Model/DataObject/ObjectTest.php
+++ b/tests/Model/DataObject/ObjectTest.php
@@ -354,26 +354,26 @@ class ObjectTest extends ModelTestCase
         $this->assertNull($value);
     }
 
-    public function testSanitization(): void
-    {
-        $db = Db::get();
-
-        $object = TestHelper::createEmptyObject();
-        $object->setWysiwyg('!@#$%^abc\'"<script>console.log("ops");</script> 测试< edf > "');
-        $object->save();
-
-        //reload from db
-        $object = DataObject::getById($object->getId(), ['force' => true]);
-
-        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', $object->getWysiwyg(), 'Asseting setter/getter value is sanitized');
-
-        $dbQueryValue = $db->fetchOne(
-            sprintf(
-                'SELECT `wysiwyg` FROM object_query_%s WHERE oo_id = %d',
-                $object->getClassName(),
-                $object->getId()
-            )
-        );
-        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', $dbQueryValue, 'Asserting object_query table value is persisted as sanitized');
-    }
+//    public function testSanitization(): void
+//    {
+//        $db = Db::get();
+//
+//        $object = TestHelper::createEmptyObject();
+//        $object->setWysiwyg('!@#$%^abc\'"<script>console.log("ops");</script> 测试< edf > "');
+//        $object->save();
+//
+//        //reload from db
+//        $object = DataObject::getById($object->getId(), ['force' => true]);
+//
+//        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', $object->getWysiwyg(), 'Asseting setter/getter value is sanitized');
+//
+//        $dbQueryValue = $db->fetchOne(
+//            sprintf(
+//                'SELECT `wysiwyg` FROM object_query_%s WHERE oo_id = %d',
+//                $object->getClassName(),
+//                $object->getId()
+//            )
+//        );
+//        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', $dbQueryValue, 'Asserting object_query table value is persisted as sanitized');
+//    }
 }

--- a/tests/Unit/Translation/TranslatorTest.php
+++ b/tests/Unit/Translation/TranslatorTest.php
@@ -247,27 +247,27 @@ class TranslatorTest extends TestCase
         $this->assertCount(count($beforeAdd) + 1, $afterAdd);
     }
 
-    public function testSanitizedTranslation(): void
-    {
-        $translation = new Translation();
-        $key = 'sanitizerTest';
-        $translation->setDomain('messages');
-        $translation->setKey($key);
-        $translation->setTranslations(['en' => '!@#$%^abc\'"<script>console.log("ops");</script> 测试< edf > "']);
-        $translation->save();
-
-        $translation = Translation::getByKey($key);
-        $getter = $translation->getTranslation('en');
-        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', $getter, 'Asserting translation is properly sanitized');
-
-        $db = Db::get();
-        $dbValue = $db->fetchOne(
-            sprintf(
-                'SELECT `text` FROM translations_messages WHERE `key` = %s AND `language` = %s',
-                $db->quote($key),
-                $db->quote('en')
-            )
-        );
-        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', $dbValue, 'Asserting translation is persisted as sanitized');
-    }
+//    public function testSanitizedTranslation(): void
+//    {
+//        $translation = new Translation();
+//        $key = 'sanitizerTest';
+//        $translation->setDomain('messages');
+//        $translation->setKey($key);
+//        $translation->setTranslations(['en' => '!@#$%^abc\'"<script>console.log("ops");</script> 测试< edf > "']);
+//        $translation->save();
+//
+//        $translation = Translation::getByKey($key);
+//        $getter = $translation->getTranslation('en');
+//        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', $getter, 'Asserting translation is properly sanitized');
+//
+//        $db = Db::get();
+//        $dbValue = $db->fetchOne(
+//            sprintf(
+//                'SELECT `text` FROM translations_messages WHERE `key` = %s AND `language` = %s',
+//                $db->quote($key),
+//                $db->quote('en')
+//            )
+//        );
+//        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', $dbValue, 'Asserting translation is persisted as sanitized');
+//    }
 }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #16011 

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 074f186</samp>

Revert a previous commit that introduced sanitization of HTML entities in the Wysiwyg editable and the translations. This commit removes the regex that replaced `<` characters with `&lt;` from the `Wysiwyg` and `Dao` classes, and comments out the test functions that checked the sanitization in the `ObjectTest` and `TranslatorTest` classes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 074f186</samp>

> _Revert `Wysiwyg`_
> _Sanitization was wrong_
> _Fall leaves are falling_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 074f186</samp>

*  Revert the sanitization of HTML tags in Wysiwyg editable and translations ([link](https://github.com/pimcore/pimcore/pull/16013/files?diff=unified&w=0#diff-0c6c24fc188205dba44a894fc6eb75aa6959974d07e633a0fc92d12e179f25e0L93-L94), [link](https://github.com/pimcore/pimcore/pull/16013/files?diff=unified&w=0#diff-0c6c24fc188205dba44a894fc6eb75aa6959974d07e633a0fc92d12e179f25e0L106-L107), [link](https://github.com/pimcore/pimcore/pull/16013/files?diff=unified&w=0#diff-d12fd3a68bfb8f0df7e549fa424f0d074eacc51fece6e6cb0c48ebaa952aee1eL104-L105))
* Comment out the test functions that check the sanitization of Wysiwyg editable and translations ([link](https://github.com/pimcore/pimcore/pull/16013/files?diff=unified&w=0#diff-5ae8bd11ad9f1d8c280eb8c6d1b9eb5580f3e58f6e6bba67b2d9b7e3d8b0e114L357-R378), [link](https://github.com/pimcore/pimcore/pull/16013/files?diff=unified&w=0#diff-72c74b38fba64391afe0b39ec146f87550f204f4171df51b8ca3a31a4b0a0826L250-R272))
