### PR TITLE
Use spaces consistently in the installer

### DIFF
--- a/bundles/InstallBundle/src/Installer.php
+++ b/bundles/InstallBundle/src/Installer.php
@@ -147,9 +147,9 @@ class Installer
         'boot_kernel' => 'Booting new kernel...',
         'setup_database' => 'Running database setup...',
         'install_assets' => 'Installing assets...',
-        'install_classes' => 'Installing classes ...',
-        'install_bundles' => 'Installing bundles ...',
-        'migrations' => 'Marking all migrations as done ...',
+        'install_classes' => 'Installing classes...',
+        'install_bundles' => 'Installing bundles...',
+        'migrations' => 'Marking all migrations as done...',
         'complete' => 'Install complete!',
     ];
 


### PR DESCRIPTION
I was a bit triggered when seeing this:

```
        W: Running database setup...
        W: 
        W:   6/11 [===============>------------]  54%
        W: 
        W: Installing assets...
        W: 
        W:   7/11 [=================>----------]  63%
        W: 
        W: Installing classes ...
        W: 
        W:   8/11 [====================>-------]  72%
```

Maybe it's just me, but it looks simple enough to fix!

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.2`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.2` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info
