### PR TITLE
Doc bugfix: Update 02_Custom_Icons.md

### DIFF
--- a/doc/18_Tools_and_Features/02_Custom_Icons.md
+++ b/doc/18_Tools_and_Features/02_Custom_Icons.md
@@ -71,6 +71,8 @@ class Car extends AdminStyle
         if ($element instanceof \App\Model\Product\Car) {
             DataObject\Service::useInheritedValues(true, function () use ($element) {
                 if ($element->getObjectType() == 'actual-car') {
+                    // setting this to false is necessary for the elementIcon to actually be used
+                    $this->elementIconClass = false;
                     $this->elementIcon = '/bundles/pimcoreadmin/img/twemoji/1f697.svg';
                 }
             });


### PR DESCRIPTION
This bit of docs is not working without the additional line that I added. 
Found it by looking at the AdminStyleTrait:

```PHP
$data['iconCls'] = $adminStyle->getElementIconClass() !== false ? $adminStyle->getElementIconClass() : null;
if (!$data['iconCls']) {
  $data['icon'] = $adminStyle->getElementIcon() !== false ? $adminStyle->getElementIcon() : null;
} else {
  $data['icon'] = null;
}