### PR TITLE
Bugfix renderlet type confusion

### DIFF
--- a/models/Document/Editable/Renderlet.php
+++ b/models/Document/Editable/Renderlet.php
@@ -155,11 +155,23 @@ class Renderlet extends Model\Document\Editable implements IdRewriterInterface, 
      */
     public function setDataFromResource(mixed $data): static
     {
-        $data = \Pimcore\Tool\Serialize::unserialize($data);
+        if (is_array($data)) {
+            $processedData = $data;
+        } elseif (is_string($data)) {
+            $processedData = \Pimcore\Tool\Serialize::unserialize($data);
+        } else {
+            throw new \InvalidArgumentException("\$data must be a string or an array.");
+        }
 
-        $this->id = $data['id'];
-        $this->type = (string) $data['type'];
-        $this->subtype = $data['subtype'];
+        foreach (['id', 'type', 'subtype'] as $key) {
+            if (!array_key_exists($key, $processedData)) {
+                throw new \InvalidArgumentException("Key '{$key}' is missing for setDataFromResource.");
+            }
+        }
+
+        $this->id = $processedData['id'];
+        $this->type = (string) $processedData['type'];
+        $this->subtype = $processedData['subtype'];
 
         $this->setElement();
 

--- a/models/Document/Editable/Renderlet.php
+++ b/models/Document/Editable/Renderlet.php
@@ -158,14 +158,18 @@ class Renderlet extends Model\Document\Editable implements IdRewriterInterface, 
         if (is_array($data)) {
             $processedData = $data;
         } elseif (is_string($data)) {
-            $processedData = \Pimcore\Tool\Serialize::unserialize($data);
+            $unserializedData = \Pimcore\Tool\Serialize::unserialize($data);
+            if (!is_array($unserializedData)) {
+                throw new \InvalidArgumentException("Unserialized data must be an array.");
+            }
+            $processedData = $unserializedData;
         } else {
-            throw new \InvalidArgumentException("\$data must be a string or an array.");
+            throw new \InvalidArgumentException("Data must be a string or an array.");
         }
 
         foreach (['id', 'type', 'subtype'] as $key) {
             if (!array_key_exists($key, $processedData)) {
-                throw new \InvalidArgumentException("Key '{$key}' is missing for setDataFromResource.");
+                throw new \InvalidArgumentException("Key '{$key}' is missing in the data array.");
             }
         }
 


### PR DESCRIPTION
Some parameter hygiene needed in setDataFromResource. Since we know what we want Exceptions are introduced for inputs not adhering to the expected data. Removed the bad practice of overwriting input parameters.