### PR TITLE
[HtmlSanitizer] Sanitize data only on save

### DIFF
--- a/doc/03_Documents/01_Editables/40_WYSIWYG.md
+++ b/doc/03_Documents/01_Editables/40_WYSIWYG.md
@@ -53,3 +53,6 @@ framework:
                     ol: ['class', 'style']
 ```
 If you want to adapt this configuration please have a look at the [symfony documentation](https://symfony.com/doc/current/html_sanitizer.html). Add your custom configuration to you project, e.g. to `config/packages/html_sanitizer.yaml`
+
+> Note: When using API to set WYSIWYG data, please pass encoded characters for html entities e.g. <,>, & etc.
+> The data is encoded by the sanitizer before persisting into db and the same encoded data will be returned by the API.

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -99,7 +99,9 @@
 #### [Security] :
 
 -  Enabled Content Security Policy by default.
--  Implemented Symfony HTML sanitizer for WYSIWYG editors.
+-  Implemented Symfony HTML sanitizer for WYSIWYG editors. Please make sure to sanitize your persisted data with help of this [script](https://gist.github.com/dvesh3/0e585a16dfbf546bc17a9eef1c5640b3).
+Also, when using API to set WYSIWYG data, please pass encoded characters for html entities <,>, & etc.
+The data is encoded by the sanitizer before persisting into db and the same encoded data will be returned by the API.
 
 
 -----------------

--- a/models/DataObject/ClassDefinition/Data/Wysiwyg.php
+++ b/models/DataObject/ClassDefinition/Data/Wysiwyg.php
@@ -99,7 +99,7 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
      */
     public function getDataForResource(mixed $data, DataObject\Concrete $object = null, array $params = []): ?string
     {
-        if (is_string($data) && !($params['no_sanitize'] ?? false)) {
+        if (is_string($data) && (!isset($params['sanitize']) || $params['sanitize'])) {
             $data = self::getWysiwygSanitizer()->sanitizeFor('body', $data);
         }
 
@@ -131,7 +131,7 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
      */
     public function getDataForQueryResource(mixed $data, DataObject\Concrete $object = null, array $params = []): ?string
     {
-        $data = $this->getDataForResource($data, $object, array_merge($params, ['no_sanitize' => true]));
+        $data = $this->getDataForResource($data, $object, array_merge($params, ['sanitize' => false]));
 
         if (null !== $data) {
             $data = strip_tags($data, '<a><img>');
@@ -166,7 +166,7 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
      */
     public function getDataForEditmode(mixed $data, DataObject\Concrete $object = null, array $params = []): ?string
     {
-        return $this->getDataForResource($data, $object, array_merge($params, ['no_sanitize' => true]));
+        return $this->getDataForResource($data, $object, array_merge($params, ['sanitize' => false]));
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Wysiwyg.php
+++ b/models/DataObject/ClassDefinition/Data/Wysiwyg.php
@@ -99,7 +99,7 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
      */
     public function getDataForResource(mixed $data, DataObject\Concrete $object = null, array $params = []): ?string
     {
-        if (is_string($data) && (!isset($params['sanitize']) || $params['sanitize'])) {
+        if (is_string($data) && ($params['sanitize'] ?? true) ){
             $data = self::getWysiwygSanitizer()->sanitizeFor('body', $data);
         }
 

--- a/models/DataObject/ClassDefinition/Data/Wysiwyg.php
+++ b/models/DataObject/ClassDefinition/Data/Wysiwyg.php
@@ -99,6 +99,10 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
      */
     public function getDataForResource(mixed $data, DataObject\Concrete $object = null, array $params = []): ?string
     {
+        if (is_string($data) && !($params['no_sanitize'] ?? false)) {
+            $data = self::getWysiwygSanitizer()->sanitizeFor('body', $data);
+        }
+
         return Text::wysiwygText($data);
     }
 
@@ -113,10 +117,6 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
      */
     public function getDataFromResource(mixed $data, DataObject\Concrete $object = null, array $params = []): ?string
     {
-        if (is_string($data)) {
-            $data = html_entity_decode(self::getWysiwygSanitizer()->sanitizeFor('body', $data));
-        }
-
         return Text::wysiwygText($data);
     }
 
@@ -131,7 +131,7 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
      */
     public function getDataForQueryResource(mixed $data, DataObject\Concrete $object = null, array $params = []): ?string
     {
-        $data = $this->getDataForResource($data, $object, $params);
+        $data = $this->getDataForResource($data, $object, array_merge($params, ['no_sanitize' => true]));
 
         if (null !== $data) {
             $data = strip_tags($data, '<a><img>');
@@ -166,7 +166,7 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
      */
     public function getDataForEditmode(mixed $data, DataObject\Concrete $object = null, array $params = []): ?string
     {
-        return $this->getDataForResource($data, $object, $params);
+        return $this->getDataForResource($data, $object, array_merge($params, ['no_sanitize' => true]));
     }
 
     /**

--- a/models/Document/Editable/Wysiwyg.php
+++ b/models/Document/Editable/Wysiwyg.php
@@ -99,8 +99,7 @@ class Wysiwyg extends Model\Document\Editable implements IdRewriterInterface, Ed
      */
     public function setDataFromEditmode(mixed $data): static
     {
-        $helper = self::getWysiwygSanitizer();
-        $this->text = $helper->sanitizeFor('body', $data);
+        $this->text = $data;
 
         return $this;
     }
@@ -148,5 +147,12 @@ class Wysiwyg extends Model\Document\Editable implements IdRewriterInterface, Ed
 
         $html->clear();
         unset($html);
+    }
+
+    public function save(): void
+    {
+        $helper = self::getWysiwygSanitizer();
+        $this->text = $helper->sanitizeFor('body', $this->text);
+        $this->getDao()->save();
     }
 }

--- a/models/Document/Editable/Wysiwyg.php
+++ b/models/Document/Editable/Wysiwyg.php
@@ -89,8 +89,7 @@ class Wysiwyg extends Model\Document\Editable implements IdRewriterInterface, Ed
      */
     public function setDataFromResource(mixed $data): static
     {
-        $helper = self::getWysiwygSanitizer();
-        $this->text = html_entity_decode($helper->sanitizeFor('body', $data));
+        $this->text = $data;
 
         return $this;
     }
@@ -101,7 +100,7 @@ class Wysiwyg extends Model\Document\Editable implements IdRewriterInterface, Ed
     public function setDataFromEditmode(mixed $data): static
     {
         $helper = self::getWysiwygSanitizer();
-        $this->text = html_entity_decode($helper->sanitizeFor('body', $data));
+        $this->text = $helper->sanitizeFor('body', $data);
 
         return $this;
     }

--- a/models/Translation/Dao.php
+++ b/models/Translation/Dao.php
@@ -105,7 +105,7 @@ class Dao extends Model\Dao\AbstractDao
                         'key' => $this->model->getKey(),
                         'type' => $this->model->getType(),
                         'language' => $language,
-                        'text' => html_entity_decode($sanitizer->sanitizeFor('body', $text)),
+                        'text' => $sanitizer->sanitizeFor('body', $text),
                         'modificationDate' => $this->model->getModificationDate(),
                         'creationDate' => $this->model->getCreationDate(),
                         'userOwner' => $this->model->getUserOwner(),

--- a/models/Translation/Dao.php
+++ b/models/Translation/Dao.php
@@ -101,11 +101,16 @@ class Dao extends Model\Dao\AbstractDao
                         continue;
                     }
 
+                    if ($text != strip_tags($text)) {
+                        $text = $sanitizer->sanitizeFor('body', $text);
+                        $this->model->addTranslation($language, $text);
+                    }
+
                     $data = [
                         'key' => $this->model->getKey(),
                         'type' => $this->model->getType(),
                         'language' => $language,
-                        'text' => $sanitizer->sanitizeFor('body', $text),
+                        'text' => $text,
                         'modificationDate' => $this->model->getModificationDate(),
                         'creationDate' => $this->model->getCreationDate(),
                         'userOwner' => $this->model->getUserOwner(),

--- a/tests/Model/DataObject/ObjectTest.php
+++ b/tests/Model/DataObject/ObjectTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Model\DataObject;
 
+use Pimcore\Cache\RuntimeCache;
 use Pimcore\Db;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\Element\Service;
@@ -354,26 +355,26 @@ class ObjectTest extends ModelTestCase
         $this->assertNull($value);
     }
 
-    //    public function testSanitization(): void
-    //    {
-    //        $db = Db::get();
-    //
-    //        $object = TestHelper::createEmptyObject();
-    //        $object->setWysiwyg('!@#$%^abc\'"<script>console.log("ops");</script> 测试< edf > "');
-    //        $object->save();
-    //
-    //        //reload from db
-    //        $object = DataObject::getById($object->getId(), ['force' => true]);
-    //
-    //        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', $object->getWysiwyg(), 'Asseting setter/getter value is sanitized');
-    //
-    //        $dbQueryValue = $db->fetchOne(
-    //            sprintf(
-    //                'SELECT `wysiwyg` FROM object_query_%s WHERE oo_id = %d',
-    //                $object->getClassName(),
-    //                $object->getId()
-    //            )
-    //        );
-    //        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', $dbQueryValue, 'Asserting object_query table value is persisted as sanitized');
-    //    }
+    public function testSanitization(): void
+    {
+        $db = Db::get();
+
+        $object = TestHelper::createEmptyObject();
+        $object->setWysiwyg('!@#$%^abc\'"<script>console.log("ops");</script> 测试&lt; edf &gt; "');
+        $object->save();
+
+        //reload from db
+        $object = DataObject::getById($object->getId(), ['force' => true]);
+
+        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', html_entity_decode($object->getWysiwyg()), 'Asseting setter/getter value is sanitized');
+
+        $dbQueryValue = $db->fetchOne(
+            sprintf(
+                'SELECT `wysiwyg` FROM object_query_%s WHERE oo_id = %d',
+                $object->getClassName(),
+                $object->getId()
+            )
+        );
+        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', html_entity_decode($dbQueryValue), 'Asserting object_query table value is persisted as sanitized');
+    }
 }

--- a/tests/Unit/Translation/TranslatorTest.php
+++ b/tests/Unit/Translation/TranslatorTest.php
@@ -261,7 +261,7 @@ class TranslatorTest extends TestCase
 
         $translation = Translation::getByKey($key);
         $getter = $translation->getTranslation('en');
-        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', $getter, 'Asserting translation is properly sanitized');
+        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', html_entity_decode($getter), 'Asserting translation is properly sanitized');
 
         $db = Db::get();
         $dbValue = $db->fetchOne(

--- a/tests/Unit/Translation/TranslatorTest.php
+++ b/tests/Unit/Translation/TranslatorTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Unit\Translation;
 
+use Pimcore\Cache\RuntimeCache;
 use Pimcore\Db;
 use Pimcore\Model\Translation;
 use Pimcore\Tests\Support\Test\TestCase;
@@ -247,27 +248,29 @@ class TranslatorTest extends TestCase
         $this->assertCount(count($beforeAdd) + 1, $afterAdd);
     }
 
-    //    public function testSanitizedTranslation(): void
-    //    {
-    //        $translation = new Translation();
-    //        $key = 'sanitizerTest';
-    //        $translation->setDomain('messages');
-    //        $translation->setKey($key);
-    //        $translation->setTranslations(['en' => '!@#$%^abc\'"<script>console.log("ops");</script> 测试< edf > "']);
-    //        $translation->save();
-    //
-    //        $translation = Translation::getByKey($key);
-    //        $getter = $translation->getTranslation('en');
-    //        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', $getter, 'Asserting translation is properly sanitized');
-    //
-    //        $db = Db::get();
-    //        $dbValue = $db->fetchOne(
-    //            sprintf(
-    //                'SELECT `text` FROM translations_messages WHERE `key` = %s AND `language` = %s',
-    //                $db->quote($key),
-    //                $db->quote('en')
-    //            )
-    //        );
-    //        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', $dbValue, 'Asserting translation is persisted as sanitized');
-    //    }
+    public function testSanitizedTranslation(): void
+    {
+        $translation = new Translation();
+        $key = 'sanitizerTest';
+        $translation->setDomain('messages');
+        $translation->setKey($key);
+        $translation->setTranslations(['en' => '!@#$%^abc\'"<script>console.log("ops");</script> 测试&lt; edf &gt; "']);
+        $translation->save();
+
+        RuntimeCache::clear();
+
+        $translation = Translation::getByKey($key);
+        $getter = $translation->getTranslation('en');
+        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', $getter, 'Asserting translation is properly sanitized');
+
+        $db = Db::get();
+        $dbValue = $db->fetchOne(
+            sprintf(
+                'SELECT `text` FROM translations_messages WHERE `key` = %s AND `language` = %s',
+                $db->quote($key),
+                $db->quote('en')
+            )
+        );
+        $this->assertEquals('!@#$%^abc\'" 测试< edf > "', html_entity_decode($dbValue), 'Asserting translation is persisted as sanitized');
+    }
 }


### PR DESCRIPTION
## Changes in this pull request  
Related to #15740

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 391ab33</samp>

This pull request improves the sanitization and encoding of WYSIWYG data for data objects and document editables, and updates the unit tests and documentation accordingly. It fixes some issues with double sanitization or decoding of the data, and provides a script to sanitize the existing data in the database.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 391ab33</samp>

> _Oh, we're the coders of the WYSIWYG_
> _And we sanitize the data as we go_
> _We encode the entities and we clear the cache_
> _And we document the changes for the users, yo ho!_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 391ab33</samp>

*  Add a note to the WYSIWYG editable documentation to inform users that they need to encode html entities when using the API ([link](https://github.com/pimcore/pimcore/pull/16086/files?diff=unified&w=0#diff-c601cb407d4defaaf4f0ab272abee11dcc09f7984d5f296e824f86e72ed7e46aR55-R56))
*  Modify the upgrade notes to include a link to a script that can sanitize the existing WYSIWYG data in the database ([link](https://github.com/pimcore/pimcore/pull/16086/files?diff=unified&w=0#diff-375aded12dfb868b84d5b8c27d1aed2358680a27b683e8a985f1b85193dd79aaL102-R103))
*  Prevent sanitization of WYSIWYG data for data objects when storing it in the `object_query` table by adding a `no_sanitize` parameter to the `getDataForResource` method ([link](https://github.com/pimcore/pimcore/pull/16086/files?diff=unified&w=0#diff-2ba4202bada58b975309826f8fc4a99d465b9ef1a6c7227bc49487f7541f44edR102-R105), [link](https://github.com/pimcore/pimcore/pull/16086/files?diff=unified&w=0#diff-2ba4202bada58b975309826f8fc4a99d465b9ef1a6c7227bc49487f7541f44edL134-R134))
*  Remove double sanitization or decoding of WYSIWYG data for data objects and document editables when loading it from the database by removing the symfony HTML sanitizer and the `html_entity_decode` function from the `getDataFromResource` and `setDataFromResource` methods ([link](https://github.com/pimcore/pimcore/pull/16086/files?diff=unified&w=0#diff-2ba4202bada58b975309826f8fc4a99d465b9ef1a6c7227bc49487f7541f44edL116-L119), [link](https://github.com/pimcore/pimcore/pull/16086/files?diff=unified&w=0#diff-0c6c24fc188205dba44a894fc6eb75aa6959974d07e633a0fc92d12e179f25e0L92-R92))
*  Uncomment and modify the unit tests for the sanitization of WYSIWYG data for data objects (`testSanitization`) and translation data for the messages domain (`testSanitizedTranslation`) by encoding the html entities in the input and clearing the runtime cache before retrieving the objects ([link](https://github.com/pimcore/pimcore/pull/16086/files?diff=unified&w=0#diff-5ae8bd11ad9f1d8c280eb8c6d1b9eb5580f3e58f6e6bba67b2d9b7e3d8b0e114R19), [link](https://github.com/pimcore/pimcore/pull/16086/files?diff=unified&w=0#diff-5ae8bd11ad9f1d8c280eb8c6d1b9eb5580f3e58f6e6bba67b2d9b7e3d8b0e114L357-R379), [link](https://github.com/pimcore/pimcore/pull/16086/files?diff=unified&w=0#diff-72c74b38fba64391afe0b39ec146f87550f204f4171df51b8ca3a31a4b0a0826R20), [link](https://github.com/pimcore/pimcore/pull/16086/files?diff=unified&w=0#diff-72c74b38fba64391afe0b39ec146f87550f204f4171df51b8ca3a31a4b0a0826L250-R275))
