### PR TITLE
[Data Objects] Password data type: fixed hash detection for password_hash algorithm

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Password.php
+++ b/models/DataObject/ClassDefinition/Data/Password.php
@@ -105,27 +105,29 @@ class Password extends Data implements ResourcePersistenceAwareInterface, QueryR
         }
 
         // is already a hashed string? Then do not re-hash
-        $info = password_get_info($data);
-        if ($info['algo'] !== null && $info['algo'] !== 0) {
-            return $data;
-        }
+        if($this->getAlgorithm() === self::HASH_FUNCTION_PASSWORD_HASH) {
+            $info = password_get_info($data);
+            if ($info['algo'] !== null && $info['algo'] !== 0) {
+                return $data;
+            }
+        } else {
+            // password_get_info() will not detect older, less secure, hashing algos.
+            // It might not detect some less common ones as well.
+            $maybeHash = preg_match('/^[a-f0-9]{32,}$/i', $data);
+            $hashLenghts = [
+                32,  // MD2, MD4, MD5, RIPEMD-128, Snefru 128, Tiger/128, HAVAL128
+                40,  // SHA-1, HAS-160, RIPEMD-160, Tiger/160, HAVAL160
+                48,  // Tiger/192, HAVAL192
+                56,  // SHA-224, HAVAL224
+                64,  // SHA-256, BLAKE-256, GOST, GOST CryptoPro, HAVAL256, RIPEMD-256, Snefru 256
+                96,  // SHA-384
+                128, // SHA-512, BLAKE-512, SWIFFT
+            ];
 
-        // password_get_info() will not detect older, less secure, hashing algos.
-        // It might not detect some less common ones as well.
-        $maybeHash = preg_match('/^[a-f0-9]{32,}$/i', $data);
-        $hashLenghts = [
-            32,  // MD2, MD4, MD5, RIPEMD-128, Snefru 128, Tiger/128, HAVAL128
-            40,  // SHA-1, HAS-160, RIPEMD-160, Tiger/160, HAVAL160
-            48,  // Tiger/192, HAVAL192
-            56,  // SHA-224, HAVAL224
-            64,  // SHA-256, BLAKE-256, GOST, GOST CryptoPro, HAVAL256, RIPEMD-256, Snefru 256
-            96,  // SHA-384
-            128, // SHA-512, BLAKE-512, SWIFFT
-        ];
-
-        if ($maybeHash && in_array(strlen($data), $hashLenghts, true)) {
-            // Probably already a hashed string
-            return $data;
+            if ($maybeHash && in_array(strlen($data), $hashLenghts, true)) {
+                // Probably already a hashed string
+                return $data;
+            }
         }
 
         $hashed = $this->calculateHash($data);


### PR DESCRIPTION
partly fixes #16236 

The idea is that we don't need to check for other algorithms when we're using `password_hash`, where we can clearly identify a string as a hash. 
So this would fix the issue described in #16236 for `password_hash` but not for all the other algos. 

I agree with @NiklasBr that we should remove the support for other algos in the future. 

@NiklasBr @schmidt-travixmedia @kingjia90 @dvesh3 WDYT? 