### PR TITLE
Fix translations missing after cache clear (multi locale)

### DIFF
--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -188,13 +188,15 @@ class Translator implements LegacyTranslatorInterface, TranslatorInterface, Tran
     public function lazyInitialize($domain, $locale)
     {
         $cacheKey = 'translation_data_' . $domain . '_' . $locale;
+        $backend = $this->getBackendForDomain($domain);
 
-        if (isset($this->initializedCatalogues[$cacheKey])) {
+        if (isset($this->initializedCatalogues[$cacheKey])
+            && (!$backend || $this->getCatalogue($locale)->defines('__pimcore_dummy', $domain))
+        ) {
             return;
         }
 
         $this->initializedCatalogues[$cacheKey] = true;
-        $backend = $this->getBackendForDomain($domain);
 
         if ($backend) {
             $catalogue = null;


### PR DESCRIPTION
## Changes in this pull request  
Fixes the bug of translations missing when cache was recently cleaned.
This affects sites that have multiple locales.
Bug takes place only when multiple locales are used within single request.

## Steps to reproduce
1. Clear cache: `bin/console c:c`
2. Visit a page that only uses single locale for translations
`{{ 'some.key'|trans({}, null, 'en') }} // output: Some Key (EN)`
3. Visit a page that uses multiple locales for translations
```
{{ 'some.key'|trans({}, null, 'en') }} // output: Some Key (EN)
{{ 'some.key'|trans({}, null, 'de') }} // output: Some Key (DE)
{{ 'some.key'|trans({}, null, 'fr') }} // output: Some Key (FR)
{{ 'some.key'|trans({}, null, 'de') }} // output: some.key
```

The last translation is left untranslated because Symfony cleared translator's catalogues. And cause Pimcore's decorated translator has flag set in `$initializedCatalogues`, DB translations do not get re-added to the new catalogue instance.

## The fix
Fix simply checks for existence of dummy key that must be present inside the catalogue after Pimcore has included DB translations. When the dummy key is not found, DB translations are added again.  
This does not affect performance as the catalogue instance containing DB translations was cached.
## Additional info
I submit this PR for anyone still using older version of Pimcore.
This issue has been resolved for Pimcore X (`APP_DEBUG: false`).