### PR TITLE
Fix invalid authenticate token

### DIFF
--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -119,11 +119,9 @@ class Authentication
 
     public static function authenticateToken(string $token, bool $adminRequired = false): ?User
     {
-        $timestamp = null;
-
         try {
             [$timestamp, $user] = self::tokenDecrypt($token);
-        } catch (CryptoException $e) {
+        } catch (CryptoException|NotFoundException) {
             return null;
         }
 


### PR DESCRIPTION
## Steps to reproduce

1. Invite a new admin user
2. The user click on the link in the email
3. The user close the browser and want to click the link again

=> Error 500 instead of login with error message.