### PR TITLE
feat: added before load event for objects, documents and assets

### DIFF
--- a/lib/Event/AssetEvents.php
+++ b/lib/Event/AssetEvents.php
@@ -119,6 +119,16 @@ final class AssetEvents
      * Arguments:
      *  - params | array | contains the values that were passed to getById() as the second parameter
      *
+     * @Event("Pimcore\Event\Model\AssetPreLoadEvent")
+     *
+     * @var string
+     */
+    const PRE_LOAD = 'pimcore.asset.preLoad';
+
+    /**
+     * Arguments:
+     *  - params | array | contains the values that were passed to getById() as the second parameter
+     *
      * @Event("Pimcore\Event\Model\AssetEvent")
      *
      * @var string

--- a/lib/Event/DataObjectEvents.php
+++ b/lib/Event/DataObjectEvents.php
@@ -121,6 +121,16 @@ final class DataObjectEvents
      * Arguments:
      *  - params | array | contains the values that were passed to getById() as the second parameter
      *
+     * @Event("Pimcore\Event\Model\DataObjectPreLoadEvent")
+     *
+     * @var string
+     */
+    const PRE_LOAD = 'pimcore.dataobject.preLoad';
+
+    /**
+     * Arguments:
+     *  - params | array | contains the values that were passed to getById() as the second parameter
+     *
      * @Event("Pimcore\Event\Model\DataObjectEvent")
      *
      * @var string

--- a/lib/Event/DocumentEvents.php
+++ b/lib/Event/DocumentEvents.php
@@ -109,6 +109,16 @@ final class DocumentEvents
      * Arguments:
      *  - params | array | contains the values that were passed to getById() as the second parameter
      *
+     * @Event("Pimcore\Event\Model\DocumentPreLoadEvent")
+     *
+     * @var string
+     */
+    const PRE_LOAD = 'pimcore.document.preLoad';
+
+    /**
+     * Arguments:
+     *  - params | array | contains the values that were passed to getById() as the second parameter
+     *
      * @Event("Pimcore\Event\Model\DocumentEvent")
      *
      * @var string

--- a/lib/Event/Model/AssetPreLoadEvent.php
+++ b/lib/Event/Model/AssetPreLoadEvent.php
@@ -25,7 +25,7 @@ class AssetPreLoadEvent extends Event implements ElementEventInterface
 {
     use ArgumentsAwareTrait;
 
-    protected ?Asset $asset = null;
+    protected ?Asset $asset;
 
     /**
      * AssetEvent constructor.

--- a/lib/Event/Model/AssetPreLoadEvent.php
+++ b/lib/Event/Model/AssetPreLoadEvent.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Event\Model;
+
+use Pimcore\Event\Traits\ArgumentsAwareTrait;
+use Pimcore\Model\Asset;
+use Pimcore\Model\Exception\NotFoundException;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class AssetPreLoadEvent extends Event implements ElementEventInterface
+{
+    use ArgumentsAwareTrait;
+
+    protected ?Asset $asset;
+
+    /**
+     * AssetEvent constructor.
+     *
+     * @param array $arguments additional parameters (e.g. "versionNote" for the version note)
+     */
+    public function __construct(?Asset $asset, array $arguments = [])
+    {
+        $this->asset = $asset;
+        $this->arguments = $arguments;
+    }
+
+    public function getAsset(): ?Asset
+    {
+        if (empty($this->document)) {
+            throw new NotFoundException();
+        }
+        return $this->asset;
+    }
+
+    public function setAsset(?Asset $asset): void
+    {
+        $this->asset = $asset;
+    }
+
+    public function getElement(): Asset
+    {
+        return $this->getAsset();
+    }
+}

