### PR TITLE
DocumentRenderer: setCurrentSite to generate correct path of document in static page generator

### DIFF
--- a/lib/Document/Renderer/DocumentRenderer.php
+++ b/lib/Document/Renderer/DocumentRenderer.php
@@ -22,6 +22,7 @@ use Pimcore\Event\Model\DocumentEvent;
 use Pimcore\Http\RequestHelper;
 use Pimcore\Localization\LocaleServiceInterface;
 use Pimcore\Model\Document;
+use Pimcore\Model\Site;
 use Pimcore\Routing\Dynamic\DocumentRouteHandler;
 use Pimcore\Templating\Renderer\ActionRenderer;
 use Pimcore\Tool;
@@ -92,6 +93,7 @@ class DocumentRenderer implements DocumentRendererInterface
 
             $host = null;
             if($site = Frontend::getSiteForDocument($document)) {
+                Site::setCurrentSite($site);
                 $host = $site->getMainDomain();
             } elseif($systemMainDomain = Tool::getHostname()) {
                 $host = $systemMainDomain;


### PR DESCRIPTION
## Problem
Static page generation via cli does not consider current site, what causes wrong link generation of documents in the generated static files.

### Expected behavior
When using sites in pimcore, the static page files contains correct generated links by `pimcore_link`etc., like `/en/products`.

### Actual behavior
When running `bin/console pimcore:maintenance --job=documents_static_page_generate` or `bin/console pimcore:documents:generate-static-pages` static page files are generated with links like `/my-site/en/products` instead of `/en/products`

## Changes in this pull request 
Set current site in DocumentRenderer, if site was found, to ensure correct link generation