### PR TITLE
Added check to see if children are excluded from navigation

### DIFF
--- a/lib/Navigation/Renderer/Menu.php
+++ b/lib/Navigation/Renderer/Menu.php
@@ -831,7 +831,7 @@ class Menu extends AbstractRenderer
                 $liClasses[] = $page->getClass();
             }
             // Add CSS class for parents to LI?
-            if ($renderParentClass && $page->hasChildren()) {
+            if ($renderParentClass && $page->hasVisiblePages()) {
                 // Check max depth
                 if ((is_int($maxDepth) && ($depth + 1 < $maxDepth))
                     || !is_int($maxDepth)


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.1`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.1` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  

### Discussed in https://github.com/pimcore/pimcore/issues/16402

There was a bug in the menu builder - the script also downloaded documents that are excluded from the navigation. 
This caused an error in the navigation renderer.

I added a mechanism that checks if the document has at least one child that is not excluded from navigation, and a mechanism that retrieves only children that are not excluded from navigation

