### PR TITLE
Installer: use a fixed build dir, do not use the one from `MicroKernelTrait`

### DIFF
--- a/bundles/InstallBundle/src/InstallerKernel.php
+++ b/bundles/InstallBundle/src/InstallerKernel.php
@@ -56,6 +56,11 @@ class InstallerKernel extends Kernel
         return $this->projectRoot . '/var/installer/cache';
     }
 
+    public function getBuildDir(): string
+    {
+        return $this->projectRoot . '/var/installer/build';
+    }
+
     public function registerBundles(): array
     {
         $bundles = [


### PR DESCRIPTION
When using `getBuildDir()` from `MicroKernelTrait` it uses the `APP_BUILD_DIR` env variable if set. 
But the installer should be completely isolated from the normal `App\Kernel`, same as with `getCacheDir()`. To be consistent we need to use a fixed  `getBuildDir()` as well in order to avoid confusion. 