### PR TITLE
Add last-modified-since option to ThumbnailsImageCommand

### DIFF
--- a/bundles/CoreBundle/src/Command/ThumbnailsImageCommand.php
+++ b/bundles/CoreBundle/src/Command/ThumbnailsImageCommand.php
@@ -37,6 +37,8 @@ class ThumbnailsImageCommand extends AbstractCommand
 {
     use Parallelization;
 
+    private const DATE_FORMAT = 'Y-m-d H:i:s';
+    
     protected function configure(): void
     {
         parent::configure();

--- a/bundles/CoreBundle/src/Command/ThumbnailsImageCommand.php
+++ b/bundles/CoreBundle/src/Command/ThumbnailsImageCommand.php
@@ -62,6 +62,12 @@ class ThumbnailsImageCommand extends AbstractCommand
                 'Filter images against the given regex pattern (path + filename), example:  ^/Sample.*urban.jpg$'
             )
             ->addOption(
+                'last-modified-since',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'only create thumbnails of images that have been modified since the given date (format: ' . self::DATE_FORMAT . ' )'
+            )
+            ->addOption(
                 'thumbnails',
                 't',
                 InputOption::VALUE_OPTIONAL,
@@ -128,6 +134,12 @@ class ThumbnailsImageCommand extends AbstractCommand
             $conditions[] = '('. implode(' OR ', $parentConditions) . ')';
         }
 
+        if ($lastModifiedSince = $input->getOption('last-modified-since')) {
+            $lastModifiedSinceDate = \DateTime::createFromFormat(self::DATE_FORMAT, $lastModifiedSince);
+            $conditions[] = 'modificationDate >= ?';
+            $conditionVariables[] = $lastModifiedSinceDate->getTimestamp();
+        }
+        
         if ($regex = $input->getOption('pathPattern')) {
             $conditions[] = 'CONCAT(`path`, filename) REGEXP ?';
             $conditionVariables[] = $regex;


### PR DESCRIPTION
## Changes in this pull request  
Add option to last-modified-since to ThumbnailsImageCommand

Currently if you want to pre-generate a specific thumbnail on a regular basis, the command has to iterate all the assets every time, no matter if they changed or not. With this new option only assets which changed since a given point in time are considered to be iterated, which reduces database i/o significantly.