### PR TITLE
fix: Environment::setCurrentCheckoutTenant() compares wrong variable

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Environment.php
+++ b/bundles/EcommerceFrameworkBundle/Environment.php
@@ -277,7 +277,7 @@ class Environment implements EnvironmentInterface
     {
         $this->load();
 
-        if ($this->currentCheckoutTenant != $tenant) {
+        if ($this->currentTransientCheckoutTenant != $tenant) {
             if ($persistent) {
                 $this->currentCheckoutTenant = $tenant;
             }


### PR DESCRIPTION
`\Pimcore\Bundle\EcommerceFrameworkBundle\Environment::setCurrentCheckoutTenant()` should compare the variable it _always_ adjusts in order to detect changes and not the one that is only conditionally adjusted.