### PR TITLE
Make `createOrUpdateUser()` and `insertDatabaseDump()` of `Pimcore\Bundle\InstallBundle\Installer` `protected` again

### DIFF
--- a/bundles/InstallBundle/src/Installer.php
+++ b/bundles/InstallBundle/src/Installer.php
@@ -733,7 +733,7 @@ class Installer
         return $files;
     }
 
-    private function createOrUpdateUser(Connection $db, array $config = []): void
+    protected function createOrUpdateUser(Connection $db, array $config = []): void
     {
         $defaultConfig = [
             'username' => 'admin',
@@ -759,7 +759,7 @@ class Installer
      *
      * @throws \Exception
      */
-    private function insertDatabaseDump(Connection $db, string $file): void
+    protected function insertDatabaseDump(Connection $db, string $file): void
     {
         $dumpFile = file_get_contents($file);
 


### PR DESCRIPTION
## Changes in this pull request  
The methods `createOrUpdateUser()` and `insertDatabaseDump()` of `Pimcore\Bundle\InstallBundle\Installer` were changed to `private` in #16730.

I kindly ask to make these methods (at least) `protected` again to be able to override them. 

## Additional info

I realize that the class is `@internal`, but we use it in our test setup to automatically install Pimcore in integration tests and have adjusted a few things.

I'll propose some of them as PR's soon, but they'll probably be considered as features, and I hope this PR will be merged as a bug fix for the next release.