### PR TITLE
[Translations] Xliff - Fix exporting source document data 

### DIFF
--- a/bundles/XliffBundle/src/ExportDataExtractorService/DataExtractor/DocumentDataExtractor.php
+++ b/bundles/XliffBundle/src/ExportDataExtractorService/DataExtractor/DocumentDataExtractor.php
@@ -79,6 +79,8 @@ class DocumentDataExtractor extends AbstractElementDataExtractor
 
         $translations = $service->getTranslations($document);
 
+        $this->resetSourceDocument($document, $result, $translations);
+
         if ($document instanceof Document\PageSnippet) {
             $editableNames = $this->EditableUsageResolver->getUsedEditableNames($document);
             foreach ($editableNames as $editableName) {
@@ -129,6 +131,8 @@ class DocumentDataExtractor extends AbstractElementDataExtractor
         $service = new Document\Service;
         $translations = $service->getTranslations($document);
 
+        $this->resetSourceDocument($document, $result, $translations);
+
         if ($document instanceof Document\Page) {
             $data = [
                 'title' => $document->getTitle(),
@@ -170,5 +174,17 @@ class DocumentDataExtractor extends AbstractElementDataExtractor
                     'navigation_accesskey',
                     'navigation_tabindex',
                 ]);
+    }
+
+    private function resetSourceDocument(Document &$document, AttributeSet $result, array $translations): void
+    {
+        if ($result->getSourceLanguage() != $result->getTargetLanguages()) {
+            $sourceDocumentId = $translations[$result->getSourceLanguage()];
+            $sourceDocument = Document::getById($sourceDocumentId);
+
+            if ($sourceDocument instanceof Document\PageSnippet) {
+                $document = $sourceDocument;
+            }
+        }
     }
 }

--- a/bundles/XliffBundle/src/ExportDataExtractorService/DataExtractor/DocumentDataExtractor.php
+++ b/bundles/XliffBundle/src/ExportDataExtractorService/DataExtractor/DocumentDataExtractor.php
@@ -179,11 +179,13 @@ class DocumentDataExtractor extends AbstractElementDataExtractor
     private function resetSourceDocument(Document &$document, AttributeSet $result, array $translations): void
     {
         if ($result->getSourceLanguage() != $result->getTargetLanguages()) {
-            $sourceDocumentId = $translations[$result->getSourceLanguage()];
-            $sourceDocument = Document::getById($sourceDocumentId);
+            $sourceDocumentId = $translations[$result->getSourceLanguage()] ?? false;
+            if ($sourceDocumentId) {
+                $sourceDocument = Document::getById($sourceDocumentId);
 
-            if ($sourceDocument instanceof Document\PageSnippet) {
-                $document = $sourceDocument;
+                if ($sourceDocument instanceof Document\PageSnippet) {
+                    $document = $sourceDocument;
+                }
             }
         }
     }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #16037

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a15dfaf</samp>

Fixed a bug in the `XliffBundle` that caused incorrect data export for multilingual documents. Added a method to `DocumentDataExtractor` to reset the source document data after each language extraction.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a15dfaf</samp>

> _The source document holds the truth_
> _Don't let the targets corrupt it_
> _Reset the data after each loop_
> _`DocumentDataExtractor` does it_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a15dfaf</samp>

* Fix a bug where the source document data was overwritten by the target language data when exporting multiple languages ([link](https://github.com/pimcore/pimcore/pull/16269/files?diff=unified&w=0#diff-7d7a0c94b91aab2386bf2e866f0cd108be765da38f033f85e3c82d2db09a6193R82-R83), [link](https://github.com/pimcore/pimcore/pull/16269/files?diff=unified&w=0#diff-7d7a0c94b91aab2386bf2e866f0cd108be765da38f033f85e3c82d2db09a6193R134-R135), [link](https://github.com/pimcore/pimcore/pull/16269/files?diff=unified&w=0#diff-7d7a0c94b91aab2386bf2e866f0cd108be765da38f033f85e3c82d2db09a6193R178-R189))
  - Add a `resetSourceDocument` method to `DocumentDataExtractor.php` that restores the original source document object if the source and target languages are different ([link](https://github.com/pimcore/pimcore/pull/16269/files?diff=unified&w=0#diff-7d7a0c94b91aab2386bf2e866f0cd108be765da38f033f85e3c82d2db09a6193R178-R189))
  - Call the `resetSourceDocument` method after extracting the document data for the source language and each target language in `extractData` ([link](https://github.com/pimcore/pimcore/pull/16269/files?diff=unified&w=0#diff-7d7a0c94b91aab2386bf2e866f0cd108be765da38f033f85e3c82d2db09a6193R82-R83), [link](https://github.com/pimcore/pimcore/pull/16269/files?diff=unified&w=0#diff-7d7a0c94b91aab2386bf2e866f0cd108be765da38f033f85e3c82d2db09a6193R134-R135))
