### PR TITLE
Add prepare guide for migrating o_ prefix data before upgrading to v11

### DIFF
--- a/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/11_Preparing_for_V11.md
+++ b/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/11_Preparing_for_V11.md
@@ -151,6 +151,10 @@ If you are sure you can run all available migrations after `composer update`, in
     
     You might also adapt the `config_location` from other extensions, like Datahub.
 
+### Migrate o_ prefix properties in the stored data
+As `o_` prefix will be removed from data objects system properties in v11. It is recommended to migrate the stored data to use new properties (without o_ prefix).
+Please adapt and use these [scripts](https://gist.github.com/dvesh3/50a1a99fd337d461e1652f2fd3b4d6cd) to migrate versions and recycle-bin data.
+
 ## Additional Things to Consider
 
 - [Web2Print] Please keep in mind that the deprecated processor `HeadlessChrome` needs to be replaced with the new processor `Chrome` in Pimcore 11.


### PR DESCRIPTION
## Changes in this pull request  
Related to #15931 & #15839

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 858c531</samp>

Added a new subsection to the documentation page `Preparing for Pimcore v11` about the removal of the `o_` prefix from data objects system properties. The subsection provides a link to migration scripts and aims to help users avoid data issues when upgrading to v11.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 858c531</samp>

> _`o_` prefix gone_
> _Prepare for Pimcore v11_
> _Scripts help in fall_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 858c531</samp>

*  Add a new subsection about data objects system properties migration to the `Configuration Adaptions` section of the documentation page for preparing for Pimcore v11 ([link](https://github.com/pimcore/pimcore/pull/16054/files?diff=unified&w=0#diff-cd2f74bb5a3e37db1fc4379c003f16c1267905e6d41f22b13d8008cb8ac286f2R154-R157))
