### PR TITLE
Update phpstan to 1.10.43

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -131,7 +131,6 @@
   },
   "conflict": {
     "symfony/symfony": "*",
-    "doctrine/doctrine-migrations-bundle": "3.1.0",
     "sabre/dav": "4.2.2",
     "thecodingmachine/safe": "<2.0"
   },
@@ -140,8 +139,8 @@
     "codeception/module-symfony": "^3.1.0",
     "codeception/phpunit-wrapper": "^9",
     "ergebnis/phpstan-rules": "^2.0",
-    "phpstan/phpstan": "1.10.39",
-    "phpstan/phpstan-symfony": "^1.3.2",
+    "phpstan/phpstan": "1.10.43",
+    "phpstan/phpstan-symfony": "^1.3.5",
     "phpunit/phpunit": "^9.3",
     "gotenberg/gotenberg-php": "^1.1",
     "composer/composer": "*",

--- a/models/Asset/MetaData/EmbeddedMetaDataTrait.php
+++ b/models/Asset/MetaData/EmbeddedMetaDataTrait.php
@@ -354,7 +354,7 @@ trait EmbeddedMetaDataTrait
                     $iptcRaw = iptcparse($info['APP13']);
                     if (is_array($iptcRaw)) {
                         foreach ($iptcRaw as $key => $value) {
-                            if (is_array($value) && count($value) === 1) {
+                            if (count($value) === 1) {
                                 $value = $value[0];
                             }
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves: https://github.com/pimcore/pimcore/issues/16181

Fix new errors:
```
 ------ -------------------------------------------------------------------------------------------------
  Line   models/Asset/MetaData/EmbeddedMetaDataTrait.php (in context of class Pimcore\Model\Asset\Image)
 ------ -------------------------------------------------------------------------------------------------
  357    Call to function is_array() with array<string> will always evaluate to true.
 ------ -------------------------------------------------------------------------------------------------

 ------ -------------------------------------------------------------------------------------------------
  Line   models/Asset/MetaData/EmbeddedMetaDataTrait.php (in context of class Pimcore\Model\Asset\Video)
 ------ -------------------------------------------------------------------------------------------------
  357    Call to function is_array() with array<string> will always evaluate to true.
 ------ -------------------------------------------------------------------------------------------------


 [ERROR] Found 2 errors
```

See https://github.com/phpstan/phpstan-src/pull/2727

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at be5b29d</samp>

This pull request updates some dependencies and improves the code quality of the `getIPTCData` function in `models/Asset/MetaData/EmbeddedMetaDataTrait.php`. It removes an unused dependency and simplifies the logic of extracting IPTC metadata from images.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at be5b29d</samp>

> _We're sailing on the code sea, with `getIPTCData` in our hand_
> _We've simplified the logic, and made it easier to understand_
> _We've tossed out the unused stuff, and updated what we need_
> _So heave away, me hearties, heave away with speed_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at be5b29d</samp>

* Remove unused dependency on doctrine/doctrine-migrations-bundle ([link](https://github.com/pimcore/pimcore/pull/16272/files?diff=unified&w=0#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L134))
* Update phpstan/phpstan and phpstan/phpstan-symfony to latest versions ([link](https://github.com/pimcore/pimcore/pull/16272/files?diff=unified&w=0#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L143-R143))
* Simplify logic of `getIPTCData` function in `models/Asset/MetaData/EmbeddedMetaDataTrait.php` by removing redundant check for is_array ([link](https://github.com/pimcore/pimcore/pull/16272/files?diff=unified&w=0#diff-a2452ff6723dd449cecd4d5b1759b85f44874ddd8cd6575bff9853948aa041afL357-R357))
