### PR TITLE
Update MaintenanceModeHelper.php - spell fix

### DIFF
--- a/lib/Tool/MaintenanceModeHelper.php
+++ b/lib/Tool/MaintenanceModeHelper.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class MaintenanceModeHelper implements MaintenanceModeHelperInterface
 {
-    protected const ENTRY_ID = 'maintenace_mode';
+    protected const ENTRY_ID = 'maintenance_mode';
 
     public function __construct(protected RequestStack $requestStack, protected Connection $db)
     {


### PR DESCRIPTION
Spell fix `maintenace_mode`  to `maintenance_mode`

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.1`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.1` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fd12d7d</samp>

Fixed a typo in the constant name `ENTRY_ID` in `MaintenanceModeHelper.php`. This constant is used to manage the maintenance mode status of the application.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fd12d7d</samp>

> _`ENTRY_ID` changed_
> _Typo fixed, code more clear_
> _Autumn of errors_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fd12d7d</samp>

* Fix typo in constant name from `maintenace_mode` to `maintenance_mode` ([link](https://github.com/pimcore/pimcore/pull/16231/files?diff=unified&w=0#diff-f16bffa67c7a8d304f9c83fade71a9374e93647a33a12b9324f083dcc506d2c0L27-R27))
