### PR TITLE
QuantityValue: unitWidth/defaultUnit can be null

### DIFF
--- a/models/DataObject/ClassDefinition/Data/AbstractQuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/AbstractQuantityValue.php
@@ -35,7 +35,7 @@ abstract class AbstractQuantityValue extends Data implements ResourcePersistence
     /**
      * @internal
      */
-    public string|int $unitWidth;
+    public string|int|null $unitWidth = null;
 
     /**
      * @internal
@@ -57,12 +57,12 @@ abstract class AbstractQuantityValue extends Data implements ResourcePersistence
      */
     public bool $autoConvert = false;
 
-    public function getUnitWidth(): int|string
+    public function getUnitWidth(): int|string|null
     {
         return $this->unitWidth;
     }
 
-    public function setUnitWidth(int|string $unitWidth): void
+    public function setUnitWidth(int|string|null $unitWidth): void
     {
         if (is_numeric($unitWidth)) {
             $unitWidth = (int)$unitWidth;

--- a/models/DataObject/ClassDefinition/Data/AbstractQuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/AbstractQuantityValue.php
@@ -85,7 +85,7 @@ abstract class AbstractQuantityValue extends Data implements ResourcePersistence
         return $this->defaultUnit;
     }
 
-    public function setDefaultUnit(string $defaultUnit): void
+    public function setDefaultUnit(?string $defaultUnit): void
     {
         $this->defaultUnit = $defaultUnit;
     }

--- a/models/DataObject/ClassDefinition/Data/AbstractQuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/AbstractQuantityValue.php
@@ -45,7 +45,7 @@ abstract class AbstractQuantityValue extends Data implements ResourcePersistence
     /**
      * @internal
      */
-    public ?array $validUnits = null;
+    public array $validUnits = [];
 
     /**
      * @internal


### PR DESCRIPTION
## Changes in this pull request  
In Pimcore 6 the unitWidth could be null. So in the update it can occur errors.

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 309245c</samp>

Fixed a bug in `AbstractQuantityValue` that caused unit width to be unset for new objects. Allowed null values for `$unitWidth` property and methods in `models/DataObject/ClassDefinition/Data/AbstractQuantityValue.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 309245c</samp>

> _There once was a class called `AbstractQuantityValue`_
> _That had a bug in its unit width property_
> _It could not handle nulls_
> _Which caused some troubles_
> _So they fixed it with a simple nullability_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 309245c</samp>

*  Allow null values for unit width in quantity value objects ([link](https://github.com/pimcore/pimcore/pull/16232/files?diff=unified&w=0#diff-3830c22d9d66e429e556a254f86745fcb037c8962f6b465bda011a537744e2fdL38-R38), [link](https://github.com/pimcore/pimcore/pull/16232/files?diff=unified&w=0#diff-3830c22d9d66e429e556a254f86745fcb037c8962f6b465bda011a537744e2fdL60-R65))
