### PR TITLE
[Assets] Do not store big embedded metadata of assets in cache

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -164,6 +164,7 @@ class Asset extends Element\AbstractElement
                     // do not store big metadata items in cache because it will blast cache database size and slow down element loading (esp. with remote cache storage)
                     if(is_string($embeddedMetaDataItem) && strlen($embeddedMetaDataItem) > 10e6) {
                         $embeddedMetaDataItem = null;
+                        $this->customSettings['embeddedMetaDataExtracted'] = false;
                     }
                 }
                 unset($embeddedMetaDataItem);

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -158,6 +158,17 @@ class Asset extends Element\AbstractElement
 
         if (!$this->isInDumpState()) {
             // for caching asset
+
+            foreach($this->customSettings as $customSetting) {
+                foreach($customSetting['embeddedMetaData'] ?? [] as &$embeddedMetaDataItem) {
+                    // do not store big metadata items in cache because it will blast cache database size and slow down element loading (esp. with remote cache storage)
+                    if(is_string($embeddedMetaDataItem) && strlen($embeddedMetaDataItem) > 10e6) {
+                        $embeddedMetaDataItem = null;
+                    }
+                }
+                unset($embeddedMetaDataItem);
+            }
+
             $blockedVars = array_merge($blockedVars, ['children', 'properties']);
         }
 


### PR DESCRIPTION
In our case we store PSD files in Pimcore. We recognized that some objects load very slowly, some others are fast. Cause was that the serialized string for the cache object was 470 MB for one single product object. This was caused by a PSD asset which was assigned to this product. The product's serialized cache content looked like this:
```
imageGallery";O:42:"Pimcore\Model\DataObject\Data\ImageGallery":4:{
  s:8:"�*�items";a:12:{
    i:0;O:42:"Pimcore\Model\DataObject\Data\Hotspotimage":7:{
      s:8:"�*�image";O:25:"Pimcore\Model\Asset\Image" ... 
      "customSettings";a:6
        {s:25:"imageDimensionsCalculated";b:1;
         s:10:"imageWidth";i:2168;
         s:11:"imageHeight";i:2728;
         s:16:"embeddedMetaData";a:140:
           {s:6:"Rating";s:1:"0";
            s:10:"ModifyDate";s:25:"2023-09-11T13:04:21+02:00";
            ... ;
            s:17:"DocumentAncestors";s:391869353:"0 | 000065CD5D73C8A6BD77958E7DC915D5 | 0000A6C7815905497C2762FB3073AC1B | 00017C97C28B0C407DB5E9F93F00B063 | 0001D2F6B1EAB928C0E4315B05B11C61 | 0001D40A7B18F3382B14F2E780D08129 | 0001FD5C142F2421AA51CDFE96051817 | 000203CC51DB617B8F482FE5A27E8334 | 00021F02EEAA8EFAF0E45E7928038F1D | 0003CB10DAE57AE18E0642BF7CBE2B60 | 0003F732405B3B63FFE3F688C0DC841D | 0004F219969ECF9B707A9B90C0D00CD1 | 00055F48F66DCEDAC47DCD3A8B94F9CB | 0005676DB8E2C0728B807BAC4FD9C977 | 000697E475988EA21350DB3A298DD0FE | 00072919E3FCD9243A279B11FA36E751 | 0007A2245BDAB57FC983C6D99B8A169D | 000861C5DABB168A7E6B07BE5F382EB5 | 0008726E8294323D8296EAACF255F542 | 0009238C384F469C2021DEDBE018E08B | 0009C3406AF0C863D560A1745E372F53 | 000A73B1BEE2374F643340C956A9322A | 000A9CFDB9301322BFB32D927943FB41 | 000ABA1A699C389D573DBC0C7944D2C3 | 000B31C4C6A0712A9EA701121B2AF287 | 000B5866682EABEA8972C10063D4366F | 000B84DD32F5ABCC8D7B5E8681465EE9 | ...
```

In this case the `DocumentAncestors` metadata contained 390 MB of useless data. 

This caused not only the asset to load slow but also to load the tree and the object where this asset was assigned to load slow.
Furthermore this led to the problem that Redis was constantly reaching the size limit and pruning some of the (actually still valid and up-to-date data). Consequently this made the cache completely useless as in a lot of cases valid items got removed due to size limit problems (Redis size was set to 400GB, so this is quite large but with every increase, it filled up again immediately). And those which were saved in cache, were slower to load than when they would have been loaded from the database instead (because in this case the embedded metadata does not get fetched anyway when only opening an object).

With this PR, embedded meta data which is bigger than 10MB will not get stored to the cache. Let's discuss if there is a better solution...