### PR TITLE
fix(models): Select - updated getDataForGrid $data parameter type

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -353,13 +353,13 @@ class Select extends Data implements
     }
 
     /**
-     * @param string|null $data
+     * @param mixed $data
      * @param DataObject\Concrete|null $object
      * @param array $params
      *
-     * @return array|string|null
+     * @return array|string|int|null
      */
-    public function getDataForGrid(?string $data, Concrete $object = null, array $params = []): array|string|null
+    public function getDataForGrid(mixed $data, Concrete $object = null, array $params = []): array|string|int|null
     {
         $optionsProvider = DataObject\ClassDefinition\Helper\OptionsProviderResolver::resolveProvider(
             $this->getOptionsProviderClass(),


### PR DESCRIPTION
## Changes in this pull request  
Updates the `$data` parameter type in the [Select](https://github.com/pimcore/pimcore/blob/7b637e528297fbd147384c78342eeb6ffc808df4/models/DataObject/ClassDefinition/Data/Select.php#L284) model `getDataForGrid` function  from `?string` to `mixed` to match with the other getDataFor... functions in the class.

This is fixing an issue when a Select OptionProvider option has a value that is an `int` and not a `string`.
If you are in a grid view and want to set the select value, you get this exception: 


> Pimcore\Model\DataObject\ClassDefinition\Data\Select::getDataForGrid(): Argument #1 ($data) must be of type ?string, int given, called in /var/www/html/vendor/pimcore/pimcore/models/DataObject/Service.php on line 733


If you check the other getDataFor... functions like [getDataForResource](https://github.com/pimcore/pimcore/blob/7b637e528297fbd147384c78342eeb6ffc808df4/models/DataObject/ClassDefinition/Data/Select.php#L126) or [getDataForEditmode](https://github.com/pimcore/pimcore/blob/7b637e528297fbd147384c78342eeb6ffc808df4/models/DataObject/ClassDefinition/Data/Select.php#L159) you will see that they have the `$data` parameter set to `mixed`.

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8749df3</samp>

Refactored type hints for `Select` data object field to support PHP 8 union and mixed types. Updated `getDataForGrid` method to match parent class and allow custom options providers.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8749df3</samp>

> _`getDataForGrid`_
> _Union types and mixed data_
> _Autumn of refactor_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8749df3</samp>

* Change type hints for `getDataForGrid` method to allow more flexibility ([link](https://github.com/pimcore/pimcore/pull/16096/files?diff=unified&w=0#diff-c622407049f7baa79f2520f1745ee112b447b41efff4f19ff50b8a7df44bd521L356-R362))
