### PR TITLE
 [Bug, EC]: Fix Sorter of classification store group collection

### DIFF
--- a/models/DataObject/Classificationstore/Dao.php
+++ b/models/DataObject/Classificationstore/Dao.php
@@ -16,6 +16,7 @@
 namespace Pimcore\Model\DataObject\Classificationstore;
 
 use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
 use Pimcore\Db\Helper;
 use Pimcore\Element\MarshallerService;
 use Pimcore\Logger;
@@ -151,6 +152,11 @@ class Dao extends Model\Dao\AbstractDao
             }
         }
 
+        $type = Connection::PARAM_INT_ARRAY;
+        if (class_exists('Doctrine\\DBAL\\ArrayParameterType')) {
+            $type = ArrayParameterType::INTEGER;
+        }
+
         // Delete the groups that are not found anymore
         $this->db->executeQuery(
             sprintf(
@@ -164,7 +170,7 @@ class Dao extends Model\Dao\AbstractDao
                 $this->db->quoteIdentifier('groupId')
             ),
             [array_unique($groupsToKeep), $groupsWithCollectionToKeep],
-            [ArrayParameterType::INTEGER, ArrayParameterType::INTEGER]
+            [$type,$type]
         );
 
         // Delete the collections that are not found anymore
@@ -179,7 +185,7 @@ class Dao extends Model\Dao\AbstractDao
                 $this->db->quoteIdentifier('collectionId'),
             ),
             [array_unique($collectionToKeep)],
-            [ArrayParameterType::INTEGER]
+            [$type]
         );
 
         // Delete the system rows that are not needed anymore as the ones with real value and keyId is filled


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.1`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.1` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/16723

## Additional info
When adding a group collection and save without any data in any of the fields,  there would de no record in `object_classification_store_xyz` due to `$items` being empty https://github.com/pimcore/pimcore/blob/cbc427c6b615e9dd1e9cbec31e878dec37de91ac/models/DataObject/Classificationstore/Dao.php#L89 won't perform any upsert https://github.com/pimcore/pimcore/blob/cbc427c6b615e9dd1e9cbec31e878dec37de91ac/models/DataObject/Classificationstore/Dao.php#L132 causing later on to lose the information that these groups belong to a collection (since it's not stored anywhere else other than [here](https://github.com/pimcore/pimcore/blob/4da5b84117965399f87d6151b765f25cddb01a6c/models/DataObject/Classificationstore/Dao.php#L101)).

WIth this PR, instead of first removing everything and upsert later, it's inverted, first upsert and keep the info needed and then delete the rest. 
Another change is that table `object_classification_store_xyz` would store empty placeholder rows with type as `<system>` that get removed(with $systemRowToDelete, not replace because couldn't find keyId to pass and it's used in the primary key) once the real data is filled.


## Tips for reviewers
With demo dump, go to classification store, get `ProductAttributes` first Collections name `Size`, add a `Sorter` value of `100` to `Dimensions`. As long as it appears as second group on save/load, then it's working.
Keep an eye on the `object_classification_store_xyz` table on each save before and after PR.

## Draft
Need to double-check inheritance (seems fine so far) and if there are any deadlocks or any performance degradation by choosing this approach. One downside is that would be filled by empty `<system>` placeholder mentioned above but seems the only way to remember which collection these groups belong to.

## Doubt
Another issue if one delete one group (x icon on object editmode) after importing the group collection, does it means that the remaining groups should be now seen as independent (remove the collectionId from them)? At the moment, it somehow re-adds in editmode, maybe need a follow-up or fix for this.

## Alternatives
Probably adding a column to `object_classificationstore_groups_xyz` would also work, but then would need more refactoring, as currently seem working all around the column in `object_classification_store_xyz`