### PR TITLE
[Bug]: Decrease Queries in Tags

### DIFF
--- a/models/Element/Tag.php
+++ b/models/Element/Tag.php
@@ -311,7 +311,12 @@ final class Tag extends Model\AbstractModel
         if ($this->children){
             return true;
         }
-
+        
+        //skip getTotalCount if array is empty fro getChildren
+        if (is_array($this->children)){
+            return false;
+        }
+        
         $listing = new Tag\Listing();
         $listing->setCondition('parentId = ?', $this->getId());
         return $listing->getTotalCount() > 0;

--- a/models/Element/Tag.php
+++ b/models/Element/Tag.php
@@ -312,7 +312,7 @@ final class Tag extends Model\AbstractModel
             return true;
         }
         
-        //skip getTotalCount if array is empty fro getChildren
+        //skip getTotalCount if array is empty
         if (is_array($this->children)){
             return false;
         }

--- a/models/Element/Tag.php
+++ b/models/Element/Tag.php
@@ -314,7 +314,7 @@ final class Tag extends Model\AbstractModel
 
         $listing = new Tag\Listing();
         $listing->setCondition('parentId = ?', $this->getId());
-         return $listing->getTotalCount() > 0;
+        return $listing->getTotalCount() > 0;
     }
 
     public function correctPath(): void

--- a/models/Element/Tag.php
+++ b/models/Element/Tag.php
@@ -308,7 +308,13 @@ final class Tag extends Model\AbstractModel
 
     public function hasChildren(): bool
     {
-        return count($this->getChildren()) > 0;
+        if ($this->children){
+            return count($this->children) > 0;
+        }
+
+        $listing = new Tag\Listing();
+        $listing->setCondition('parentId = ?', $this->getId());
+         return $listing->getTotalCount() > 0;
     }
 
     public function correctPath(): void

--- a/models/Element/Tag.php
+++ b/models/Element/Tag.php
@@ -292,7 +292,7 @@ final class Tag extends Model\AbstractModel
      */
     public function getChildren(): array
     {
-        if ($this->children == null) {
+        if ($this->children === null) {
             if ($this->getId()) {
                 $listing = new Tag\Listing();
                 $listing->setCondition('parentId = ?', $this->getId());

--- a/models/Element/Tag.php
+++ b/models/Element/Tag.php
@@ -309,7 +309,7 @@ final class Tag extends Model\AbstractModel
     public function hasChildren(): bool
     {
         if ($this->children){
-            return count($this->children) > 0;
+            return true;
         }
 
         $listing = new Tag\Listing();


### PR DESCRIPTION
## Changes in this pull request  
May improve https://github.com/pimcore/pimcore/issues/16327

## Additional info

It gets unnecessary and repeated/recursive DAO Listing calls when it's an empty array
https://www.php.net/manual/en/language.types.null.php#103620

`$listing->load()` is more expensive than `getTotalCount()` due
https://github.com/pimcore/pimcore/blob/68f198d32add713f2e4025b5dcb6414754133145/models/Element/Tag/Listing/Dao.php#L37