### PR TITLE
Include tests into dist zip again

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,6 @@
 # Exclude build/test files from archive to reduce ZIP size for composer dist download
 /.github export-ignore
 /doc export-ignore
-/tests export-ignore
 /.editorconfig export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
@@ -13,5 +12,4 @@
 /.php-cs-fixer.dist.php export-ignore
 /CLA.md export-ignore
 /CONTRIBUTING.md export-ignore
-/codeception.dist.yml export-ignore
 /phpstan* export-ignore


### PR DESCRIPTION
needed for distribution of enterprise packages via private packagist, as in that case `source` as install source does not work (because it would come from a private repos) and so installs depending on test classes do not work anymore. 
