### PR TITLE
Fix filtering for tags with option Consider child tags

### DIFF
--- a/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
+++ b/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
@@ -228,7 +228,7 @@ class SearchController extends UserAwareController
 
             foreach ($tagIds as $tagId) {
                 if (($allParams['considerChildTags'] ?? 'false') === 'true') {
-                    $tag = Element\Tag::getById($tagId);
+                    $tag = Element\Tag::getById((int)$tagId);
                     if ($tag) {
                         $tagPath = $tag->getFullIdPath();
                         $conditionParts[] = 'id IN (SELECT cId FROM tags_assignment INNER JOIN tags ON tags.id = tags_assignment.tagid WHERE '.$tagsTypeCondition.' (id = ' .(int)$tagId. ' OR idPath LIKE ' . $db->quote(Helper::escapeLike($tagPath) . '%') . '))';

--- a/doc/26_Best_Practice/85_Using_Tags_for_Filtering.md
+++ b/doc/26_Best_Practice/85_Using_Tags_for_Filtering.md
@@ -117,7 +117,7 @@ Important to know:
 
                 //decide if child tags should be considered or not
                 if ($request->get("considerChildTags") == "true") {
-                    $tag = \Pimcore\Model\Element\Tag::getById($tagId);
+                    $tag = \Pimcore\Model\Element\Tag::getById((int)$tagId);
                     if ($tag) {
                         //get ID path of tag or filtering the child tags
                         $tagPath = $tag->getFullIdPath();


### PR DESCRIPTION
## Changes in this pull request  
Resolves #16169

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6dbb275</samp>

Cast `$tagId` to integer in `SearchController` and documentation. This fixes some bugs and improves the reliability of the Simple Backend Search Bundle, which enables tag-based searching in the admin interface.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6dbb275</samp>

> _`$tagId` must be_
> _an integer for searching_
> _autumn leaves by tags_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6dbb275</samp>

*  Cast `$tagId` to integer before calling `Element\Tag::getById` to prevent errors or unexpected results ([link](https://github.com/pimcore/pimcore/pull/16190/files?diff=unified&w=0#diff-207990d985e92b09e3a3f299f24164018ffc0148aa79e0e55e5f0ee687b9b992L231-R231), [link](https://github.com/pimcore/pimcore/pull/16190/files?diff=unified&w=0#diff-6e927d22fa5607e5944de41adb13e40c9ead9e617def7665cffbb60063188e1fL120-R120))
*  Update code example in `doc/26_Best_Practice/85_Using_Tags_for_Filtering.md` to match the actual code in `SearchController` and to include the casting of `$tagId` ([link](https://github.com/pimcore/pimcore/pull/16190/files?diff=unified&w=0#diff-6e927d22fa5607e5944de41adb13e40c9ead9e617def7665cffbb60063188e1fL120-R120))
