### PR TITLE
chore: Use \Throwable instead \Exception for generic catch statements

### DIFF
--- a/bundles/CoreBundle/src/Command/Asset/GenerateChecksumCommand.php
+++ b/bundles/CoreBundle/src/Command/Asset/GenerateChecksumCommand.php
@@ -109,7 +109,7 @@ class GenerateChecksumCommand extends AbstractCommand
 
                     $this->output->writeln(' generating checksum for asset: ' . $asset->getRealFullPath() . ' | ' . $asset->getId());
                     $asset->generateChecksum();
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     $this->output->writeln(' error generating checksum for asset: ' . $asset->getRealFullPath() . ' | ' . $asset->getId());
                 }
             }

--- a/bundles/CoreBundle/src/Command/Bundle/InstallCommand.php
+++ b/bundles/CoreBundle/src/Command/Bundle/InstallCommand.php
@@ -56,7 +56,7 @@ class InstallCommand extends AbstractBundleCommand
             $this->bundleManager->install($bundle);
 
             $this->io->success(sprintf('Bundle "%s" was successfully installed', $bundle->getName()));
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return $this->handlePrerequisiteError($e->getMessage());
         }
 

--- a/bundles/CoreBundle/src/Command/Bundle/UninstallCommand.php
+++ b/bundles/CoreBundle/src/Command/Bundle/UninstallCommand.php
@@ -55,7 +55,7 @@ class UninstallCommand extends AbstractBundleCommand
             $this->bundleManager->uninstall($bundle);
 
             $this->io->success(sprintf('Bundle "%s" was successfully uninstalled', $bundle->getName()));
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return $this->handlePrerequisiteError($e->getMessage());
         }
 

--- a/bundles/CoreBundle/src/Command/ClassesRebuildCommand.php
+++ b/bundles/CoreBundle/src/Command/ClassesRebuildCommand.php
@@ -127,7 +127,7 @@ class ClassesRebuildCommand extends AbstractCommand
 
             try {
                 $brickDefinition->save(false);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $output->write((string)$e);
             }
         }

--- a/bundles/CoreBundle/src/Command/Definition/Import/CustomLayoutCommand.php
+++ b/bundles/CoreBundle/src/Command/Definition/Import/CustomLayoutCommand.php
@@ -112,7 +112,7 @@ class CustomLayoutCommand extends AbstractStructureImportCommand
             $definition->save();
 
             return true;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error($e->getMessage());
         }
 

--- a/bundles/CoreBundle/src/Command/Document/GeneratePagePreviews.php
+++ b/bundles/CoreBundle/src/Command/Document/GeneratePagePreviews.php
@@ -114,7 +114,7 @@ class GeneratePagePreviews extends AbstractCommand
              */
             try {
                 $success = Document\Service::generatePagePreview($doc->getId(), null, $hostUrl);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $this->io->error($e->getMessage());
             }
         }

--- a/bundles/CoreBundle/src/Command/LowQualityImagePreviewCommand.php
+++ b/bundles/CoreBundle/src/Command/LowQualityImagePreviewCommand.php
@@ -116,7 +116,7 @@ class LowQualityImagePreviewCommand extends AbstractCommand
                     try {
                         $this->output->writeln('generating low quality preview for image: ' . $image->getRealFullPath() . ' | ' . $image->getId());
                         $image->generateLowQualityPreview($generator);
-                    } catch (\Exception $e) {
+                    } catch (\Throwable $e) {
                         $this->output->writeln('<error>'.$e->getMessage().'</error>');
                     }
                 }

--- a/bundles/CoreBundle/src/Command/Migrate/StorageCommand.php
+++ b/bundles/CoreBundle/src/Command/Migrate/StorageCommand.php
@@ -60,7 +60,7 @@ class StorageCommand extends AbstractCommand
             try {
                 $sourceStorage = $this->locator->get($storageSourceName);
                 $targetStorage = $this->locator->get($storageTargetName);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $this->io->warning(sprintf('Skipped migrating storage "%s": please make sure "%s" and "%s" configuration exists.', $storageName, $storageSourceName, $storageTargetName));
 
                 continue;
@@ -88,7 +88,7 @@ class StorageCommand extends AbstractCommand
                         } else {
                             $progressBar->setMessage(sprintf('Skipping %s: %s', $storageName, $item->path()));
                         }
-                    } catch (\Exception $e) {
+                    } catch (\Throwable $e) {
                         $progressBar->setMessage(sprintf('Skipping %s: %s', $storageName, $item->path()));
                     }
                     $progressBar->advance();

--- a/bundles/CoreBundle/src/Command/MysqlToolsCommand.php
+++ b/bundles/CoreBundle/src/Command/MysqlToolsCommand.php
@@ -63,7 +63,7 @@ class MysqlToolsCommand extends AbstractCommand
                 try {
                     Logger::debug('Running: OPTIMIZE TABLE ' . $t);
                     $db->executeQuery('OPTIMIZE TABLE ' . $t);
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     Logger::error((string) $e);
                 }
             }
@@ -77,7 +77,7 @@ class MysqlToolsCommand extends AbstractCommand
                     Logger::debug("Running: SELECT COUNT(*) FROM $t");
                     $res = $db->fetchOne("SELECT COUNT(*) FROM $t");
                     Logger::debug('Result: ' . $res);
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     Logger::error((string) $e);
                 }
             }

--- a/bundles/CoreBundle/src/Command/RecyclebinCleanupCommand.php
+++ b/bundles/CoreBundle/src/Command/RecyclebinCleanupCommand.php
@@ -62,7 +62,7 @@ class RecyclebinCleanupCommand extends AbstractCommand
         foreach ($recyclebinItems->load() as $recyclebinItem) {
             try {
                 $recyclebinItem->delete();
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $msg = "Could not delete {$recyclebinItem->getPath()} ({$recyclebinItem->getId()}) because of: {$e->getMessage()}";
                 Logger::error($msg);
                 $this->output->writeln($msg);

--- a/bundles/CoreBundle/src/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/src/Controller/PublicServicesController.php
@@ -53,7 +53,7 @@ class PublicServicesController extends Controller
             }
 
             throw new \Exception('Unable to generate '.$config['type'].' thumbnail, see logs for details.');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error($e->getMessage());
 
             return new RedirectResponse('/bundles/pimcoreadmin/img/filetype-not-supported.svg');

--- a/bundles/CoreBundle/src/Controller/WebDavController.php
+++ b/bundles/CoreBundle/src/Controller/WebDavController.php
@@ -47,7 +47,7 @@ class WebDavController extends Controller
             $server->addPlugin(new \Sabre\DAV\Browser\Plugin());
 
             $server->start();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error((string)$e);
         }
 

--- a/bundles/CoreBundle/src/EventListener/Frontend/FullPageCacheListener.php
+++ b/bundles/CoreBundle/src/EventListener/Frontend/FullPageCacheListener.php
@@ -212,7 +212,7 @@ class FullPageCacheListener
 
                 return;
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error((string) $e);
 
             $this->disable('ERROR: Exception (see log files in /var/log)');
@@ -346,7 +346,7 @@ class FullPageCacheListener
                 }
 
                 Cache::save($cacheItem, $cacheKey, $tags, $this->lifetime, 1000, true);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::error((string) $e);
 
                 return;

--- a/bundles/CoreBundle/src/EventListener/Frontend/StaticPageGeneratorListener.php
+++ b/bundles/CoreBundle/src/EventListener/Frontend/StaticPageGeneratorListener.php
@@ -113,7 +113,7 @@ class StaticPageGeneratorListener implements EventSubscriberInterface
 
                 $event->setResponse($reponse);
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error($e->getMessage());
         }
     }
@@ -162,7 +162,7 @@ class StaticPageGeneratorListener implements EventSubscriberInterface
                     || $this->staticPageGenerator->pageExists($document)) {
                     $this->staticPageGenerator->remove($document);
                 }
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::error((string) $e);
 
                 return;

--- a/bundles/CoreBundle/src/EventListener/ResponseExceptionListener.php
+++ b/bundles/CoreBundle/src/EventListener/ResponseExceptionListener.php
@@ -116,7 +116,7 @@ class ResponseExceptionListener implements EventSubscriberInterface
                 'exception' => $exception,
                 PimcoreContextListener::ATTRIBUTE_PIMCORE_CONTEXT_FORCE_RESOLVING => true,
             ]);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             // we are even not able to render the error page, so we send the client a unicorn
             $response = 'Page not found. 🦄';
             $this->logger->emergency('Unable to render error page, exception thrown');

--- a/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
+++ b/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
@@ -248,7 +248,7 @@ class CustomReportController extends UserAwareController
             }
 
             $success = true;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $errorMessage = $e->getMessage();
         }
 

--- a/bundles/GlossaryBundle/src/Model/Glossary/Listing/Dao.php
+++ b/bundles/GlossaryBundle/src/Model/Glossary/Listing/Dao.php
@@ -63,7 +63,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne('SELECT COUNT(*) FROM glossary ' . $this->getCondition(), $this->model->getConditionVariables());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 0;
         }
     }

--- a/bundles/InstallBundle/src/Installer.php
+++ b/bundles/InstallBundle/src/Installer.php
@@ -290,7 +290,7 @@ class Installer
             if (count($errors) > 0) {
                 return $errors;
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $errors[] = sprintf('Couldn\'t establish connection to MySQL: %s', $e->getMessage());
 
             return $errors;
@@ -677,7 +677,7 @@ class Installer
 
                     $this->createOrUpdateUser($userCredentials);
                 }
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $this->logger->error((string) $e);
                 $errors[] = $e->getMessage();
             }

--- a/bundles/SeoBundle/src/Controller/RedirectsController.php
+++ b/bundles/SeoBundle/src/Controller/RedirectsController.php
@@ -257,7 +257,7 @@ class RedirectsController extends UserAwareController
             }
 
             return $this->jsonResponse(['success' => true]);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error($e->getMessage());
 
             return $this->jsonResponse(['success' => false]);

--- a/bundles/SeoBundle/src/Model/Redirect.php
+++ b/bundles/SeoBundle/src/Model/Redirect.php
@@ -225,7 +225,7 @@ final class Redirect extends AbstractModel
         // this is mostly called in Redirect\Dao not here
         try {
             \Pimcore\Cache::clearTag('redirect');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::crit((string) $e);
         }
     }

