### PR TITLE
fix(models): QuantityValueRange - updated toArray return

### DIFF
--- a/models/DataObject/Data/QuantityValueRange.php
+++ b/models/DataObject/Data/QuantityValueRange.php
@@ -77,6 +77,7 @@ class QuantityValueRange extends AbstractQuantityValue
         return [
             'minimum' => $this->getMinimum(),
             'maximum' => $this->getMaximum(),
+            'unitId' => $this->getUnitId(),
         ];
     }
 


### PR DESCRIPTION
Added "unitId" to toArray return to fix denormalize issue in block context.
  
  

## Changes in this pull request  
Resolves issue when using a `QuantityValueRange` field inside a Block.
Exception thrown on save:
![Screenshot 2023-12-07 at 10 36](https://github.com/pimcore/pimcore/assets/2734232/b845e66a-f628-4fba-a1a5-20fec0624390)

In the `denormalize` function the `unitId` value is used but missing in the `$value` array. https://github.com/pimcore/pimcore/blob/5a632fa7b4c5dd5d3052a41b95ac4a6f075fbbba/models/DataObject/ClassDefinition/Data/QuantityValueRange.php#L253-L260

There reason for that is that `unitId` is not set in the `toArray` function here: 
https://github.com/pimcore/pimcore/blob/5a632fa7b4c5dd5d3052a41b95ac4a6f075fbbba/models/DataObject/Data/QuantityValueRange.php#L75-L81
