### PR TITLE
[BUG FIX] passwortRecoveryToken column length to small

### DIFF
--- a/bundles/CoreBundle/src/Migrations/Version20240131080600.php
+++ b/bundles/CoreBundle/src/Migrations/Version20240131080600.php
@@ -44,8 +44,3 @@ final class Version20240131080600 extends AbstractMigration
         }
     }
 }
-
-
-
-
-20240131080600

--- a/bundles/CoreBundle/src/Migrations/Version20240131080600.php
+++ b/bundles/CoreBundle/src/Migrations/Version20240131080600.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240131080600 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Increase passwordRecoveryToken column length on users table';
+    }
+
+    public function up(Schema $schema): void
+    {      
+        if ($schema->getTable('users')->hasColumn('passwordRecoveryToken')) {
+            $this->addSql(
+                'ALTER TABLE `users` MODIFY `passwordRecoveryToken` varchar(290);'
+            );
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if ($schema->getTable('users')->hasColumn('passwordRecoveryToken')) {
+            $this->addSql('ALTER TABLE `users` DROP COLUMN `passwordRecoveryToken`;');
+            $this->addSql('ALTER TABLE `users` ADD COLUMN `passwordRecoveryToken` varchar(255) DEFAULT NULL AFTER `password`;');
+        }
+    }
+}
+
+
+
+
+20240131080600

--- a/bundles/InstallBundle/dump/install.sql
+++ b/bundles/InstallBundle/dump/install.sql
@@ -479,7 +479,7 @@ CREATE TABLE `users` (
   `websiteTranslationLanguagesView` LONGTEXT NULL DEFAULT NULL,
   `lastLogin` int(11) unsigned DEFAULT NULL,
   `keyBindings` json NULL,
-  `passwordRecoveryToken` varchar(255) DEFAULT NULL,
+  `passwordRecoveryToken` varchar(290) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `type_name` (`type`,`name`),
   KEY `parentId` (`parentId`),


### PR DESCRIPTION
Bugfix for to small column length of the passwortRecoveryToken column in the users table.

To reproduce bug, create a new user with username length >= 33 chars and use the "Login as this user in a different browser" you will get an exception with "Token does not match any user."