### PR TITLE
Deprecate LocaleServiceInterface aliases

### DIFF
--- a/bundles/CoreBundle/config/aliases.yaml
+++ b/bundles/CoreBundle/config/aliases.yaml
@@ -8,8 +8,19 @@ services:
     Symfony\Bridge\Twig\Extension\WebLinkExtension: '@twig.extension.weblink'
     Doctrine\Persistence\ConnectionRegistry: '@doctrine'
     Symfony\Contracts\Translation\TranslatorInterface: '@Pimcore\Translation\Translator'
-    Pimcore\Localization\LocaleService: '@Pimcore\Localization\LocaleServiceInterface'
     GuzzleHttp\ClientInterface: '@pimcore.http_client'
     Symfony\Component\HttpKernel\EventListener\SessionListener: '@session_listener'
 
-    pimcore.locale: '@Pimcore\Localization\LocaleServiceInterface'
+    Pimcore\Localization\LocaleService:
+        alias: Pimcore\Localization\LocaleServiceInterface
+        deprecated:
+            message: 'The "%alias_id%" alias is deprecated, use "Pimcore\Localization\LocaleServiceInterface" instead.'
+            package: pimcore/pimcore
+            version: 11.2
+
+    pimcore.locale:
+        alias: Pimcore\Localization\LocaleServiceInterface
+        deprecated:
+            message: 'The "%alias_id%" alias is deprecated, use "Pimcore\Localization\LocaleServiceInterface" instead.'
+            package: pimcore/pimcore
+            version: 11.2

--- a/bundles/CoreBundle/src/Migrations/Version20231127124738.php
+++ b/bundles/CoreBundle/src/Migrations/Version20231127124738.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Pimcore\DataObject\ClassBuilder\PHPClassDumperInterface;
+use Pimcore\DataObject\ClassBuilder\PHPFieldCollectionClassDumperInterface;
+use Pimcore\DataObject\ClassBuilder\PHPObjectBrickClassDumperInterface;
+use Pimcore\DataObject\ClassBuilder\PHPObjectBrickContainerClassDumperInterface;
+use Pimcore\Model\DataObject;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+final class Version20231127124738 extends AbstractMigration implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    public function getDescription(): string
+    {
+        return 'Regenerate class/objectbrick/fieldcollection php files';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->regenerate();
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->regenerate();
+    }
+
+    /**
+     * @throws \Exception
+     */
+    private function regenerate(): void
+    {
+        $classDumper = $this->container->get(PHPClassDumperInterface::class);
+        $brickClassDumper = $this->container->get(PHPObjectBrickClassDumperInterface::class);
+        $brickContainerClassDumper = $this->container->get(PHPObjectBrickContainerClassDumperInterface::class);
+        $collectionClassDumper = $this->container->get(PHPFieldCollectionClassDumperInterface::class);
+
+
+        $listing = new DataObject\ClassDefinition\Listing();
+        foreach ($listing->getClasses() as $class) {
+            $this->write(sprintf('Saving php files for class: %s', $class->getName()));
+            $classDumper->dumpPHPClasses($class);
+        }
+
+        $list = new DataObject\Objectbrick\Definition\Listing();
+        $list = $list->load();
+        foreach ($list as $brickDefinition) {
+            $this->write(sprintf('Saving php files for objectbrick: %s', $brickDefinition->getKey()));
+            $brickClassDumper->dumpPHPClasses($brickDefinition);
+            $brickContainerClassDumper->dumpContainerClasses($brickDefinition);
+        }
+
+        $list = new DataObject\Fieldcollection\Definition\Listing();
+        $list = $list->load();
+        foreach ($list as $fcDefinition) {
+            $this->write(sprintf('Saving php files for fieldcollection: %s', $fcDefinition->getKey()));
+            $collectionClassDumper->dumpPHPClass($fcDefinition);
+        }
+    }
+}

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -6,6 +6,9 @@
 - Using `outputFormat` config for `Pimcore\Model\Document\Editable\Date` editable is deprecated, use `outputIsoFormat` config instead.
 #### [Data Objects]:
 - Methods `getAsIntegerCast()` and `getAsFloatCast()` of the `Pimcore\Model\DataObject\Data` class are deprecated now.
+-----------------
+### General
+- Service `Pimcore\Localization\LocaleService` and `pimcore.locale` are deprecated, use `Pimcore\Localization\LocaleServiceInterface` instead.
 
 ## Pimcore 11.1.0
 ### Elements

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -9,8 +9,9 @@
 
 -----------------
 ### General
+#### [Localization]
 - Services `Pimcore\Localization\LocaleService` and `pimcore.locale` are deprecated, use `Pimcore\Localization\LocaleServiceInterface` instead.
