### PR TITLE
Also check Pimcore context in `GlobalTemplateVariablesListener::onKernelResponse()`

### DIFF
--- a/bundles/CoreBundle/src/EventListener/Frontend/GlobalTemplateVariablesListener.php
+++ b/bundles/CoreBundle/src/EventListener/Frontend/GlobalTemplateVariablesListener.php
@@ -75,6 +75,10 @@ class GlobalTemplateVariablesListener implements EventSubscriberInterface, Logge
 
     public function onKernelResponse(ResponseEvent $event): void
     {
+        if (!$this->matchesPimcoreContext($event->getRequest(), PimcoreContextResolver::CONTEXT_DEFAULT)) {
+            return;
+        }
+
         if (count($this->globalsStack)) {
             $globals = array_pop($this->globalsStack);
             if ($globals !== false) {


### PR DESCRIPTION
## Changes in this pull request  
I was browsing the core code and stumbled over this one (I haven't tried it, though):
If we check the Pimcore context before pushing the Twig globals onto the stack in `onKernelController()`, shouldn't we also check it before popping them in `onKernelResponse()`? Otherwise, we might pop more often than we push, which probably wouldn't be good, right?

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 111581b</samp>

Fix global template variables being overwritten by admin context. Add a condition to `GlobalTemplateVariablesListener.php` to only set the variables for the default Pimcore context.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 111581b</samp>

> _`Pimcore context`_
> _Check before setting globals_
> _Avoids conflicts - spring_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 111581b</samp>

* Fix a bug where the global template variables were overwritten by the admin context ([link](https://github.com/pimcore/pimcore/pull/16186/files?diff=unified&w=0#diff-11fa36d43466d831f348318e77b6a32e7a6b28f45872631421e99835f31901e7R78-R81))
