### PR TITLE
Fixed Video.getErrorCode preg_match function by casting to string

### DIFF
--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -508,7 +508,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
         $width = $this->getWidth();
         // If contains at least one digit (0-9), then assume it is a value that can be calculated,
         // otherwise it is likely be `auto`,`inherit`,etc..
-        if (preg_match('/[\d]/', $width)) {
+        if (preg_match('/[\d]/', (string) $width)) {
             // when is numeric, assume there are no length units nor %, and considering the value as pixels
             if (is_numeric($width)) {
                 $width .= 'px';
@@ -517,7 +517,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
         }
 
         $height = $this->getHeight();
-        if (preg_match('/[\d]/', $height)) {
+        if (preg_match('/[\d]/', (string) $height)) {
             if (is_numeric($height)) {
                 $height .= 'px';
             }


### PR DESCRIPTION
preg_match expects $subject to be of type string, but `getWidth()` and `getHeight` possibly also return int.
