### PR TITLE
[Video thumbnails] Support creating mpg video thumbnails

### DIFF
--- a/lib/Video/Adapter/Ffmpeg.php
+++ b/lib/Video/Adapter/Ffmpeg.php
@@ -148,6 +148,10 @@ class Ffmpeg extends Adapter
                 array_push($command, '-adaptation_sets', 'id=0,streams=v id=1,streams=a');
                 array_push($command, '-single_file', '1');
                 array_push($command, '-f', 'dash');
+            } elseif ($this->getFormat() === 'mpg') {
+                array_push($command, '-c:v', 'mpeg2video');
+                array_push($command, '-c:a', 'mp2');
+                array_push($command, '-f', 'vob');
             } else {
                 throw new \Exception('Unsupported video output format: ' . $this->getFormat());
             }


### PR DESCRIPTION
Currently it is only possible to create MP4, WebM and MPD video thumbnails. This PR adds support for converting videos to MPG.

Example code:
```php
$video = \Pimcore\Model\Asset\Video::getById(123);
$video->getThumbnail('my-video-thumbnail', ['mpg']);
```