### PR TITLE
[Docs] Add missing upgrade notes for Redis cache

### DIFF
--- a/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
+++ b/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
@@ -76,6 +76,20 @@ If you are not using Web2Print functionality, set the flag to false.
 ### WYSIWYG-Editor
 Please add all html tags with attributes you want to allow to the html_sanitizer like described [here](../../03_Documents/01_Editables/40_WYSIWYG.md)
 
+### Redis Cache Configuration
+If you are using `Redis` adapter for `Pimcore\Cache` then adapt the configuration as below:
+```yaml
+framework:
+    cache:
+        pools:
+            pimcore.cache.pool:
+                #tags: true remove it
+                public: true 
+                default_lifetime: 31536000  # 1 year
+                adapter: cache.adapter.redis_tag_aware #do not use pimcore.cache.adapter.redis_tag_aware
+                ...
+```
+
 ## Update Pimcore via Composer
 
 Update Pimcore to Pimcore 11 via composer statement `composer require -W pimcore/pimcore:^11.0 pimcore/admin-ui-classic-bundle`. 

--- a/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
+++ b/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
@@ -83,10 +83,10 @@ framework:
     cache:
         pools:
             pimcore.cache.pool:
-                #tags: true remove it
+                #tags: true // this line needs to be removed
                 public: true 
                 default_lifetime: 31536000  # 1 year
-                adapter: cache.adapter.redis_tag_aware #do not use pimcore.cache.adapter.redis_tag_aware
+                adapter: cache.adapter.redis_tag_aware # use this instead of pimcore.cache.adapter.redis_tag_aware
                 ...
 ```
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15605#issuecomment-1792354942

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bf44749</samp>

This change updates the documentation for upgrading Pimcore from version 10 to 11. It adds a new subsection on how to configure the `Redis` cache adapter for `Pimcore\Cache` in the `WYSIWYG-Editor` section of the file `doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bf44749</samp>

> _`Redis` cache adapter_
> _New section in upgrade guide_
> _Spring cleaning for code_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bf44749</samp>

*  Add a new subsection for configuring the Redis cache adapter for Pimcore\Cache in the upgrade from version 10 to 11 of Pimcore ([link](https://github.com/pimcore/pimcore/pull/16197/files?diff=unified&w=0#diff-8a0efdf0f7447004dad83da8352b444c4af86c46bf531df1fa0a11a805ed9b7aR79-R92))
