### PR TITLE
Remove unused parameter and command option from low-quality image preview generation

### DIFF
--- a/bundles/CoreBundle/src/Command/LowQualityImagePreviewCommand.php
+++ b/bundles/CoreBundle/src/Command/LowQualityImagePreviewCommand.php
@@ -30,9 +30,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[AsCommand(
     name: 'pimcore:image:low-quality-preview',
-    description: 'Regenerates low quality image previews for all image assets',
+    description: 'Regenerates low-quality image previews for all image assets',
     aliases: ['pimcore:image:svg-preview']
-
 )]
 class LowQualityImagePreviewCommand extends AbstractCommand
 {
@@ -62,8 +61,7 @@ class LowQualityImagePreviewCommand extends AbstractCommand
                 'f',
                 InputOption::VALUE_NONE,
                 'generate preview regardless if it already exists or not'
-            )
-            ->addOption('generator', 'g', InputOption::VALUE_OPTIONAL, 'Force a generator, either `svg` or `imagick`');
+            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -92,11 +90,6 @@ class LowQualityImagePreviewCommand extends AbstractCommand
             $conditionVariables[] = $regex;
         }
 
-        $generator = null;
-        if ($input->getOption('generator')) {
-            $generator = $input->getOption('generator');
-        }
-
         $force = $input->getOption('force');
 
         $list = new Asset\Listing();
@@ -114,8 +107,8 @@ class LowQualityImagePreviewCommand extends AbstractCommand
                 $progressBar->advance();
                 if ($force || !$image->getLowQualityPreviewDataUri()) {
                     try {
-                        $this->output->writeln('generating low quality preview for image: ' . $image->getRealFullPath() . ' | ' . $image->getId());
-                        $image->generateLowQualityPreview($generator);
+                        $this->output->writeln('generating low-quality preview for image: ' . $image->getRealFullPath() . ' | ' . $image->getId());
+                        $image->generateLowQualityPreview();
                     } catch (\Exception $e) {
                         $this->output->writeln('<error>'.$e->getMessage().'</error>');
                     }

--- a/bundles/CoreBundle/src/Command/LowQualityImagePreviewCommand.php
+++ b/bundles/CoreBundle/src/Command/LowQualityImagePreviewCommand.php
@@ -61,11 +61,16 @@ class LowQualityImagePreviewCommand extends AbstractCommand
                 'f',
                 InputOption::VALUE_NONE,
                 'generate preview regardless if it already exists or not'
-            );
+            )
+            ->addOption('generator', 'g', InputOption::VALUE_OPTIONAL, 'Force a generator, either `svg` or `imagick`');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        if ($input->hasOption('generator')) {
+            trigger_deprecation('pimcore/pimcore', '11.2.0', 'Using the "generator" option is deprecated and will be removed in Pimcore 12.');
+        }
+
         $conditionVariables = [];
 
         // get only images

--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -63,7 +63,7 @@ class Image extends Model\Asset
      *
      * @internal
      */
-    public function generateLowQualityPreview(string $generator = null): false|string
+    public function generateLowQualityPreview(): false|string
     {
         if (!$this->isLowQualityPreviewEnabled()) {
             return false;


### PR DESCRIPTION
## Changes in this pull request  
I'm not sure if this is a breaking change for the command. If you think it is, we should probably keep the option and print some warning that it does nothing instead.

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 23ec1e8</samp>

This pull request refactors the low-quality image preview feature, removing unnecessary parameters and options, and fixing some minor issues. It affects the `pimcore:image:low-quality-preview` command and the `Image` class in `models/Asset/Image.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 23ec1e8</samp>

> _Oh we're the coders of the `Image` class_
> _And we like to keep our code neat and fast_
> _We don't need no extra `generator`_
> _We use the `lowQualityPreviewGenerator` instead_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 23ec1e8</samp>

* Fix typo in command description ([link](https://github.com/pimcore/pimcore/pull/16195/files?diff=unified&w=0#diff-2a625c13eb2b3590b3924d0ae1f4f97f929cade5494303044eda5d17d115b8b2L33-R34))
* Remove unused `generator` option and variable from `LowQualityImagePreviewCommand` class ([link](https://github.com/pimcore/pimcore/pull/16195/files?diff=unified&w=0#diff-2a625c13eb2b3590b3924d0ae1f4f97f929cade5494303044eda5d17d115b8b2L65-R64), [link](https://github.com/pimcore/pimcore/pull/16195/files?diff=unified&w=0#diff-2a625c13eb2b3590b3924d0ae1f4f97f929cade5494303044eda5d17d115b8b2L95-L99))
* Simplify `generateLowQualityPreview` method in `Image` class by using configuration option instead of parameter ([link](https://github.com/pimcore/pimcore/pull/16195/files?diff=unified&w=0#diff-5cc2bbd78fc2da7dfcf976d8120a6bbec2deab1b113c1f0c7a8b17840a191720L66-R66), [link](https://github.com/pimcore/pimcore/pull/16195/files?diff=unified&w=0#diff-2a625c13eb2b3590b3924d0ae1f4f97f929cade5494303044eda5d17d115b8b2L117-R111))
