### PR TITLE
Set Data.php to support dirty detection on simple data fields

### DIFF
--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -1307,7 +1307,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
     public function supportsDirtyDetection(): bool
     {
-        return false;
+        return true;
     }
 
     public function markLazyloadedFieldAsLoaded(Localizedfield|AbstractData|Model\DataObject\Objectbrick\Data\AbstractData|Concrete $object): void


### PR DESCRIPTION
This PR enables the dirty detection for simple data fields in the DataObject. Use cases would be for any custom event listener or processing on a DataObject Pre-Save event might want to know which fields have been modified to reduce duplicate work.

I however am not positive of the downstream affects this would have or why this was disabled by default. Would this be something that needs other fixes to make sense, or could be controlled with configuration instead?

## Changes in this pull request  
Resolves #5689

## Additional info
