### PR TITLE
[bugfix] Table calls htmlspecialchars with null value

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Table.php
+++ b/models/DataObject/ClassDefinition/Data/Table.php
@@ -398,7 +398,7 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
                 if (is_array($row)) {
                     foreach ($row as $cell) {
                         $html .= '<td>';
-                        $html .= htmlspecialchars($cell, ENT_QUOTES, 'UTF-8');
+                        $html .= htmlspecialchars($cell ?? '', ENT_QUOTES, 'UTF-8');
                         $html .= '</td>';
                     }
                 }


### PR DESCRIPTION
In models/DataObject/ClassDefinition/Data/Table.php could cause errors when dealing with legacy data. The problem was that htmlspecialchars would be called with a null value.