### PR TITLE
[Bug]: Fixes "bin/console doctrine:migrations:migrate" error "The prefix option does not exist."

### DIFF
--- a/lib/Console/Application.php
+++ b/lib/Console/Application.php
@@ -122,6 +122,10 @@ final class Application extends \Symfony\Bundle\FrameworkBundle\Console\Applicat
 
     public function add(Command $command): ?Command
     {
+        if ($command instanceof LazyCommand) {
+            $command = $command->getCommand();
+        }
+        
         if ($command instanceof DoctrineCommand) {
             $definition = $command->getDefinition();
 

--- a/lib/Console/Application.php
+++ b/lib/Console/Application.php
@@ -25,6 +25,7 @@ use Pimcore\Tool\Admin;
 use Pimcore\Tool\MaintenanceModeHelperInterface;
 use Pimcore\Version;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LazyCommand;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
@@ -122,7 +123,7 @@ final class Application extends \Symfony\Bundle\FrameworkBundle\Console\Applicat
 
     public function add(Command $command): ?Command
     {
-        if ($command instanceof LazyCommand) {
+        if ($command instanceof LazyCommand && str_starts_with($command->getName(), 'doctrine:')) {
             $command = $command->getCommand();
         }
         


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/16160

## Additional info
Based on suggested solution on https://github.com/pimcore/pimcore/pull/16162#issuecomment-1808487067  and rebased https://github.com/pimcore/pimcore/pull/16162


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bd3cccb</samp>

Support lazy commands in Pimcore console application. Fix `add` method to unwrap lazy command objects before adding them to the application.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bd3cccb</samp>

> _`add` method checks_
> _for lazy commands in spring_
> _unwrap them with care_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bd3cccb</samp>

*  Add support for lazy commands in the console application ([link](https://github.com/pimcore/pimcore/pull/16257/files?diff=unified&w=0#diff-f1b341f8c516eb5173d334d53d8890aecf4038817679a3ebebd734af044c6ea1R125-R128))
