### PR TITLE
Fix: Thumbnails generation with frame=true throw exception, if GD image adapter in use

### DIFF
--- a/lib/Image/Adapter/GD.php
+++ b/lib/Image/Adapter/GD.php
@@ -188,8 +188,8 @@ class GD extends Adapter
 
         $this->contain($width, $height, $forceResize);
 
-        $x = ($width - $this->getWidth()) / 2;
-        $y = ($height - $this->getHeight()) / 2;
+        $x = (int)(($width - $this->getWidth()) / 2);
+        $y = (int)(($height - $this->getHeight()) / 2);
 
         $newImage = $this->createImage($width, $height);
         imagecopy($newImage, $this->resource, $x, $y, 0, 0, $this->getWidth(), $this->getHeight());


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/16693