-### [Navigation]
+#### [Navigation]
 - Add rootCallback option to `Pimcore\Navigation\Builder::getNavigation()`
 
 ## Pimcore 11.1.0

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -8,7 +8,7 @@
 - Methods `getAsIntegerCast()` and `getAsFloatCast()` of the `Pimcore\Model\DataObject\Data` class are deprecated now.
 -----------------
 ### General
-- Service `Pimcore\Localization\LocaleService` and `pimcore.locale` are deprecated, use `Pimcore\Localization\LocaleServiceInterface` instead.
+- Services `Pimcore\Localization\LocaleService` and `pimcore.locale` are deprecated, use `Pimcore\Localization\LocaleServiceInterface` instead.
 
 ## Pimcore 11.1.0
 ### Elements

--- a/models/DataObject/ClassDefinition/Data/CalculatedValue.php
+++ b/models/DataObject/ClassDefinition/Data/CalculatedValue.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
+use Pimcore\Localization\LocaleServiceInterface;
 use Pimcore\Model;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
@@ -232,7 +233,7 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
         $code .= '{' . "\n";
         $code .= "\t" . 'if (!$language) {' . "\n";
         $code .= "\t\t" . 'try {' . "\n";
-        $code .= "\t\t\t" . '$locale = \Pimcore::getContainer()->get("pimcore.locale")->getLocale();'  . "\n";
+        $code .= "\t\t\t" . '$locale = \Pimcore::getContainer()->get("' . LocaleServiceInterface::class . '")->getLocale();'  . "\n";
         $code .= "\t\t\t" . 'if (\Pimcore\Tool::isValidLanguage($locale)) {'  . "\n";
         $code .= "\t\t\t\t" . '$language = (string) $locale;'  . "\n";
         $code .= "\t\t\t" . '} else {'  . "\n";

--- a/models/Translation.php
+++ b/models/Translation.php
@@ -315,7 +315,7 @@ final class Translation extends AbstractModel
             }
 
             if (!$language) {
-                $language = \Pimcore::getContainer()->get('pimcore.locale')->findLocale();
+                $language = \Pimcore::getContainer()->get(LocaleServiceInterface::class)->findLocale();
             }
 
             if (!in_array($language, Tool\Admin::getLanguages())) {


### PR DESCRIPTION
## Changes in this pull request  
Followup to https://github.com/pimcore/pimcore/pull/16216

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b1c082f</samp>

This pull request replaces the deprecated `Pimcore\Localization\LocaleService` and `pimcore.locale` service identifiers with `Pimcore\Localization\LocaleServiceInterface` in various classes and files. This improves the code quality and follows the best practices of dependency injection and interface segregation.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b1c082f</samp>

> _To follow the interface segregation_
> _We deprecated the old localization_
> _Use `LocaleServiceInterface`_
> _For better code practice_
> _And check the upgrade notes for information_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b1c082f</samp>

*  Deprecate `Pimcore\Localization\LocaleService` and `pimcore.locale` aliases and replace them with `Pimcore\Localization\LocaleServiceInterface` to follow interface segregation principle and avoid using concrete classes as service identifiers ([link](https://github.com/pimcore/pimcore/pull/16268/files?diff=unified&w=0#diff-8956b26f969d558f5439a822f728343b53f375132eaf399393d4921918e82040L11-R26), [link](https://github.com/pimcore/pimcore/pull/16268/files?diff=unified&w=0#diff-375aded12dfb868b84d5b8c27d1aed2358680a27b683e8a985f1b85193dd79aaR9-R11))
*  Import `Pimcore\Localization\LocaleServiceInterface` in `CalculatedValue` class and use it to get the current locale in `getGetterCodeLocalizedfields` method instead of `pimcore.locale` ([link](https://github.com/pimcore/pimcore/pull/16268/files?diff=unified&w=0#diff-9197600062620cefad4f515549e171801ea8cf56834b11aaaa20474f93f680bdR19), [link](https://github.com/pimcore/pimcore/pull/16268/files?diff=unified&w=0#diff-9197600062620cefad4f515549e171801ea8cf56834b11aaaa20474f93f680bdL235-R236))
*  Use `Pimcore\Localization\LocaleServiceInterface` to find the locale in `getByKeyLocalized` method of `Translation` class instead of `pimcore.locale` ([link](https://github.com/pimcore/pimcore/pull/16268/files?diff=unified&w=0#diff-d0dc6d8e60e668f42bd2013951b548bf2c28f63b0a6a2cf0dd1a0d9ecb0a8425L318-R318))
