### PR TITLE
fix mysql reserved keywords error by quoting property name

### DIFF
--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -1037,7 +1037,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
     {
         $propertyName = lcfirst(preg_replace('/^getBy/i', '', $method));
 
-        $db = \Pimcore\Db::get();
+        $db = Db::get();
 
         if (in_array(strtolower($propertyName), self::$objectColumns)) {
             $value = array_key_exists(0, $arguments) ? $arguments[0] : throw new \InvalidArgumentException('Mandatory argument $value not set.');
@@ -1045,7 +1045,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
             $offset = $arguments[2] ?? 0;
             $objectTypes = $arguments[3] ?? null;
 
-            $defaultCondition = $propertyName.' = '.Db::get()->quote($value).' ';
+            $defaultCondition = $db->quoteIdentifier($propertyName) . ' = ' . $db->quote($value) . ' ';
 
             $listConfig = [
                 'condition' => $defaultCondition,


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.1`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.1` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves mysql error when running static getBy methods on objects when property name is a mysql reserved keyword (for example: getByKey)

## Additional info

Call ::getByKey($key) on an pimcore object class. Fails with mysql error for unquoted column name key