--- a/bundles/SeoBundle/src/Model/Redirect/Listing/Dao.php
+++ b/bundles/SeoBundle/src/Model/Redirect/Listing/Dao.php
@@ -48,7 +48,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne('SELECT COUNT(*) FROM redirects ' . $this->getCondition(), $this->model->getConditionVariables());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 0;
         }
     }

--- a/bundles/SeoBundle/src/Redirect/RedirectHandler.php
+++ b/bundles/SeoBundle/src/Redirect/RedirectHandler.php
@@ -257,7 +257,7 @@ final class RedirectHandler
                     $this->redirects = $list->load();
 
                     Cache::save($this->redirects, $cacheKey, ['system', 'redirect', 'route'], null, 998, true);
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     $this->logger->error('Failed to load redirects');
                 }
             }

--- a/bundles/SeoBundle/src/Sitemap/Document/DocumentTreeGenerator.php
+++ b/bundles/SeoBundle/src/Sitemap/Document/DocumentTreeGenerator.php
@@ -87,7 +87,7 @@ class DocumentTreeGenerator extends AbstractElementGenerator
                     $siteSection = sprintf('site_%s', $currentSite->getId());
                     $this->populateCollection($urlContainer, $rootDocument, $siteSection, $currentSite);
                 }
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::error('Cannot determine current domain for sitemap generation');
             }
         }

--- a/bundles/SimpleBackendSearchBundle/src/Command/SearchBackendReindexCommand.php
+++ b/bundles/SimpleBackendSearchBundle/src/Command/SearchBackendReindexCommand.php
@@ -95,7 +95,7 @@ class SearchBackendReindexCommand extends AbstractCommand
                         }
 
                         $searchEntry->save();
-                    } catch (\Exception $e) {
+                    } catch (\Throwable $e) {
                         Logger::err((string) $e);
                     }
                 }

--- a/bundles/SimpleBackendSearchBundle/src/Model/Search/Backend/Data.php
+++ b/bundles/SimpleBackendSearchBundle/src/Model/Search/Backend/Data.php
@@ -402,7 +402,7 @@ class Data extends AbstractModel
                             $contentText = preg_replace('/[ ]+/', ' ', $contentText);
                             $this->data .= ' ' . $contentText;
                         }
-                    } catch (\Exception $e) {
+                    } catch (\Throwable $e) {
                         Logger::error((string) $e);
                     }
                 }
@@ -414,7 +414,7 @@ class Data extends AbstractModel
                         $contentText = Encoding::toUTF8($contentText);
                         $this->data .= ' ' . $contentText;
                     }
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     Logger::error((string) $e);
                 }
             } elseif ($element instanceof Asset\Image) {
@@ -427,7 +427,7 @@ class Data extends AbstractModel
                             $this->data .= ' ' . $key . ' : ' . $value;
                         }
                     }
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     Logger::error((string) $e);
                 }
             }
@@ -528,7 +528,7 @@ class Data extends AbstractModel
                     $this->commit();
 
                     break; // transaction was successfully completed, so we cancel the loop here -> no restart required
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     try {
                         $this->rollBack();
                     } catch (\Exception $er) {

--- a/bundles/SimpleBackendSearchBundle/src/Model/Search/Backend/Data/Dao.php
+++ b/bundles/SimpleBackendSearchBundle/src/Model/Search/Backend/Data/Dao.php
@@ -49,7 +49,7 @@ class Dao extends AbstractDao
                 $this->assignVariablesToModel($data);
                 $this->model->setId(new Backend\Data\Id($element));
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
         }
     }
 
@@ -108,7 +108,7 @@ class Dao extends AbstractDao
     {
         try {
             return (int) $this->db->fetchOne('SELECT @@innodb_ft_min_token_size');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 3;
         }
     }
@@ -117,7 +117,7 @@ class Dao extends AbstractDao
     {
         try {
             return (int) $this->db->fetchOne('SELECT @@innodb_ft_max_token_size');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 84;
         }
     }

--- a/bundles/StaticRoutesBundle/src/Model/Staticroute.php
+++ b/bundles/StaticRoutesBundle/src/Model/Staticroute.php
@@ -112,7 +112,7 @@ final class Staticroute extends AbstractModel
             if (!$route) {
                 throw new \Exception('Route in registry is null');
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             try {
                 $route = new self();
                 $route->setId($id);

--- a/bundles/WordExportBundle/src/Controller/TranslationController.php
+++ b/bundles/WordExportBundle/src/Controller/TranslationController.php
@@ -234,7 +234,7 @@ class TranslationController extends UserAwareController
                     fwrite($f, $output);
                     fclose($f);
                 }
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::error('Word Export: ' . $e);
 
                 throw $e;

--- a/bundles/XliffBundle/src/Controller/XliffTranslationController.php
+++ b/bundles/XliffBundle/src/Controller/XliffTranslationController.php
@@ -145,7 +145,7 @@ class XliffTranslationController extends UserAwareController
             } else {
                 Logger::warning(sprintf('Could not resolve element %s', $id));
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::err($e->getMessage());
 
             return $this->jsonResponse([

--- a/bundles/XliffBundle/src/ImporterService/Importer/AbstractElementImporter.php
+++ b/bundles/XliffBundle/src/ImporterService/Importer/AbstractElementImporter.php
@@ -70,7 +70,7 @@ class AbstractElementImporter implements ImporterInterface
     {
         try {
             $element->save();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             throw new \Exception('Unable to save ' . Element\Service::getElementType($element) . ' with id ' . $element->getId() . ' because of the following reason: ' . $e->getMessage());
         }
     }

--- a/lib/DataObject/BlockDataMarshaller/EncryptedField.php
+++ b/lib/DataObject/BlockDataMarshaller/EncryptedField.php
@@ -93,7 +93,7 @@ class EncryptedField implements MarshallerInterface
 
             try {
                 $key = Key::loadFromAsciiSafeString($key);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 throw new \Exception('could not load key');
             }
             // store it in raw binary mode to preserve space
@@ -128,7 +128,7 @@ class EncryptedField implements MarshallerInterface
 
                 try {
                     $key = Key::loadFromAsciiSafeString($key);
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     throw new \Exception('could not load key');
                 }
 
@@ -141,7 +141,7 @@ class EncryptedField implements MarshallerInterface
                 }
 
                 return $data;
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::error((string) $e);
 
                 throw new \Exception('encrypted field ' . $delegateFd->getName() . ' cannot be decoded');

--- a/lib/DataObject/ClassificationstoreDataMarshaller/EncryptedField.php
+++ b/lib/DataObject/ClassificationstoreDataMarshaller/EncryptedField.php
@@ -118,7 +118,7 @@ class EncryptedField implements MarshallerInterface
 
             try {
                 $key = Key::loadFromAsciiSafeString($key);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 throw new \Exception('could not load key');
             }
             // store it in raw binary mode to preserve space
@@ -153,7 +153,7 @@ class EncryptedField implements MarshallerInterface
 
                 try {
                     $key = Key::loadFromAsciiSafeString($key);
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     throw new \Exception('could not load key');
                 }
 
@@ -166,7 +166,7 @@ class EncryptedField implements MarshallerInterface
                 }
 
                 return $data;
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::error((string) $e);
 
                 throw new \Exception('encrypted field ' . $delegateFd->getName() . ' cannot be decoded');

--- a/lib/Db/Helper.php
+++ b/lib/Db/Helper.php
@@ -84,7 +84,7 @@ class Helper
     {
         try {
             return $db->executeQuery($sql);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             foreach ($exclusions as $exclusion) {
                 if ($e instanceof $exclusion) {
                     throw new ValidationException($e->getMessage(), 0, $e);

--- a/lib/Document.php
+++ b/lib/Document.php
@@ -43,7 +43,7 @@ class Document
                     return $adapter;
                 }
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::crit('Unable to load document adapter: ' . $e->getMessage());
 
             throw $e;
@@ -95,7 +95,7 @@ class Document
                     if ($adapter->isAvailable()) {
                         return $adapter;
                     }
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     Logger::warning((string) $e);
                 }
             }

--- a/lib/Document/Adapter/Ghostscript.php
+++ b/lib/Document/Adapter/Ghostscript.php
@@ -41,7 +41,7 @@ class Ghostscript extends Adapter
             if ($ghostscript && $phpCli) {
                 return true;
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::notice($e->getMessage());
         }
 
@@ -180,7 +180,7 @@ class Ghostscript extends Adapter
             $process->run();
 
             return $this;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error((string) $e);
 
             return false;
@@ -205,7 +205,7 @@ class Ghostscript extends Adapter
             }
 
             return $this->convertPdfToText($page, $path);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error((string) $e);
 
             return false;
@@ -219,7 +219,7 @@ class Ghostscript extends Adapter
     {
         try {
             $pdftotextBin = self::getPdftotextCli();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $pdftotextBin = false;
         }
 

--- a/lib/Document/Adapter/Gotenberg.php
+++ b/lib/Document/Adapter/Gotenberg.php
@@ -38,7 +38,7 @@ class Gotenberg extends Ghostscript
             if ($lo && parent::isAvailable()) { // GhostScript is necessary for pdf count, pdf to text conversion
                 return true;
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::notice($e->getMessage());
         }
 
@@ -120,7 +120,7 @@ class Gotenberg extends Ghostscript
             if (parent::isFileTypeSupported($asset->getFilename())) {
                 return parent::getPdf($asset);
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             // nothing to do, delegate to gotenberg
         }
 

--- a/lib/Document/Adapter/LibreOffice.php
+++ b/lib/Document/Adapter/LibreOffice.php
@@ -35,7 +35,7 @@ class LibreOffice extends Ghostscript
             if ($lo && parent::isAvailable()) { // LibreOffice and GhostScript is necessary
                 return true;
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::notice($e->getMessage());
         }
 
@@ -100,7 +100,7 @@ class LibreOffice extends Ghostscript
             if (parent::isFileTypeSupported($asset->getFilename())) {
                 return parent::getPdf($asset);
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             // nothing to do, delegate to libreoffice
         }
 
@@ -177,7 +177,7 @@ class LibreOffice extends Ghostscript
             }
 
             return parent::getText($page, $asset, $path);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::debug($e->getMessage());
 
             return ''; // default empty string

--- a/lib/Document/Editable/EditableHandler.php
+++ b/lib/Document/Editable/EditableHandler.php
@@ -132,7 +132,7 @@ class EditableHandler implements LoggerAwareInterface
                         // build URL to icon
                         $icon = $this->webPathResolver->getPath($bundle, 'areas/' . $brick->getId(), 'icon.png');
                     }
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     $icon = '';
                 }
             }

