### PR TITLE
use `getObjectVars` in link isEmpty method

### DIFF
--- a/models/DataObject/Data/Link.php
+++ b/models/DataObject/Data/Link.php
@@ -422,7 +422,7 @@ class Link implements OwnerAwareFieldInterface
 
     public function isEmpty(): bool
     {
-        $vars = get_object_vars($this);
+        $vars = $this->getObjectVars();
         foreach ($vars as $value) {
             if (!empty($value)) {
                 return false;


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info
`$link->isEmpty()` returns always false if `_owner` is set.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f7528e</samp>

Fixed a bug in the `isEmpty` function of the `Link` class by using `getObjectVars` instead of `get_object_vars`. This ensures that only public properties of the link are checked for emptiness.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1f7528e</samp>

> _`isEmpty` fixed_
> _`getObjectVars` respects_
> _visibility - fall_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1f7528e</samp>

*  Fixed a bug where the `isEmpty` function of the `Link` class would return false for empty links that had private or protected properties set ([link](https://github.com/pimcore/pimcore/pull/16109/files?diff=unified&w=0#diff-c4397b14d09f0d8e2394dc937225c5bda11c39efae3c98c9c138e06a8ddc519cL425-R425))
