### PR TITLE
fix: improved diff calculation for suggestion of the right image dime…

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -410,7 +410,7 @@ class Asset extends Element\AbstractElement
             if ($imagePixels > $maxPixels) {
                 Logger::error("Image to be created {$localPath} (temp. path) exceeds max pixel size of {$maxPixels}, you can change the value in config pimcore.assets.image.max_pixels");
 
-                $diff = sqrt(1 + ($maxPixels / $imagePixels));
+                $diff = sqrt(1 + $imagePixels / $maxPixels);
                 $suggestion_0 = (int)round($size[0] / $diff, -2, PHP_ROUND_HALF_DOWN);
                 $suggestion_1 = (int)round($size[1] / $diff, -2, PHP_ROUND_HALF_DOWN);
 


### PR DESCRIPTION
Resolves/Improves wrong calculation of suggested image dimensions on asset upload error overlay.

Problem:
for a e.g. 8192*4951px image and a pimcore.assets.image.maxpixels=2073600 (which is 1920*1080px) combination a Suggestion of 4000*8000px was displayed.

see:

![image](https://github.com/pimcore/pimcore/assets/72381611/14e09937-e217-458f-a69d-8eb2f2ab810e)
