### PR TITLE
Fix: Use LocaleServiceInterface instead LocaleService

### DIFF
--- a/lib/Document/Renderer/DocumentRenderer.php
+++ b/lib/Document/Renderer/DocumentRenderer.php
@@ -20,7 +20,7 @@ namespace Pimcore\Document\Renderer;
 use Pimcore\Event\DocumentEvents;
 use Pimcore\Event\Model\DocumentEvent;
 use Pimcore\Http\RequestHelper;
-use Pimcore\Localization\LocaleService;
+use Pimcore\Localization\LocaleServiceInterface;
 use Pimcore\Model\Document;
 use Pimcore\Routing\Dynamic\DocumentRouteHandler;
 use Pimcore\Templating\Renderer\ActionRenderer;
@@ -43,7 +43,7 @@ class DocumentRenderer implements DocumentRendererInterface
 
     private EventDispatcherInterface $eventDispatcher;
 
-    private LocaleService $localeService;
+    private LocaleServiceInterface $localeService;
 
     public function __construct(
         RequestHelper $requestHelper,
@@ -51,7 +51,7 @@ class DocumentRenderer implements DocumentRendererInterface
         FragmentRendererInterface $fragmentRenderer,
         DocumentRouteHandler $documentRouteHandler,
         EventDispatcherInterface $eventDispatcher,
-        LocaleService $localeService
+        LocaleServiceInterface $localeService
     ) {
         $this->requestHelper = $requestHelper;
         $this->actionRenderer = $actionRenderer;


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/16215

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f385e9d</samp>

Refactored document rendering to use an interface for locale service. This allows for better decoupling and testing of `DocumentRenderer` and `LocaleService`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f385e9d</samp>

> _Oh we are the coders of the sea, me hearties_
> _We write the code that makes the documents shine_
> _We use `LocaleServiceInterface` for dependency_
> _And we test our code with every pull and line_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f385e9d</samp>

*  Replace `LocaleService` with `LocaleServiceInterface` in `DocumentRenderer` class to allow dependency injection and mocking ([link](https://github.com/pimcore/pimcore/pull/16216/files?diff=unified&w=0#diff-29ee94726c0bbd4602ec6202c94c2d68c557621d0e50f057b37efed3a299652aL23-R23), [link](https://github.com/pimcore/pimcore/pull/16216/files?diff=unified&w=0#diff-29ee94726c0bbd4602ec6202c94c2d68c557621d0e50f057b37efed3a299652aL46-R46), [link](https://github.com/pimcore/pimcore/pull/16216/files?diff=unified&w=0#diff-29ee94726c0bbd4602ec6202c94c2d68c557621d0e50f057b37efed3a299652aL54-R54))
