### PR TITLE
[bugfix] cast to int when calling setQuality

### DIFF
--- a/bundles/SimpleBackendSearchBundle/src/Model/Search/Backend/Data.php
+++ b/bundles/SimpleBackendSearchBundle/src/Model/Search/Backend/Data.php
@@ -252,7 +252,7 @@ class Data extends AbstractModel
     /**
      * @return $this
      */
-    public function setUserOwner(int $userOwner): static
+    public function setUserOwner(?int $userOwner): static
     {
         $this->userOwner = $userOwner;
 

--- a/lib/Cache/Core/CoreCacheHandler.php
+++ b/lib/Cache/Core/CoreCacheHandler.php
@@ -803,7 +803,7 @@ class CoreCacheHandler implements LoggerAwareInterface
             $tags = $this->prepareCacheTags($queueItem->getKey(), $queueItem->getData(), $queueItem->getTags());
             if (null === $tags) {
                 $result = false;
-            // item shouldn't go to the cache (either because it's tags are ignored or were cleared within this process) -> see $this->prepareCacheTags();
+                // item shouldn't go to the cache (either because it's tags are ignored or were cleared within this process) -> see $this->prepareCacheTags();
             } else {
                 $result = $this->storeCacheData($queueItem->getKey(), $queueItem->getData(), $tags, $queueItem->getLifetime(), $queueItem->isForce());
             }

--- a/models/Asset/Image/Thumbnail/Config.php
+++ b/models/Asset/Image/Thumbnail/Config.php
@@ -506,7 +506,7 @@ final class Config extends Model\AbstractModel
         }
 
         if (isset($config['quality'])) {
-            $pipe->setQuality($config['quality']);
+            $pipe->setQuality((int)$config['quality']);
         }
 
         if (isset($config['cover'])) {

--- a/models/DataObject/ClassDefinition/Data/UrlSlug.php
+++ b/models/DataObject/ClassDefinition/Data/UrlSlug.php
@@ -220,9 +220,9 @@ class UrlSlug extends Data implements CustomResourcePersistingInterface, LazyLoa
                                     return;
                                 }
 
-                            // if now exception is thrown then the slug is owned by a diffrent object/field
-                            throw new \Exception('Unique constraint violated. Slug "' . $slug['slug'] . '" is already used by object '
-                                . $existingSlug->getObjectId() . ', fieldname: ' . $existingSlug->getFieldname());
+                                // if now exception is thrown then the slug is owned by a diffrent object/field
+                                throw new \Exception('Unique constraint violated. Slug "' . $slug['slug'] . '" is already used by object '
+                                    . $existingSlug->getObjectId() . ', fieldname: ' . $existingSlug->getFieldname());
                             }
                         }
 

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -1826,7 +1826,7 @@ class Service extends Model\Element\Service
                             );
                         }
                     }
-                //key value store - ignore for now
+                    //key value store - ignore for now
                 } elseif (count($fieldParts) > 1) {
                     // brick
                     $brickType = $fieldParts[0];

--- a/models/Document/Editable/Area.php
+++ b/models/Document/Editable/Area.php
@@ -240,7 +240,7 @@ class Area extends Model\Document\Editable
      *
      *
      */
-    public function getElement(string $name): Model\Document\Editable
+    public function getElement(string $name): ?Model\Document\Editable
     {
         $document = $this->getDocument();
         $parentBlockNames = $this->getParentBlockNames();


### PR DESCRIPTION
[bugfix] Stronger typing of int in Config::setQuality clashes when config is read from request where everything is an array of string. Therefore this added cast to int before calling setQuality.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.1`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.1` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info
