### PR TITLE
[Bug] Pimcore\Model\DataObject\ClassDefinition\Data\ExternalImage::getVersionPreview(): Return value must be of type string, Pimcore\Model\DataObject\Data\ExternalImage returned

### DIFF
--- a/models/DataObject/ClassDefinition/Data/ExternalImage.php
+++ b/models/DataObject/ClassDefinition/Data/ExternalImage.php
@@ -172,9 +172,9 @@ class ExternalImage extends Data implements ResourcePersistenceAwareInterface, Q
     {
         if ($data instanceof Model\DataObject\Data\ExternalImage && $data->getUrl()) {
             return '<img style="max-width:200px;max-height:200px" src="' . $data->getUrl()  . '" /><br><a href="' . $data->getUrl() . '">' . $data->getUrl() . '</>';
-        }
+        } 
 
-        return $data;
+        return '';
     }
 
     public function getForCsvExport(DataObject\Localizedfield|DataObject\Fieldcollection\Data\AbstractData|DataObject\Objectbrick\Data\AbstractData|DataObject\Concrete $object, array $params = []): string


### PR DESCRIPTION


##
Resolves #
Issue fixed:  Pimcore\Model\DataObject\ClassDefinition\Data\ExternalImage::getVersionPreview(): Return value must be of type string, Pimcore\Model\DataObject\Data\ExternalImage returned


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b0ea6d4</samp>

Fixed a bug in `ExternalImage` data type that caused an error when previewing data objects with empty or invalid external image fields. Modified `getVersionPreview` function in `models/DataObject/ClassDefinition/Data/ExternalImage.php` to return an empty string in such cases.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b0ea6d4</samp>

> _`getVersionPreview`_
> _Returns empty string now_
> _Fixing winter bugs_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b0ea6d4</samp>

* Fix a bug that caused an error when previewing data objects with external image fields that were empty or invalid by returning an empty string instead of the original data object in the `getVersionPreview` function of the `ExternalImage` class ([link](https://github.com/pimcore/pimcore/pull/16100/files?diff=unified&w=0#diff-425e20f0eacc9e45de44514638f09c7b9e72cf31d7fdd07b3b1c4ca6ffd6aaccL175-R177)) in `models/DataObject/ClassDefinition/Data/ExternalImage.php`
