### PR TITLE
fix: determine object aware fields at wakeup time

### DIFF
--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -733,12 +733,26 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
 
     public function __wakeup(): void
     {
+        // parent::__wakeup() will call $this->setInDumpState(false) but we'll need the original value below
+        $wasInDumpState = $this->isInDumpState();
+
         parent::__wakeup();
 
-        // renew object reference to other object aware fields
-        foreach ($this->__objectAwareFields as $objectAwareField => $exists) {
-            if (isset($this->$objectAwareField)) {
-                if ($this->$objectAwareField instanceof ObjectAwareFieldInterface) {
+        // Renew object reference to object aware fields
+        if ($wasInDumpState) {
+            // We're reloading version data, there might be fields that now implement the ObjectAwareFieldInterface but
+            // aren't included in the $this->__objectAwareFields array - for example versions created in Pimcore <= 10.x
+            // containing LocalizedFields. Verify all fields in this object.
+            foreach (get_object_vars($this) as $propertyValue) {
+                if ($propertyValue instanceof ObjectAwareFieldInterface) {
+                    $propertyValue->setObject($this);
+                }
+            }
+        } else {
+            // We're reloading from cache, optimize by only reloading known object aware fields (instead of verifying
+            // all fields within this object).
+            foreach ($this->__objectAwareFields as $objectAwareField => $exists) {
+                if (isset($this->$objectAwareField) && $this->$objectAwareField instanceof ObjectAwareFieldInterface) {
                     $this->$objectAwareField->setObject($this);
                 }
             }

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -765,7 +765,7 @@ class Service extends Model\AbstractModel
                 foreach ($properties as $name => $value) {
                     //do not renew object reference of ObjectAwareFieldInterface - as object might point to a
                     //specific version of the object and must not be reloaded with DB version of object
-                    if (($data instanceof ObjectAwareFieldInterface || $data instanceof DataObject\Localizedfield) && $name === 'object') {
+                    if ($data instanceof ObjectAwareFieldInterface && $name === 'object') {
                         continue;
                     }
 


### PR DESCRIPTION
Error: migrated versions with localized fields can't be displayed
Caused by: 'localizedfields' not included in the __objectAwareFields array at sleep time
Resolved with: checking all fields if they implement the ObjectAwareFieldInterface

## Steps to reproduce

1. On a Pimcore 10.6 installation create a class definition with a localized field
2. Create a dataobject & version data
3. Upgrade to Pimcore 11
4. Try to load the version
5. It will give an error "Call to a member function getClass() on null" in models/DataObject/Localizedfield.php:307 on `$object = $this->getObject(); $container = $object->getClass();`

The error is caused by: The serialize data doesn't include `'localizedfields'` within the `__objectAwareFields` array, because at sleep time (the time the version was created and the data was serialized) the `Localizedfield` didn't implement `ObjectAwareFieldInterface` yet, var_dump of unserialized data:
```
  ["__objectAwareFields"]=>
  array(0) {
  }
```

## Additional info

This solution should also prevent any future errors if `ObjectAwareFieldInterface` is added on other data types.
