### PR TITLE
[Bug]: getByKey for DataObjects results in invalid SQL query

### DIFF
--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -1045,7 +1045,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
             $offset = $arguments[2] ?? 0;
             $objectTypes = $arguments[3] ?? null;
 
-            $defaultCondition = $db->quoteIdentifier($propertyName).' = '.Db::get()->quote($value).' ';
+            $defaultCondition = $db->quoteIdentifier($propertyName).' = '.$db->quote($value).' ';
 
             $listConfig = [
                 'condition' => $defaultCondition,

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -1045,7 +1045,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
             $offset = $arguments[2] ?? 0;
             $objectTypes = $arguments[3] ?? null;
 
-            $defaultCondition = $propertyName.' = '.Db::get()->quote($value).' ';
+            $defaultCondition = $db->quoteIdentifier($propertyName).' = '.Db::get()->quote($value).' ';
 
             $listConfig = [
                 'condition' => $defaultCondition,


### PR DESCRIPTION
## Issue
After upgrade from Pimcore 10 (was 10.6.9) to Pimcore 11 (11.1.5) all calls of `<objectclass>::getByKey(<key>)` result in SQL Exception 1064:
`Doctrine\\DBAL\\Exception\\SyntaxErrorException(code: 1064): An exception occurred while executing a query: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'key = '<key>'  AND  objects.type IN ('variant','object')`

## Root cause
The reason for that seems to be the change of removing the 'o_' prefix of the columns in the `objects` table. This means that for the `key` property the column name changed for `o_key` to `key` and this is a reserved word (at least in MariaDB version I use). The problem occurs in `AbstractObject::__callStatic` where the handling of the object columns is implemented (see https://github.com/pimcore/pimcore/pull/10712). Other object columns in the generated SQL query are prefixed with column name (e.g `objects.id` and `objects.type`)

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.1`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.1` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Analog to the object columns mentioned above I added the table name prefix also to the property of the default condition. 

## Additional info
Although getByKey is not used e.g. in demo to reproduce the error you can easily test with Folder object with following test command:
```
<?php
namespace App\Command;

use Pimcore\Console\AbstractCommand;
use Symfony\Component\Console\Attribute\AsCommand;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;

#[AsCommand(
    name: 'app:test',
    description: 'test command'
)]
        
class TestCommand  extends AbstractCommand
{
    protected function execute(InputInterface $input, OutputInterface $output): int
    {
        $list = \Pimcore\Model\DataObject\Folder::getByKey('test');
        foreach ($list as $element)
        {
            $output->writeln('folder ' . $element->getId());
        }
        return 0;
    }
}
```