--- a/lib/Document/Renderer/DocumentRenderer.php
+++ b/lib/Document/Renderer/DocumentRenderer.php
@@ -88,7 +88,7 @@ class DocumentRenderer implements DocumentRendererInterface
 
         try {
             $request = $this->requestHelper->getCurrentRequest();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
 
             $host = null;
             if($site = Frontend::getSiteForDocument($document)) {

--- a/lib/Document/StaticPageGenerator.php
+++ b/lib/Document/StaticPageGenerator.php
@@ -95,7 +95,7 @@ class StaticPageGenerator
             }
 
             $storage->write($storagePath, $response);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::debug('Error generating static Page ' . $storagePath .': ' . $e->getMessage());
 
             return false;

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -47,7 +47,7 @@ final class Image
             } else {
                 return Pimcore::getContainer()->get(Adapter\GD::class);
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::crit('Unable to load image extensions: ' . $e->getMessage());
 
             throw $e;

--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -132,12 +132,12 @@ class Imagick extends Adapter
                     $i->setImageAlphaChannel(\Imagick::ALPHACHANNEL_TRANSPARENT);
                     $i->clipImage();
                     $i->setImageAlphaChannel(\Imagick::ALPHACHANNEL_OPAQUE);
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     Logger::info(sprintf('Although automatic clipping support is enabled, your current ImageMagick / Imagick version does not support this operation on the image %s', $imagePath));
                 }
                 //}
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error('Unable to load image ' . $imagePath . ': ' . $e);
 
             return false;
@@ -374,7 +374,7 @@ class Imagick extends Adapter
                     // if getImageColorspace() says SRGB but the embedded icc profile is CMYK profileImage() will throw an exception
                     $this->resource->profileImage('icc', self::getRGBColorProfile());
                     $this->resource->setImageColorspace(\Imagick::COLORSPACE_SRGB);
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     Logger::warn((string) $e);
                 }
             }
@@ -902,7 +902,7 @@ class Imagick extends Adapter
                     return true;
                 }
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::err((string) $e);
         }
 
@@ -985,7 +985,7 @@ class Imagick extends Adapter
             unlink($tmpFile);
 
             return true;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return false;
         }
     }

--- a/lib/Image/Chromium.php
+++ b/lib/Image/Chromium.php
@@ -37,7 +37,7 @@ class Chromium
         if (!empty($chromiumUri)) {
             try {
                 return (new Connection($chromiumUri))->connect();
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::debug((string) $e);
 
                 return false;
@@ -68,7 +68,7 @@ class Chromium
         if (!empty($chromiumUri)) {
             try {
                 $browser = BrowserFactory::connectToBrowser($chromiumUri);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::debug((string) $e);
 
                 return false;

--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -491,7 +491,7 @@ class Mail extends Email
             try {
                 //if no mailer given, get default mailer from container
                 $mailer = \Pimcore::getContainer()->get(Mailer::class);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $sendingFailedException = $e;
             }
         }
@@ -512,7 +512,7 @@ class Mail extends Email
 
             try {
                 $mailer->send($this);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $sendingFailedException = new \Exception($e->getMessage(), 0, $e);
             }
         }
@@ -526,7 +526,7 @@ class Mail extends Email
 
             try {
                 $this->lastLogEntry = MailHelper::logEmail($this, $recipients, $sendingFailedException === null ? null : $sendingFailedException->getMessage());
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::emerg("Couldn't log Email");
             }
         }
@@ -697,7 +697,7 @@ class Mail extends Email
                 unset($html);
 
                 $content = $this->html2Text($htmlContent);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::err((string) $e);
                 $content = '';
             }
@@ -786,7 +786,7 @@ class Mail extends Email
                 $converter = new HtmlConverter();
                 $converter->getConfig()->merge($this->getHtml2TextOptions());
                 $content = $converter->convert($htmlContent);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::warning('Converting HTML to plain text failed, no plain text part will be attached to the sent email');
             }
         }

--- a/lib/Maintenance/Executor.php
+++ b/lib/Maintenance/Executor.php
@@ -58,7 +58,7 @@ final class Executor implements ExecutorInterface
             $this->logger->info('Finished job with ID {id}', [
                 'id' => $name,
             ]);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->logger->error('Failed to execute job with ID {id}: {exception}', [
                 'id' => $name,
                 'exception' => $e,

--- a/lib/Maintenance/Tasks/DbCleanupBrokenViewsTask.php
+++ b/lib/Maintenance/Tasks/DbCleanupBrokenViewsTask.php
@@ -46,7 +46,7 @@ class DbCleanupBrokenViewsTask implements TaskInterface
             if ($type === 'VIEW') {
                 try {
                     $createStatement = $this->db->fetchAssociative('SHOW FIELDS FROM '.$name);
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     if (str_contains($e->getMessage(), 'references invalid table')) {
                         $this->logger->error('view '.$name.' seems to be a broken one, it will be removed');
                         $this->logger->error('error message was: '.$e->getMessage());

--- a/lib/Maintenance/Tasks/LowQualityImagePreviewTask.php
+++ b/lib/Maintenance/Tasks/LowQualityImagePreviewTask.php
@@ -67,7 +67,7 @@ class LowQualityImagePreviewTask implements TaskInterface
                         try {
                             $this->logger->debug(sprintf('Generate LQIP for asset %s', $image->getId()));
                             $image->generateLowQualityPreview();
-                        } catch (\Exception $e) {
+                        } catch (\Throwable $e) {
                             $this->logger->error((string) $e);
                         }
                     }

--- a/lib/Maintenance/Tasks/ScheduledTasksTask.php
+++ b/lib/Maintenance/Tasks/ScheduledTasksTask.php
@@ -121,7 +121,7 @@ class ScheduledTasksTask implements TaskInterface
 
                 $task->setActive(false);
                 $task->save();
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $this->logger->error('There was a problem with the scheduled task ID: '.$task->getId());
                 $this->logger->error((string) $e);
             }

--- a/lib/Maintenance/Tasks/StaticPagesGenerationTask.php
+++ b/lib/Maintenance/Tasks/StaticPagesGenerationTask.php
@@ -69,7 +69,7 @@ class StaticPagesGenerationTask implements TaskInterface
                         if ($generate) {
                             $this->generator->generate($page, ['is_cli' => true]);
                         }
-                    } catch (\Exception $e) {
+                    } catch (\Throwable $e) {
                         $this->logger->debug('Unable to generate Static Page for document ID:' . $page->getId() . ', reason: ' . $e->getMessage());
                     }
                 }

--- a/lib/Messenger/Handler/AssetUpdateTasksHandler.php
+++ b/lib/Messenger/Handler/AssetUpdateTasksHandler.php
@@ -123,7 +123,7 @@ class AssetUpdateTasksHandler
                 $image->setCustomSetting('imageHeight', $dimensions['height']);
                 $imageDimensionsCalculated = true;
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->logger->warning('Problem getting the dimensions of the image with ID ' . $image->getId());
         }
 
@@ -136,7 +136,7 @@ class AssetUpdateTasksHandler
 
         try {
             $image->handleEmbeddedMetaData(true);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->logger->warning($e->getMessage());
         }
 
@@ -148,7 +148,7 @@ class AssetUpdateTasksHandler
 
         try {
             $image->generateLowQualityPreview();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->logger->warning($e->getMessage());
         }
     }

--- a/lib/Messenger/Handler/GeneratePagePreviewHandler.php
+++ b/lib/Messenger/Handler/GeneratePagePreviewHandler.php
@@ -34,7 +34,7 @@ class GeneratePagePreviewHandler
     {
         try {
             Service::generatePagePreview($message->getPageId(), null, $message->getHostUrl());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::err(sprintf('Unable to generate preview of document: %s, reason: %s ', $message->getPageId(), $e->getMessage()));
         }
     }

--- a/lib/Messenger/Handler/VersionDeleteHandler.php
+++ b/lib/Messenger/Handler/VersionDeleteHandler.php
@@ -49,7 +49,7 @@ class VersionDeleteHandler implements BatchHandlerInterface
                 foreach ($versions as $version) {
                     try {
                         $version->delete();
-                    } catch (\Exception $e) {
+                    } catch (\Throwable $e) {
                         Logger::err(sprintf('Problem deleting the version with Id: %s, reason: %s', $version->getId(), $e->getMessage()));
                     }
                 }

--- a/lib/Model/AbstractModel.php
+++ b/lib/Model/AbstractModel.php
@@ -220,7 +220,7 @@ abstract class AbstractModel implements ModelInterface
                 $r = call_user_func_array([$this->getDao(), $method], $args);
 
                 return $r;
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::emergency((string) $e);
 
                 throw $e;

--- a/lib/Model/Listing/Dao/QueryBuilderHelperTrait.php
+++ b/lib/Model/Listing/Dao/QueryBuilderHelperTrait.php
@@ -160,7 +160,7 @@ trait QueryBuilderHelperTrait
             if ($query->getQueryPart($part)) {
                 return true;
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             // do nothing
         }
 

--- a/lib/Pimcore.php
+++ b/lib/Pimcore.php
@@ -80,7 +80,7 @@ class Pimcore
             \Pimcore\Db::get()->fetchOne('SELECT id FROM assets LIMIT 1');
 
             return true;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return false;
         }
     }

--- a/lib/Templating/Renderer/IncludeRenderer.php
+++ b/lib/Templating/Renderer/IncludeRenderer.php
@@ -55,13 +55,13 @@ class IncludeRenderer
         if (is_numeric($include)) {
             try {
                 $include = Model\Document::getById($include);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $include = $originalInclude;
             }
         } elseif (is_string($include)) {
             try {
                 $include = Model\Document::getByPath($include);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $include = $originalInclude;
             }
         }
@@ -153,7 +153,7 @@ class IncludeRenderer
 
             $html->clear();
             unset($html);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             // add a div container if the include doesn't contain markup/html
             $content = '<div class="' . $editmodeClass . '" pimcore_id="' . $include->getId() . '" pimcore_type="' . $include->getType() . '">' . $content . '</div>';
         }

--- a/lib/Tool.php
+++ b/lib/Tool.php
@@ -469,7 +469,7 @@ final class Tool
             if ($response->getStatusCode() < 300) {
                 return (string)$response->getBody();
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
         }
 
         return false;

