### PR TITLE
Fix database error when filtering in localized field in the object search

### DIFF
--- a/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
+++ b/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
@@ -146,7 +146,8 @@ class SearchController extends UserAwareController
 
                 if (
                     isset($class->getFieldDefinitions()['localizedfields'])
-                    && $class->getFieldDefinitions()['localizedfields']->getFieldDefinition($paramConditionObject['property'])
+                    && method_exists($class->getFieldDefinitions()['localizedfields'], 'getFieldDefinition')
+                    && ($class->getFieldDefinitions()['localizedfields'])->getFieldDefinition($paramConditionObject['property'])
                 ) {
                     $localizedFieldsFilters[] = $paramConditionObject;
                     continue;

--- a/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
+++ b/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
@@ -143,7 +143,11 @@ class SearchController extends UserAwareController
                 //this loop divides filter parameters to localized and unlocalized groups
                 $definitionExists = in_array($paramConditionObject['property'], DataObject\Service::getSystemFields())
                     || $class->getFieldDefinition($paramConditionObject['property']);
-                if ($definitionExists) { //TODO: for sure, we can add additional condition like getLocalizedFieldDefinition()->getFieldDefiniton(...
+
+                if (
+                    $definitionExists
+                    && !$class->getFieldDefinitions()['localizedfields']->getFieldDefinition($paramConditionObject['property'])
+                ) {
                     $unlocalizedFieldsFilters[] = $paramConditionObject;
                 } else {
                     $localizedFieldsFilters[] = $paramConditionObject;

--- a/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
+++ b/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
@@ -145,12 +145,15 @@ class SearchController extends UserAwareController
                     || $class->getFieldDefinition($paramConditionObject['property']);
 
                 if (
-                    $definitionExists
-                    && !$class->getFieldDefinitions()['localizedfields']->getFieldDefinition($paramConditionObject['property'])
+                    isset($class->getFieldDefinitions()['localizedfields'])
+                    && $class->getFieldDefinitions()['localizedfields']->getFieldDefinition($paramConditionObject['property'])
                 ) {
-                    $unlocalizedFieldsFilters[] = $paramConditionObject;
-                } else {
                     $localizedFieldsFilters[] = $paramConditionObject;
+                    continue;
+                }
+
+                if ($definitionExists) {
+                    $unlocalizedFieldsFilters[] = $paramConditionObject;
                 }
             }
 


### PR DESCRIPTION
## Situation:
- Open an "Event" object in the demo.
- Go to the "Cars" tab and start the search in the "Cars" relation.
- Activate the filtering in the "Name" column.
- An error message appears in the database.

## Expected Behavior:
It should be possible to filter in the localized fields in the search as usual.

## Fix:
In which we check whether this field is contained in the Localizedfields Field Definition.