### PR TITLE
Fix Permission wipe after "login as this user in a different browser" / user token

### DIFF
--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -128,6 +128,8 @@ class Authentication
         }
 
         if (self::isValidUser($user)) {
+            $user = User::getById($user->getId());
+
             // expiring the token
             $user->setPasswordRecoveryToken(null);
             $user->save();


### PR DESCRIPTION
Situation:
Create / edit a user.
Now change the user workspaces ( Assets / Documents / Data Objects)
Save the changes and log into the account using the "Login as this user in a different browser" button.
After you have logged in, the "Workspaces" have been reset and the user has lost their rights.

Expected Behaviour:
The user should keep the workspaces after logging in

Fix:
The user who comes back with tokenDecrypt does not get the values set, so you then get the complete user via the UserID