### PR TITLE
[bugfix] Areablock empty data causes Exception

### DIFF
--- a/models/Document/Editable/Areablock.php
+++ b/models/Document/Editable/Areablock.php
@@ -248,10 +248,12 @@ class Areablock extends Model\Document\Editable implements BlockInterface
 
     public function setDataFromResource(mixed $data): static
     {
-        $unserializedData = Tool\Serialize::unserialize($data);
+        if (is_string($data)) {
+            $data = Tool\Serialize::unserialize($data);
+        }
 
-        if (is_array($unserializedData)) {
-            $this->indices = $unserializedData;
+        if (is_array($data)) {
+            $this->indices = $data;
         } else {
             $this->indices = [];
         }

--- a/models/Document/Editable/Areablock.php
+++ b/models/Document/Editable/Areablock.php
@@ -248,12 +248,10 @@ class Areablock extends Model\Document\Editable implements BlockInterface
 
     public function setDataFromResource(mixed $data): static
     {
-        if (is_string($data)) {
-            $data = Tool\Serialize::unserialize($data);
-        }
+        $unserializedData = Tool\Serialize::unserialize($data);
 
-        if (is_array($data)) {
-            $this->indices = $data;
+        if (is_array($unserializedData)) {
+            $this->indices = $unserializedData;
         } else {
             $this->indices = [];
         }

--- a/models/Document/Editable/Areablock.php
+++ b/models/Document/Editable/Areablock.php
@@ -248,8 +248,11 @@ class Areablock extends Model\Document\Editable implements BlockInterface
 
     public function setDataFromResource(mixed $data): static
     {
-        $this->indices = Tool\Serialize::unserialize($data);
-        if (!is_array($this->indices)) {
+        $unserializedData = Tool\Serialize::unserialize($data);
+
+        if (is_array($unserializedData)) {
+            $this->indices = $unserializedData;
+        } else {
             $this->indices = [];
         }
 


### PR DESCRIPTION
This PR solves an error when legacy Areablocks contains empty data field. The Twig would state the following error:
An exception has been thrown during the rendering of a template ("Cannot assign string to property Pimcore\Model\Document\Editable\Areablock::$indices of type array

The error is due to the strong typing inside Areablock of $this->indices as array and the fact that Tool\Serialize::unserialize($data); might return something else (empty string in my case). This leads to an exception that was quite hard to pinpoint.

As you can see in the old code of Areablock some type of measure was taken to handle when unserialize wouldn't return array, but because of the strong typing an Exception is raised before that measure, and hence I removed it and took care of it before it could lead to a type error.