### PR TITLE
fix psd files with alpha channels

### DIFF
--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -71,6 +71,10 @@ class Imagick extends Adapter
                 $i->setResolution($options['resolution']['x'], $options['resolution']['y']);
             }
 
+            if (isset($options['asset']) && $options['asset']->getMimeType() === 'image/vnd.adobe.photoshop') {
+                $i->setOption('psd:alpha-unblend', 'off');
+            }
+
             $imagePathLoad = $imagePath;
 
             $imagePathLoad = $imagePathLoad . '[0]';


### PR DESCRIPTION
 ## Changes in this pull request  
fix an issue with black fringes on PSD files with alpha channels and thumbnail export/download.

## Additional info
create a basic thumbnail config that does an Original conversion.
![Screenshot 2023-12-19 at 15 48 53](https://github.com/pimcore/pimcore/assets/45163659/4f74cafe-92aa-4c4b-85bf-c5c4140268fb)

download a thumbnail of a PSD file with alpha channel with your created basic thumbnail config on the Asset view
![Screenshot 2023-12-19 at 15 50 38](https://github.com/pimcore/pimcore/assets/45163659/c6c36ca6-08f5-4cd2-9ed9-4e6706d35de6)

resulting PSD has a slight black fringe around the masked area, left with fix, right without
<img width="1394" alt="Screenshot 2023-12-19 at 15 43 46" src="https://github.com/pimcore/pimcore/assets/45163659/d67ad91b-03cd-4197-ba5a-0e38ee7710a8">

testfile: [alpha.psd.zip](https://github.com/pimcore/pimcore/files/13717043/alpha.psd.zip)
download without fix: [alpha-witoutfix.psd.zip](https://github.com/pimcore/pimcore/files/13717050/alpha-witoutfix.psd.zip)
download with fix: [alpha-fix.psd.zip](https://github.com/pimcore/pimcore/files/13717055/alpha-fix.psd.zip)

related issue and discussion on the imagemagick repo with more test files.
https://github.com/ImageMagick/ImageMagick/issues/4494
https://github.com/ImageMagick/ImageMagick/discussions/6477

the issue can be reproduced and fixed with following CLI calls:
```
magick alpha.psd alpha-broken.psd
magick -define psd:alpha-unblend=off alpha.psd alpha-fix.psd

```
