### PR TITLE
Remove Copilot for Pull Requests from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,11 +20,3 @@ Before working on a contribution, you must determine on which branch you need to
 Resolves #
 
 ## Additional info
-
-### WHAT
-copilot:summary
-
-copilot:poem
-
-### HOW
-copilot:walkthrough


### PR DESCRIPTION
It's deprecated and will conclude on December 15, see: https://githubnext.com/copilot-for-prs-sunset

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e897921</samp>

Removed Copilot placeholder code from the pull request template. Simplified the template to help contributors provide relevant information about their changes.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e897921</samp>

> _`Copilot` removed_
> _Template is more concise now_
> _Autumn of placeholders_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e897921</samp>

*  Removed Copilot commands from the pull request template ([link](https://github.com/pimcore/pimcore/pull/16271/files?diff=unified&w=0#diff-18813c86948efc57e661623d7ba48ff94325c9b5421ec9177f724922dd553a35L23-L30)) to make it more clear and concise for contributors