--- a/lib/Tool/Admin.php
+++ b/lib/Tool/Admin.php
@@ -103,7 +103,7 @@ class Admin
         try {
             $sniffer = new Csv();
             $dialect = $sniffer->detect($sample);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             // use default settings
             $dialect = new \stdClass();
             $dialect->delimiter = ';';

--- a/lib/Tool/Console.php
+++ b/lib/Tool/Console.php
@@ -82,7 +82,7 @@ final class Console
             if (!empty($systemConfig['path_variable'])) {
                 $paths = explode(PATH_SEPARATOR, $systemConfig['path_variable']);
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::warning((string) $e);
         }
 
@@ -112,7 +112,7 @@ final class Console
                         return $fullQualifiedPath;
                     }
                 }
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 // nothing to do ...
             }
         }
@@ -158,7 +158,7 @@ final class Console
             if (!$phpPath) {
                 throw new NotFoundException('No PHP executable found, get from getExecutable()');
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $phpPath = self::getExecutable('php', true, false);
         }
 

--- a/lib/Tool/MaintenanceModeHelper.php
+++ b/lib/Tool/MaintenanceModeHelper.php
@@ -80,7 +80,7 @@ class MaintenanceModeHelper implements MaintenanceModeHelperInterface
     {
         try {
             $tmpStore = TmpStore::get(self::ENTRY_ID);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             //nothing to log as the tmp doesn't exist
             return null;
         }
@@ -92,7 +92,7 @@ class MaintenanceModeHelper implements MaintenanceModeHelperInterface
     {
         try {
             TmpStore::delete(self::ENTRY_ID);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             //nothing to log as the tmp doesn't exist
         }
     }

--- a/lib/Tool/Requirements.php
+++ b/lib/Tool/Requirements.php
@@ -57,7 +57,7 @@ final class Requirements
                     'state' => $varWritable ? Check::STATE_OK : Check::STATE_ERROR,
                     'message' => str_replace(PIMCORE_PROJECT_ROOT, '', $varDir) . ' needs to be writable by PHP',
                 ]);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $checks[] = new Check([
                     'name' => str_replace(PIMCORE_PROJECT_ROOT, '', $varDir) . ' (not checked - too many files)',
                     'state' => Check::STATE_WARNING,
@@ -126,7 +126,7 @@ final class Requirements
                   field varchar(190) DEFAULT NULL,
                   PRIMARY KEY (id)
                 ) DEFAULT CHARSET=utf8mb4;');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $queryCheck = false;
         }
 
@@ -140,7 +140,7 @@ final class Requirements
 
         try {
             $db->executeQuery('ALTER TABLE __pimcore_req_check ADD COLUMN alter_field varchar(190) NULL DEFAULT NULL');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $queryCheck = false;
         }
 
@@ -155,7 +155,7 @@ final class Requirements
         try {
             $db->executeQuery('CREATE INDEX field_alter_field ON __pimcore_req_check (field, alter_field);');
             $db->executeQuery('DROP INDEX field_alter_field ON __pimcore_req_check;');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $queryCheck = false;
         }
 
@@ -169,7 +169,7 @@ final class Requirements
 
         try {
             $db->executeQuery('ALTER TABLE __pimcore_req_check ADD FULLTEXT INDEX `fulltextFieldIndex` (`field`)');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $queryCheck = false;
         }
 
@@ -186,7 +186,7 @@ final class Requirements
                 'field' => uniqid(),
                 'alter_field' => uniqid(),
             ]);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $queryCheck = false;
         }
 
@@ -203,7 +203,7 @@ final class Requirements
                 'field' => uniqid(),
                 'alter_field' => uniqid(),
             ]);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $queryCheck = false;
         }
 
@@ -217,7 +217,7 @@ final class Requirements
 
         try {
             $db->fetchAllAssociative('SELECT * FROM __pimcore_req_check');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $queryCheck = false;
         }
 
@@ -231,7 +231,7 @@ final class Requirements
 
         try {
             $db->executeQuery('CREATE OR REPLACE VIEW __pimcore_req_check_view AS SELECT * FROM __pimcore_req_check');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $queryCheck = false;
         }
 
@@ -245,7 +245,7 @@ final class Requirements
 
         try {
             $db->fetchAllAssociative('SELECT * FROM __pimcore_req_check_view');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $queryCheck = false;
         }
 
@@ -259,7 +259,7 @@ final class Requirements
 
         try {
             $db->executeQuery('DELETE FROM __pimcore_req_check');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $queryCheck = false;
         }
 
@@ -273,7 +273,7 @@ final class Requirements
 
         try {
             $db->executeQuery('SHOW CREATE VIEW __pimcore_req_check_view');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $queryCheck = false;
         }
 
@@ -287,7 +287,7 @@ final class Requirements
 
         try {
             $db->executeQuery('SHOW CREATE TABLE __pimcore_req_check');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $queryCheck = false;
         }
 
@@ -301,7 +301,7 @@ final class Requirements
 
         try {
             $db->executeQuery('DROP VIEW __pimcore_req_check_view');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $queryCheck = false;
         }
 
@@ -315,7 +315,7 @@ final class Requirements
 
         try {
             $db->executeQuery('DROP TABLE __pimcore_req_check');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $queryCheck = false;
         }
 
@@ -334,7 +334,7 @@ final class Requirements
                 )
                 SELECT * from counter'
             );
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $queryCheck = false;
         }
 
@@ -356,7 +356,7 @@ final class Requirements
         // PHP CLI BIN
         try {
             $phpCliBin = (bool) \Pimcore\Tool\Console::getPhpCli();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $phpCliBin = false;
         }
 
@@ -374,7 +374,7 @@ final class Requirements
         // FFMPEG BIN
         try {
             $ffmpegBin = (bool) \Pimcore\Video\Adapter\Ffmpeg::getFfmpegCli();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $ffmpegBin = false;
         }
 
@@ -386,7 +386,7 @@ final class Requirements
         // Chromium BIN
         try {
             $chromiumBin = (bool) \Pimcore\Image\Chromium::getChromiumBinary();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $chromiumBin = false;
         }
 
@@ -398,7 +398,7 @@ final class Requirements
         // ghostscript BIN
         try {
             $ghostscriptBin = (bool) \Pimcore\Document\Adapter\Ghostscript::getGhostscriptCli();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $ghostscriptBin = false;
         }
 
@@ -410,7 +410,7 @@ final class Requirements
         // LibreOffice BIN
         try {
             $libreofficeBin = (bool) \Pimcore\Document\Adapter\LibreOffice::getLibreOfficeCli();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $libreofficeBin = false;
         }
 
@@ -423,7 +423,7 @@ final class Requirements
         foreach (['jpegoptim', 'pngquant', 'optipng', 'exiftool'] as $optimizerName) {
             try {
                 $optimizerAvailable = \Pimcore\Tool\Console::getExecutable($optimizerName);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $optimizerAvailable = false;
             }
 
@@ -436,7 +436,7 @@ final class Requirements
         // timeout binary
         try {
             $timeoutBin = (bool) \Pimcore\Tool\Console::getTimeoutBinary();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $timeoutBin = false;
         }
 
@@ -448,7 +448,7 @@ final class Requirements
         // pdftotext binary
         try {
             $pdftotextBin = (bool) \Pimcore\Document\Adapter\Ghostscript::getPdftotextCli();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $pdftotextBin = false;
         }
 
@@ -459,7 +459,7 @@ final class Requirements
 
         try {
             $graphvizAvailable = \Pimcore\Tool\Console::getExecutable('dot');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $graphvizAvailable = false;
         }
 

--- a/lib/Video.php
+++ b/lib/Video.php
@@ -41,7 +41,7 @@ class Video
                     return $adapter;
                 }
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::crit('Unable to load video adapter: ' . $e->getMessage());
 
             throw $e;
@@ -71,7 +71,7 @@ class Video
                     if ($adapter->isAvailable()) {
                         return $adapter;
                     }
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     Logger::warning((string) $e);
                 }
             }

--- a/lib/Video/Adapter/Ffmpeg.php
+++ b/lib/Video/Adapter/Ffmpeg.php
@@ -44,7 +44,7 @@ class Ffmpeg extends Adapter
             if ($ffmpeg && $phpCli) {
                 return true;
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::warning((string) $e);
         }
 
@@ -263,7 +263,7 @@ class Ffmpeg extends Adapter
             throw new \Exception(
                 'Could not read duration with FFMPEG Adapter. File: ' . $this->file . '. Output: ' . $output
             );
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error($e->getMessage());
         }
 
@@ -285,7 +285,7 @@ class Ffmpeg extends Adapter
             throw new \Exception(
                 'Could not read dimensions with FFMPEG Adapter. File: ' . $this->file . '. Output: ' . $output
             );
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error($e->getMessage());
         }
 

--- a/lib/Workflow/Notification/NotificationEmailService.php
+++ b/lib/Workflow/Notification/NotificationEmailService.php
@@ -108,7 +108,7 @@ class NotificationEmailService extends AbstractNotificationService
                         break;
                 }
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             \Pimcore\Logger::error('Error sending Workflow change notification email.');
         }
     }

--- a/lib/Workflow/Notification/PimcoreNotificationService.php
+++ b/lib/Workflow/Notification/PimcoreNotificationService.php
@@ -70,7 +70,7 @@ class PimcoreNotificationService extends AbstractNotificationService
                     $this->notificationService->sendToUser($recipient->getId(), 0, $title, $message, $subject);
                 }
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             \Pimcore\Logger::error('Error sending Workflow change notification.');
         }
     }

--- a/models/Asset/Dao.php
+++ b/models/Asset/Dao.php
@@ -294,7 +294,7 @@ class Dao extends Model\Element\Dao
 
         try {
             $path = $this->db->fetchOne('SELECT CONCAT(`path`,filename) as `path` FROM assets WHERE id = ?', [$this->model->getId()]);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error('could not get  current asset path from DB');
         }
 
@@ -483,7 +483,7 @@ class Dao extends Model\Element\Dao
                     return true;
                 }
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::warn('Unable to get permission ' . $type . ' for asset ' . $this->model->getId());
         }
 

--- a/models/Asset/Document.php
+++ b/models/Asset/Document.php
@@ -71,7 +71,7 @@ class Document extends Model\Asset
             // read from blob here, because in $this->update() $this->getFileSystemPath() contains the old data
             $pageCount = $converter->getPageCount();
             $this->setCustomSetting('document_page_count', $pageCount);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error((string) $e);
             $this->setCustomSetting('document_page_count', 'failed');
         }

