### PR TITLE
[Personalization] fix overwrite editable blocks (https://github.com/pimcore/personalization-bundle/issues/61)

### DIFF
--- a/.github/workflows/clone-branch.yml
+++ b/.github/workflows/clone-branch.yml
@@ -1,0 +1,25 @@
+name: Clone branch
+on:
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        required: true
+        type: string
+        description: Base branch name for cloning
+      ref_name:
+        required: true
+        type: string
+        description: Branch name on destination repo
+
+jobs:
+  clone-branch:
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-clone-branch.yaml@v1.0.0-rc.2
+    if: github.repository == 'pimcore/pimcore' 
+    with:
+      base_ref: ${{ inputs.base_ref }}
+      ref_name: ${{ inputs.ref_name }}
+      target_repo: 'ee-pimcore'
+    secrets:
+      SYNC_TOKEN: ${{ secrets.SYNC_TOKEN }}
+      GIT_NAME: ${{ secrets.GIT_NAME }}
+      GIT_EMAIL: ${{ secrets.GIT_EMAIL }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,8 @@
 If you think that you have found a security issue, 
 don’t use the bug tracker and don’t publish it publicly. 
 Instead, all security issues must be reported via a private vulnerability report.
-Additionally, we also check issues reported via [huntr.dev](https://huntr.dev/repos/pimcore/pimcore/).
+
+Please follow the [instructions](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) to submit a private report.
 
 
 ## Resolving Process

--- a/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
+++ b/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
@@ -228,7 +228,7 @@ class SearchController extends UserAwareController
 
             foreach ($tagIds as $tagId) {
                 if (($allParams['considerChildTags'] ?? 'false') === 'true') {
-                    $tag = Element\Tag::getById($tagId);
+                    $tag = Element\Tag::getById((int)$tagId);
                     if ($tag) {
                         $tagPath = $tag->getFullIdPath();
                         $conditionParts[] = 'id IN (SELECT cId FROM tags_assignment INNER JOIN tags ON tags.id = tags_assignment.tagid WHERE '.$tagsTypeCondition.' (id = ' .(int)$tagId. ' OR idPath LIKE ' . $db->quote(Helper::escapeLike($tagPath) . '%') . '))';

--- a/doc/03_Documents/01_Editables/40_WYSIWYG.md
+++ b/doc/03_Documents/01_Editables/40_WYSIWYG.md
@@ -4,6 +4,17 @@
 
 Similar to Textarea and Input you can use the WYSIWYG editable in the templates to provide rich-text editing. TinyMce is installed by default in our demo. Another editor can be installed via the wysiwyg-events you find in `events.js`
 
+## Enable TinyMce
+
+Add the bundle in your `config/bundles.php` file:
+
+```php
+\Pimcore\Bundle\TinymceBundle\PimcoreTinymceBundle::class => ['all' => true],
+```
+
+After this, make sure PimcoreTinymceBundle is installed with `bin/console pimcore:bundle:list`.
+If it is not installed, you can install it with `bin/console pimcore:bundle:install PimcoreTinymceBundle`.
+
 ## Add a Custom Editor
 Make sure that you add the Editor to `pimcore.wysiwyg.editors`. This array can be used to have different editors for different use cases(documents, objects ...):
 ```javascript

--- a/doc/26_Best_Practice/85_Using_Tags_for_Filtering.md
+++ b/doc/26_Best_Practice/85_Using_Tags_for_Filtering.md
@@ -117,7 +117,7 @@ Important to know:
 
                 //decide if child tags should be considered or not
                 if ($request->get("considerChildTags") == "true") {
-                    $tag = \Pimcore\Model\Element\Tag::getById($tagId);
+                    $tag = \Pimcore\Model\Element\Tag::getById((int)$tagId);
                     if ($tag) {
                         //get ID path of tag or filtering the child tags
                         $tagPath = $tag->getFullIdPath();

--- a/models/Document/Editable.php
+++ b/models/Document/Editable.php
@@ -557,7 +557,7 @@ abstract class Editable extends Model\AbstractModel implements Model\Document\Ed
         // targeting prefix if configured on the document. hasBlocks() determines if
         // there are any parent blocks for the current element
         $targetGroupEditableName = null;
-        if ($document && class_exists(TargetingDocumentInterface::class) && $document instanceof TargetingDocumentInterface) {
+        if ($document && interface_exists(TargetingDocumentInterface::class) && $document instanceof TargetingDocumentInterface) {
             $targetGroupEditableName = $document->getTargetGroupEditableName($name);
 
             if (!$blockState->hasBlocks()) {
@@ -670,7 +670,7 @@ abstract class Editable extends Model\AbstractModel implements Model\Document\Ed
         // if element not nested inside a hierarchical element (e.g. block), add the
         // targeting prefix if configured on the document. hasBlocks() determines if
         // there are any parent blocks for the current element
-        if (class_exists(TargetingDocumentInterface::class) && $document instanceof TargetingDocumentInterface && !$blockState->hasBlocks()) {
+        if (interface_exists(TargetingDocumentInterface::class) && $document instanceof TargetingDocumentInterface && !$blockState->hasBlocks()) {
             $name = $document->getTargetGroupEditableName($name);
         }
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/personalization-bundle/issues/61

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ab51129</samp>

Fixed a bug in `Editable.php` that caused errors when working with targeting documents. Improved the compatibility of `buildEditableName` and `buildEditableRealName` functions with the `TargetingDocumentInterface`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ab51129</samp>

> _`class_exists` fixed_
> _Targeting documents work_
> _Winter of errors_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ab51129</samp>

* Fix potential bug in `buildEditableName` and `buildEditableRealName` functions by using `interface_exists` instead of `class_exists` to check for `TargetingDocumentInterface` ([link](https://github.com/pimcore/pimcore/pull/16150/files?diff=unified&w=0#diff-629c3ab163921129218936956cf2db0761d23c958f2b554ad5e5225acc699cd8L560-R560), [link](https://github.com/pimcore/pimcore/pull/16150/files?diff=unified&w=0#diff-629c3ab163921129218936956cf2db0761d23c958f2b554ad5e5225acc699cd8L673-R673)) in file `models/Document/Editable.php`
