### PR TITLE
[Asset] Image thumbnails deferred url should always return file from …

### DIFF
--- a/bundles/CoreBundle/src/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/src/Controller/PublicServicesController.php
@@ -47,9 +47,9 @@ class PublicServicesController extends Controller
         ];
 
         try {
-            $thumbnail = Asset\Service::getImageThumbnailByArrayConfig($config);
-            if ($thumbnail) {
-                return Asset\Service::getStreamedResponseFromImageThumbnail($thumbnail, $config);
+            $response = Asset\Service::getStreamedResponseForThumbnail($config, $request->getPathInfo());
+            if($response) {
+                return $response;
             }
 
             throw new \Exception('Unable to generate '.$config['type'].' thumbnail, see logs for details.');

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -27,6 +27,8 @@ use Pimcore\Model\Asset;
 use Pimcore\Model\Tool\TmpStore;
 use Pimcore\Tool\Storage;
 use Symfony\Component\Lock\LockFactory;
+use function ltrim;
+use function md5;
 
 /**
  * @internal
@@ -212,12 +214,12 @@ class Processor
         // the configuration is saved for later use in
         // \Pimcore\Bundle\CoreBundle\Controller\PublicServicesController::thumbnailAction()
         // so that it can be used also with dynamic configurations
+        $pathInfo = ltrim($asset->getRealPath(), '/') . $asset->getId() . '/' . $config->getName() . '/' . $filename;
+        $tmpStoreDeferredConfigId = 'thumb_' . $asset->getId() . '__' . md5($pathInfo);
         if ($deferred) {
             // only add the config to the TmpStore if necessary (e.g. if the config is auto-generated)
             if (!Config::exists($config->getName())) {
-                $pathInfo = ltrim($asset->getRealPath(), '/') . $asset->getId() . '/' . $config->getName() . '/' . $filename;
-                $configId = 'thumb_' . $asset->getId() . '__' . md5($pathInfo);
-                TmpStore::add($configId, $config, 'thumbnail_deferred');
+                TmpStore::add($tmpStoreDeferredConfigId, $config, 'thumbnail_deferred');
             }
 
             return [
@@ -343,6 +345,11 @@ class Processor
                 if ($statusCacheEnabled && $asset instanceof Asset\Image) {
                     //update thumbnail dimensions to cache
                     $asset->addThumbnailFileToCache($tmpFsPath, $filename, $config);
+                }
+
+                if (!Config::exists($config->getName())) {
+                    // delete dynamic thumbnail configs out of the TmpStore as soon as we've generated the thumbnail file
+                    TmpStore::delete($tmpStoreDeferredConfigId);
                 }
 
                 $generated = true;

--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -500,7 +500,8 @@ class Service extends Model\Element\Service
 
                 if ($thumbnailConfigItem = TmpStore::get($deferredConfigId)) {
                     $thumbnailConfig = $thumbnailConfigItem->getData();
-                    TmpStore::delete($deferredConfigId);
+                    // the dynamic config get's deleted out of the TmpStore in the Processor after the thumbnail
+                    // file was generated, to avoid race conditions and other unintended behavior
 
                     if (!$thumbnailConfig instanceof $thumbnailConfigClass) {
                         throw new \Exception('Deferred thumbnail config file doesn\'t contain a valid '.$thumbnailConfigClass.' object');

--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -36,6 +36,7 @@ use function date;
 use function fpassthru;
 use function preg_quote;
 use function preg_replace;
+use function strlen;
 use function time;
 use function urldecode;
 
@@ -685,7 +686,8 @@ class Service extends Model\Element\Service
             $storagePath = preg_replace('/^' . preg_quote($prefix, '/') . '/', '', $storagePath);
         }
 
-        if ($storage->fileExists($storagePath)) {
+        // thumbnail urls are at least 10 characters long
+        if (strlen($uri) > 10 && $storage->fileExists($storagePath)) {
             $stream = $storage->readStream($storagePath);
 
             $lifetime = 86400 * 7; // 1 week lifetime, same as direct delivery in .htaccess

--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -665,7 +665,7 @@ class Service extends Model\Element\Service
         $config = self::extractThumbnailInfoFromUri($uri);
 
         if ($config) {
-            return self::getStreamedResponseForThumbnailConfig($config, $uri);
+            return self::getStreamedResponseForThumbnail($config, $uri);
         }
 
         return null;

--- a/tests/Model/Asset/AssetThumbnailCacheTest.php
+++ b/tests/Model/Asset/AssetThumbnailCacheTest.php
@@ -97,6 +97,7 @@ class AssetThumbnailCacheTest extends TestCase
             'prefix' => '',
         ]);
         $response = $controller->thumbnailAction($subRequest);
+        $response->sendContent(); // calls getStream() in order to generate the thumbnail file
 
         //check if cache is filled
         $this->assertNotNull($asset->getDao()->getCachedThumbnailModificationDate($thumbnailName, $thumbConfig->getFilename()));


### PR DESCRIPTION
…storage if exists, independent if the existence of the thumbnail config

Fixes #16486 
Alternative approach to: #16523 

The issue it that not all thumbnail configurations are persistent, such as dynamic thumbnail configs passed directly to `getThumbnail(['width' => 300])` or when using cropping functionality on image data types. 
So the bug was that when calling the deferred image URL after the thumbnail file was already generated, Pimcore was looking for the config, which didn't exist anymore in the `TmpStore`, so it assumed that it's obsolete and cleared all related stuff, such as the image thumbnail cache for this thumbnail config name. 

This fix checks for the existence of the image thumbnail file before it goes through the normal thumbnail generating process (which is correct). 