### PR TITLE
BlockElement memory usage improvements

### DIFF
--- a/models/DataObject/Data/BlockElement.php
+++ b/models/DataObject/Data/BlockElement.php
@@ -19,6 +19,7 @@ namespace Pimcore\Model\DataObject\Data;
 use DeepCopy\DeepCopy;
 use DeepCopy\Filter\SetNullFilter;
 use DeepCopy\Matcher\PropertyNameMatcher;
+use DeepCopy\Reflection\ReflectionHelper;
 use Pimcore\Cache\Core\CacheMarshallerInterface;
 use Pimcore\Cache\RuntimeCache;
 use Pimcore\Model\AbstractModel;
@@ -31,6 +32,7 @@ use Pimcore\Model\Element\ElementDumpStateInterface;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Element\Service;
 use Pimcore\Model\Version\SetDumpStateFilter;
+use ReflectionProperty;
 
 class BlockElement extends AbstractModel implements OwnerAwareFieldInterface, CacheMarshallerInterface
 {
@@ -140,6 +142,18 @@ class BlockElement extends AbstractModel implements OwnerAwareFieldInterface, Ca
              */
             public function matches($object, $property): bool
             {
+                $reflectionProperty = null;
+                if ($object instanceof Video) {
+                    $reflectionProperty = ReflectionHelper::getProperty($object, 'data');
+                }
+                if ($object instanceof Hotspotimage) {
+                    $reflectionProperty = ReflectionHelper::getProperty($object, 'image');
+                }
+
+                if ($reflectionProperty instanceof ReflectionProperty) {
+                    return $reflectionProperty->getValue($object) instanceof AbstractElement;
+                }
+
                 return $object instanceof AbstractElement;
             }
         });

--- a/models/DataObject/Data/BlockElement.php
+++ b/models/DataObject/Data/BlockElement.php
@@ -151,7 +151,7 @@ class BlockElement extends AbstractModel implements OwnerAwareFieldInterface, Ca
                 }
 
                 if ($reflectionProperty instanceof ReflectionProperty) {
-                    return $reflectionProperty->getValue($object) instanceof AbstractElement;
+                    return !($reflectionProperty->getValue($object) instanceof ElementDescriptor);
                 }
 
                 return $object instanceof AbstractElement;


### PR DESCRIPTION
This PR is a follow-up PR to #11917. It improves the memory usage of BlockElements when the image advanced or video data types are used. Depending on the number of BlockElements and involved assets we could still produce massive amounts of memory while deep-copying the objects.

With this fix we try to reduce the memory overhead.