--- a/models/Asset/Document/ImageThumbnail.php
+++ b/models/Asset/Document/ImageThumbnail.php
@@ -92,7 +92,7 @@ final class ImageThumbnail implements ImageThumbnailInterface
                         $this->pathReference = Image\Thumbnail\Processor::process($this->asset, $config, $cacheFileStream, $deferred, $generated);
                     }
                 }
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::error("Couldn't create image-thumbnail of document " . $this->asset->getRealFullPath() . ': ' . $e);
             }
         }

--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -151,7 +151,7 @@ EOT;
 
         try {
             $dataUri = 'data:image/svg+xml;base64,' . base64_encode(Storage::get('thumbnail')->read($this->getLowQualityPreviewStoragePath()));
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $dataUri = null;
         }
 
@@ -198,7 +198,7 @@ EOT;
     {
         try {
             $image = \Pimcore\Image::getInstance();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $image = null;
         }
 

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -124,7 +124,7 @@ final class Thumbnail implements ThumbnailInterface
                 try {
                     $deferred = $deferredAllowed && $this->deferred;
                     $this->pathReference = Thumbnail\Processor::process($this->asset, $this->config, null, $deferred, $generated);
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     Logger::error("Couldn't create thumbnail of image " . $this->asset->getRealFullPath() . ': ' . $e);
                 }
             }

--- a/models/Asset/Image/Thumbnail/Config.php
+++ b/models/Asset/Image/Thumbnail/Config.php
@@ -156,7 +156,7 @@ final class Config extends Model\AbstractModel
         if (is_string($config)) {
             try {
                 $thumbnail = self::getByName($config);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::error('requested thumbnail ' . $config . ' is not defined');
 
                 return null;
@@ -195,7 +195,7 @@ final class Config extends Model\AbstractModel
             }
 
             $thumbnail->setName($name);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             try {
                 $thumbnail = new self();
                 /** @var Model\Asset\Image\Thumbnail\Config\Dao $dao */

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -242,7 +242,7 @@ class Processor
             } else {
                 $fileExists = true;
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::debug($e->getMessage());
         }
 

--- a/models/Asset/MetaData/EmbeddedMetaDataTrait.php
+++ b/models/Asset/MetaData/EmbeddedMetaDataTrait.php
@@ -74,7 +74,7 @@ trait EmbeddedMetaDataTrait
         } else {
             try {
                 $xmp = $this->flattenArray($this->getXMPData($filePath));
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $xmp = [];
                 Logger::error('Problem reading XMP metadata of the image with ID ' . $this->getId() . ' Reason: '
                     . $e->getMessage());

--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -322,7 +322,7 @@ class Service extends Model\Element\Service
 
                 return true;
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
         }
 
         return false;

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -186,7 +186,7 @@ trait ImageThumbnailTrait
                         $dimensions['height'] = $thumbnail['height'];
                     }
                 }
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 // noting to do
             }
         }

--- a/models/Asset/Video.php
+++ b/models/Asset/Video.php
@@ -108,7 +108,7 @@ class Video extends Model\Asset
 
                     return $customSetting[$thumbnail->getName()];
                 }
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::error("Couldn't create thumbnail of video " . $this->getRealFullPath() . ': ' . $e);
             }
         }

--- a/models/Asset/Video/ImageThumbnail.php
+++ b/models/Asset/Video/ImageThumbnail.php
@@ -151,7 +151,7 @@ final class ImageThumbnail implements ImageThumbnailInterface
                             $deferred,
                             $generated
                         );
-                    } catch (\Exception $e) {
+                    } catch (\Throwable $e) {
                         Logger::error("Couldn't create image-thumbnail of video " . $this->asset->getRealFullPath() . ': ' . $e);
                     }
                 }

--- a/models/Asset/Video/Thumbnail/Config.php
+++ b/models/Asset/Video/Thumbnail/Config.php
@@ -115,7 +115,7 @@ final class Config extends Model\AbstractModel
             if (!$thumbnail) {
                 throw new \Exception('Thumbnail in registry is null');
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             try {
                 $thumbnail = new self();
                 /** @var Model\Asset\Video\Thumbnail\Config\Dao $dao */

--- a/models/Asset/Video/Thumbnail/Processor.php
+++ b/models/Asset/Video/Thumbnail/Processor.php
@@ -261,7 +261,7 @@ class Processor
                 }
 
                 $converter->destroy();
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::error((string) $e);
             }
         }

--- a/models/Asset/WebDAV/Folder.php
+++ b/models/Asset/WebDAV/Folder.php
@@ -51,7 +51,7 @@ class Folder extends DAV\Collection
         foreach ($childrenList as $child) {
             try {
                 $children[] = $this->getChild($child);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::warning((string) $e);
             }
         }

--- a/models/Asset/WebDAV/Tree.php
+++ b/models/Asset/WebDAV/Tree.php
@@ -79,7 +79,7 @@ class Tree extends DAV\Tree
             $user = \Pimcore\Tool\Admin::getCurrentUser();
             $asset->setUserModification($user->getId());
             $asset->save();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error((string) $e);
         }
     }

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -478,7 +478,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
                     $parent->setChildren(null);
                 }
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             try {
                 $this->rollBack();
             } catch (\Exception $er) {
@@ -567,7 +567,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
                     $this->commit();
 
                     break; // transaction was successfully completed, so we cancel the loop here -> no restart required
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     try {
                         $this->rollBack();
                     } catch (\Exception $er) {
@@ -626,7 +626,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
             }
 
             return $this;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $failureEvent = new DataObjectEvent($this, $parameters);
             $failureEvent->setArgument('exception', $e);
             if ($isUpdate) {
@@ -760,7 +760,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
             $tags = array_merge($tags, $additionalTags);
 
             Cache::clearTags($tags);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::crit((string) $e);
         }
     }

--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -528,7 +528,7 @@ class Dao extends Model\Element\Dao
                     return true;
                 }
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::warn('Unable to get permission ' . $type . ' for object ' . $this->model->getId());
         }
 
@@ -603,7 +603,7 @@ class Dao extends Model\Element\Dao
             $permissions = $this->db->fetchAssociative('SELECT ' . $queryType . ' FROM users_workspaces_object WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $user->getId() . ') DESC' . $orderByType . ' LIMIT 1');
 
             return $permissions ?: null;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::warn('Unable to get permission ' . $type . ' for object ' . $this->model->getId());
         }
 
@@ -626,7 +626,7 @@ class Dao extends Model\Element\Dao
             $cid = $this->model->getId();
             $sql = 'SELECT ' . $type . ' FROM users_workspaces_object WHERE cid != ' . $cid . ' AND cpath LIKE ' . $this->db->quote(Helper::escapeLike($this->model->getRealFullPath()) . '%') . ' AND userId IN (' . implode(',', $userIds) . ') ORDER BY LENGTH(cpath) DESC';
             $permissions = $this->db->fetchAllAssociative($sql);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::warn('Unable to get permission ' . $type . ' for object ' . $this->model->getId());
         }
 

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -220,7 +220,7 @@ final class ClassDefinition extends Model\AbstractModel implements ClassDefiniti
             if (!$class) {
                 throw new \Exception('Class in registry is null');
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             try {
                 $class = new self();
                 $name = $class->getDao()->getNameById($id);
@@ -238,7 +238,7 @@ final class ClassDefinition extends Model\AbstractModel implements ClassDefiniti
                 $class->setId($id);
 
                 RuntimeCache::set($cacheKey, $class);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::info($e->getMessage());
 
                 return null;
@@ -389,7 +389,7 @@ final class ClassDefinition extends Model\AbstractModel implements ClassDefiniti
         // empty object cache
         try {
             Cache::clearTag('class_'.$this->getId());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
         }
 
         foreach ($fieldDefinitions as $fd) {
@@ -501,13 +501,13 @@ final class ClassDefinition extends Model\AbstractModel implements ClassDefiniti
         // empty object cache
         try {
             Cache::clearTag('class_'.$this->getId());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
         }
 
         // empty output cache
         try {
             Cache::clearTag('output');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
         }
 
         $customLayouts = new ClassDefinition\CustomLayout\Listing();
@@ -1201,7 +1201,7 @@ final class ClassDefinition extends Model\AbstractModel implements ClassDefiniti
             }
 
             $class->setId($id);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::info($e->getMessage());
 
             return null;

--- a/models/DataObject/ClassDefinition/CustomLayout.php
+++ b/models/DataObject/ClassDefinition/CustomLayout.php
@@ -65,7 +65,7 @@ class CustomLayout extends Model\AbstractModel
             if (!$customLayout) {
                 throw new \Exception('Custom Layout in registry is null');
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             try {
                 $customLayout = new self();
                 $customLayout->getDao()->getById($id);
@@ -92,7 +92,7 @@ class CustomLayout extends Model\AbstractModel
             if (!$customLayout) {
                 throw new \Exception('Custom Layout in registry is null');
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             try {
                 $customLayout = new self();
                 $customLayout->getDao()->getByName($name);
@@ -190,7 +190,7 @@ class CustomLayout extends Model\AbstractModel
         // empty custom layout cache
         try {
             Cache::clearTag('customlayout_' . $this->getId());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
         }
     }
 
@@ -226,7 +226,7 @@ class CustomLayout extends Model\AbstractModel
             $customLayout = new self();
 
             return $customLayout->getDao()->getLatestIdentifier($classId);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error((string) $e);
 
             return null;
@@ -245,13 +245,13 @@ class CustomLayout extends Model\AbstractModel
         // empty object cache
         try {
             Cache::clearTag('customlayout_' . $this->getId());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
         }
 
         // empty output cache
         try {
             Cache::clearTag('output');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
         }
 
         $this->getDao()->delete();

--- a/models/DataObject/ClassDefinition/CustomLayout/Listing/Dao.php
+++ b/models/DataObject/ClassDefinition/CustomLayout/Listing/Dao.php
@@ -65,7 +65,7 @@ class Dao extends Model\DataObject\ClassDefinition\CustomLayout\Dao
             }
 
             return count($layouts);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 0;
         }
     }

--- a/models/DataObject/ClassDefinition/Dao.php
+++ b/models/DataObject/ClassDefinition/Dao.php
@@ -44,7 +44,7 @@ class Dao extends Model\Dao\AbstractDao
                     return $name;
                 }
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
         }
 
         return null;
