### PR TITLE
Update h* elements to allow in html_sanitizer default config

### DIFF
--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -69,6 +69,11 @@ framework:
                     strong: 'class'
                     em: 'class'
                     h1: [ 'class', 'id' ]
+                    h2: [ 'class', 'id' ]
+                    h3: [ 'class', 'id' ]
+                    h4: [ 'class', 'id' ]
+                    h5: [ 'class', 'id' ]
+                    h6: [ 'class', 'id' ]
                     a: [ 'class', 'id', 'href', 'target', 'title', 'rel', 'style' ]
                     table: [ 'class', 'style', 'cellspacing', 'cellpadding', 'border', 'width', 'height', 'id' ]
                     colgroup: 'class'


### PR DESCRIPTION
## Changes in this pull request  
The html sanitizer doesn't allow h2-h6 but the default tinyMCE config allows those elements, so add these to the whitelist
