### PR TITLE
[Bug]: Fix Static Routes Bundle to follow PIMCORE_CONFIGURATION_DIRECTORY constant 

### DIFF
--- a/bundles/CustomReportsBundle/src/DependencyInjection/Configuration.php
+++ b/bundles/CustomReportsBundle/src/DependencyInjection/Configuration.php
@@ -74,7 +74,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end();
 
-        ConfigurationHelper::addConfigLocationWithWriteTargetNodes($rootNode, ['custom_reports' => '/var/config/custom_reports']);
+        ConfigurationHelper::addConfigLocationWithWriteTargetNodes($rootNode, ['custom_reports' => PIMCORE_CONFIGURATION_DIRECTORY . '/custom_reports']);
 
         return $treeBuilder;
     }

--- a/bundles/StaticRoutesBundle/src/DependencyInjection/Configuration.php
+++ b/bundles/StaticRoutesBundle/src/DependencyInjection/Configuration.php
@@ -56,7 +56,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end();
 
-        ConfigurationHelper::addConfigLocationWithWriteTargetNodes($rootNode, ['staticroutes' => '/var/config/staticroutes']);
+        ConfigurationHelper::addConfigLocationWithWriteTargetNodes($rootNode, ['staticroutes' => PIMCORE_CONFIGURATION_DIRECTORY . '/staticroutes']);
 
         return $treeBuilder;
     }


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/16330

Follow up https://github.com/pimcore/pimcore/pull/15735

## Additional info
Wondering if this change may cause BC break? 
If `PIMCORE_CONFIGURATION_DIRECTORY` was set differently to `/var/config` wasn't working anyway right? Read target wouldn't match the write target