### PR TITLE
DotEnv support BC layer - regression fix for #16652, follow up #16796

### DIFF
--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -104,7 +104,8 @@ class Bootstrap
             trigger_deprecation(
                 'pimcore/skeleton',
                 '11.2.0',
-                sprintf('For consistency purpose, it is recommended to use the autoload from Symfony Runtime. When using it, the line "Bootstrap::bootstrap();" in `public/index.php` should be moved just above "$kernel = Bootstrap::kernel();"', )
+                'For consistency purpose, it is recommended to use the autoload from Symfony Runtime. 
+                When using it, the line "Bootstrap::bootstrap();" in `public/index.php` should be moved just above "$kernel = Bootstrap::kernel();" and within the closure'
             );
             self::bootDotEnvVariables();
         }

--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -106,7 +106,7 @@ class Bootstrap
                 '11.2.0',
                 sprintf('For consistency purpose, it is recommended to use the autoload from Symfony Runtime. When using it, the line "Bootstrap::bootstrap();" in `public/index.php` should be moved just above "$kernel = Bootstrap::kernel();"', )
             );
-            self::prepareEnvVariables();
+            self::bootDotEnvVariables();
         }
 
         self::defineConstants();
@@ -126,16 +126,10 @@ class Bootstrap
     /**
      * @deprecated only for compatibility reasons, will be removed in Pimcore 12
      */
-    private static function prepareEnvVariables(): void
+    private static function bootDotEnvVariables(): void
     {
-        if(!isset($_SERVER['SYMFONY_DOTENV_VARS'])) {
-            if (class_exists('Symfony\Component\Dotenv\Dotenv')) {
-                (new Dotenv())->bootEnv(PIMCORE_PROJECT_ROOT . '/.env');
-            } else {
-                $_SERVER += $_ENV;
-            }
-
-            self::setTrustedProxies();
+        if (class_exists('Symfony\Component\Dotenv\Dotenv')) {
+            (new Dotenv())->bootEnv(PIMCORE_PROJECT_ROOT . '/.env');
         }
     }
 

--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -104,8 +104,9 @@ class Bootstrap
             trigger_deprecation(
                 'pimcore/skeleton',
                 '11.2.0',
-                sprintf('In `public/index.php` the "Bootstrap::bootstrap();" should be moved just above "$kernel = Bootstrap::kernel();"', )
+                sprintf('For consistency purpose, it is recommended to use the autoload from Symfony Runtime. When using it, the line "Bootstrap::bootstrap();" in `public/index.php` should be moved just above "$kernel = Bootstrap::kernel();"', )
             );
+            self::prepareEnvVariables();
         }
 
         self::defineConstants();
@@ -210,9 +211,6 @@ class Bootstrap
 
     public static function kernel(): Kernel|\App\Kernel|KernelInterface
     {
-        // this is for compatibility reasons, will be removed in Pimcore 12
-        self::prepareEnvVariables();
-
         $environment = Config::getEnvironment();
 
         $debug = (bool) ($_SERVER['APP_DEBUG'] ?? false);


### PR DESCRIPTION
## Changes in this pull request  
Plays around the fact that we may be **NOT** using `autoload_runtime`, if `bootstrap()` is called before the `setCurrentRequest`, supposing is on pimcore `11.2` [without the recommended index.php changes](https://github.com/pimcore/skeleton/blob/5377528a16bc3050a98f7d607b28a3dd2324fcb4/public/index.php#L22-L28) so we have the BC layer to make it work as it used to; if it's after `setCurrentRequest`, then it's likely using the runtime autoload and [within the closure](https://github.com/pimcore/skeleton/blob/041376c318479018e9a1e0f7fc15c0cc4b776576/public/index.php#L27-L29)


Also must not be `CLI` because in there, it always was like that and, of course, without dealing with any `Request` so it would be always `null` https://github.com/pimcore/pimcore/blob/ffc43e73a7fd0991234d1a780798e37bd152fca5/lib/Bootstrap.php#L48

