### PR TITLE
Make the return type of `Pimcore\Tool::getHttpData()` more precise

### DIFF
--- a/lib/Tool.php
+++ b/lib/Tool.php
@@ -432,7 +432,7 @@ final class Tool
         return $mail;
     }
 
-    public static function getHttpData(string $url, array $paramsGet = [], array $paramsPost = [], array $options = []): bool|string
+    public static function getHttpData(string $url, array $paramsGet = [], array $paramsPost = [], array $options = []): false|string
     {
         $client = \Pimcore::getContainer()->get('pimcore.http_client');
         $requestType = 'GET';


### PR DESCRIPTION
## Changes in this pull request  
The method never returns `true`.

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4eb0889</samp>

Updated the return type of `getHttpData` in `lib/Tool.php` to use PHP 8 union types. This is part of a pull request to make the code PHP 8 compatible.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4eb0889</samp>

> _`getHttpData` changed_
> _false or string, not just bool_
> _PHP 8 awaits_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4eb0889</samp>

* Change the return type of `getHttpData` method to `false|string` for PHP 8 compatibility ([link](https://github.com/pimcore/pimcore/pull/16191/files?diff=unified&w=0#diff-214f01c1c5bb57516e182edb3c147c5be07eff7fe243c3229b491ad3eb445dd6L435-R435))
