### PR TITLE
bugfix(copy-document) compare serialized texts the same way when copy…

### DIFF
--- a/models/Document/Editable/Wysiwyg.php
+++ b/models/Document/Editable/Wysiwyg.php
@@ -124,7 +124,7 @@ class Wysiwyg extends Model\Document\Editable implements IdRewriterInterface, Ed
             }
         }
 
-        $this->text = $html->html();
+        $this->setDataFromResource($html->html());
 
         $html->clear();
         unset($html);


### PR DESCRIPTION
When you copy and paste documents all (wysiwyg) editables will be created on the target document also with the exact same content.

This is not correct because of once serialzed html decoded text with one html encoded text. 