### PR TITLE
Recreate TODO comment, removed by php-cs-fixer

### DIFF
--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -1045,6 +1045,9 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
         return null;
     }
 
+    /**
+     * TODO Pimcore 12: Change empty string return to null
+     */
     public function getImageThumbnail(string|Asset\Video\Thumbnail\Config $config): Asset\Video\ImageThumbnailInterface|Asset\Image\ThumbnailInterface|string
     {
         if ($this->poster && ($poster = Asset\Image::getById($this->poster))) {


### PR DESCRIPTION
Was removed in 11.1 and 11.x:
https://github.com/pimcore/pimcore/commit/d33d1a7901692fe14b3a786e8c56fca66917630a
https://github.com/pimcore/pimcore/commit/2b3bb4d10f4c32270589bb37557b932ca38d2a7e