### PR TITLE
StopMessenger trait should work in maintenance mode

### DIFF
--- a/lib/Helper/StopMessengerWorkersTrait.php
+++ b/lib/Helper/StopMessengerWorkersTrait.php
@@ -34,6 +34,7 @@ trait StopMessengerWorkersTrait
             'command' => 'messenger:stop-workers',
             '--no-ansi' => null,
             '--no-interaction' => null,
+            '--ignore-maintenance-mode' => null,
         ]);
 
         $output = new BufferedOutput();


### PR DESCRIPTION
StopMessenger trait should call messenger:stop-workers with --ignore-maintenance-mode so it works in any situation

