### PR TITLE
[Asset::create()] Prevent warning "unlink(...): No such file or directory" for importing local file as stream

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -388,7 +388,7 @@ class Asset extends Element\AbstractElement
             $asset->save();
         }
 
-        if ($tmpFile) {
+        if (file_exists($tmpFile)) {
             unlink($tmpFile);
         }
 


### PR DESCRIPTION
Steps to reproduce bug:

Run following script:
```php
<?php
$asset = \Pimcore\Model\Asset::create(1, ['filename' => 'test', 'stream' => fopen(__FILE__, 'rb')], false);
```

This will lead to
> Warning: unlink(/var/www/html/var/tmp/asset-create-tmp-file-652b90f6b61fd.): No such file or directory  

This is caused by https://github.com/pimcore/pimcore/blob/8949fc94ec559a22a92a55de061e8f2b20abed6d/models/Asset.php#L301-L333

In https://github.com/pimcore/pimcore/blob/8949fc94ec559a22a92a55de061e8f2b20abed6d/models/Asset.php#L302 `$tmpFilePath` gets defined.

In the above case when providing `$data['stream']` of a local file we get to https://github.com/pimcore/pimcore/blob/8949fc94ec559a22a92a55de061e8f2b20abed6d/models/Asset.php#L315-L316
Nothing is written to `$tmpFilePath` here.

Thus, the check in 
https://github.com/pimcore/pimcore/blob/8949fc94ec559a22a92a55de061e8f2b20abed6d/models/Asset.php#L367-L369
is `true` but there is no file to be `unlink`ed.