### PR TITLE
[Bug] Fix bundle priority issue

### DIFF
--- a/lib/HttpKernel/BundleCollection/BundleCollection.php
+++ b/lib/HttpKernel/BundleCollection/BundleCollection.php
@@ -37,7 +37,11 @@ class BundleCollection
 
         // a bundle can only be registered once
         if ($this->hasItem($identifier)) {
-            return $this;
+            $bundle = $this->getItem($identifier);
+            // if the new item has a higher priority, we replace the existing item
+            if ($bundle->getPriority() >= $item->getPriority()) {
+                return $this;
+            }
         }
 
         $this->items[$identifier] = $item;

--- a/tests/Unit/HttpKernel/BundleCollection/BundleCollectionTest.php
+++ b/tests/Unit/HttpKernel/BundleCollection/BundleCollectionTest.php
@@ -296,8 +296,10 @@ class BundleCollectionTest extends TestCase
         $this->assertTrue($collection->hasItem(BundleH::class));
         $this->assertTrue($collection->hasItem(BundleJ::class));
 
-        $this->assertEquals(10, $collection->getItem(BundleG::class)->getPriority()); // will be overwritten because of higher prio
-        $this->assertEquals(50, $collection->getItem(BundleH::class)->getPriority()); // as set here when adding the item
+        // will be overwritten because of higher prio
+        $this->assertEquals(10, $collection->getItem(BundleG::class)->getPriority());
+        // as set here when adding the item
+        $this->assertEquals(50, $collection->getItem(BundleH::class)->getPriority());
     }
 }
 

--- a/tests/Unit/HttpKernel/BundleCollection/BundleCollectionTest.php
+++ b/tests/Unit/HttpKernel/BundleCollection/BundleCollectionTest.php
@@ -276,10 +276,11 @@ class BundleCollectionTest extends TestCase
     {
         $collection = new BundleCollection();
 
-        // add BundleH explicitely
+        // add BundleH explicitly
         $collection->addBundle(new BundleH, 50);
 
-        // BundleG tries to add BundleH, but it will be ignored as it is already registered
+        // BundleG tries to add BundleH, but it will be ignored as it is already registered with a higher priority
+        // BundleG is registered with priority 10, which is higher than in BundleH and will so the new prio will be 10
         $collection->addBundle(new BundleG, 10);
 
         // BundleJ will try to add BundleH again with prio 9
@@ -295,7 +296,7 @@ class BundleCollectionTest extends TestCase
         $this->assertTrue($collection->hasItem(BundleH::class));
         $this->assertTrue($collection->hasItem(BundleJ::class));
 
-        $this->assertEquals(5, $collection->getItem(BundleG::class)->getPriority()); // as set in BundleH dependency
+        $this->assertEquals(10, $collection->getItem(BundleG::class)->getPriority()); // will be overwritten because of higher prio
         $this->assertEquals(50, $collection->getItem(BundleH::class)->getPriority()); // as set here when adding the item
     }
 }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.1`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.1` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #16544 

## Additional info
If a bundle is registered, use the higher priority instead of just using the first come first serve principle. (Loading order of bundles determined the overall priority for a bundle)
