### PR TITLE
Update migration to prevent duplicate key error in Pimcore 10->11 upgrades

### DIFF
--- a/bundles/CoreBundle/src/Migrations/Version20230111074323.php
+++ b/bundles/CoreBundle/src/Migrations/Version20230111074323.php
@@ -37,6 +37,9 @@ final class Version20230111074323 extends AbstractMigration
             SettingsStore::set('BUNDLE_INSTALLED__Pimcore\\Bundle\\WordExportBundle\\PimcoreWordExportBundle', true, SettingsStore::TYPE_BOOLEAN, 'pimcore');
         }
 
+        // Delete this definition if it already exists, because upgrades from pimcore 10 sometimes get stuck in this state. See #14995
+        $this->addSql("DELETE FROM `users_permission_definitions` WHERE `key` = 'word_export'");
+
         // Append to the comma separated list whenever the permissions text field has 'translation' but not already word_export
         $this->addSql("INSERT INTO `users_permission_definitions` (`key`, `category`) VALUES ('word_export', 'Pimcore Word Export Bundle')");
 

--- a/bundles/CoreBundle/src/Migrations/Version20230111074323.php
+++ b/bundles/CoreBundle/src/Migrations/Version20230111074323.php
@@ -37,11 +37,8 @@ final class Version20230111074323 extends AbstractMigration
             SettingsStore::set('BUNDLE_INSTALLED__Pimcore\\Bundle\\WordExportBundle\\PimcoreWordExportBundle', true, SettingsStore::TYPE_BOOLEAN, 'pimcore');
         }
 
-        // Delete this definition if it already exists, because upgrades from pimcore 10 sometimes get stuck in this state. See #14995
-        $this->addSql("DELETE FROM `users_permission_definitions` WHERE `key` = 'word_export'");
-
         // Append to the comma separated list whenever the permissions text field has 'translation' but not already word_export
-        $this->addSql("INSERT INTO `users_permission_definitions` (`key`, `category`) VALUES ('word_export', 'Pimcore Word Export Bundle')");
+        $this->addSql("INSERT INTO `users_permission_definitions` (`key`, `category`) VALUES ('word_export', 'Pimcore Word Export Bundle') ON DUPLICATE KEY UPDATE `category` = 'Pimcore Word Export Bundle';");
 
         $this->addSql('UPDATE `users` SET `permissions`=CONCAT(`permissions`, \',word_export\') WHERE `permissions` REGEXP \'(?:^|,)translations(?:$|,)\'');
 


### PR DESCRIPTION
Changes in this pull request
Resolves pimcore#14995

Additional info
Pimcore 10 to 11 upgrades sometimes get stuck being unable to complete because the migrations are unable to run. The issue appears to be that this migration tries to add a row to a table which already exists. This was reported a couple times on the issue above which was closed due to inactivity and not because it was resolved. We have also experienced it with multiple of our clients doing Pimcore 11 upgrades where manually deleting the offending database row unsticks the migrations.
