### PR TITLE
skip crop on vector graphics thumbnails

### DIFF
--- a/models/Document/Editable/Image.php
+++ b/models/Document/Editable/Image.php
@@ -429,7 +429,8 @@ class Image extends Model\Document\Editable implements IdRewriterInterface, Edit
         $image = $this->getImage();
         if ($image instanceof Asset\Image) {
             $thumbConfig = $image->getThumbnail($conf)->getConfig();
-            if ($thumbConfig && $this->cropPercent) {
+            if ($thumbConfig && $this->cropPercent && (!$image->isVectorGraphic() || $thumbConfig->getFormat() !== 'ORIGINAL')) {
+                // only apply crop on non vector graphics OR if the thumbnail format is not set to original
                 $this->applyCustomCropping($thumbConfig);
                 $thumbConfig->generateAutoName();
             }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.1`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.1` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
SVG Image Thumbnails cannot be cropped if the Thumbnail config uses the original format.

Imagemagick tries to crop the svg and fails with:
```
ImagickException: delegate failed `'potrace' --svg --output '%o' '%i'' @ error/delegate.c/InvokeDelegate/1924 in /var/www/html/vendor/pimcore/pimcore/lib/Image/Adapter/Imagick.php:262
```

I fixed it with skipping the crop mechanism on vector graphics if the thumbnail configuration uses the original format.

### Steps to reproduce
 - create thumbnail config with format = original
 - create image editable that uses the thumbnail
 - add svg image to editable and crop image to a different size

## Additional info
- not sure if we should document this and if yes where
- maybe we have to exclude multiple formats?
- i tried with `isRasterizedSVG` but this produces the same error when Format was original