@@ -63,7 +63,7 @@ class Dao extends Model\Dao\AbstractDao
             if (!empty($name)) {
                 $id = $this->db->fetchOne('SELECT id FROM classes WHERE name = ?', [$name]);
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
         }
 
         if (empty($id)) {
@@ -210,7 +210,7 @@ class Dao extends Model\Dao\AbstractDao
         try {
             //$this->db->executeQuery('CREATE OR REPLACE VIEW `' . $objectView . '` AS SELECT * FROM `objects` left JOIN `' . $objectTable . '` ON `objects`.`id` = `' . $objectTable . '`.`oo_id` WHERE `objects`.`classId` = ' . $this->model->getId() . ';');
             $this->db->executeQuery('CREATE OR REPLACE VIEW `' . $objectView . '` AS SELECT * FROM `' . $objectTable . '` JOIN `objects` ON `objects`.`id` = `' . $objectTable . '`.`oo_id`;');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::debug((string) $e);
         }
 

--- a/models/DataObject/ClassDefinition/Data/AbstractQuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/AbstractQuantityValue.php
@@ -226,7 +226,7 @@ abstract class AbstractQuantityValue extends Data implements ResourcePersistence
                     Cache::save($table, Model\DataObject\QuantityValue\Unit::CACHE_KEY, [], null, 995, true);
                     RuntimeCache::set(Model\DataObject\QuantityValue\Unit::CACHE_KEY, $table);
                 }
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::error((string) $e);
             }
 

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -224,7 +224,7 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation implemen
 
                         try {
                             $columnData[$c['key']] = $metaObject->$getter();
-                        } catch (\Exception $e) {
+                        } catch (\Throwable $e) {
                             Logger::debug('Meta column '.$c['key'].' does not exist');
                         }
                     }

--- a/models/DataObject/ClassDefinition/Data/CalculatedValue.php
+++ b/models/DataObject/ClassDefinition/Data/CalculatedValue.php
@@ -238,7 +238,7 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
         $code .= "\t\t\t" . '} else {'  . "\n";
         $code .= "\t\t\t\t" . 'throw new \Exception("Not supported language");'  . "\n";
         $code .= "\t\t\t" . '}'  . "\n";
-        $code .= "\t\t" . '} catch (\Exception $e) {' . "\n";
+        $code .= "\t\t" . '} catch (\Throwable $e) {' . "\n";
         $code .= "\t\t\t" . '$language = \Pimcore\Tool::getDefaultLanguage();' . "\n";
         $code .= "\t\t" . '}' . "\n";
         $code .= "\t" . '}'  . "\n";

--- a/models/DataObject/ClassDefinition/Data/EncryptedField.php
+++ b/models/DataObject/ClassDefinition/Data/EncryptedField.php
@@ -94,7 +94,7 @@ class EncryptedField extends Data implements ResourcePersistenceAwareInterface, 
 
             try {
                 $key = Key::loadFromAsciiSafeString($key);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 throw new \Exception('Could not find config "pimcore.encryption.secret". Please run "vendor/bin/generate-defuse-key" from command line and add the result to config/config.yaml');
             }
             // store it in raw binary mode to preserve space
@@ -121,7 +121,7 @@ class EncryptedField extends Data implements ResourcePersistenceAwareInterface, 
 
                 try {
                     $key = Key::loadFromAsciiSafeString($key);
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     if (!self::isStrictMode()) {
                         Logger::error('failed to load key');
 
@@ -142,7 +142,7 @@ class EncryptedField extends Data implements ResourcePersistenceAwareInterface, 
                 }
 
                 return $data;
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::error((string) $e);
                 if (self::isStrictMode()) {
                     throw new \Exception('encrypted field ' . $this->getName() . ' cannot be decoded');

--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -645,7 +645,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
                                 $dataForValidityCheck[$language][$fd->getName()] = null;
                             }
                             $fd->checkValidity($dataForValidityCheck[$language][$fd->getName()], false, $params);
-                        } catch (\Exception $e) {
+                        } catch (\Throwable $e) {
                             if ($data->getObject()->getClass()->getAllowInherit() && $fd->supportsInheritance() && $fd->isEmpty($dataForValidityCheck[$language][$fd->getName()])) {
                                 //try again with parent data when inheritance is activated
                                 try {
@@ -668,7 +668,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
 
                                     $fd->checkValidity($value, $omitMandatoryCheck, $params);
                                     DataObject::setGetInheritedValues($getInheritedValues);
-                                } catch (\Exception $e) {
+                                } catch (\Throwable $e) {
                                     if (!$e instanceof Model\Element\ValidationException) {
                                         throw $e;
                                     }

--- a/models/DataObject/ClassDefinition/Data/Objectbricks.php
+++ b/models/DataObject/ClassDefinition/Data/Objectbricks.php
@@ -542,7 +542,7 @@ class Objectbricks extends Data implements CustomResourcePersistingInterface, Ty
                                         $fd->checkValidity($item->$getter(), $omitMandatoryCheck, $params);
 
                                         DataObject::setGetInheritedValues($getInheritedValues);
-                                    } catch (\Exception $e) {
+                                    } catch (\Throwable $e) {
                                         if (!$e instanceof Model\Element\ValidationException) {
                                             throw $e;
                                         }

--- a/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
+++ b/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
@@ -133,7 +133,7 @@ abstract class AbstractRelations extends Data implements
                     // relation needs to be an array with src_id, dest_id, type, fieldname
                     try {
                         $db->insert('object_relations_' . $classId, Db\Helper::quoteDataIdentifiers($db, $relation));
-                    } catch (\Exception $e) {
+                    } catch (\Throwable $e) {
                         Logger::error('It seems that the relation ' . $relation['src_id'] . ' => ' . $relation['dest_id']
                             . ' (fieldname: ' . $this->getName() . ') already exist -> please check immediately!');
                         Logger::error((string)$e);

--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -75,7 +75,7 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
                 if($class instanceof DataObject\ClassDefinition) {
                     $this->ownerClassName = $class->getName();
                 }
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::error($e->getMessage());
             }
         }
@@ -94,7 +94,7 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
                     return null;
                 }
                 $this->ownerClassId = $class->getId();
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::error($e->getMessage());
             }
         }

--- a/models/DataObject/ClassDefinition/Data/UrlSlug.php
+++ b/models/DataObject/ClassDefinition/Data/UrlSlug.php
@@ -203,7 +203,7 @@ class UrlSlug extends Data implements CustomResourcePersistingInterface, LazyLoa
                     // relation needs to be an array with src_id, dest_id, type, fieldname
                     try {
                         $db->insert(Model\DataObject\Data\UrlSlug::TABLE_NAME, $slug);
-                    } catch (\Exception $e) {
+                    } catch (\Throwable $e) {
                         Logger::error((string)$e);
                         if ($e instanceof UniqueConstraintViolationException) {
                             // check if the slug action can be resolved.
@@ -214,7 +214,7 @@ class UrlSlug extends Data implements CustomResourcePersistingInterface, LazyLoa
                                 // retrying the transaction should success the next time
                                 try {
                                     $existingSlug->getAction();
-                                } catch (\Exception $e) {
+                                } catch (\Throwable $e) {
                                     $db->insert(Model\DataObject\Data\UrlSlug::TABLE_NAME, $slug);
 
                                     return;

--- a/models/DataObject/ClassDefinition/Data/User.php
+++ b/models/DataObject/ClassDefinition/Data/User.php
@@ -55,7 +55,7 @@ class User extends Model\DataObject\ClassDefinition\Data\Select
         if (!empty($data)) {
             try {
                 $this->checkValidity($data, true, $params);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $data = null;
             }
         }
@@ -75,7 +75,7 @@ class User extends Model\DataObject\ClassDefinition\Data\Select
         if (!empty($data)) {
             try {
                 $this->checkValidity($data, true, $params);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $data = null;
             }
         }

--- a/models/DataObject/ClassDefinition/Listing/Dao.php
+++ b/models/DataObject/ClassDefinition/Listing/Dao.php
@@ -50,7 +50,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne('SELECT COUNT(*) FROM classes ' . $this->getCondition(), $this->model->getConditionVariables());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 0;
         }
     }

--- a/models/DataObject/Classificationstore/CollectionConfig/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/CollectionConfig/Listing/Dao.php
@@ -55,7 +55,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . DataObject\Classificationstore\CollectionConfig\Dao::TABLE_NAME_COLLECTIONS . ' '. $this->getCondition(), $this->model->getConditionVariables());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 0;
         }
     }

--- a/models/DataObject/Classificationstore/CollectionGroupRelation/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/CollectionGroupRelation/Listing/Dao.php
@@ -71,7 +71,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . DataObject\Classificationstore\CollectionGroupRelation\Dao::TABLE_NAME_RELATIONS . ' '. $this->getCondition(), $this->model->getConditionVariables());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 0;
         }
     }

--- a/models/DataObject/Classificationstore/GroupConfig/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/GroupConfig/Listing/Dao.php
@@ -57,7 +57,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . DataObject\Classificationstore\GroupConfig\Dao::TABLE_NAME_GROUPS . ' '. $this->getCondition(), $this->model->getConditionVariables());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 0;
         }
     }

--- a/models/DataObject/Classificationstore/KeyConfig/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/KeyConfig/Listing/Dao.php
@@ -58,7 +58,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . DataObject\Classificationstore\KeyConfig\Dao::TABLE_NAME_KEYS . ' '. $this->getCondition(), $this->model->getConditionVariables());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 0;
         }
     }

--- a/models/DataObject/Classificationstore/StoreConfig/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/StoreConfig/Listing/Dao.php
@@ -55,7 +55,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . DataObject\Classificationstore\StoreConfig\Dao::TABLE_NAME_STORES . ' '. $this->getCondition(), $this->model->getConditionVariables());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 0;
         }
     }

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -144,7 +144,7 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
                             $params['resetInvalidFields'] = true;
                         }
                         $fd->checkValidity($value, $omitMandatoryCheck, $params);
