### PR TITLE
[BUG] Fix argument of strlen on null

### DIFF
--- a/models/Document/Editable/Area.php
+++ b/models/Document/Editable/Area.php
@@ -208,7 +208,7 @@ class Area extends Model\Document\Editable
 
     public function setDataFromResource(mixed $data): static
     {
-        if (strlen($data) > 2) {
+        if (is_string($data) && strlen($data) > 2) {
             $data = Serialize::unserialize($data);
         }
 


### PR DESCRIPTION
Prevent the strlen method throwing an error because its argument is null.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fbc109d</samp>

Fixed a bug in `setDataFromResource` method of `Area` editable that caused errors when the data was not a string. Added a type check to prevent invalid data from being passed to the method.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fbc109d</samp>

> _`is_string` check_
> _avoids errors from arrays_
> _bug fixed in autumn_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fbc109d</samp>

*  Added a check for the `$data` parameter type in the `setDataFromResource` method of the `Area` class ([link](https://github.com/pimcore/pimcore/pull/16134/files?diff=unified&w=0#diff-b511b88988f140188545381ff9b7e470ba1440d2fec538550b929017379e5771L211-R211)). This prevents errors when the parameter is not a string, as reported in issue #10676. The method expects a JSON-encoded string from the database, but some legacy data might be stored as arrays.
