### PR TITLE
fix: Pimcore 10.6 path in editable for relation

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetHelperController.php
@@ -789,6 +789,7 @@ class AssetHelperController extends AdminAbstractController
     public function encodeFunc($value)
     {
         $value = str_replace('"', '""', $value);
+
         //force wrap value in quotes and return
         return '"' . $value . '"';
     }

--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
@@ -97,6 +97,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
             $this->checkPermission('objects');
         } catch (AccessDeniedHttpException $e) {
             Logger::log('[Startup] Object types are not loaded as "objects" permission is missing');
+
             //return empty string to avoid error on startup
             return $this->adminJson([]);
         }

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -1447,6 +1447,7 @@ class DataObjectHelperController extends AdminAbstractController
     public function encodeFunc($value)
     {
         $value = str_replace('"', '""', $value);
+
         //force wrap value in quotes and return
         return '"' . $value . '"';
     }

--- a/bundles/AdminBundle/Controller/Admin/External/AdminerController.php
+++ b/bundles/AdminBundle/Controller/Admin/External/AdminerController.php
@@ -270,6 +270,7 @@ namespace {
                 public function database()
                 {
                     $db = \Pimcore\Db::get();
+
                     // database name, will be escaped by Adminer
                     return $db->getDatabase();
                 }

--- a/bundles/AdminBundle/Controller/Admin/SettingsController.php
+++ b/bundles/AdminBundle/Controller/Admin/SettingsController.php
@@ -1076,6 +1076,7 @@ class SettingsController extends AdminAbstractController
             $this->checkPermission('documents');
         } catch (AccessDeniedHttpException $e) {
             Logger::log('[Startup] Sites are not loaded as "documents" permission is missing');
+
             //return empty string to avoid error on startup
             return $this->adminJson([]);
         }

--- a/bundles/EcommerceFrameworkBundle/VoucherService/TokenManager/Pattern.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/TokenManager/Pattern.php
@@ -460,8 +460,8 @@ class Pattern extends AbstractTokenManager implements ExportableTokenManagerInte
                 if ($this->tokenExists($checkTokens, $insertCheckTokens)) {
                     $checkTokenCount--;
                     unset($checkTokens[$token]);
-                    // Check if the length of the checkTokens Array matches the defined step range
-                    // so the the checkTokens get matched against the database.
+                // Check if the length of the checkTokens Array matches the defined step range
+                // so the the checkTokens get matched against the database.
                 } elseif ($checkTokenCount == $tokenCheckStep) {
                     // Check if any of the tokens in the temporary array checkTokens already exists,
                     // if not so, merge the checkTokens array with the array of tokens to insert and

--- a/lib/Cache/Core/CoreCacheHandler.php
+++ b/lib/Cache/Core/CoreCacheHandler.php
@@ -907,7 +907,7 @@ class CoreCacheHandler implements LoggerAwareInterface
             $tags = $this->prepareCacheTags($queueItem->getKey(), $queueItem->getData(), $queueItem->getTags());
             if (null === $tags) {
                 $result = false;
-                // item shouldn't go to the cache (either because it's tags are ignored or were cleared within this process) -> see $this->prepareCacheTags();
+            // item shouldn't go to the cache (either because it's tags are ignored or were cleared within this process) -> see $this->prepareCacheTags();
             } else {
                 $result = $this->storeCacheData($queueItem->getKey(), $queueItem->getData(), $tags, $queueItem->getLifetime(), $queueItem->isForce());
             }

--- a/lib/Db/PimcoreExtensionsTrait.php
+++ b/lib/Db/PimcoreExtensionsTrait.php
@@ -330,6 +330,7 @@ trait PimcoreExtensionsTrait
     public function fetchOne($sql, $params = [], $types = [])
     {
         $params = $this->prepareParams($params);
+
         // unfortunately Mysqli driver doesn't support \PDO::FETCH_COLUMN, so we have to use $this->fetchColumn() instead
         return parent::fetchOne($sql, $params, $types);
     }

--- a/lib/Web2Print/Processor/HeadlessChrome.php
+++ b/lib/Web2Print/Processor/HeadlessChrome.php
@@ -130,6 +130,7 @@ class HeadlessChrome extends Processor
 
             return $path;
         }
+
         /** @var StringOutput $output */
         return $output->get();
     }

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -188,6 +188,7 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation implemen
                 }
             }
         }
+
         //must return array - otherwise this means data is not loaded
         return $list;
     }

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -169,6 +169,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
                 $objects['dirty'] = true;
             }
         }
+
         //must return array - otherwise this means data is not loaded
         return $objects;
     }
@@ -260,6 +261,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
                 }
             }
         }
+
         //must return array if data shall be set
         return $objects;
     }

--- a/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
@@ -292,6 +292,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
                 $elements['dirty'] = true;
             }
         }
+
         //must return array - otherwise this means data is not loaded
         return $elements;
     }
@@ -398,6 +399,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
                 }
             }
         }
+
         //must return array if data shall be set
         return $elements;
     }

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -2032,7 +2032,7 @@ class Service extends Model\Element\Service
                             );
                         }
                     }
-                    //key value store - ignore for now
+                //key value store - ignore for now
                 } elseif (count($fieldParts) > 1) {
                     // brick
                     $brickType = $fieldParts[0];

--- a/models/Document/Editable/Snippet.php
+++ b/models/Document/Editable/Snippet.php
@@ -86,7 +86,7 @@ class Snippet extends Model\Document\Editable implements IdRewriterInterface, Ed
         if ($this->snippet instanceof Document\Snippet) {
             return [
                 'id' => $this->id,
-                'path' => $this->snippet->getFullPath(),
+                'path' => $this->snippet->getPath() . $this->snippet->getKey(),
             ];
         }
 


### PR DESCRIPTION
in editmode the editable relation path should be the internal path (like domain.com/domain/snippet) and not the full path (like: domain2.com/snippet).
This cause an error in snippet or it looks blank.

Fix issue https://github.com/pimcore/pimcore/issues/16192 for Pimcore 10.6


## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2806035</samp>

Fix snippet path resolution in edit mode. Use `getPath` and `getKey` instead of `getFullPath` in `models/Document/Editable/Snippet.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2806035</samp>

> _`getDataEditmode`_
> _Fixes snippet path bug now_
> _Autumn leaves falling_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2806035</samp>

* Fix bug in resolving snippet path for edit mode ([link](https://github.com/pimcore/pimcore/pull/16247/files?diff=unified&w=0#diff-9517869607837ce0877e8f55c48c95d2300ab55633f5b01c823a0765a785d56eL89-R89))
