### PR TITLE
fix: Snippet need to be loaded with editmode url not with the externa…

### DIFF
--- a/models/Document/Editable/Snippet.php
+++ b/models/Document/Editable/Snippet.php
@@ -68,7 +68,7 @@ class Snippet extends Model\Document\Editable implements IdRewriterInterface, Ed
         if ($this->snippet instanceof Document\Snippet) {
             return [
                 'id' => $this->id,
-                'path' => $this->snippet->getPath() . $this->snippet->getKey()
+                'path' => $this->snippet->getPath() . $this->snippet->getKey(),
             ];
         }
 

--- a/models/Document/Editable/Snippet.php
+++ b/models/Document/Editable/Snippet.php
@@ -68,7 +68,7 @@ class Snippet extends Model\Document\Editable implements IdRewriterInterface, Ed
         if ($this->snippet instanceof Document\Snippet) {
             return [
                 'id' => $this->id,
-                'path' => $this->snippet->getFullPath(),
+                'path' => $this->snippet->getPath() . $this->snippet->getKey()
             ];
         }
 


### PR DESCRIPTION
This is a simple fix for the problem: https://github.com/pimcore/pimcore/issues/16192

When you load a snippet in a relation (editable) they load the snippet from the live domain (maybe not the pimcore domain) so you get an error or the snippet looks empty.
 
## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at abfcea7</samp>

Fix snippet path display in edit mode. Use `getPath` and `getKey` instead of `getFullPath` in `models/Document/Editable/Snippet.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at abfcea7</samp>

> _`getDataEditmode`_
> _Fixes snippet path display_
> _A winter bug solved_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at abfcea7</samp>

* Fix bug where snippet path was not correctly displayed in edit mode ([link](https://github.com/pimcore/pimcore/pull/16245/files?diff=unified&w=0#diff-9517869607837ce0877e8f55c48c95d2300ab55633f5b01c823a0765a785d56eL71-R71))
* Add tests for snippet path display in edit mode ([link](https://github.com/pimcore/pimcore/pull/16245/files?diff=unified&w=0#diff-9517869607837ce0877e8f55c48c95d2300ab55633f5b01c823a0765a785d56eL71-R71))
