### PR TITLE
[Task]: Fix Sitemap doc referencing a wrong node instead of `pimcore_seo`

### DIFF
--- a/doc/18_Tools_and_Features/39_Sitemaps.md
+++ b/doc/18_Tools_and_Features/39_Sitemaps.md
@@ -82,7 +82,7 @@ registered via config. `generator_id` in the config below references a generator
 as service. As you can see, generators can be enabled/disabled and ordered by priority.
 
 ```yaml
-pimcore:
+pimcore_seo:
     sitemaps:
         generators:
             app_news:

--- a/doc/18_Tools_and_Features/39_Sitemaps.md
+++ b/doc/18_Tools_and_Features/39_Sitemaps.md
@@ -258,7 +258,7 @@ Make the generator available to the core listener by registering it on the confi
 ```yaml
 # config.yaml
 
-pimcore:
+pimcore_seo:
     sitemaps:
         generators:
             app_blog:


### PR DESCRIPTION
change pimcore to pimcore_seo

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info

### WHAT
I found a mistake in the documentation, it should be pimcore_seo not pimcore

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 23ea6bf</samp>

> _`pimcore` is gone_
> _`pimcore_seo` takes its place_
> _docs reflect the change_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 23ea6bf</samp>

* Change the configuration key for sitemap generators from `pimcore` to `pimcore_seo` to match the new namespace of the SEO bundle ([link](https://github.com/pimcore/pimcore/pull/16138/files?diff=unified&w=0#diff-b671f79e13fefcf9fba446a109d741b50194a48a63892e8696ad4080eb30166bL85-R85))
