### PR TITLE
[Tool] Use neitanod/forceutf8 library to convert texts to UTF8

### DIFF
--- a/lib/Tool/Text.php
+++ b/lib/Tool/Text.php
@@ -265,12 +265,7 @@ class Text
 
     public static function convertToUTF8(string $text): string
     {
-        $encoding = self::detectEncoding($text);
-        if ($encoding) {
-            $text = iconv($encoding, 'UTF-8', $text);
-        }
-
-        return $text;
+        return \ForceUTF8\Encoding::toUTF8($text);
     }
 
     public static function detectEncoding(string $text): string


### PR DESCRIPTION
For importing CSV files in translations and data objects https://github.com/pimcore/pimcore/blob/3a26a8d76d78f794f7274cf2afe3bcdec3528ca9/lib/Tool/Text.php#L266-L309 gets used to convert input data to UTF-8.

We encountered some problems recently when importing translations with special characters, currently they look like this:
<img width="626" alt="Bildschirmfoto 2023-11-23 um 08 43 47" src="https://github.com/pimcore/pimcore/assets/8749138/316390db-0dce-4df9-af71-b218cf7fcdb2">
The original string was `+5 ± 10 % V DC` but it got scrambled to those other versions. I do not know what caused this - maybe it was Excel's "interesting" CSV implementation, a certain server configuration (especially `iconv`) or Pimcore's UTF-8 conversion but maybe we can enhance this behaviour. 

Pimcore already uses `neitanod/forceutf8` in a lot of places to convert input data to UTF-8, for example
- importing redirects (in SEO bundle)
- loading asset metadata
- preview of text assets

As this is a library whose only focus is to solve this one task in an excellent way, I also tried to apply it in `\Pimcore\Tool\Text::convertToUTF8()`. And with this those problem are gone.