### PR TITLE
Fix Malformed UTF8 message when saving DataObject

### DIFF
--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -803,7 +803,7 @@ class Service extends Model\AbstractModel
         // correct wrong path (root-node problem)
         $path = str_replace('//', '/', $path);
 
-        if (str_contains($path, '%')) {
+        if (str_contains($path, '%') && mb_check_encoding(rawurldecode($path), 'UTF-8')) {
             $path = rawurldecode($path);
         }
 


### PR DESCRIPTION
## Changes in this pull request  

When saving a DataObject having a `%` in it's key, the method `correctPath` calls a PHP method `rawurldecode` which checks if the string passed as parameter has a '%' sign followed by a pair hexadecial characters (0-9, a-f).

In my case, I had a DataObject which did not cause any problem in Pimcore 10.x and that I couldn't save anymore in Pimcore 11. The error message was the following : 
`Malformed UTF-8 characters, possibly incorrectly encoded (500 Internal Server Error)`

After some digging, it appeared that my object had the following in its path : `%AF...` which Pimcore tried to convert to an UTF8 character.

This PR checks if the resulted string is a correct UTF8 string before operating the change.

