### PR TITLE
Fix rehashing passwords

### DIFF
--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -160,9 +160,7 @@ class Authentication
             return false;
         }
 
-        $password = self::preparePlainTextPassword($user->getName(), $password);
-
-        if (!password_verify($password, $user->getPassword())) {
+        if (!password_verify(self::preparePlainTextPassword($user->getName(), $password), $user->getPassword())) {
             return false;
         }
 


### PR DESCRIPTION
## Changes in this pull request  
This PR doesn't overwrite the `$password` variable in `Authentication::verifyPassword()` with the result of `Authentication::preparePlainTextPassword()` anymore.

## Additional info
`Authentication::verifyPassword()` gets the plain password as an argument via the `$password` parameter. Until now, it was replaced by the results of `::preparePlainTextPassword()` before calling `password_verify()`, which is correct and necessary, but a few lines later, when `password_needs_rehash()` returned `true`, the (*transformed*) password was rehashed through `::getPasswordHash()`, which itself calls `::preparePlainTextPassword()` (so it gets applied *twice*) and updated in the user object. 

After this happened, the user was not able to log in anymore.

The solution is to apply `::preparePlainTextPassword()` before checking the password via `password_verify()`, but *not* update the `$password` variable, because we need the *raw* password to be passed to `::getPasswordHash()`.

---

It seems like this bug basically exists like forever (it looks like [it broke during this refactoring](https://github.com/pimcore/pimcore/commit/b31b567d56325751b64be30b988896aebd1b3133#diff-9d8744d933cccfeed7ab57ded4be009734d54edc1dcf4898467654c364d88d1eR122) in `v2.2.0` in 2014!), but `password_needs_rehash()` probably rarely returned `true` until users were able to configure the password hashing algorithm themselves since #14297.