### PR TITLE
Drop foreign key constraint with o_ prefix if it exists and re-create it

### DIFF
--- a/bundles/CoreBundle/src/Migrations/Version20230616085142.php
+++ b/bundles/CoreBundle/src/Migrations/Version20230616085142.php
@@ -25,6 +25,7 @@ final class Version20230616085142 extends AbstractMigration
 {
     private const ID_COLUMN = 'id';
 
+    private const O_PREFIX = 'o_';
     private const PK_COLUMNS = '`' . self::ID_COLUMN .
     '`,`dest_id`, `type`, `fieldname`, `column`, `ownertype`, `ownername`, `position`, `index`';
 
@@ -51,10 +52,13 @@ final class Version20230616085142 extends AbstractMigration
             $tableName = current($table);
             $metaDataTable = $schema->getTable($tableName);
             $foreignKeyName = AbstractDao::getForeignKeyName($tableName, self::ID_COLUMN);
+            $foreignKeyNameWithOPrefix = AbstractDao::getForeignKeyName($tableName, self::O_PREFIX . self::ID_COLUMN);
 
             if (!$metaDataTable->hasColumn(self::AUTO_ID)) {
                 if ($recreateForeignKey = $metaDataTable->hasForeignKey($foreignKeyName)) {
                     $this->addSql('ALTER TABLE `' . $tableName . '` DROP FOREIGN KEY `' . $foreignKeyName . '`');
+                } elseif ($recreateForeignKey = $metaDataTable->hasForeignKey($foreignKeyNameWithOPrefix)) {
+                    $this->addSql('ALTER TABLE `' . $tableName . '` DROP FOREIGN KEY `' . $foreignKeyNameWithOPrefix . '`');
                 }
 
                 if ($metaDataTable->hasPrimaryKey()) {


### PR DESCRIPTION
Ensures that the foreign key constraint on `object_metadata_%` tables are also renamed and updated properly when upgrading from Pimcore 10.6 to 11.1.5

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.1`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.1` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #16620

## Additional info
