### PR TITLE
Installer: consistent log directory in /var/installer/log

### DIFF
--- a/bundles/InstallBundle/src/Command/InstallCommand.php
+++ b/bundles/InstallBundle/src/Command/InstallCommand.php
@@ -373,7 +373,7 @@ class InstallCommand extends Command
         }
 
         $this->io->writeln(sprintf(
-            'Running installation. You can find a detailed install log in <comment>var/log/%s.log</comment>',
+            'Running installation. You can find a detailed install log in <comment>var/installer/log/%s.log</comment>',
             $this->getApplication()->getKernel()->getEnvironment()
         ));
 

--- a/bundles/InstallBundle/src/InstallerKernel.php
+++ b/bundles/InstallBundle/src/InstallerKernel.php
@@ -48,7 +48,7 @@ class InstallerKernel extends Kernel
 
     public function getLogDir(): string
     {
-        return $this->projectRoot . '/var/log';
+        return $this->projectRoot . '/var/installer/log';
     }
 
     public function getCacheDir(): string


### PR DESCRIPTION
Log dir should be in consistent location, together with cache and build files