### PR TITLE
fix: in editmode relation the path should be the internal path and ...

### DIFF
--- a/models/Document/Editable/Snippet.php
+++ b/models/Document/Editable/Snippet.php
@@ -86,7 +86,7 @@ class Snippet extends Model\Document\Editable implements IdRewriterInterface, Ed
         if ($this->snippet instanceof Document\Snippet) {
             return [
                 'id' => $this->id,
-                'path' => $this->snippet->getFullPath(),
+                'path' => $this->snippet->getPath() . $this->snippet->getKey(),
             ];
         }
 


### PR DESCRIPTION
in editmode the editable relation path should be the internal path (like domain.com/domain/snippet) and not the full path (like: domain2.com/snippet).
This cause an error in snippet or it looks blank.

Fix issue https://github.com/pimcore/pimcore/issues/16192 for Pimcore 10.6

## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 88c26f6</samp>

Fix snippet path resolution in edit mode. Use `getPath` and `getKey` instead of `getFullPath` in `models/Document/Editable/Snippet.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 88c26f6</samp>

> _`getDataEditmode`_
> _Fixes snippet path bug now_
> _Autumn leaves fall fast_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 88c26f6</samp>

* Fix bug where snippet path was not resolved correctly in edit mode ([link](https://github.com/pimcore/pimcore/pull/16246/files?diff=unified&w=0#diff-9517869607837ce0877e8f55c48c95d2300ab55633f5b01c823a0765a785d56eL89-R89))
