### PR TITLE
[Translations] Admins should be able to edit all languages

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -593,11 +593,9 @@ final class User extends User\UserRole implements UserInterface
     public function getAllowedLanguagesForEditingWebsiteTranslations(): ?array
     {
         $mergedWebsiteTranslationLanguagesEdit = $this->getMergedWebsiteTranslationLanguagesEdit();
-        if (empty($mergedWebsiteTranslationLanguagesEdit) || $this->isAdmin()) {
-            $mergedWebsiteTranslationLanguagesView = $this->getMergedWebsiteTranslationLanguagesView();
-            if (empty($mergedWebsiteTranslationLanguagesView)) {
-                return Tool::getValidLanguages();
-            }
+         if ((empty($mergedWebsiteTranslationLanguagesEdit) && empty($this->getMergedWebsiteTranslationLanguagesView())) 
+            || $this->isAdmin()) { 
+            return Tool::getValidLanguages(); 
         }
 
         return $mergedWebsiteTranslationLanguagesEdit;

--- a/models/User.php
+++ b/models/User.php
@@ -593,8 +593,10 @@ final class User extends User\UserRole implements UserInterface
     public function getAllowedLanguagesForEditingWebsiteTranslations(): ?array
     {
         $mergedWebsiteTranslationLanguagesEdit = $this->getMergedWebsiteTranslationLanguagesEdit();
-         if ((empty($mergedWebsiteTranslationLanguagesEdit) && empty($this->getMergedWebsiteTranslationLanguagesView())) 
-            || $this->isAdmin()) { 
+         if (
+             (!$mergedWebsiteTranslationLanguagesEdit && !$this->getMergedWebsiteTranslationLanguagesView()) ||
+             $this->isAdmin()
+         ) { 
             return Tool::getValidLanguages(); 
         }
 


### PR DESCRIPTION
## Changes in this pull request  
Alternative to https://github.com/pimcore/pimcore/pull/15717
As seen on https://github.com/pimcore/pimcore/pull/15717#issuecomment-1792616423

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9db7ab3</samp>

Fix a bug in `User::getAllowedLanguagesForEditingWebsiteTranslations` that prevented some users from editing website translations. Simplify the function logic by merging two conditions.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9db7ab3</samp>

> _`getAllowedLanguages`_
> _Simpler logic, fewer bugs_
> _Autumn of errors_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9db7ab3</samp>

* Fix a bug that prevented users from editing website translations in some languages by simplifying the logic of `getAllowedLanguagesForEditingWebsiteTranslations` ([link](https://github.com/pimcore/pimcore/pull/16234/files?diff=unified&w=0#diff-606c30f14301fee5176f53f2477b0ce0c3ecce17a5e99779f466f02e309d5038L596-R598))
