### PR TITLE
Consistently use "utf8mb4_general_ci" as database collation

### DIFF
--- a/doc/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
+++ b/doc/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
@@ -9,7 +9,7 @@ If you create a new database just set the character set to `utf8mb4`.
 ### Command to Create a new Database
 
 ```bash
-mysql -u root -p -e "CREATE DATABASE project_database charset=utf8mb4;"
+mysql -u root -p -e "CREATE DATABASE project_database CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;"
 ```
 
 ### Permissions needed for Pimcore
@@ -41,7 +41,7 @@ default-character-set=utf8mb4
 # Applies to mysql server
 [mysqld]
 character-set-server=utf8mb4
-collation-server=utf8mb4_unicode_ci
+collation-server=utf8mb4_general_ci
 init-connect='SET NAMES utf8mb4'
 lower_case_table_names=1
 ```

--- a/tests/bin/docker-compose.yaml
+++ b/tests/bin/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     db:
         image: mariadb:10.7
         working_dir: /application
-        command: [mysqld, --character-set-server=utf8mb4, --collation-server=utf8mb4_unicode_ci, --innodb-file-per-table=1]
+        command: [mysqld, --character-set-server=utf8mb4, --collation-server=utf8mb4_general_ci, --innodb-file-per-table=1]
         environment:
             MYSQL_ROOT_PASSWORD: ROOT
             MYSQL_DATABASE: pimcore_test


### PR DESCRIPTION
## Changes in this pull request  
In the documentation sometimes "utf8mb4_unicode_ci" is used, but as pimcore itself uses "utf8mb4_general_ci" we should change it to "utf8mb4_general_ci".

It is also be good to define the collation on the database level for cases when we cannot define it in the server configuration. 
