### PR TITLE
Fix error when $include is null when rendering

### DIFF
--- a/lib/Templating/Renderer/IncludeRenderer.php
+++ b/lib/Templating/Renderer/IncludeRenderer.php
@@ -91,7 +91,7 @@ class IncludeRenderer
             });
 
             // TODO is this enough for cache or should we disable caching completely?
-            if (method_exists($include, 'getUseTargetGroup') && $include->getUseTargetGroup()) {
+            if (is_object($include) && method_exists($include, 'getUseTargetGroup') && $include->getUseTargetGroup()) {
                 $cacheParams['target_group'] = $include->getUseTargetGroup();
             }
 


### PR DESCRIPTION
when calling `IncludeRenderer::render` with `$include == null` (which is theoretically possible), an error is thrown... 

This PR fixes that. 