### PR TITLE
[Task]: Swap order between install bundles and install classes

### DIFF
--- a/bundles/InstallBundle/src/Installer.php
+++ b/bundles/InstallBundle/src/Installer.php
@@ -442,13 +442,13 @@ class Installer
         $this->dispatchStepEvent('install_assets');
         $this->installAssets($kernel);
 
-        $this->dispatchStepEvent('install_classes');
-        $this->installClasses();
-
         if (!empty($this->bundlesToInstall)) {
             $this->dispatchStepEvent('install_bundles');
             $this->installBundles();
         }
+        
+        $this->dispatchStepEvent('install_classes');
+        $this->installClasses();
 
         $this->dispatchStepEvent('migrations');
         $this->markMigrationsAsDone();


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/demo/issues/566

## Additional info
It seems that some classes may require some bundle being installed first, like PersonalizationBundle
By swapping the order, it should be able to automatize the process and avoid to manually do as 
https://github.com/pimcore/demo/issues/566#issuecomment-1931889028