### PR TITLE
Fix MaintenanceModeHelper->isActive() for a NULL $matchSessionId

### DIFF
--- a/lib/Tool/MaintenanceModeHelper.php
+++ b/lib/Tool/MaintenanceModeHelper.php
@@ -55,6 +55,9 @@ class MaintenanceModeHelper implements MaintenanceModeHelperInterface
     public function isActive(string $matchSessionId = null): bool
     {
         if ($this->db->isConnected() && $maintenanceModeEntry = $this->getEntry()) {
+            if ($matchSessionId === null && $maintenanceModeEntry !== null) {
+                return true;
+            }
             if ($matchSessionId && $matchSessionId !== $maintenanceModeEntry) {
                 return true;
             }


### PR DESCRIPTION
Issue:
In an enabled maintenance mode, the `isActive()` always return `false`. 

Details:
For a  `$this->maintenanceModeHelper->isActive()`  case it was always `false`.
For a  `$this->maintenanceModeHelper->isActive('some_session_id')`  case it worked properly.

Fix:
Now, when `$matchSessionId` is NULL by default and in a DB we have row with `maintanance_mode` it'll return `true` as expected.


<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.1`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.1` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e8aecb8</samp>

Allow bypassing maintenance mode for specific sessions. Add a condition in `MaintenanceModeHelper.php` to check if the current session ID matches the maintenance mode entry.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e8aecb8</samp>

> _`maintenance_mode`_
> _Only for other sessions_
> _A winter bypass_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e8aecb8</samp>

*  Add a feature to bypass the maintenance mode for specific sessions ([link](https://github.com/pimcore/pimcore/pull/16235/files?diff=unified&w=0#diff-f16bffa67c7a8d304f9c83fade71a9374e93647a33a12b9324f083dcc506d2c0R58-R60))
