### PR TITLE
[Elements]: Add '$params' parameter to ElementInterface::getById

### DIFF
--- a/models/Element/ElementInterface.php
+++ b/models/Element/ElementInterface.php
@@ -62,7 +62,7 @@ interface ElementInterface extends ModelInterface
     public function setUserModification(int $userModification): static;
 
     //TODO add $params parameter in Pimcore 12
-    public static function getById(int $id, /* array $params = [] */): ?static;
+    public static function getById(int $id /* array $params = [] */): ?static;
 
     /**
      * get possible types

--- a/models/Element/ElementInterface.php
+++ b/models/Element/ElementInterface.php
@@ -61,7 +61,7 @@ interface ElementInterface extends ModelInterface
 
     public function setUserModification(int $userModification): static;
 
-    public static function getById(int $id): ?static;
+    public static function getById(int $id, array $params = []): ?static;
 
     /**
      * get possible types

--- a/models/Element/ElementInterface.php
+++ b/models/Element/ElementInterface.php
@@ -61,7 +61,8 @@ interface ElementInterface extends ModelInterface
 
     public function setUserModification(int $userModification): static;
 
-    public static function getById(int $id, array $params = []): ?static;
+    //TODO add $params parameter in Pimcore 12
+    public static function getById(int $id, /* array $params = [] */): ?static;
 
     /**
      * get possible types

--- a/models/Element/ElementInterface.php
+++ b/models/Element/ElementInterface.php
@@ -62,7 +62,7 @@ interface ElementInterface extends ModelInterface
     public function setUserModification(int $userModification): static;
 
     //TODO add $params parameter in Pimcore 12
-    public static function getById(int $id /* array $params = [] */): ?static;
+    public static function getById(int $id /*, array $params = [] */): ?static;
 
     /**
      * get possible types


### PR DESCRIPTION
Related to https://github.com/pimcore/pimcore/issues/15199

### Changes in this pull request  
Add `$params` parameter to `ElementInterface::getById`.  
This introduces a BC break since the interface is not marked as internal.  
All currently available implementations in the pimcore code are already satisfying this signature.