### PR TITLE
[Assets] Calculate Spherical MetaData in AssetUpdateTasksHandler

### DIFF
--- a/lib/Messenger/Handler/AssetUpdateTasksHandler.php
+++ b/lib/Messenger/Handler/AssetUpdateTasksHandler.php
@@ -92,7 +92,14 @@ class AssetUpdateTasksHandler
             $asset->removeCustomSetting('videoHeight');
         }
 
-        $asset->handleEmbeddedMetaData(true);
+        $sphericalMetaData = $asset->getSphericalMetaDataFromBackend();
+        if (!empty($sphericalMetaData)) {
+            $asset->setCustomSetting('SphericalMetaData', $sphericalMetaData);
+        } else {
+            $asset->removeCustomSetting('SphericalMetaData');
+        }
+
+        $asset->handleEmbeddedMetaData();
         $this->saveAsset($asset);
 
         if ($asset->getCustomSetting('videoWidth') && $asset->getCustomSetting('videoHeight')) {

--- a/models/Asset/Video.php
+++ b/models/Asset/Video.php
@@ -213,7 +213,6 @@ class Video extends Model\Asset
 
     public function getDimensions(): ?array
     {
-        $dimensions = null;
         $width = $this->getCustomSetting('videoWidth');
         $height = $this->getCustomSetting('videoHeight');
         if (!$width || !$height) {
@@ -262,6 +261,15 @@ class Video extends Model\Asset
      */
     public function getSphericalMetaData(): array
     {
+        return $this->getCustomSetting('SphericalMetaData') ?? [];
+    }
+
+    /**
+     * @internal
+     *
+     */
+    public function getSphericalMetaDataFromBackend(): array
+    {
         $data = [];
 
         if (in_array(pathinfo($this->getFilename(), PATHINFO_EXTENSION), ['mp4', 'webm'])) {
@@ -295,17 +303,16 @@ class Video extends Model\Asset
                 $offset = 0;
                 while (($position = strpos($buffer, $tag, $offset)) === false && ($chunk = fread($file_pointer,
                     $chunkSize)) !== false && !empty($chunk)) {
-                    $offset = strlen($buffer) - $tagLength; // subtract the tag size just in case it's split between chunks.
+                    $offset = strlen($buffer) - $tagLength; //subtract the tag size for case it's split between chunks
                     $buffer .= $chunk;
                 }
 
                 if ($position === false) {
                     // this would mean the open tag was found, but the close tag was not.  Maybe file corruption?
                     throw new \RuntimeException('No close tag found.  Possibly corrupted file.');
-                } else {
-                    $buffer = substr($buffer, 0, $position + $tagLength);
                 }
 
+                $buffer = substr($buffer, 0, $position + $tagLength);
                 $buffer = preg_replace('/xmlns[^=]*="[^"]*"/i', '', $buffer);
                 $buffer = preg_replace('@<(/)?([a-zA-Z]+):([a-zA-Z]+)@', '<$1$2____$3', $buffer);
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #6820

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 93d9046</samp>

This pull request enhances the support for spherical video assets in Pimcore. It adds a new function to `Video` class to fetch spherical metadata, and updates the `AssetUpdateTasksHandler` class to store and remove the metadata as a custom setting for the video asset.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 93d9046</samp>

> _`processVideo` checks_
> _spherical metadata now_
> _autumn of VR_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 93d9046</samp>

*  Add logic to handle spherical metadata for video assets ([link](https://github.com/pimcore/pimcore/pull/16023/files?diff=unified&w=0#diff-f9779d6bf7f7d2cfcbd48f036980ea510e017943bf93f2edbcc968d60689a020L95-R102), [link](https://github.com/pimcore/pimcore/pull/16023/files?diff=unified&w=0#diff-4eaa1c878354dcae14b1783aaa196ab21e1ccf324cd6f33657671083abc50b42R264-R272), [link](https://github.com/pimcore/pimcore/pull/16023/files?diff=unified&w=0#diff-4eaa1c878354dcae14b1783aaa196ab21e1ccf324cd6f33657671083abc50b42L298-R306), [link](https://github.com/pimcore/pimcore/pull/16023/files?diff=unified&w=0#diff-4eaa1c878354dcae14b1783aaa196ab21e1ccf324cd6f33657671083abc50b42L305-R315))
* Remove unused variable from `getDimensions` function in `Video.php` ([link](https://github.com/pimcore/pimcore/pull/16023/files?diff=unified&w=0#diff-4eaa1c878354dcae14b1783aaa196ab21e1ccf324cd6f33657671083abc50b42L216))
