### PR TITLE
Fix height and width in localized fields

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -32,6 +32,8 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
 {
     use Layout\Traits\LabelTrait;
     use DataObject\Traits\ClassSavedTrait;
+    use DataObject\Traits\DataWidthTrait;
+    use DataObject\Traits\DataHeightTrait;
     use DataObject\Traits\FieldDefinitionEnrichmentDataTrait;
 
     /**


### PR DESCRIPTION
## Situation:
- Add a Localized Field in a class definition
- Set the height and width of the localized field
- Save the class definition
- Open the class definition
- Height and width of the localized field is no longer set

## Expected Behavior:
That the height and width remain set in the localized field and work in the interface.

## Fix:
Add the two traits for height and width.