### PR TITLE
fix: tinymce using innerHTML instead of getContent

### DIFF
--- a/bundles/TinymceBundle/public/js/editor.js
+++ b/bundles/TinymceBundle/public/js/editor.js
@@ -106,7 +106,7 @@ pimcore.bundle.tinymce.editor = Class.create({
                     document.dispatchEvent(new CustomEvent(pimcore.events.changeWysiwyg, {
                         detail: {
                             e: eChange,
-                            data: tinymce.activeEditor.contentAreaContainer.innerHTML,
+                            data: tinymce.activeEditor.getContent(),
                             context: e.detail.context
                         }
                     }));
@@ -115,7 +115,7 @@ pimcore.bundle.tinymce.editor = Class.create({
                     document.dispatchEvent(new CustomEvent(pimcore.events.changeWysiwyg, {
                         detail: {
                             e: eChange,
-                            data: tinymce.activeEditor.contentAreaContainer.innerHTML,
+                            data: tinymce.activeEditor.getContent(),
                             context: e.detail.context
                         }
                     }));

--- a/doc/03_Documents/01_Editables/40_WYSIWYG.md
+++ b/doc/03_Documents/01_Editables/40_WYSIWYG.md
@@ -19,7 +19,7 @@ The Editor als needs to dispatch the `pimcore.events.changeWysiwyg` to set the v
 document.dispatchEvent(new CustomEvent(pimcore.events.changeWysiwyg, {
     detail: {
         e: eChange,
-        data: tinymce.activeEditor.contentAreaContainer.innerHTML, //text of the editor-field
+        data: tinymce.activeEditor.getContent(), //text of the editor-field
         context: e.detail.context //the context in which the editor is registered (object, document ...) 
     }
 }));


### PR DESCRIPTION
## Changes in this pull request  
Resolves #16372 #16317

TinyMCE use getContent() instead of innerHTML to get the content for saving
