### PR TITLE
adds class to a tag tinymce

### DIFF
--- a/bundles/TinymceBundle/public/js/editor.js
+++ b/bundles/TinymceBundle/public/js/editor.js
@@ -96,7 +96,7 @@ pimcore.bundle.tinymce.editor = Class.create({
             base_url: '/bundles/pimcoretinymce/build/tinymce',
             suffix: '.min',
             convert_urls: false,
-            extended_valid_elements: 'a[name|href|target|title|pimcore_id|pimcore_type],img[style|longdesc|usemap|src|border|alt=|title|hspace|vspace|width|height|align|pimcore_id|pimcore_type]',
+            extended_valid_elements: 'a[class|name|href|target|title|pimcore_id|pimcore_type],img[style|longdesc|usemap|src|border|alt=|title|hspace|vspace|width|height|align|pimcore_id|pimcore_type]',
             init_instance_callback: function (editor) {
                 editor.on('input', function (eChange) {
                     const charCount = tinymce.activeEditor.plugins.wordcount.body.getCharacterCount();

--- a/bundles/TinymceBundle/public/js/editor.js
+++ b/bundles/TinymceBundle/public/js/editor.js
@@ -96,7 +96,7 @@ pimcore.bundle.tinymce.editor = Class.create({
             base_url: '/bundles/pimcoretinymce/build/tinymce',
             suffix: '.min',
             convert_urls: false,
-            extended_valid_elements: 'a[class|name|href|target|title|pimcore_id|pimcore_type],img[style|longdesc|usemap|src|border|alt=|title|hspace|vspace|width|height|align|pimcore_id|pimcore_type]',
+            extended_valid_elements: 'a[class|name|href|target|title|pimcore_id|pimcore_type],img[class|style|longdesc|usemap|src|border|alt=|title|hspace|vspace|width|height|align|pimcore_id|pimcore_type]',
             init_instance_callback: function (editor) {
                 editor.on('input', function (eChange) {
                     const charCount = tinymce.activeEditor.plugins.wordcount.body.getCharacterCount();


### PR DESCRIPTION
adds class to Anchor tag tinymce

Before this pull request, if you save the content in WSYWIG, it would remove the class in the <a> tag. This pull request adds functionality to TinyMCE for assigning a specific class to anchor tags (<a>)