### PR TITLE
[Link generator] Forward context parameters to Text::wysiwygText()

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Wysiwyg.php
+++ b/models/DataObject/ClassDefinition/Data/Wysiwyg.php
@@ -98,7 +98,11 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
             $data = self::getWysiwygSanitizer()->sanitizeFor('body', $data);
         }
 
-        return Text::wysiwygText($data);
+        return Text::wysiwygText($data, [
+            'object' => $params['owner'] ?? null,
+            'context' => $this,
+            'language' => $params['language'] ?? null,
+        ]);
     }
 
     /**
@@ -108,7 +112,11 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
      */
     public function getDataFromResource(mixed $data, DataObject\Concrete $object = null, array $params = []): ?string
     {
-        return Text::wysiwygText($data);
+        return Text::wysiwygText($data, [
+            'object' => $params['owner'] ?? null,
+            'context' => $this,
+            'language' => $params['language'] ?? null,
+        ]);
     }
 
     /**


### PR DESCRIPTION
Pimcore supports to drag & drop data objects to Wysiwyg fields to link them within the HTML content. The actual URL gets generated by a [link generator](https://pimcore.com/docs/platform/Pimcore/Objects/Object_Classes/Class_Settings/Link_Generator/).

A getter method for a localized wysiwyg field looks like this:
```php
public function getDescription(?string $language = null): ?string
{
	$data = $this->getLocalizedfields()->getLocalizedValue("description", $language);
	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
		$preValue = $this->preGetValue("description");
		if ($preValue !== null) {
			return $preValue;
		}
	}

	if ($data instanceof \Pimcore\Model\DataObject\Data\EncryptedField) {
		return $data->getPlain();
	}

	return $data;
}
```

In `Localizedfield::getLocalizedValue()` https://github.com/pimcore/pimcore/blob/512cc910427e8603572508da1d782b8c6a0ebb5a/models/DataObject/Localizedfield.php#L479-L488 gets executed, which results in https://github.com/pimcore/pimcore/blob/512cc910427e8603572508da1d782b8c6a0ebb5a/models/DataObject/ClassDefinition/Data/Wysiwyg.php#L192-L210

Here the parameters for `Text::wysiwygText()` get populated, incl. `language`.
In `Text::wysiwygText()` the link generator gets called and may use those parameters:
https://github.com/pimcore/pimcore/blob/512cc910427e8603572508da1d782b8c6a0ebb5a/lib/Tool/Text.php#L81-L86

But when an object gets saved or loaded via `getDataForResource()` / `getDataFromResource()` the function `Text::wysiwygText()` gets also called but here without any parameters:
https://github.com/pimcore/pimcore/blob/512cc910427e8603572508da1d782b8c6a0ebb5a/models/DataObject/ClassDefinition/Data/Wysiwyg.php#L101
and
https://github.com/pimcore/pimcore/blob/512cc910427e8603572508da1d782b8c6a0ebb5a/models/DataObject/ClassDefinition/Data/Wysiwyg.php#L111

Depending on how the link generator is written this may cause errors.
But anyway, to harmonize the different entry points of `Text::wysiwygText()` this PR provides the same parameters when `Text::wysiwygText()` gets called from `getDataForResource()` / `getDataFromResource()`.