### PR TITLE
fix apache configuration documentation

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/01_Apache_Configuration.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/01_Apache_Configuration.md
@@ -107,7 +107,7 @@ RewriteRule ^cache-buster\-[\d]+/(.*) $1 [PT,L]
 
 # If the requested filename exists, simply serve it.
 # We only want to let Apache serve files and not directories.
-RewriteCond %{REQUEST_FILENAME} -f
+RewriteCond %{DOCUMENT_ROOT}/%{REQUEST_FILENAME} -f
 RewriteRule ^ - [L]
 
 # Rewrite all other queries to the front controller.


### PR DESCRIPTION
## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/` 
- [x] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.1` (see Readme.md for the list of supported versions)
- [x] Meet all coding standards (see PhpStan actions) 

## Changes in this pull request  

I tried the setup instructions but did not get static files to be served. Not sure if the original configuration would be the correct one for some versions of Apache (its been quite a while since i had to use it), but with my 2.4.57, the REQUEST_FILENAME is only the path and we need to prepend the DOCUMENT_ROOT

