### PR TITLE
Fix missing QueryBuilder parameter support in Listing Dao

### DIFF
--- a/.github/workflows/clone-branch.yml
+++ b/.github/workflows/clone-branch.yml
@@ -1,0 +1,25 @@
+name: Clone branch
+on:
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        required: true
+        type: string
+        description: Base branch name for cloning
+      ref_name:
+        required: true
+        type: string
+        description: Branch name on destination repo
+
+jobs:
+  clone-branch:
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-clone-branch.yaml@v1.0.0-rc.2
+    if: github.repository == 'pimcore/pimcore' 
+    with:
+      base_ref: ${{ inputs.base_ref }}
+      ref_name: ${{ inputs.ref_name }}
+      target_repo: 'ee-pimcore'
+    secrets:
+      SYNC_TOKEN: ${{ secrets.SYNC_TOKEN }}
+      GIT_NAME: ${{ secrets.GIT_NAME }}
+      GIT_EMAIL: ${{ secrets.GIT_EMAIL }}

--- a/models/DataObject/Listing/Dao.php
+++ b/models/DataObject/Listing/Dao.php
@@ -78,7 +78,11 @@ class Dao extends Model\Listing\Dao\AbstractDao
         $queryBuilder = $this->getQueryBuilder();
         $this->prepareQueryBuilderForTotalCount($queryBuilder, $this->getTableName() . '.id');
 
-        $totalCount = $this->db->fetchOne((string) $queryBuilder, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
+        $totalCount = $this->db->fetchOne(
+            $queryBuilder->getSQL(),
+            $this->model->getConditionVariables() + $queryBuilder->getParameters(),
+            $this->model->getConditionVariableTypes() + $queryBuilder->getParameterTypes()
+        );
 
         return (int) $totalCount;
     }
@@ -102,7 +106,11 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function loadIdList(): array
     {
         $queryBuilder = $this->getQueryBuilder([sprintf('%s as id', $this->getTableName() . '.id'), sprintf('%s as `type`', $this->getTableName() . '.type')]);
-        $objectIds = $this->db->fetchFirstColumn((string) $queryBuilder, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
+        $objectIds = $this->db->fetchFirstColumn(
+            $queryBuilder->getSQL(),
+            $this->model->getConditionVariables() + $queryBuilder->getParameters(),
+            $this->model->getConditionVariableTypes() + $queryBuilder->getParameterTypes()
+        );
 
         return array_map('intval', $objectIds);
     }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves  #16114

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 68404fa</samp>

Fix bug in data object listing with advanced query conditions. Pass query builder parameters and types to `models/DataObject/Listing/Dao.php` methods.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 68404fa</samp>

> _`query builder` fixed_
> _count and ID list match now_
> _autumn bug no more_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 68404fa</samp>

*  Fix incorrect total count of data objects when using advanced object query conditions ([link](https://github.com/pimcore/pimcore/pull/16180/files?diff=unified&w=0#diff-a22bfc49a183215d9f0b666804f2c4ff3f957c6b9fd93353f344411868421254L81-R85), models/DataObject/Listing/Dao.php)
