### PR TITLE
[Bug] Fix cache clear memory issue

### DIFF
--- a/lib/HttpKernel/CacheWarmer/PimcoreCoreCacheWarmer.php
+++ b/lib/HttpKernel/CacheWarmer/PimcoreCoreCacheWarmer.php
@@ -79,8 +79,9 @@ class PimcoreCoreCacheWarmer implements CacheWarmerInterface
                 $className = preg_replace('@\.php$@', '', $className);
                 $className = str_replace(DIRECTORY_SEPARATOR, '\\', $className);
 
-                // do not load all classes here / causes memory issues
-                if (class_exists($className, false)) {
+                // include classes, interfaces and traits
+                // exclude invalid files like helper-functions
+                if (!preg_match('/[_.-]/', $className)) {
                     $classes[] = $className;
                 }
             }

--- a/lib/HttpKernel/CacheWarmer/PimcoreCoreCacheWarmer.php
+++ b/lib/HttpKernel/CacheWarmer/PimcoreCoreCacheWarmer.php
@@ -79,7 +79,8 @@ class PimcoreCoreCacheWarmer implements CacheWarmerInterface
                 $className = preg_replace('@\.php$@', '', $className);
                 $className = str_replace(DIRECTORY_SEPARATOR, '\\', $className);
 
-                if (class_exists($className)) {
+                // do not load all classes here / causes memory issues
+                if (class_exists($className, false)) {
                     $classes[] = $className;
                 }
             }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #16068 

## Additional info
In PimcoreCoreCacheWarmer every class is loaded via class_exists check even though we only need the FQN here. 
This causes memory issues while cache:clear.

The preloader actually already takes care of it: https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/DependencyInjection/Dumper/Preloader.php#L80

Including now interfaces and traits.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4d18c0b</samp>

Filter out non-class files in core cache warmer. This prevents errors or warnings when loading files that are not classes, interfaces or traits, such as `helper-functions.php`, from directories scanned by `getClassesFromDirectory`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4d18c0b</samp>

> _`getClassesFromDirectory`_
> _Filters out non-class files_
> _Autumn leaves no trace_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4d18c0b</samp>

*  Filter out invalid files from class scanning ([link](https://github.com/pimcore/pimcore/pull/16069/files?diff=unified&w=0#diff-ca023d4b8c811a986f30c80457319d74e2af1630e460d7d04577d4f3197f4dc7L82-R84))
