### PR TITLE
[Thumbnails] Scaling animated GIFs does not work

### DIFF
--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -542,8 +542,11 @@ class Imagick extends Adapter
     {
         $this->preModify();
 
-        $this->resource->cropImage($width, $height, $x, $y);
-        $this->resource->setImagePage($width, $height, 0, 0);
+        // loop is for animated GIFs which in fact consist of multiple images
+        foreach($this->resource as $resource) {
+            $resource->cropImage($width, $height, $x, $y);
+            $resource->setImagePage($width, $height, 0, 0);
+        }
 
         $this->setWidth($width);
         $this->setHeight($height);


### PR DESCRIPTION
Steps to reproduce:
1. Upload this image to Pimcore assets
![5d667803a7a67_gif1-Everyonelovesgifs_4ef1dbef8a604a3e1b26eebf2c000ef0](https://github.com/pimcore/pimcore/assets/8749138/1ee7cf16-3049-4d47-8bb0-1c70213273f4)

2. Create this thumbnail definition:
```yaml
pimcore:
    assets:
        image:
            thumbnails:
                definitions:
                    test:
                        items:
                            -
                                method: cover
                                arguments:
                                    width: 200
                                    height: 80
                                    positioning: center
                                    forceResize: false
                        medias: {  }
                        name: test
                        description: test
                        group: ''
                        format: ORIGINAL
                        quality: 85
                        highResolution: 0.0
                        preserveColor: false
                        preserveMetaData: false
                        rasterizeSVG: false
                        downloadable: true
                        modificationDate: 1697029839
                        creationDate: 1694377896
                        preserveAnimation: true
```

Open the asset and download it with thumbnail definition `test`.

Generated thumbnail will look like this:
![5d667803a7a67_gif1-everyonelovesgifs_4ef1dbef8a604a3e1b26eebf2c000ef0(2)](https://github.com/pimcore/pimcore/assets/8749138/49281bba-886f-4910-a972-1af949996330)

See that only the first frame is scaled correctly, all others are unscaled (but do not fit into viewport anymore of course).

Output with this PR:
![5d667803a7a67_gif1-everyonelovesgifs_4ef1dbef8a604a3e1b26eebf2c000ef0(3)](https://github.com/pimcore/pimcore/assets/8749138/bfb45f95-8929-4afa-9d55-7d71881f5980)

I have not checked for other transformations than `cover` but I guess those have the same problem...
