### PR TITLE
[Task]: Follow up 16652

### DIFF
--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -129,6 +129,7 @@ class Bootstrap
 
     public static function defineConstants(): void
     {
+        $_SERVER += $_ENV;
         // load custom constants
         $customConstantsFile = PIMCORE_PROJECT_ROOT . '/config/pimcore/constants.php';
         if (file_exists($customConstantsFile)) {


### PR DESCRIPTION
When dotenv wasn't used (for example in tests) there was an appending

https://github.com/pimcore/pimcore/pull/16652/files#diff-ae4fd3053efaec0fe50cc39c28378027e8884af72d1facbb19980ade26f36220L127

Draft: Maybe not the right fix yet