### PR TITLE
Fix suggested Pimcore version in `11_Preparing_for_V11.md`

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/11_Preparing_for_V11.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/11_Preparing_for_V11.md
@@ -1,7 +1,7 @@
 # Preparing Pimcore for Version 11
 
 ## Preparatory Work
-- Upgrade to version 10.5.x, if you are using a lower version.
+- Upgrade to version 10.6.x, if you are using a lower version.
 - [Security] Enable New Security Authenticator and adapt your security.yaml as per changes [here](https://github.com/pimcore/demo/blob/11.x/config/packages/security.yaml) :
     ```
     security:


### PR DESCRIPTION
## Changes in this pull request  
I know Pimcore 10 is EOL, but hopefully you'll still accept changes for the upgrade docs.

It currently says you should update to `Pimcore 10.5.x` to prepare for the `Pimcore 11` upgrade. But you should upgrade to `Pimcore 10.6.x` instead, right? Because this is the latest minor version, and it contains most of the deprecations and BC layers.

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c5a0130</samp>

Updated the documentation for upgrading to Pimcore 11. Fixed a typo and clarified the minimum required version in `doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/11_Preparing_for_V11.md`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c5a0130</samp>

> _`Pimcore` upgrade_
> _Fix typo, raise version_
> _Spring cleaning docs_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c5a0130</samp>

* Update the minimum required version for upgrading to Pimcore 11 from 10.5.x to 10.6.x ([link](https://github.com/pimcore/pimcore/pull/16248/files?diff=unified&w=0#diff-f584251600f27223f1baa0adf6907b18a9812c79fd72375c5e880a5c7aaf7bdfL4-R4))
* Fix a typo in the word `processor` in the documentation ([link](https://github.com/pimcore/pimcore/pull/16248/files?diff=unified&w=0#diff-f584251600f27223f1baa0adf6907b18a9812c79fd72375c5e880a5c7aaf7bdfL124-R124))
