### PR TITLE
Suggest instead of conflict for pimcore/admin-ui-classic-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -133,8 +133,7 @@
     "symfony/symfony": "*",
     "doctrine/doctrine-migrations-bundle": "3.1.0",
     "sabre/dav": "4.2.2",
-    "thecodingmachine/safe": "<2.0",
-    "pimcore/admin-ui-classic-bundle": "<1.2"
+    "thecodingmachine/safe": "<2.0"
   },
   "require-dev": {
     "codeception/codeception": "^5.0.3",
@@ -158,7 +157,8 @@
     "elasticsearch/elasticsearch": "Required for Elastic Search service",
     "chrome-php/chrome": "Required for Documents Page Previews",
     "webmozarts/console-parallelization": "Required for parallelization of console commands",
-    "symfony/dotenv": "Required for loading environment vars from .env files"
+    "symfony/dotenv": "Required for loading environment vars from .env files",
+    "pimcore/admin-ui-classic-bundle": "^1.2.0"
   },
   "autoload": {
     "files": [


### PR DESCRIPTION
## Changes in this pull request  
Resolves #16173

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 14bff82</samp>

Made classic admin UI theme optional and moved it to dev dependencies. Updated `composer.json` to reflect this change.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 14bff82</samp>

> _Oh we're the coders of the sea, and we work with `composer.json`_
> _We tweak the `require` and the `require-dev`, to make our bundles run_
> _Heave away, me hearties, heave away_
> _We don't need the classic UI, we've got a modern one_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 14bff82</samp>

*  Remove `pimcore/admin-ui-classic-bundle` from the `require` section of `composer.json` ([link](https://github.com/pimcore/pimcore/pull/16178/files?diff=unified&w=0#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L136-R136))
*  Add `pimcore/admin-ui-classic-bundle` to the `require-dev` section of `composer.json` with a version constraint of `^1.2.0` ([link](https://github.com/pimcore/pimcore/pull/16178/files?diff=unified&w=0#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L161-R161))