--- a/lib/Event/Model/AssetPreLoadEvent.php
+++ b/lib/Event/Model/AssetPreLoadEvent.php
@@ -40,7 +40,7 @@ class AssetPreLoadEvent extends Event implements ElementEventInterface
 
     public function getAsset(): ?Asset
     {
-        if (empty($this->document)) {
+        if (empty($this->asset)) {
             throw new NotFoundException();
         }
         return $this->asset;

--- a/lib/Event/Model/AssetPreLoadEvent.php
+++ b/lib/Event/Model/AssetPreLoadEvent.php
@@ -25,7 +25,7 @@ class AssetPreLoadEvent extends Event implements ElementEventInterface
 {
     use ArgumentsAwareTrait;
 
-    protected ?Asset $asset;
+    protected ?Asset $asset = null;
 
     /**
      * AssetEvent constructor.
@@ -40,7 +40,7 @@ class AssetPreLoadEvent extends Event implements ElementEventInterface
 
     public function getAsset(): Asset
     {
-        if (empty($this->asset)) {
+        if ($this->asset === null) {
             throw new NotFoundException();
         }
         return $this->asset;

--- a/lib/Event/Model/AssetPreLoadEvent.php
+++ b/lib/Event/Model/AssetPreLoadEvent.php
@@ -38,7 +38,7 @@ class AssetPreLoadEvent extends Event implements ElementEventInterface
         $this->arguments = $arguments;
     }
 
-    public function getAsset(): ?Asset
+    public function getAsset(): Asset
     {
         if (empty($this->asset)) {
             throw new NotFoundException();

--- a/lib/Event/Model/DataObjectPreLoadEvent.php
+++ b/lib/Event/Model/DataObjectPreLoadEvent.php
@@ -25,7 +25,7 @@ class DataObjectPreLoadEvent extends Event implements ElementEventInterface
 {
     use ArgumentsAwareTrait;
 
-    protected ?AbstractObject $object;
+    protected ?AbstractObject $object = null;
 
     /**
      * DataObjectEvent constructor.
@@ -39,7 +39,7 @@ class DataObjectPreLoadEvent extends Event implements ElementEventInterface
 
     public function getObject(): AbstractObject
     {
-        if (empty($this->object)) {
+        if ($this->object === null) {
             throw new NotFoundException();
         }
         return $this->object;

--- a/lib/Event/Model/DataObjectPreLoadEvent.php
+++ b/lib/Event/Model/DataObjectPreLoadEvent.php
@@ -25,7 +25,7 @@ class DataObjectPreLoadEvent extends Event implements ElementEventInterface
 {
     use ArgumentsAwareTrait;
 
-    protected ?AbstractObject $object = null;
+    protected ?AbstractObject $object;
 
     /**
      * DataObjectEvent constructor.

--- a/lib/Event/Model/DataObjectPreLoadEvent.php
+++ b/lib/Event/Model/DataObjectPreLoadEvent.php
@@ -37,7 +37,7 @@ class DataObjectPreLoadEvent extends Event implements ElementEventInterface
         $this->arguments = $arguments;
     }
 
-    public function getObject(): ?AbstractObject
+    public function getObject(): AbstractObject
     {
         if (empty($this->object)) {
             throw new NotFoundException();

--- a/lib/Event/Model/DataObjectPreLoadEvent.php
+++ b/lib/Event/Model/DataObjectPreLoadEvent.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Event\Model;
+
+use Pimcore\Event\Traits\ArgumentsAwareTrait;
+use Pimcore\Model\DataObject\AbstractObject;
+use Pimcore\Model\Exception\NotFoundException;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class DataObjectPreLoadEvent extends Event implements ElementEventInterface
+{
+    use ArgumentsAwareTrait;
+
+    protected ?AbstractObject $object;
+
+    /**
+     * DataObjectEvent constructor.
+     *
+     */
+    public function __construct(?AbstractObject $object, array $arguments = [])
+    {
+        $this->object = $object;
+        $this->arguments = $arguments;
+    }
+
+    public function getObject(): ?AbstractObject
+    {
+        if (empty($this->object)) {
+            throw new NotFoundException();
+        }
+        return $this->object;
+    }
+
+    public function setObject(?AbstractObject $object): void
+    {
+        $this->object = $object;
+    }
+
+    public function getElement(): AbstractObject
+    {
+        return $this->getObject();
+    }
+}

--- a/lib/Event/Model/DocumentPreLoadEvent.php
+++ b/lib/Event/Model/DocumentPreLoadEvent.php
@@ -25,7 +25,7 @@ class DocumentPreLoadEvent extends Event implements ElementEventInterface
 {
     use ArgumentsAwareTrait;
 
-    protected ?Document $document = null;
+    protected ?Document $document;
 
     /**
      * DocumentEvent constructor.

--- a/lib/Event/Model/DocumentPreLoadEvent.php
+++ b/lib/Event/Model/DocumentPreLoadEvent.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Event\Model;
+
+use Pimcore\Event\Traits\ArgumentsAwareTrait;
+use Pimcore\Model\Document;
+use Pimcore\Model\Exception\NotFoundException;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class DocumentPreLoadEvent extends Event implements ElementEventInterface
+{
+    use ArgumentsAwareTrait;
+
+    protected ?Document $document;
+
+    /**
+     * DocumentEvent constructor.
+     *
+     */
+    public function __construct(?Document $document, array $arguments = [])
+    {
+        $this->document = $document;
+        $this->arguments = $arguments;
+    }
+
+    public function getDocument(): ?Document
+    {
+        if (empty($this->document)) {
+            throw new NotFoundException();
+        }
+        return $this->document;
+    }
+
+    public function setDocument(?Document $document): void
+    {
+        $this->document = $document;
+    }
+
+    public function getElement(): Document
+    {
+        return $this->getDocument();
+    }
+}

--- a/lib/Event/Model/DocumentPreLoadEvent.php
+++ b/lib/Event/Model/DocumentPreLoadEvent.php
@@ -37,7 +37,7 @@ class DocumentPreLoadEvent extends Event implements ElementEventInterface
         $this->arguments = $arguments;
     }
 
-    public function getDocument(): ?Document
+    public function getDocument(): Document
     {
         if (empty($this->document)) {
             throw new NotFoundException();

--- a/lib/Event/Model/DocumentPreLoadEvent.php
+++ b/lib/Event/Model/DocumentPreLoadEvent.php
@@ -25,7 +25,7 @@ class DocumentPreLoadEvent extends Event implements ElementEventInterface
 {
     use ArgumentsAwareTrait;
 
-    protected ?Document $document;
+    protected ?Document $document = null;
 
     /**
      * DocumentEvent constructor.
@@ -39,7 +39,7 @@ class DocumentPreLoadEvent extends Event implements ElementEventInterface
 
     public function getDocument(): Document
     {
-        if (empty($this->document)) {
+        if ($this->document === null) {
             throw new NotFoundException();
         }
         return $this->document;

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -251,6 +251,7 @@ class Asset extends Element\AbstractElement
                 // fire pre load event
                 $preLoadEvent = new AssetPreLoadEvent($asset, ['params' => $params]);
                 \Pimcore::getEventDispatcher()->dispatch($preLoadEvent, AssetEvents::PRE_LOAD);
+                /** @var ?static $asset */
                 $asset = $preLoadEvent->getAsset();
 
                 $className = \Pimcore::getContainer()->get('pimcore.class.resolver.asset')->resolve($asset->getType());

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -251,7 +251,6 @@ class Asset extends Element\AbstractElement
                 // fire pre load event
                 $preLoadEvent = new AssetPreLoadEvent($asset, ['params' => $params]);
                 \Pimcore::getEventDispatcher()->dispatch($preLoadEvent, AssetEvents::PRE_LOAD);
-                /** @var ?static $asset */
                 $asset = $preLoadEvent->getAsset();
 
                 $className = \Pimcore::getContainer()->get('pimcore.class.resolver.asset')->resolve($asset->getType());
@@ -277,7 +276,6 @@ class Asset extends Element\AbstractElement
                 // fire pre load event
                 $preLoadEvent = new AssetPreLoadEvent($asset, ['params' => $params]);
                 \Pimcore::getEventDispatcher()->dispatch($preLoadEvent, AssetEvents::PRE_LOAD);
-                /** @var ?static $asset */
                 $asset = $preLoadEvent->getAsset();
             } catch (NotFoundException $e) {
                 return null;
@@ -293,7 +291,7 @@ class Asset extends Element\AbstractElement
         } else {
             $asset = null;
         }
-
+        /** @var ?static $asset */
         return $asset;
     }
 

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -17,8 +17,6 @@ namespace Pimcore\Model;
 
 use Doctrine\DBAL\Exception\DeadlockException;
 use Exception;
-use Pimcore\Event\DocumentEvents;
-use Pimcore\Event\Model\DocumentPreLoadEvent;
 use function is_array;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
@@ -274,6 +272,14 @@ class Asset extends Element\AbstractElement
                 $asset = null;
             }
         } else {
+            try {
+                // fire pre load event
+                $preLoadEvent = new AssetPreLoadEvent($asset, ['params' => $params]);
+                \Pimcore::getEventDispatcher()->dispatch($preLoadEvent, AssetEvents::PRE_LOAD);
+                $asset = $preLoadEvent->getAsset();
+            } catch (NotFoundException $e) {
+                return null;
+            }
             RuntimeCache::set($cacheKey, $asset);
         }
 

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -17,6 +17,8 @@ namespace Pimcore\Model;
 
 use Doctrine\DBAL\Exception\DeadlockException;
 use Exception;