-                    } catch (\Exception $e) {
+                    } catch (\Throwable $e) {
                         if ($this->getClass()->getAllowInherit() && $fd->supportsInheritance() && $fd->isEmpty($value)) {
                             //try again with parent data when inheritance is activated
                             try {
@@ -155,7 +155,7 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
                                 $fd->checkValidity($value, $omitMandatoryCheck, $params);
 
                                 DataObject::setGetInheritedValues($getInheritedValues);
-                            } catch (\Exception $e) {
+                            } catch (\Throwable $e) {
                                 if (!$e instanceof Model\Element\ValidationException) {
                                     throw $e;
                                 }
@@ -288,7 +288,7 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
             }
 
             return $version;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $postUpdateFailureEvent = new DataObjectEvent($this, [
                 'saveVersionOnly' => true,
                 'exception' => $e,
@@ -636,7 +636,7 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
 
         try {
             return call_user_func_array([parent::class, $method], $arguments);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             // there is no property for the called method, so throw an exception
             Logger::error('Class: DataObject\\Concrete => call to undefined static method '.$method);
 

--- a/models/DataObject/Data/EncryptedField.php
+++ b/models/DataObject/Data/EncryptedField.php
@@ -82,7 +82,7 @@ class EncryptedField implements OwnerAwareFieldInterface
 
                 $data = Crypto::encrypt($data, $key, true);
                 $this->encrypted = $data;
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::error((string) $e);
 
                 throw new \Exception('could not load key');
@@ -114,7 +114,7 @@ class EncryptedField implements OwnerAwareFieldInterface
                 }
 
                 $this->plain = $data;
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::error((string) $e);
 
                 throw new \Exception('could not load key');

--- a/models/DataObject/Data/UrlSlug.php
+++ b/models/DataObject/Data/UrlSlug.php
@@ -230,7 +230,7 @@ class UrlSlug implements OwnerAwareFieldInterface
             if ($rawItem) {
                 $slug = self::createFromDataRow($rawItem);
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error((string) $e);
         }
 

--- a/models/DataObject/Fieldcollection/Dao.php
+++ b/models/DataObject/Fieldcollection/Dao.php
@@ -55,7 +55,7 @@ class Dao extends Model\Dao\AbstractDao
 
             try {
                 $results = $this->db->fetchAllAssociative('SELECT * FROM ' . $tableName . ' WHERE id = ? AND fieldname = ? ORDER BY `index` ASC', [$object->getId(), $this->model->getFieldname()]);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $results = [];
             }
 
@@ -168,7 +168,7 @@ class Dao extends Model\Dao\AbstractDao
                         'fieldname' => $this->model->getFieldname(),
                     ]);
                 }
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 // create definition if it does not exist
                 $definition->createUpdateTable($object->getClass());
             }
@@ -185,7 +185,7 @@ class Dao extends Model\Dao\AbstractDao
                             'fieldname' => $this->model->getFieldname(),
                         ]);
                     }
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     Logger::error((string) $e);
                 }
             }

--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -99,7 +99,7 @@ class Definition extends Model\AbstractModel
             if (!$fc) {
                 throw new \Exception('FieldCollection in registry is not valid');
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $def = new Definition();
             $def->setKey($key);
             $fieldFile = $def->getDefinitionFile();

--- a/models/DataObject/Listing/Concrete/Dao.php
+++ b/models/DataObject/Listing/Concrete/Dao.php
@@ -43,7 +43,7 @@ class Dao extends Model\DataObject\Listing\Dao
     {
         try {
             return parent::loadIdList();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return $this->exceptionHandler($e);
         }
     }

--- a/models/DataObject/Localizedfield.php
+++ b/models/DataObject/Localizedfield.php
@@ -279,7 +279,7 @@ final class Localizedfield extends Model\AbstractModel implements
             }
 
             throw new \Exception('Not supported language');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return Tool::getDefaultLanguage();
         }
     }

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -497,7 +497,7 @@ class Dao extends Model\Dao\AbstractDao
                     $fd->delete($object, $params);
                 }
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error((string) $e);
 
             if ($isUpdate && $e instanceof TableNotFoundException) {
@@ -769,7 +769,7 @@ QUERY;
 
                 // execute
                 $this->db->executeQuery($viewQuery);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 Logger::error((string) $e);
             }
         }

--- a/models/DataObject/Objectbrick/Dao.php
+++ b/models/DataObject/Objectbrick/Dao.php
@@ -46,7 +46,7 @@ class Dao extends Model\DataObject\Fieldcollection\Dao
 
             try {
                 $results = $this->db->fetchAllAssociative('SELECT * FROM '.$tableName.' WHERE id = ? AND fieldname = ?', [$object->getId(), $this->model->getFieldname()]);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $results = [];
             }
 

--- a/models/DataObject/Objectbrick/Data/Dao.php
+++ b/models/DataObject/Objectbrick/Data/Dao.php
@@ -87,7 +87,7 @@ class Dao extends Model\Dao\AbstractDao
             } else {
                 $this->db->executeStatement('DELETE FROM object_relations_' . $object->getClassId() . ' WHERE ' . $where);
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::warning('Error during removing old relations: ' . $e);
         }
 

--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -75,7 +75,7 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
             if (!$brick) {
                 throw new \Exception('ObjectBrick in Registry is not valid');
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $def = new Definition();
             $def->setKey($key);
             $fieldFile = $def->getDefinitionFile();

--- a/models/DataObject/QuantityValue/Service.php
+++ b/models/DataObject/QuantityValue/Service.php
@@ -47,7 +47,7 @@ class Service
             foreach ($units as $unit) {
                 $unit->save();
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return false;
         }
 
@@ -73,7 +73,7 @@ class Service
                         true));
                 }
                 $result[] = $unit->getObjectVars();
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 return false;
             }
         }

--- a/models/DataObject/QuantityValue/Unit.php
+++ b/models/DataObject/QuantityValue/Unit.php
@@ -98,7 +98,7 @@ class Unit extends Model\AbstractModel
                 Cache::save($table, self::CACHE_KEY, [], null, 995, true);
                 Cache\RuntimeCache::set(self::CACHE_KEY, $table);
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return null;
         }
 

--- a/models/DataObject/QuantityValue/Unit/Listing/Dao.php
+++ b/models/DataObject/QuantityValue/Unit/Listing/Dao.php
@@ -47,7 +47,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne('SELECT COUNT(*) FROM '.DataObject\QuantityValue\Unit\Dao::TABLE_NAME.' ' . $this->getCondition(), $this->model->getConditionVariables());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 0;
         }
     }

--- a/models/DataObject/SelectOptions/Config.php
+++ b/models/DataObject/SelectOptions/Config.php
@@ -190,7 +190,7 @@ final class Config extends AbstractModel implements \JsonSerializable
             if (!$selectOptions instanceof self) {
                 throw new \RuntimeException('Select options in registry is invalid', 1678353750987);
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             try {
                 $selectOptions = new self();
                 /** @var Config\Dao $dao */

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -847,7 +847,7 @@ class Service extends Model\Element\Service
 
                 return true;
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
         }
 
         return false;

--- a/models/Dependency/Dao.php
+++ b/models/Dependency/Dao.php
@@ -193,7 +193,7 @@ class Dao extends Model\Dao\AbstractDao
             }
 
             Helper::selectAndDeleteWhere($this->db, 'dependencies', 'id', Helper::quoteInto($this->db, 'sourceid = ?', $id) . ' AND  ' . Helper::quoteInto($this->db, 'sourcetype = ?', $type));
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error((string) $e);
         }
     }
@@ -206,7 +206,7 @@ class Dao extends Model\Dao\AbstractDao
     {
         try {
             Helper::selectAndDeleteWhere($this->db, 'dependencies', 'id', Helper::quoteInto($this->db, 'sourceid = ?', $this->model->getSourceId()) . ' AND  ' . Helper::quoteInto($this->db, 'sourcetype = ?', $this->model->getSourceType()));
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error((string) $e);
         }
     }

--- a/models/Document.php
+++ b/models/Document.php
@@ -336,7 +336,7 @@ class Document extends Element\AbstractElement
                     $this->commit();
 
                     break; // transaction was successfully completed, so we cancel the loop here -> no restart required
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     try {
                         $this->rollBack();
                     } catch (\Exception $er) {
@@ -382,7 +382,7 @@ class Document extends Element\AbstractElement
             }
 
             return $this;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $failureEvent = new DocumentEvent($this, $parameters);
             $failureEvent->setArgument('exception', $e);
             if ($isUpdate) {
@@ -521,7 +521,7 @@ class Document extends Element\AbstractElement
             $tags = array_merge($tags, $additionalTags);
 
             \Pimcore\Cache::clearTags($tags);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::crit((string) $e);
         }
     }
@@ -671,7 +671,7 @@ class Document extends Element\AbstractElement
                     $parent->setChildren(null);
                 }
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->rollBack();
             $failureEvent = new DocumentEvent($this);
             $failureEvent->setArgument('exception', $e);
@@ -705,7 +705,7 @@ class Document extends Element\AbstractElement
                     }
                 }
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error((string) $e);
         }
 
@@ -827,7 +827,7 @@ class Document extends Element\AbstractElement
                     }
                 }
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error((string) $e);
         }
 

--- a/models/Document/Dao.php
+++ b/models/Document/Dao.php
@@ -226,7 +226,7 @@ class Dao extends Model\Element\Dao
 
         try {
             $path = $this->db->fetchOne('SELECT CONCAT(`path`,`key`) as `path` FROM documents WHERE id = ?', [$this->model->getId()]);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error('could not  get current document path from DB');
         }
 
@@ -530,7 +530,7 @@ class Dao extends Model\Element\Dao
                     return true;
                 }
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::warn('Unable to get permission ' . $type . ' for document ' . $this->model->getId());
         }
 

--- a/models/Document/DocType.php
+++ b/models/Document/DocType.php
@@ -103,7 +103,7 @@ class DocType extends Model\AbstractModel
             $docType->getDao()->getById($id);
 
             return $docType;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return null;
         }
     }

--- a/models/Document/Link.php
+++ b/models/Document/Link.php
@@ -291,7 +291,7 @@ class Link extends Model\Document
                     $this->object = Model\DataObject\Concrete::getById($this->internal);
                 }
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::warn((string) $e);
             $this->internalType = '';
             $this->internal = null;

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -204,7 +204,7 @@ abstract class PageSnippet extends Model\Document
             }
 
             return $version;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $postUpdateFailureEvent = new DocumentEvent($this, [
                 'saveVersionOnly' => true,
                 'exception' => $e,
@@ -316,7 +316,7 @@ abstract class PageSnippet extends Model\Document
                 $this->editables[$name]->setName($name);
                 $this->editables[$name]->setDocument($this);
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::warning("can't set element " . $name . ' with the type ' . $type . ' to the document: ' . $this->getRealFullPath());
         }
 
@@ -636,7 +636,7 @@ abstract class PageSnippet extends Model\Document
                         }
                     }
                 }
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 // noting to do, as rendering the document failed for whatever reason
             }
         }

--- a/models/Document/Service.php
+++ b/models/Document/Service.php
@@ -322,7 +322,7 @@ class Service extends Model\Element\Service
 
                 return true;
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
         }
 
         return false;

