### PR TITLE
fix(type): allow null for getElementById

### DIFF
--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -200,7 +200,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
     /**
      * Static helper to get an object by the passed ID
      */
-    public static function getById(int|string $id, array $params = []): ?static
+    public static function getById(int|string|null $id, array $params = []): ?static
     {
         if (is_string($id)) {
             trigger_deprecation(

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -444,7 +444,7 @@ class Service extends Model\AbstractModel
         };
     }
 
-    public static function getElementById(string $type, int|string $id, array $params = []): Asset|Document|AbstractObject|null
+    public static function getElementById(string $type, int|string|null $id, array $params = []): Asset|Document|AbstractObject|null
     {
         if (is_string($id)) {
             trigger_deprecation(


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.1`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.1` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

When an Image is deleted, but still connected with an Object the ID can be null. 
In this Pull Request null is added as possible type to resolve this issue.

## Additional info
