### PR TITLE
docs: add /admin/ to webdav route

### DIFF
--- a/doc/04_Assets/05_Accessing_Assets_via_WebDAV.md
+++ b/doc/04_Assets/05_Accessing_Assets_via_WebDAV.md
@@ -1,7 +1,7 @@
 # Accessing Pimcore Assets via WebDAV
 
 Pimcore provides the option to access all assets via [WebDAV](https://en.wikipedia.org/wiki/WebDAV). To do so, 
-just open following URL via your browser or WebDAV client: https://YOUR-DOMAIN/asset/webdav
+just open following URL via your browser or WebDAV client: https://YOUR-DOMAIN/admin/asset/webdav
 
 As user credentials use any Pimcore Backend user. Permissions for asset access are based on the users permissions.  
 


### PR DESCRIPTION
## Changes in this pull request  
There was a wrong path to the webdav admin
before: /asset/webdav
now: /admin/asset/webdav

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d8f647a</samp>

Updated the WebDAV URL in the documentation for assets to use the new admin path in Pimcore 10. This change affects the file `doc/04_Assets/05_Accessing_Assets_via_WebDAV.md`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d8f647a</samp>

> _`WebDAV` URL changed_
> _New admin path for assets_
> _Spring cleaning docs_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d8f647a</samp>

* Update the WebDAV URL to use the new admin path `/admin` instead of `/pimcore` ([link](https://github.com/pimcore/pimcore/pull/16047/files?diff=unified&w=0#diff-82be0ccee7a311e041cdbb335fcd179e460f4cf203d7e07aeb186dce33616f2eL4-R4))
