### PR TITLE
[Bug]: Fix Unique Constraint Violation 

### DIFF
--- a/lib/Db/Helper.php
+++ b/lib/Db/Helper.php
@@ -56,6 +56,7 @@ class Helper
                         }
                     }
                 }
+                throw new \LogicException(sprintf('Key "%s" passed for upsert not found in data', implode(', ', $checkKeys)));
             }
 
             return $connection->update($table, $data, $criteria);

--- a/lib/Db/Helper.php
+++ b/lib/Db/Helper.php
@@ -38,13 +38,27 @@ class Helper
 
             return $connection->insert($table, $data);
         } catch (\Doctrine\DBAL\Exception\UniqueConstraintViolationException $exception) {
-            $critera = [];
+            $criteria = [];
+            $checkKeys = [];
+            
             foreach ($keys as $key) {
-                $key = $quoteIdentifiers ? $connection->quoteIdentifier($key) : $key;
-                $critera[$key] = $data[$key] ?? throw new \LogicException(sprintf('Key "%s" passed for upsert not found in data', $key));
+                $quotedKey = $quoteIdentifiers ? $connection->quoteIdentifier($key) : $key;
+                $criteria[$quotedKey] = $data[$quotedKey] ?? $checkKeys[] = $key;
             }
 
-            return $connection->update($table, $data, $critera);
+            if ($checkKeys) {
+                $schemaManager = $connection->createSchemaManager();
+                $indexes = $schemaManager->listTableIndexes($table);
+                foreach ($checkKeys as $key) {
+                    foreach ($indexes as $index) {
+                        if ([$key] === $index->getColumns() && $index->isUnique()) {
+                            throw new \LogicException($exception->getMessage(), $exception->getCode(), $exception);
+                        }
+                    }
+                }
+            }
+
+            return $connection->update($table, $data, $criteria);
         }
     }
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.1`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.1` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Potentially resolves https://github.com/pimcore/pimcore/issues/15976

## Additional info
The problem is the fact that upsert relies on `UniqueConstraintViolationException` to guess if it's not a new row to be inserted but an existing row to be updated, and at the same time, we may encounter this exception for cases where it's throw because there's an unique index that we cannot insert (and is also not meant to update).

This PR put aside the criteria keys (that have no $data value) and check if these are actually unique indexes. 
Draft because it looks hacky, doesn't cover composite indexes and may be expensive perfomance-wise as it's not early-exiting anymore



### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e8da777</samp>

Improved `upsert` function in `Helper.php` to handle missing keys in data array. Fixed a typo in variable name.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e8da777</samp>

> _`upsert` function_
> _handles missing keys better_
> _autumn of errors_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e8da777</samp>

*  Modify `upsert` function to handle missing keys in data array ([link](https://github.com/pimcore/pimcore/pull/16212/files?diff=unified&w=0#diff-c515d6fefe7fe5cbbb74adc0c6c8bcb70572ff59b9607ffb4611a7d72da6c209L41-R61))
