### PR TITLE
Fix: Error when $_SERVER['REQUEST_URI'] is not set

### DIFF
--- a/bundles/SeoBundle/src/Redirect/RedirectHandler.php
+++ b/bundles/SeoBundle/src/Redirect/RedirectHandler.php
@@ -223,7 +223,7 @@ final class RedirectHandler
 
         $response->headers->set(self::RESPONSE_HEADER_NAME_ID, (string) $redirect->getId());
 
-        $this->redirectLogger->info(Tool::getAnonymizedClientIp() ?? 'Anonymous', ['Custom-Redirect ID: ' . $redirect->getId() . ', Source: ' . $_SERVER['REQUEST_URI'] . ' -> ' . $url]);
+        $this->redirectLogger->info(Tool::getAnonymizedClientIp() ?? 'Anonymous', ['Custom-Redirect ID: ' . $redirect->getId() . ', Source: ' . $request->getRequestUri() . ' -> ' . $url]);
 
         return $response;
     }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.1`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.1` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves error when `$_SERVER['REQUEST_URI']` is not set. That is usually not the case but it's very much possible. Also the global $_SERVER['REQUEST_URI'] might be different from the one on which the Redirect is being handled - in that case the Log entry is misleading.

## Additional info
To reproduce one muset create a valid redirect inside Pimcore admin and then let Symfony Http Kernel handle manually created request with URL that is meant to be redirected.

```php
// assuming existing Redirect for source URL "http://pimcore.test/redirect-me"

use Symfony\Component\HttpFoundation\Request;
use Pimcore\Kernel;

$request = Request::create('http://pimcore.test/redirect-me');
/** @var Kernel $kernel */
$kernel->handle(request: $request, catch: true);
```