### PR TITLE
Fix values in shown fields in relations

### DIFF
--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -432,11 +432,12 @@ class Service extends Model\Element\Service
                                     }
                                 }
                             } else {
+                                $inheritanceBackup = AbstractObject::getGetInheritedValues();
                                 AbstractObject::setGetInheritedValues(true);
 
-                                $data[$dataKey] = $object->get($key, $user->getLanguage());
+                                $data[$dataKey] = $object->get($key, $user?->getLanguage());
 
-                                AbstractObject::setGetInheritedValues(false);
+                                AbstractObject::setGetInheritedValues($inheritanceBackup);
                             }
                         }
                     }

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -432,7 +432,11 @@ class Service extends Model\Element\Service
                                     }
                                 }
                             } else {
-                                $data[$dataKey] = $valueObject->value;
+                                AbstractObject::setGetInheritedValues(true);
+
+                                $data[$dataKey] = $object->get($key, $user->getLanguage());
+
+                                AbstractObject::setGetInheritedValues(false);
                             }
                         }
                     }


### PR DESCRIPTION
Situation:
Create a many to many object relationship under a localised field. Then set the visible fields there.
You will see that these fields are not filled in the "Preview". 

Expected Behaviour:
In the Relation & Grid View, the values should be displayed for the configured fields

Fix:
Use the getter function and access the field directly, allow the use of inherited values so that this also works correctly in the grid view