### PR TITLE
Implemented pre-publish and pre-unpublish events

### DIFF
--- a/lib/Event/DataObjectEvents.php
+++ b/lib/Event/DataObjectEvents.php
@@ -161,4 +161,18 @@ final class DataObjectEvents
      * @var string
      */
     const POST_CSV_ITEM_EXPORT = 'pimcore.dataobject.postCsvItemExport';
+
+    /**
+     * @Event("Pimcore\Event\Model\DataObjectEvent")
+     *
+     * @var string
+     */
+    const PRE_PUBLISH = 'pimcore.dataobject.prePublish';
+
+    /**
+     * @Event("Pimcore\Event\Model\DataObjectEvent")
+     *
+     * @var string
+     */
+    const PRE_UNPUBLISH = 'pimcore.dataobject.preUnpublish';
 }

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -446,6 +446,8 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
      */
     public function setPublished(bool $published): static
     {
+        $this->markFieldDirty('published');
+
         $this->published = $published;
 
         return $this;
@@ -660,6 +662,11 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
         } elseif ($this->getClass()->getAllowInherit() && $this->isFieldDirty('parentId')) {
             // if inherit is enabled and the data object is moved the query table should be updated
             DataObject::disableDirtyDetection();
+        }
+
+        if ($this->isFieldDirty('published')) {
+            $event = $this->getPublished() ? DataObjectEvents::PRE_PUBLISH : DataObjectEvents::PRE_UNPUBLISH;
+            \Pimcore::getEventDispatcher()->dispatch(new DataObjectEvent($this), $event);
         }
 
         try {


### PR DESCRIPTION
## Changes in this pull request  

Adds two new events, `PRE_PUBLISH` and `PRE_UNPUBLISH` for Data-Objects, specifically only for `Concrete` DO's as only these have a published state.

