### PR TITLE
fix(AbstractObject): ModificationDate could be null at this point

### DIFF
--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -241,7 +241,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
                     $object = self::getModelFactory()->build($className);
                     RuntimeCache::set($cacheKey, $object);
                     $object->getDao()->getById($id);
-                    $object->__setDataVersionTimestamp($object->getModificationDate());
+                    $object->__setDataVersionTimestamp($object->getModificationDate() ?? 0);
 
                     Service::recursiveResetDirtyMap($object);
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves TypeError

## Additional info
If an object is loaded via getById and the modificationDate is "null", the error occurs.