### PR TITLE
[Bug]: Fix static page generated via CLI having invalid hostname

### DIFF
--- a/lib/Document/Renderer/DocumentRenderer.php
+++ b/lib/Document/Renderer/DocumentRenderer.php
@@ -93,7 +93,7 @@ class DocumentRenderer implements DocumentRendererInterface
             $host = null;
             if($site = Frontend::getSiteForDocument($document)) {
                 $host = $site->getMainDomain();
-            } elseif($systemMainDomain = Tool::getHostUrl()) {
+            } elseif($systemMainDomain = Tool::getHostname()) {
                 $host = $systemMainDomain;
             }
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.1`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.1` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/16408

## Additional info
`getHostUrl` includes the protocol, making it conflicting later on in some sanitization/parsing and resulting in `https://http/my-document1`
`getHostname` gets the current request host and fallbacks to system configuration main domain. Alternatively should be replaced by `SystemSettingsConfig::get()['general']['domain']` since the variable name is `$systemMainDomain`