--- a/models/Element/Editlock.php
+++ b/models/Element/Editlock.php
@@ -76,7 +76,7 @@ final class Editlock extends Model\AbstractModel
             $lock->getDao()->clearSession($sessionId);
 
             return true;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return null;
         }
     }

--- a/models/Element/Note/Listing/Dao.php
+++ b/models/Element/Note/Listing/Dao.php
@@ -71,7 +71,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
                 $this->model->getConditionVariables(),
                 $this->model->getConditionVariableTypes()
             );
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 0;
         }
     }

--- a/models/Element/PermissionChecker.php
+++ b/models/Element/PermissionChecker.php
@@ -134,7 +134,7 @@ class PermissionChecker
                             continue;
                         }
                     }
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     Logger::warn('Unable to get permission '.$type.' for object '.$element->getId());
                 }
             }

--- a/models/Element/Recyclebin/Item.php
+++ b/models/Element/Recyclebin/Item.php
@@ -141,7 +141,7 @@ class Item extends Model\AbstractModel
             $this->doRecursiveRestore($element);
 
             DataObject::setDisableDirtyDetection($isDirtyDetectionDisabled);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error((string) $e);
             if ($dummy) {
                 $dummy->delete();

--- a/models/Element/Recyclebin/Item/Dao.php
+++ b/models/Element/Recyclebin/Item/Dao.php
@@ -60,7 +60,7 @@ class Dao extends Model\Dao\AbstractDao
         try {
             $this->db->insert('recyclebin', $data);
             $this->model->setId((int) $this->db->lastInsertId());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::error((string) $e);
         }
 

--- a/models/Element/Recyclebin/Item/Listing/Dao.php
+++ b/models/Element/Recyclebin/Item/Listing/Dao.php
@@ -50,7 +50,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne('SELECT COUNT(*) FROM recyclebin ' . $this->getCondition(), $this->model->getConditionVariables());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 0;
         }
     }

--- a/models/Element/Tag.php
+++ b/models/Element/Tag.php
@@ -173,7 +173,7 @@ final class Tag extends Model\AbstractModel
     {
         try {
             return (new self)->getDao()->getByPath($path);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return null;
         }
     }

--- a/models/Element/Tag/Dao.php
+++ b/models/Element/Tag/Dao.php
@@ -85,7 +85,7 @@ class Dao extends Model\Dao\AbstractDao
             $this->db->commit();
 
             return true;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->db->rollBack();
 
             throw $e;
@@ -109,7 +109,7 @@ class Dao extends Model\Dao\AbstractDao
             $this->db->executeStatement('DELETE FROM tags WHERE ' . Helper::quoteInto($this->db, 'idPath LIKE ?', Helper::escapeLike($this->model->getIdPath()) . $this->model->getId() . '/%'));
 
             $this->db->commit();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->db->rollBack();
 
             throw $e;
@@ -177,7 +177,7 @@ class Dao extends Model\Dao\AbstractDao
             }
 
             $this->db->commit();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->db->rollBack();
 
             throw $e;

--- a/models/Element/Tag/Listing/Dao.php
+++ b/models/Element/Tag/Listing/Dao.php
@@ -58,7 +58,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne('SELECT COUNT(*) FROM tags ' . $this->getCondition(), $this->model->getConditionVariables());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 0;
         }
     }

--- a/models/Element/WorkflowState/Listing/Dao.php
+++ b/models/Element/WorkflowState/Listing/Dao.php
@@ -48,7 +48,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne('SELECT COUNT(*) FROM element_workflow_state ' . $this->getCondition(), $this->model->getConditionVariables());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 0;
         }
     }

--- a/models/Property/Predefined.php
+++ b/models/Property/Predefined.php
@@ -72,7 +72,7 @@ final class Predefined extends Model\AbstractModel
             if (!$property) {
                 throw new \Exception('Predefined property in registry is null');
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             try {
                 $property = new self();
                 $property->getDao()->getByKey($key);

--- a/models/Schedule/Task.php
+++ b/models/Schedule/Task.php
@@ -51,7 +51,7 @@ class Task extends Model\AbstractModel
             if (!$task) {
                 throw new \Exception('Scheduled Task in Registry is not valid');
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             try {
                 $task = new self();
                 $task->getDao()->getById($id);

--- a/models/Schedule/Task/Listing/Dao.php
+++ b/models/Schedule/Task/Listing/Dao.php
@@ -46,7 +46,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne('SELECT COUNT(*) FROM schedule_tasks ' . $this->getCondition(), $this->model->getConditionVariables());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 0;
         }
     }

--- a/models/Site.php
+++ b/models/Site.php
@@ -328,7 +328,7 @@ final class Site extends AbstractModel
         // this is mostly called in Site\Dao not here
         try {
             \Pimcore\Cache::clearTag('site');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::crit((string) $e);
         }
     }

--- a/models/Site/Listing/Dao.php
+++ b/models/Site/Listing/Dao.php
@@ -46,7 +46,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne('SELECT COUNT(*) FROM sites ' . $this->getCondition(), $this->model->getConditionVariables());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 0;
         }
     }

--- a/models/Tool/Email/Blocklist/Listing/Dao.php
+++ b/models/Tool/Email/Blocklist/Listing/Dao.php
@@ -48,7 +48,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne('SELECT COUNT(*) FROM email_blocklist ' . $this->getCondition(), $this->model->getConditionVariables());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 0;
         }
     }

--- a/models/Tool/Email/Log/Dao.php
+++ b/models/Tool/Email/Log/Dao.php
@@ -84,7 +84,7 @@ class Dao extends Model\Dao\AbstractDao
 
         try {
             $this->db->update(self::$dbTable, $data, ['id' => $this->model->getId()]);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::emerg('Could not Save emailLog with the id "'.$this->model->getId().'" ');
         }
     }

--- a/models/Tool/Email/Log/Listing/Dao.php
+++ b/models/Tool/Email/Log/Listing/Dao.php
@@ -60,7 +60,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne('SELECT COUNT(*) FROM email_log ' . $this->getCondition(), $this->model->getConditionVariables());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 0;
         }
     }

--- a/models/Tool/SettingsStore/Dao.php
+++ b/models/Tool/SettingsStore/Dao.php
@@ -39,7 +39,7 @@ class Dao extends Model\Dao\AbstractDao
             ], $this->getPrimaryKey(self::TABLE_NAME));
 
             return true;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return false;
         }
     }

--- a/models/Tool/TmpStore/Dao.php
+++ b/models/Tool/TmpStore/Dao.php
@@ -44,7 +44,7 @@ class Dao extends Model\Dao\AbstractDao
             ], $this->getPrimaryKey('tmp_store'));
 
             return true;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return false;
         }
     }

--- a/models/Translation.php
+++ b/models/Translation.php
@@ -254,7 +254,7 @@ final class Translation extends AbstractModel
 
         try {
             $translation->getDao()->getByKey($id, $languages);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             if (!$create && !$returnIdIfEmpty) {
                 return null;
             }

--- a/models/Translation/Dao.php
+++ b/models/Translation/Dao.php
@@ -177,7 +177,7 @@ class Dao extends Model\Dao\AbstractDao
             $this->db->fetchOne(sprintf('SELECT * FROM translations_%s LIMIT 1;', $domain));
 
             return true;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return false;
         }
     }

--- a/models/User/AbstractUser.php
+++ b/models/User/AbstractUser.php
@@ -179,7 +179,7 @@ abstract class AbstractUser extends Model\AbstractModel implements AbstractUserI
             $this->update();
 
             $this->commit();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->rollBack();
 
             throw $e;

--- a/models/User/Listing/AbstractListing/Dao.php
+++ b/models/User/Listing/AbstractListing/Dao.php
@@ -65,7 +65,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne('SELECT COUNT(*) FROM users ' . $this->getCondition(), $this->model->getConditionVariables());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 0;
         }
     }

--- a/models/User/Permission/Definition/Dao.php
+++ b/models/User/Permission/Definition/Dao.php
@@ -33,7 +33,7 @@ class Dao extends Model\Dao\AbstractDao
                 'key' => $this->model->getKey(),
                 'category' => $this->model->getCategory() ? $this->model->getCategory() : '',
             ], $this->getPrimaryKey('users_permission_definitions'));
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::warn((string) $e);
         }
     }

--- a/models/User/Permission/Definition/Listing/Dao.php
+++ b/models/User/Permission/Definition/Listing/Dao.php
@@ -47,7 +47,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne('SELECT COUNT(*) FROM users_permission_definitions ' . $this->getCondition(), $this->model->getConditionVariables());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 0;
         }
     }

--- a/models/Version.php
+++ b/models/Version.php
@@ -145,7 +145,7 @@ final class Version extends AbstractModel
         if ($this->getGenerateStackTrace()) {
             try {
                 throw new \Exception('not a real exception ... ;-)');
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $this->stackTrace = $e->getTraceAsString();
             }
         }

--- a/models/Version/Listing/Dao.php
+++ b/models/Version/Listing/Dao.php
@@ -71,7 +71,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne('SELECT COUNT(*) FROM versions ' . $this->getCondition(), $this->model->getConditionVariables());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return 0;
         }
     }

--- a/models/WebsiteSetting.php
+++ b/models/WebsiteSetting.php
@@ -63,7 +63,7 @@ final class WebsiteSetting extends AbstractModel
             if (!$setting) {
                 throw new \Exception('Website setting in registry is null');
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             try {
                 $setting = new self();
                 $setting->getDao()->getById($id);


### PR DESCRIPTION
## Changes in this pull request  

Replaced all occurrences of `catch (\Exception $e)` with `catch (\Throwable $e)` for the generic catch conditions.

### Why

`\Exception` misses errors - a concrete example we encountered was in 10.x where `\Pimcore\Bundle\CoreBundle\Controller\PublicServicesController::thumbnailAction()` executed:
```php
$thumbnail = $asset->getImageThumbnail($thumbnailConfig, $time);
$thumbnailStream = $thumbnail->getStream();
````
The `getStream()` triggers a generate of the thumbnail - all of which is lacking a condition to check if the file actually exists.
Because the call to `\Pimcore\Image\Adapter::scaleByWidth()` without a file and hence no valid dimensions we ended up with a `\DivisionByZeroError` Error - which is _not_ an `\Exception` but a `\Throwable`.
All of which bypassed the error handling in `PublicServicesController::thumbnailAction()` leading to uncool 500er errors in the frontend.
