### PR TITLE
fix "Call to a member function getType() on null" error

### DIFF
--- a/models/DataObject/Traits/ElementWithMetadataComparisonTrait.php
+++ b/models/DataObject/Traits/ElementWithMetadataComparisonTrait.php
@@ -46,12 +46,12 @@ trait ElementWithMetadataComparisonTrait
                 return !$container1 && !$container2;
             }
 
-            /** @var ElementInterface $el1 */
+            /** @var ElementInterface|null $el1 */
             $el1 = $container1->getElement();
-            /** @var ElementInterface $el2 */
+            /** @var ElementInterface|null $el2 */
             $el2 = $container2->getElement();
 
-            if (! ($el1->getType() == $el2->getType() && ($el1->getId() == $el2->getId()))) {
+            if (! ($el1?->getType() == $el2?->getType() && ($el1?->getId() == $el2?->getId()))) {
                 return false;
             }
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.1`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.1` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #
```
{
    "class": "Error",
    "message": "Call to a member function getType() on null",
    "code": 0,
    "file": "/var/www/html/vendor/pimcore/pimcore/models/DataObject/Traits/ElementWithMetadataComparisonTrait.php:59",
    "trace": [
        "/var/www/html/var/classes/DataObject/Book.php:456",
        "/var/www/html/vendor/pimcore/pimcore/lib/Model/AbstractModel.php:206",
        "/var/www/html/vendor/pimcore/pimcore/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php:1406",
        "/var/www/html/vendor/symfony/http-kernel/HttpKernel.php:163",
        "/var/www/html/vendor/symfony/http-kernel/HttpKernel.php:75",
        "/var/www/html/vendor/symfony/http-kernel/Kernel.php:202",
        "/var/www/html/public/index.php:35"
    ]
}
```

## Additional info
