### PR TITLE
Avoid letting video thumbnail processor fail catastrophically

### DIFF
--- a/bundles/CoreBundle/src/Command/ThumbnailsVideoCommand.php
+++ b/bundles/CoreBundle/src/Command/ThumbnailsVideoCommand.php
@@ -141,7 +141,15 @@ class ThumbnailsVideoCommand extends AbstractCommand
 
         // initial delay
         $video = Asset\Video::getById($videoId);
-        $thumb = $video?->getThumbnail($thumbnail);
+
+        if (!$video instanceof Asset\Video) {
+            $message = 'video ['.$videoId.'] could not be found. Skipping ...';
+            Logger::error($message);
+
+            return;
+        }
+
+        $thumb = $video->getThumbnail($thumbnail);
         if ($thumb !== null && $thumb['status'] !== 'finished') {
             sleep(20);
         }
@@ -150,13 +158,6 @@ class ThumbnailsVideoCommand extends AbstractCommand
             \Pimcore::collectGarbage();
 
             $video = Asset\Video::getById($videoId);
-
-            if (!$video instanceof Asset\Video) {
-                $message = 'video ['.$videoId.'] could not be found. Skipping ...';
-                Logger::error($message);
-
-                break;
-            }
 
             $thumb = $video->getThumbnail($thumbnail);
 
@@ -176,7 +177,7 @@ class ThumbnailsVideoCommand extends AbstractCommand
                 sleep(5);
             } else {
                 // error
-                Logger::debug('video [' . $video->getId() . "] has status: ['" . $thumb['status'] . "'] -> skipping");
+                Logger::debug('video [' . $video->getId() . "] has status: ['" . $thumb['status'] . "'] -> skipping ...");
 
                 break;
             }

--- a/bundles/CoreBundle/src/Command/ThumbnailsVideoCommand.php
+++ b/bundles/CoreBundle/src/Command/ThumbnailsVideoCommand.php
@@ -176,7 +176,7 @@ class ThumbnailsVideoCommand extends AbstractCommand
                 sleep(5);
             } else {
                 // error
-                Logger::debug('video [' . $video->getId() . "] has status: ['" . $thumb['status'] ?? 'invalid status | thumb could not be loaded' . "'] -> skipping");
+                Logger::debug('video [' . $video->getId() . "] has status: ['" . $thumb['status'] . "'] -> skipping");
 
                 break;
             }

--- a/bundles/CoreBundle/src/Command/ThumbnailsVideoCommand.php
+++ b/bundles/CoreBundle/src/Command/ThumbnailsVideoCommand.php
@@ -141,8 +141,8 @@ class ThumbnailsVideoCommand extends AbstractCommand
 
         // initial delay
         $video = Asset\Video::getById($videoId);
-        $thumb = $video->getThumbnail($thumbnail);
-        if ($thumb['status'] != 'finished') {
+        $thumb = $video?->getThumbnail($thumbnail);
+        if ($thumb !== null && $thumb['status'] !== 'finished') {
             sleep(20);
         }
 
@@ -150,16 +150,33 @@ class ThumbnailsVideoCommand extends AbstractCommand
             \Pimcore::collectGarbage();
 
             $video = Asset\Video::getById($videoId);
+
+            if (!$video instanceof Asset\Video) {
+                $message = 'video ['.$videoId.'] could not be found. Skipping ...';
+                Logger::error($message);
+
+                break;
+            }
+
             $thumb = $video->getThumbnail($thumbnail);
-            if ($thumb['status'] == 'finished') {
+
+            if ($thumb === null) {
+                $message = 'video ['.$videoId.'] with thumbnail ['.(is_string($thumbnail) ? $thumbnail : $thumbnail->getName()).'] is invalid. Skipping ...';
+                Logger::error($message);
+                $this->output->writeln($message);
+
+                break;
+            }
+
+            if ($thumb['status'] === 'finished') {
                 $finished = true;
                 Logger::debug('video [' . $video->getId() . '] FINISHED');
-            } elseif ($thumb['status'] == 'inprogress') {
+            } elseif ($thumb['status'] === 'inprogress') {
                 Logger::debug('video [' . $video->getId() . '] in progress ...');
                 sleep(5);
             } else {
                 // error
-                Logger::debug('video [' . $video->getId() . "] has status: '" . $thumb['status'] . "' -> skipping");
+                Logger::debug('video [' . $video->getId() . "] has status: ['" . $thumb['status'] ?? 'invalid status | thumb could not be loaded' . "'] -> skipping");
 
                 break;
             }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.2`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.2` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  

In some circumstances the Thumbnail Definition of a Video File cannot be loaded. This will cause the whole process to abrot and not continue. This PR will fix this behaviour and simply Log the output and write it to the console output so if the process is ran manually you will get the output directly.

## Additional info
