### PR TITLE
[bugfix] Duplicate key exception during install

### DIFF
--- a/bundles/SeoBundle/src/Installer.php
+++ b/bundles/SeoBundle/src/Installer.php
@@ -47,10 +47,13 @@ class Installer extends SettingsStoreAwareInstaller
         $db = \Pimcore\Db::get();
 
         foreach (self::USER_PERMISSIONS as $permission) {
-            $db->insert('users_permission_definitions', [
-                $db->quoteIdentifier('key') => $permission,
-                $db->quoteIdentifier('category') => self::USER_PERMISSIONS_CATEGORY,
-            ]);
+            $permissionExists = $db->fetchOne('SELECT count(*) FROM users_permission_definitions');
+            if (!$permissionExists) {
+                $db->insert('users_permission_definitions', [
+                    $db->quoteIdentifier('key') => $permission,
+                    $db->quoteIdentifier('category') => self::USER_PERMISSIONS_CATEGORY,
+                ]);
+            }
         }
     }
 


### PR DESCRIPTION
During install of Pimcore 11 SeoBundle I got duplicate key exception for "robots.txt". 
This fix checks if the key it want's to add exists and skip the insert if so.