+use Pimcore\Event\DocumentEvents;
+use Pimcore\Event\Model\DocumentPreLoadEvent;
 use function is_array;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
@@ -29,6 +31,7 @@ use Pimcore\Config;
 use Pimcore\Event\AssetEvents;
 use Pimcore\Event\FrontendEvents;
 use Pimcore\Event\Model\AssetEvent;
+use Pimcore\Event\Model\AssetPreLoadEvent;
 use Pimcore\File;
 use Pimcore\Helper\TemporaryFileHelperTrait;
 use Pimcore\Loader\ImplementationLoader\Exception\UnsupportedException;
@@ -247,6 +250,10 @@ class Asset extends Element\AbstractElement
 
             try {
                 $asset->getDao()->getById($id);
+                // fire pre load event
+                $preLoadEvent = new AssetPreLoadEvent($asset, ['params' => $params]);
+                \Pimcore::getEventDispatcher()->dispatch($preLoadEvent, AssetEvents::PRE_LOAD);
+                $asset = $preLoadEvent->getAsset();
 
                 $className = \Pimcore::getContainer()->get('pimcore.class.resolver.asset')->resolve($asset->getType());
                 /** @var Asset $newAsset */

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -276,6 +276,7 @@ class Asset extends Element\AbstractElement
                 // fire pre load event
                 $preLoadEvent = new AssetPreLoadEvent($asset, ['params' => $params]);
                 \Pimcore::getEventDispatcher()->dispatch($preLoadEvent, AssetEvents::PRE_LOAD);
+                /** @var ?static $asset */
                 $asset = $preLoadEvent->getAsset();
             } catch (NotFoundException $e) {
                 return null;

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -271,6 +271,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
                 // fire pre load event
                 $preLoadEvent = new DataObjectPreLoadEvent($object, ['params' => $params]);
                 \Pimcore::getEventDispatcher()->dispatch($preLoadEvent, DataObjectEvents::PRE_LOAD);
+                /** @var ?static $object */
                 $object = $preLoadEvent->getObject();
             } catch (Model\Exception\NotFoundException $e) {
                 return null;

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -246,7 +246,6 @@ abstract class AbstractObject extends Model\Element\AbstractElement
                     // fire pre load event
                     $preLoadEvent = new DataObjectPreLoadEvent($object, ['params' => $params]);
                     \Pimcore::getEventDispatcher()->dispatch($preLoadEvent, DataObjectEvents::PRE_LOAD);
-                    /** @var ?static $object */
                     $object = $preLoadEvent->getObject();
 
                     $object->__setDataVersionTimestamp($object->getModificationDate());
@@ -272,7 +271,6 @@ abstract class AbstractObject extends Model\Element\AbstractElement
                 // fire pre load event
                 $preLoadEvent = new DataObjectPreLoadEvent($object, ['params' => $params]);
                 \Pimcore::getEventDispatcher()->dispatch($preLoadEvent, DataObjectEvents::PRE_LOAD);
-                /** @var ?static $object */
                 $object = $preLoadEvent->getObject();
             } catch (Model\Exception\NotFoundException $e) {
                 return null;
@@ -288,7 +286,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
             new DataObjectEvent($object, ['params' => $params]),
             DataObjectEvents::POST_LOAD
         );
