### PR TITLE
Refix generation of thumbnails with inline thumbnail config

### DIFF
--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -215,7 +215,7 @@ class Processor
         if ($deferred) {
             // only add the config to the TmpStore if necessary (e.g. if the config is auto-generated)
             if (!Config::exists($config->getName())) {
-                $pathInfo = trim($asset->getRealPath(), '/').'/'.$asset->getId() . '/';
+                $pathInfo = trim($asset->getRealPath(), '/').'/'.$asset->getId() . '/' . $config->getName();
                 $configId = 'thumb_' . $asset->getId() . '__' . md5($pathInfo);
                 TmpStore::add($configId, $config, 'thumbnail_deferred');
             }

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -215,7 +215,7 @@ class Processor
         if ($deferred) {
             // only add the config to the TmpStore if necessary (e.g. if the config is auto-generated)
             if (!Config::exists($config->getName())) {
-                $pathInfo = trim($asset->getRealPath(), '/').'/'.$asset->getId() . '/' . $config->getName() . '/' . $filename;
+                $pathInfo = ltrim($asset->getRealPath(), '/') . $asset->getId() . '/' . $config->getName() . '/' . $filename;
                 $configId = 'thumb_' . $asset->getId() . '__' . md5($pathInfo);
                 TmpStore::add($configId, $config, 'thumbnail_deferred');
             }

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -215,7 +215,7 @@ class Processor
         if ($deferred) {
             // only add the config to the TmpStore if necessary (e.g. if the config is auto-generated)
             if (!Config::exists($config->getName())) {
-                $pathInfo = trim($asset->getRealPath(), '/').'/'.$asset->getId() . '/' . $config->getName();
+                $pathInfo = trim($asset->getRealPath(), '/').'/'.$asset->getId() . '/' . $config->getName() . '/' . $filename;
                 $configId = 'thumb_' . $asset->getId() . '__' . md5($pathInfo);
                 TmpStore::add($configId, $config, 'thumbnail_deferred');
             }

--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -488,7 +488,7 @@ class Service extends Model\Element\Service
             if (!$thumbnailConfig) {
                 // check if there's an item in the TmpStore
                 // remove an eventually existing cache-buster prefix first (eg. when using with a CDN)
-                $pathInfo = preg_replace('@^/cache-buster\-[\d]+@', '', $config['prefix']) . $config['thumbnail_name'] . '/' . $config['filename'];
+                $pathInfo = preg_replace('@^cache-buster\-[\d]+/@', '', $config['prefix']) . $config['thumbnail_name'] . '/' . $config['filename'];
                 $deferredConfigId = 'thumb_' . $config['asset_id'] . '__' . md5(urldecode($pathInfo));
 
                 if ($thumbnailConfigItem = TmpStore::get($deferredConfigId)) {

--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -488,7 +488,7 @@ class Service extends Model\Element\Service
             if (!$thumbnailConfig) {
                 // check if there's an item in the TmpStore
                 // remove an eventually existing cache-buster prefix first (eg. when using with a CDN)
-                $pathInfo = preg_replace('@^/cache-buster\-[\d]+@', '', $config['prefix']) . $config['thumbnail_name'];
+                $pathInfo = preg_replace('@^/cache-buster\-[\d]+@', '', $config['prefix']) . $config['thumbnail_name'] . '/' . $config['filename'];
                 $deferredConfigId = 'thumb_' . $config['asset_id'] . '__' . md5(urldecode($pathInfo));
 
                 if ($thumbnailConfigItem = TmpStore::get($deferredConfigId)) {

--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -488,7 +488,7 @@ class Service extends Model\Element\Service
             if (!$thumbnailConfig) {
                 // check if there's an item in the TmpStore
                 // remove an eventually existing cache-buster prefix first (eg. when using with a CDN)
-                $pathInfo = preg_replace('@^/cache-buster\-[\d]+@', '', $config['prefix']);
+                $pathInfo = preg_replace('@^/cache-buster\-[\d]+@', '', $config['prefix']) . $config['thumbnail_name'];
                 $deferredConfigId = 'thumb_' . $config['asset_id'] . '__' . md5(urldecode($pathInfo));
 
                 if ($thumbnailConfigItem = TmpStore::get($deferredConfigId)) {


### PR DESCRIPTION
fix of #15198 had a problem, when different croppings of the same image were rendered in one page ...

see in demo 

first request: 
![image](https://github.com/pimcore/pimcore/assets/8792145/3c130e96-6635-4ae7-9899-ee0a6c7b90e4)

second request: 
![image](https://github.com/pimcore/pimcore/assets/8792145/63ef3632-9e10-4eb0-8c94-cae436c9a726)

third request: 
![image](https://github.com/pimcore/pimcore/assets/8792145/356e5201-35f8-42cd-a957-67448c16cc2f)

forth request (finally correct): 
![image](https://github.com/pimcore/pimcore/assets/8792145/812047ca-76f5-4c94-956e-443066675ad5)


problem was, that pathinfo doesn't contain all necessary information. 
