### PR TITLE
Fix: when table data is not saved as string.

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Table.php
+++ b/models/DataObject/ClassDefinition/Data/Table.php
@@ -413,7 +413,7 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
                 if (is_array($row)) {
                     foreach ($row as $cell) {
                         $html .= '<td>';
-                        $html .= htmlspecialchars((string)$cell ?? '', ENT_QUOTES, 'UTF-8');
+                        $html .= htmlspecialchars((string) $cell, ENT_QUOTES, 'UTF-8');
                         $html .= '</td>';
                     }
                 }

--- a/models/DataObject/ClassDefinition/Data/Table.php
+++ b/models/DataObject/ClassDefinition/Data/Table.php
@@ -413,7 +413,7 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
                 if (is_array($row)) {
                     foreach ($row as $cell) {
                         $html .= '<td>';
-                        $html .= htmlspecialchars($cell ?? '', ENT_QUOTES, 'UTF-8');
+                        $html .= htmlspecialchars((string)$cell ?? '', ENT_QUOTES, 'UTF-8');
                         $html .= '</td>';
                     }
                 }


### PR DESCRIPTION
htmlspecialchars needs the first argument to be string, if any version data has integer saved, it will fail in version preview

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.2`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.2` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info

![image](https://github.com/pimcore/pimcore/assets/10167719/917ce101-9356-4f17-8222-c41f2ff17e32)
