### PR TITLE
Fix: ApplicationLogger Bundle logs not stored in UTC

### DIFF
--- a/bundles/ApplicationLoggerBundle/src/Handler/ApplicationLoggerDb.php
+++ b/bundles/ApplicationLoggerBundle/src/Handler/ApplicationLoggerDb.php
@@ -42,7 +42,7 @@ class ApplicationLoggerDb extends AbstractProcessingHandler
             'pid' => getmypid(),
             'priority' => $record->level->toPsrLogLevel(),
             'message' => $record->message,
-            'timestamp' => $record->datetime->format('Y-m-d H:i:s'),
+            'timestamp' => $record->datetime->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s'),
             'component' => $record->context['component'] ?? $record->channel,
             'fileobject' => $record->context['fileObject'] ?? null,
             'relatedobject' => $record->context['relatedObject'] ?? null,


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/16667