### PR TITLE
Refine some return types

### DIFF
--- a/bundles/CoreBundle/src/Command/Definition/Import/AbstractStructureImportCommand.php
+++ b/bundles/CoreBundle/src/Command/Definition/Import/AbstractStructureImportCommand.php
@@ -127,19 +127,13 @@ abstract class AbstractStructureImportCommand extends AbstractCommand
 
     /**
      * Load JSON data from file
-     *
-     *
-     * @return string|false
      */
-    protected function getJson(string $path): bool|string
+    protected function getJson(string $path): string
     {
         $content = file_get_contents($path);
 
         // try to decode json here as we want to fail early if file is no valid JSON
-        $json = json_decode($content);
-        if (null === $json) {
-            throw new \InvalidArgumentException('JSON could not be decoded');
-        }
+        json_decode($content, flags: JSON_THROW_ON_ERROR);
 
         // return string content as service import
         // methods decode JSON by their own

--- a/bundles/StaticRoutesBundle/src/Model/Staticroute.php
+++ b/bundles/StaticRoutesBundle/src/Model/Staticroute.php
@@ -454,25 +454,12 @@ final class Staticroute extends AbstractModel
      *
      * @throws \Exception
      */
-    public function match(string $path, array $params = []): bool|array
+    public function match(string $path, array $params = []): false|array
     {
         if (@preg_match($this->getPattern(), $path)) {
             // check for site
             if ($this->getSiteId()) {
-                if (!Site::isSiteRequest()) {
-                    return false;
-                }
-
-                $siteMatched = false;
-                $siteIds = $this->getSiteId();
-                foreach ($siteIds as $siteId) {
-                    if ($siteId == Site::getCurrentSite()->getId()) {
-                        $siteMatched = true;
-
-                        break;
-                    }
-                }
-                if (!$siteMatched) {
+                if (!Site::isSiteRequest() || !in_array(Site::getCurrentSite()->getId(), $this->getSiteId())) {
                     return false;
                 }
             }
@@ -482,7 +469,7 @@ final class Staticroute extends AbstractModel
             preg_match_all($this->getPattern(), $path, $matches);
 
             foreach ($matches as $index => $match) {
-                if (isset($variables[$index - 1]) && $variables[$index - 1]) {
+                if (!empty($variables[$index - 1])) {
                     $paramValue = urldecode($match[0]);
                     if (!empty($paramValue) || !array_key_exists($variables[$index - 1], $params)) {
                         $params[$variables[$index - 1]] = $paramValue;

--- a/lib/Localization/IntlFormatter.php
+++ b/lib/Localization/IntlFormatter.php
@@ -103,79 +103,64 @@ class IntlFormatter
      */
     protected function buildDateTimeFormatters(string $format): \IntlDateFormatter
     {
-        switch ($format) {
-            case self::DATE_SHORT:
-                return \IntlDateFormatter::create(
-                    $this->getLocale(),
-                    \IntlDateFormatter::SHORT,
-                    \IntlDateFormatter::NONE
-                );
-            case self::DATE_MEDIUM:
-                return \IntlDateFormatter::create(
-                    $this->getLocale(),
-                    \IntlDateFormatter::MEDIUM,
-                    \IntlDateFormatter::NONE
-                );
-            case self::DATE_LONG:
-                return \IntlDateFormatter::create(
-                    $this->getLocale(),
-                    \IntlDateFormatter::LONG,
-                    \IntlDateFormatter::NONE
-                );
-            case self::DATETIME_SHORT:
-                return \IntlDateFormatter::create(
-                    $this->getLocale(),
-                    \IntlDateFormatter::SHORT,
-                    \IntlDateFormatter::SHORT
-                );
-            case self::DATETIME_MEDIUM:
-                return \IntlDateFormatter::create(
-                    $this->getLocale(),
-                    \IntlDateFormatter::MEDIUM,
-                    \IntlDateFormatter::MEDIUM
-                );
-            case self::DATETIME_LONG:
-                return \IntlDateFormatter::create(
-                    $this->getLocale(),
-                    \IntlDateFormatter::LONG,
-                    \IntlDateFormatter::LONG
-                );
-            case self::TIME_SHORT:
-                return \IntlDateFormatter::create(
-                    $this->getLocale(),
-                    \IntlDateFormatter::NONE,
-                    \IntlDateFormatter::SHORT
-                );
-            case self::TIME_MEDIUM:
-                return \IntlDateFormatter::create(
-                    $this->getLocale(),
-                    \IntlDateFormatter::NONE,
-                    \IntlDateFormatter::MEDIUM
-                );
-            case self::TIME_LONG:
-                return \IntlDateFormatter::create(
-                    $this->getLocale(),
-                    \IntlDateFormatter::NONE,
-                    \IntlDateFormatter::LONG
-                );
-            default:
-                throw new \RuntimeException("Invalid format '$format'' for date formatter.");
-        }
+        return match ($format) {
+            self::DATE_SHORT => \IntlDateFormatter::create(
+                $this->getLocale(),
+                \IntlDateFormatter::SHORT,
+                \IntlDateFormatter::NONE
+            ),
+            self::DATE_MEDIUM => \IntlDateFormatter::create(
+                $this->getLocale(),
+                \IntlDateFormatter::MEDIUM,
+                \IntlDateFormatter::NONE
+            ),
+            self::DATE_LONG => \IntlDateFormatter::create(
+                $this->getLocale(),
+                \IntlDateFormatter::LONG,
+                \IntlDateFormatter::NONE
+            ),
+            self::DATETIME_SHORT => \IntlDateFormatter::create(
+                $this->getLocale(),
+                \IntlDateFormatter::SHORT,
+                \IntlDateFormatter::SHORT
+            ),
+            self::DATETIME_MEDIUM => \IntlDateFormatter::create(
+                $this->getLocale(),
+                \IntlDateFormatter::MEDIUM,
+                \IntlDateFormatter::MEDIUM
+            ),
+            self::DATETIME_LONG => \IntlDateFormatter::create(
+                $this->getLocale(),
+                \IntlDateFormatter::LONG,
+                \IntlDateFormatter::LONG
+            ),
+            self::TIME_SHORT => \IntlDateFormatter::create(
+                $this->getLocale(),
+                \IntlDateFormatter::NONE,
+                \IntlDateFormatter::SHORT
+            ),
+            self::TIME_MEDIUM => \IntlDateFormatter::create(
+                $this->getLocale(),
+                \IntlDateFormatter::NONE,
+                \IntlDateFormatter::MEDIUM
+            ),
+            self::TIME_LONG => \IntlDateFormatter::create(
+                $this->getLocale(),
+                \IntlDateFormatter::NONE,
+                \IntlDateFormatter::LONG
+            ),
+            default => throw new \RuntimeException("Invalid format '{$format}' for date formatter."),
+        };
     }
 
     /**
      * formats given datetime in given format
      *
-     *
+     * @return false|string
      */
     public function formatDateTime(\DateTimeInterface|int|string $dateTime, string $format = self::DATETIME_MEDIUM): bool|string
     {
-        if (isset($this->dateFormatters[$format])) {
-            $formatter = $this->dateFormatters[$format];
-        } else {
-            $formatter = $this->buildDateTimeFormatters($format);
-            $this->dateFormatters[$format] = $formatter;
-        }
+        $formatter = $this->dateFormatters[$format] ??= $this->buildDateTimeFormatters($format);
 
         return $formatter->format($dateTime);
     }
@@ -183,13 +168,11 @@ class IntlFormatter
     /**
      * formats given value as number based on current locale
      *
-     *
+     * @return false|string
      */
     public function formatNumber(float|int $value): bool|string
     {
-        if (empty($this->numberFormatter)) {
-            $this->numberFormatter = new \NumberFormatter($this->getLocale(), \NumberFormatter::DECIMAL);
-        }
+        $this->numberFormatter ??= new \NumberFormatter($this->getLocale(), \NumberFormatter::DECIMAL);
 
         return $this->numberFormatter->format($value);
     }

--- a/lib/Tool/Frontend.php
+++ b/lib/Tool/Frontend.php
@@ -98,6 +98,9 @@ final class Frontend
         return $siteMapping;
     }
 
+    /**
+     * @return false|array{enabled: true, lifetime: int|null}
+     */
     public static function isOutputCacheEnabled(): bool|array
     {
         $cacheService = Pimcore::getContainer()->get(FullPageCacheListener::class);

--- a/lib/Tool/Text/Csv.php
+++ b/lib/Tool/Text/Csv.php
@@ -120,7 +120,7 @@ class Csv
     /**
      * @phpstan-param non-empty-string $linefeed
      */
-    protected function guessDelim(string $data, string $linefeed, string $quotechar): bool|string
+    protected function guessDelim(string $data, string $linefeed, string $quotechar): false|string
     {
         $charcount = count_chars($data, 1);
 

--- a/lib/Twig/Extension/Templating/HeadLink.php
+++ b/lib/Twig/Extension/Templating/HeadLink.php
@@ -389,8 +389,7 @@ class HeadLink extends CacheBusterAware
     /**
      * Create item for stylesheet link item
      *
-     *
-     * @return \stdClass|false Returns fals if stylesheet is a duplicate
+     * @return \stdClass|false Returns false if stylesheet is a duplicate
      */
     public function createDataStylesheet(array $args): bool|\stdClass
     {
@@ -415,9 +414,7 @@ class HeadLink extends CacheBusterAware
         }
         if (0 < count($args)) {
             $conditionalStylesheet = array_shift($args);
-            if (!empty($conditionalStylesheet) && is_string($conditionalStylesheet)) {
-                $conditionalStylesheet = $conditionalStylesheet;
-            } else {
+            if (empty($conditionalStylesheet) || !is_string($conditionalStylesheet)) {
                 $conditionalStylesheet = null;
             }
         }

--- a/lib/Video/Adapter/Ffmpeg.php
+++ b/lib/Video/Adapter/Ffmpeg.php
@@ -55,7 +55,7 @@ class Ffmpeg extends Adapter
      *
      * @throws \Exception
      */
-    public static function getFfmpegCli(): bool|string
+    public static function getFfmpegCli(): false|string
     {
         return \Pimcore\Tool\Console::getExecutable('ffmpeg', true);
     }

--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -63,7 +63,7 @@ class Image extends Model\Asset
      *
      * @internal
      */
-    public function generateLowQualityPreview(string $generator = null): bool|string
+    public function generateLowQualityPreview(string $generator = null): false|string
     {
         if (!$this->isLowQualityPreviewEnabled()) {
             return false;


### PR DESCRIPTION
## Changes in this pull request  
Refines some return types. Those methods don't actually return `bool` but `false`.

I also refactored some code blocks I encountered on the way. 
Please tell me if you want to split those into a separate PR.

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 38126c8</samp>

This pull request refactors and simplifies some methods in various classes to improve code quality, readability, and performance. It also fixes some minor documentation and type errors. It makes use of some PHP 8 features such as the `match` expression, the null coalescing assignment operator, and the union types. It affects the files `Staticroute.php`, `IntlFormatter.php`, `HeadLink.php`, `AbstractStructureImportCommand.php`, `Frontend.php`, `Csv.php`, `Ffmpeg.php`, and `Image.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 38126c8</samp>

> _We're sailing on the PHP 8 ship, hooray, hooray_
> _We're simplifying our methods, every day, every day_
> _We're using union types and flags, to make our code more clear_
> _We're refactoring and documenting, so we can drink some beer_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 38126c8</samp>

*  Simplify JSON parsing and error handling in `getJson` method using `JSON_THROW_ON_ERROR` flag ([link](https://github.com/pimcore/pimcore/pull/16194/files?diff=unified&w=0#diff-4e2a7f849a75fc970c977124522160ee1725f11f9026dc8993feffe5b03d10b8L130-R136))
*  Refactor `match` method in `Staticroute` class to use single `if` condition and `empty` function for site id and variable matching ([link](https://github.com/pimcore/pimcore/pull/16194/files?diff=unified&w=0#diff-1fcceb1365586a8ef35025b516b45f69cb9927e124ec44021f2508fe07a546a6L457-R464),[link](https://github.com/pimcore/pimcore/pull/16194/files?diff=unified&w=0#diff-1fcceb1365586a8ef35025b516b45f69cb9927e124ec44021f2508fe07a546a6L485-R472))
*  Rewrite `buildDateTimeFormatters` method in `IntlFormatter` class to use `match` expression instead of `switch` statement ([link](https://github.com/pimcore/pimcore/pull/16194/files?diff=unified&w=0#diff-b54272dd308a2a9db04c27254bb81c44b8d90cee0562ee089acf6bd9e1f6b9edL106-R153))
*  Update `formatDateTime` and `formatNumber` methods in `IntlFormatter` class to use null coalescing assignment operator (`??=`) for formatter initialization ([link](https://github.com/pimcore/pimcore/pull/16194/files?diff=unified&w=0#diff-b54272dd308a2a9db04c27254bb81c44b8d90cee0562ee089acf6bd9e1f6b9edL169-R163),[link](https://github.com/pimcore/pimcore/pull/16194/files?diff=unified&w=0#diff-b54272dd308a2a9db04c27254bb81c44b8d90cee0562ee089acf6bd9e1f6b9edL186-R175))
*  Annotate `getCacheOptions` method in `Frontend` class with PHPDoc comment to specify return type as array or false ([link](https://github.com/pimcore/pimcore/pull/16194/files?diff=unified&w=0#diff-70872bf267f26d57e847bc8a26e2319100c3ef7a153fbbc8c8ff6827374bef55R101-R103))
*  Change `guessDelim`, `getFfmpegCli`, and `generateLowQualityPreview` methods to use `false|string` union type instead of `bool|string` union type ([link](https://github.com/pimcore/pimcore/pull/16194/files?diff=unified&w=0#diff-20127b0030dacf166cabe5ae9c48f3fc6ecc8de23a1577577eba6e21db349d87L123-R123),[link](https://github.com/pimcore/pimcore/pull/16194/files?diff=unified&w=0#diff-b539b3eb22bb1fc850f115bf6c978988f7a6abe8f38f72d657ff119454fbcfc7L58-R58),[link](https://github.com/pimcore/pimcore/pull/16194/files?diff=unified&w=0#diff-5cc2bbd78fc2da7dfcf976d8120a6bbec2deab1b113c1f0c7a8b17840a191720L66-R66))
*  Correct typo in PHPDoc comment of `createDataStylesheet` method in `HeadLink` class ([link](https://github.com/pimcore/pimcore/pull/16194/files?diff=unified&w=0#diff-83adf525359502600dda2cf1094e0122252889fdecada22357655320e412e20dL392-R392))
*  Simplify conditional stylesheet assignment in `createDataStylesheet` method in `HeadLink` class using single `if` condition ([link](https://github.com/pimcore/pimcore/pull/16194/files?diff=unified&w=0#diff-83adf525359502600dda2cf1094e0122252889fdecada22357655320e412e20dL418-R417))
