### PR TITLE
[Documents] Add type check for data before passing to sanitizer in wysiwg

### DIFF
--- a/models/Document/Editable/Wysiwyg.php
+++ b/models/Document/Editable/Wysiwyg.php
@@ -130,8 +130,10 @@ class Wysiwyg extends Model\Document\Editable implements IdRewriterInterface, Ed
 
     public function save(): void
     {
-        $helper = self::getWysiwygSanitizer();
-        $this->text = $helper->sanitizeFor('body', $this->text);
+        if(is_string($this->text)) {
+            $helper = self::getWysiwygSanitizer();
+            $this->text = $helper->sanitizeFor('body', $this->text);
+        }
         $this->getDao()->save();
     }
 }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Follow up to https://github.com/pimcore/pimcore/pull/16086

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e5132d</samp>

Fix Wysiwyg sanitization for non-string values. Add a type check for the `text` property in `models/Document/Editable/Wysiwyg.php` to avoid errors when creating Wysiwyg objects from data objects.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2e5132d</samp>

> _`$this->text` checked_
> _Sanitize only strings_
> _Winter bug is fixed_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2e5132d</samp>

* Add type check for `$this->text` property before sanitizing it to prevent errors when it is not a string ([link](https://github.com/pimcore/pimcore/pull/16129/files?diff=unified&w=0#diff-0c6c24fc188205dba44a894fc6eb75aa6959974d07e633a0fc92d12e179f25e0L133-R136))
