### PR TITLE
Fix: Response can't be cached

### DIFF
--- a/bundles/CoreBundle/src/EventListener/Frontend/FullPageCacheListener.php
+++ b/bundles/CoreBundle/src/EventListener/Frontend/FullPageCacheListener.php
@@ -362,13 +362,9 @@ class FullPageCacheListener
     {
         $cache = true;
 
-        // do not cache when the application indicated one of the 'no-cache' directives in the response Cache-Control header
-        foreach (['no-cache', 'private', 'no-store'] as $directive) {
-            if ($response->headers->getCacheControlDirective($directive)) {
-                $cache = false;
-
-                break;
-            }
+        // do not cache when the application indicated the 'no-store' directives in the response Cache-Control header
+        if ($response->headers->hasCacheControlDirective('no-store')) {
+            $cache = false;
         }
 
         // do not cache common responses

--- a/doc/19_Development_Tools_and_Details/09_Cache/03_Full_Page_Cache.md
+++ b/doc/19_Development_Tools_and_Details/09_Cache/03_Full_Page_Cache.md
@@ -50,14 +50,10 @@ Sometimes it is more useful to deactivate the full page cache directly in the co
 it's not possible to define an exclude-regex, or for similar reasons.
 
 ### Disable caching via the response headers
-Adding the `Cache-Control: no-cache`, `Cache-Control: private` or `Cache-Control: no-store` header to your response will disable the full page cache as well as any other
+Adding the `Cache-Control: no-store` header to your response will disable the full page cache as well as any other
 middleware and browser caching:
 ```php
 <?php
-$response->headers->addCacheControlDirective('no-cache');
-// and/or
-$response->headers->addCacheControlDirective('private');
-// and/or
 $response->headers->addCacheControlDirective('no-store');
 ```
 
@@ -115,4 +111,3 @@ To use the bookmarklet, just drag the following Link into your bookmark toolbar 
 * <a href="javascript:(function() {document.cookie='pimcore_admin_sid=disablethecachebaby'+(Math.floor(Math.random() * 147483648) + 2000)+';path=/;';})()">Disable Pimcore Cache</a>
 
 * <a href='javascript:void((function(){var a,b,c,e,f;f=0;a=document.cookie.split("; ");for(e=0;e<a.length&&a[e];e++){f++;for(b="."+location.host;b;b=b.replace(/^(?:%5C.|[^%5C.]+)/,"")){for(c=location.pathname;c;c=c.replace(/.$/,"")){document.cookie=(a[e]+"; domain="+b+"; path="+c+"; expires="+new Date((new Date()).getTime()-1e11).toGMTString());}}}alert("Expired "+f+" cookies");})())'>Enable Pimcore Cache</a>
-

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -597,7 +597,7 @@ pimcore_seo:
 #### [Cache] :
 
 -  Removed `psr/simple-cache` dependency, due to the lack of usage in the Core.
--  Responses containing a header `Cache-Control: no-cache`, `Cache-Control: private` or `Cache-Control: no-store` will no longer be cached by the full page cache.
+-  Responses containing a header `Cache-Control: no-store` will no longer be cached by the full page cache.
 -  Removed the `Pimcore\Cache\Runtime` cache helper and `Pimcore\Cache\RuntimeCacheTrait`. The runtime cache is now handled by `Pimcore\Cache\RuntimeCache`.
 
 #### [Console] :


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/16057

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8ca3a06</samp>

This pull request refactors and optimizes the full page cache feature by removing an unnecessary dependency, simplifying the response header logic, and updating the documentation accordingly. It also fixes a minor formatting error in the cache documentation.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8ca3a06</samp>

> _Sing, O Muse, of the swift and skillful coder_
> _Who reforged the cache feature with cunning and power_
> _Like Hephaestus, who shapes the metal with his hammer_
> _He simplified the logic with the `no-store` header_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8ca3a06</samp>

*  Simplify and optimize the full page cache feature by only checking for the `no-store` response header directive ([link](https://github.com/pimcore/pimcore/pull/16171/files?diff=unified&w=0#diff-01412579da1c44e9702d4a42a5c250818f9398583c92ab65b33f972129085a3cL365-R367),[link](https://github.com/pimcore/pimcore/pull/16171/files?diff=unified&w=0#diff-d4c656ba0890d5cfe638ab5d8164b91ae56f1361a8f5da6a32cdf85950a8f833L53-R56),[link](https://github.com/pimcore/pimcore/pull/16171/files?diff=unified&w=0#diff-375aded12dfb868b84d5b8c27d1aed2358680a27b683e8a985f1b85193dd79aaL600-R600))
*  Update the documentation and the upgrade notes to reflect the changes in the cache feature and remove an empty code block ([link](https://github.com/pimcore/pimcore/pull/16171/files?diff=unified&w=0#diff-d4c656ba0890d5cfe638ab5d8164b91ae56f1361a8f5da6a32cdf85950a8f833L53-R56),[link](https://github.com/pimcore/pimcore/pull/16171/files?diff=unified&w=0#diff-d4c656ba0890d5cfe638ab5d8164b91ae56f1361a8f5da6a32cdf85950a8f833L118),[link](https://github.com/pimcore/pimcore/pull/16171/files?diff=unified&w=0#diff-375aded12dfb868b84d5b8c27d1aed2358680a27b683e8a985f1b85193dd79aaL600-R600))