-
+        /** @var ?static $object */
         return $object;
     }
 

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -23,6 +23,7 @@ use Pimcore\Cache\RuntimeCache;
 use Pimcore\Db;
 use Pimcore\Event\DataObjectEvents;
 use Pimcore\Event\Model\DataObjectEvent;
+use Pimcore\Event\Model\DataObjectPreLoadEvent;
 use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\DataObject;
@@ -242,6 +243,11 @@ abstract class AbstractObject extends Model\Element\AbstractElement
                     $object = self::getModelFactory()->build($className);
                     RuntimeCache::set($cacheKey, $object);
                     $object->getDao()->getById($id);
+                    // fire pre load event
+                    $preLoadEvent = new DataObjectPreLoadEvent($object, ['params' => $params]);
+                    \Pimcore::getEventDispatcher()->dispatch($preLoadEvent, DataObjectEvents::PRE_LOAD);
+                    $object = $preLoadEvent->getObject();
+
                     $object->__setDataVersionTimestamp($object->getModificationDate());
 
                     Service::recursiveResetDirtyMap($object);

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -246,6 +246,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
                     // fire pre load event
                     $preLoadEvent = new DataObjectPreLoadEvent($object, ['params' => $params]);
                     \Pimcore::getEventDispatcher()->dispatch($preLoadEvent, DataObjectEvents::PRE_LOAD);
+                    /** @var ?static $object */
                     $object = $preLoadEvent->getObject();
 
                     $object->__setDataVersionTimestamp($object->getModificationDate());

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -267,6 +267,14 @@ abstract class AbstractObject extends Model\Element\AbstractElement
                 return null;
             }
         } else {
+            try {
+                // fire pre load event
+                $preLoadEvent = new DataObjectPreLoadEvent($object, ['params' => $params]);
+                \Pimcore::getEventDispatcher()->dispatch($preLoadEvent, DataObjectEvents::PRE_LOAD);
+                $object = $preLoadEvent->getObject();
+            } catch (Model\Exception\NotFoundException $e) {
+                return null;
+            }
             RuntimeCache::set($cacheKey, $object);
         }
 

