### PR TITLE
[Personalization] fix overwrite editable blocks when targeting group …

### DIFF
--- a/models/Document/Editable.php
+++ b/models/Document/Editable.php
@@ -557,7 +557,7 @@ abstract class Editable extends Model\AbstractModel implements Model\Document\Ed
         // targeting prefix if configured on the document. hasBlocks() determines if
         // there are any parent blocks for the current element
         $targetGroupEditableName = null;
-        if ($document && class_exists(TargetingDocumentInterface::class) && $document instanceof TargetingDocumentInterface) {
+        if ($document && interface_exists(TargetingDocumentInterface::class) && $document instanceof TargetingDocumentInterface) {
             $targetGroupEditableName = $document->getTargetGroupEditableName($name);
 
             if (!$blockState->hasBlocks()) {
@@ -670,7 +670,7 @@ abstract class Editable extends Model\AbstractModel implements Model\Document\Ed
         // if element not nested inside a hierarchical element (e.g. block), add the
         // targeting prefix if configured on the document. hasBlocks() determines if
         // there are any parent blocks for the current element
-        if (class_exists(TargetingDocumentInterface::class) && $document instanceof TargetingDocumentInterface && !$blockState->hasBlocks()) {
+        if (interface_exists(TargetingDocumentInterface::class) && $document instanceof TargetingDocumentInterface && !$blockState->hasBlocks()) {
             $name = $document->getTargetGroupEditableName($name);
         }
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/personalization-bundle/issues/61

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ab51129</samp>

Fixed a bug in `Editable.php` that caused errors when working with targeting documents. Improved the compatibility of `buildEditableName` and `buildEditableRealName` functions with the `TargetingDocumentInterface`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ab51129</samp>

> _`class_exists` fixed_
> _Targeting documents work_
> _Winter of errors_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ab51129</samp>

* Fix potential bug in `buildEditableName` and `buildEditableRealName` functions by using `interface_exists` instead of `class_exists` to check for `TargetingDocumentInterface` ([link](https://github.com/pimcore/pimcore/pull/16150/files?diff=unified&w=0#diff-629c3ab163921129218936956cf2db0761d23c958f2b554ad5e5225acc699cd8L560-R560), [link](https://github.com/pimcore/pimcore/pull/16150/files?diff=unified&w=0#diff-629c3ab163921129218936956cf2db0761d23c958f2b554ad5e5225acc699cd8L673-R673)) in file `models/Document/Editable.php`
