### PR TITLE
Fix type error in Document\Editable\Video->setDataFromResource()

### DIFF
--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -354,7 +354,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
      */
     public function setDataFromResource(mixed $data): static
     {
-        if (!empty($data)) {
+        if (!empty($data) && is_string($data)) {
             $data = Serialize::unserialize($data);
         }
 

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -358,11 +358,11 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
             $data = Serialize::unserialize($data);
         }
 
-        $this->id = $data['id'];
-        $this->type = $data['type'];
-        $this->poster = $data['poster'];
-        $this->title = $data['title'];
-        $this->description = $data['description'];
+        $this->id = $data['id'] ?? null;
+        $this->type = $data['type'] ?? null;
+        $this->poster = $data['poster'] ?? null;
+        $this->title = $data['title'] ?? '';
+        $this->description = $data['description'] ?? '';
 
         return $this;
     }

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -354,7 +354,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
      */
     public function setDataFromResource(mixed $data): static
     {
-        if (!empty($data) && is_string($data)) {
+        if (is_string($data) && $data) {
             $data = Serialize::unserialize($data);
         }
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/16038

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 87cfd9b</samp>

Fixed potential errors and security issues with unserializing data from the database in the `Video` editable class. Added a string check to the `setDataFromResource` function in `models/Document/Editable/Video.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 87cfd9b</samp>

> _`setDataFromResource`_
> _Checks string before unserializing_
> _A cold winter bug_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 87cfd9b</samp>

*  Prevent errors or security issues when unserializing video data from the database by checking if the data is a string ([link](https://github.com/pimcore/pimcore/pull/16058/files?diff=unified&w=0#diff-9cba4e2ecaf34598897940fdff3416069ea2708f77e953bf87f08b2529651007L357-R357))