--- a/models/Document.php
+++ b/models/Document.php
@@ -21,6 +21,7 @@ use Pimcore\Cache\RuntimeCache;
 use Pimcore\Event\DocumentEvents;
 use Pimcore\Event\FrontendEvents;
 use Pimcore\Event\Model\DocumentEvent;
+use Pimcore\Event\Model\DocumentPreLoadEvent;
 use Pimcore\Logger;
 use Pimcore\Model\Document\Hardlink\Wrapper\WrapperInterface;
 use Pimcore\Model\Document\Listing;
@@ -211,6 +212,10 @@ class Document extends Element\AbstractElement
 
             try {
                 $document->getDao()->getById($id);
+                // fire pre load event
+                $preLoadEvent = new DocumentPreLoadEvent($document, ['params' => $params]);
+                \Pimcore::getEventDispatcher()->dispatch($preLoadEvent, DocumentEvents::PRE_LOAD);
+                $document = $preLoadEvent->getDocument();
             } catch (NotFoundException $e) {
                 return null;
             }

--- a/models/Document.php
+++ b/models/Document.php
@@ -244,6 +244,7 @@ class Document extends Element\AbstractElement
                 // fire pre load event
                 $preLoadEvent = new DocumentPreLoadEvent($document, ['params' => $params]);
                 \Pimcore::getEventDispatcher()->dispatch($preLoadEvent, DocumentEvents::PRE_LOAD);
+                /** @var ?static $document */
                 $document = $preLoadEvent->getDocument();
             } catch (NotFoundException $e) {
                 return null;

--- a/models/Document.php
+++ b/models/Document.php
@@ -215,6 +215,7 @@ class Document extends Element\AbstractElement
                 // fire pre load event
                 $preLoadEvent = new DocumentPreLoadEvent($document, ['params' => $params]);
                 \Pimcore::getEventDispatcher()->dispatch($preLoadEvent, DocumentEvents::PRE_LOAD);
+                /** @var ?static $document */
                 $document = $preLoadEvent->getDocument();
             } catch (NotFoundException $e) {
                 return null;

--- a/models/Document.php
+++ b/models/Document.php
@@ -215,7 +215,6 @@ class Document extends Element\AbstractElement
                 // fire pre load event
                 $preLoadEvent = new DocumentPreLoadEvent($document, ['params' => $params]);
                 \Pimcore::getEventDispatcher()->dispatch($preLoadEvent, DocumentEvents::PRE_LOAD);
-                /** @var ?static $document */
                 $document = $preLoadEvent->getDocument();
             } catch (NotFoundException $e) {
                 return null;
@@ -245,7 +244,6 @@ class Document extends Element\AbstractElement
                 // fire pre load event
                 $preLoadEvent = new DocumentPreLoadEvent($document, ['params' => $params]);
                 \Pimcore::getEventDispatcher()->dispatch($preLoadEvent, DocumentEvents::PRE_LOAD);
-                /** @var ?static $document */
                 $document = $preLoadEvent->getDocument();
             } catch (NotFoundException $e) {
                 return null;
@@ -261,7 +259,7 @@ class Document extends Element\AbstractElement
             new DocumentEvent($document, ['params' => $params]),
             DocumentEvents::POST_LOAD
         );
-
+        /** @var ?static $document */
         return $document;
     }
 

--- a/models/Document.php
+++ b/models/Document.php
@@ -240,6 +240,14 @@ class Document extends Element\AbstractElement
 
             \Pimcore\Cache::save($document, $cacheKey);
         } else {
+            try {
+                // fire pre load event
+                $preLoadEvent = new DocumentPreLoadEvent($document, ['params' => $params]);
+                \Pimcore::getEventDispatcher()->dispatch($preLoadEvent, DocumentEvents::PRE_LOAD);
+                $document = $preLoadEvent->getDocument();
+            } catch (NotFoundException $e) {
+                return null;
+            }
             RuntimeCache::set($cacheKey, $document);
         }
 


### PR DESCRIPTION
## Changes in this pull request  

## Additional info
added pre load events for objects, documents and assets

### WHAT
we need to check some stuff before a "entity" (object, document, asset) is loaded and need to be able to return nothing respective throw an exception which is the same as an entity not exists.

As there are no other possiblities to hook in into the DB-queries this seems to be the cleanest solution.
