### PR TITLE
[DataObject] Fix query data for many-to-one relation field

### DIFF
--- a/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
@@ -207,13 +207,18 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
      */
     public function getDataForQueryResource(mixed $data, DataObject\Concrete $object = null, array $params = []): array
     {
-        $return = [];
+        $idIndex = $this->getName() . '__id';
+        $typeIndex = $this->getName() . '__type';
+
+        $return = [$idIndex => null, $typeIndex => null];
 
         if ($data != null) {
             $rData = $this->prepareDataForPersistence($data, $object, $params);
 
-            $return[$this->getName() . '__id'] = isset($rData[0]['dest_id']) ? $rData[0]['dest_id'] : null;
-            $return[$this->getName() . '__type'] = isset($rData[0]['type']) ? $rData[0]['type'] : null;
+            $return = [
+                $idIndex => $rData[0]['dest_id'] ?? null,
+                $typeIndex => $rData[0]['type'] ?? null
+            ];
         }
 
         return $return;


### PR DESCRIPTION
## Changes in this pull request  
Resolves #16071

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a117772</samp>

Refactor `getDataForQueryResource` in `ManyToOneRelation` to simplify code and prevent notices. Use null coalescing and array initialization to handle missing or null values.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a117772</samp>

> _`getDataForQuery`_
> _Simpler with null coalescing_
> _Autumn leaves no trace_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a117772</samp>

*  Simplify and optimize the code for getting and setting the data of many-to-one relations in DataObject classes ([link](https://github.com/pimcore/pimcore/pull/16095/files?diff=unified&w=0#diff-cf6e3e2d1ae52145eab9d3d2bb7e0fc84ed837c640960592449f628b89ea3901L210-R221),                            F0
