### PR TITLE
Added dirty state for the published property of Concretes and Documents

### DIFF
--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -446,6 +446,7 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
      */
     public function setPublished(bool $published): static
     {
+        $this->markFieldDirty('published');
         $this->published = $published;
 
         return $this;

--- a/models/Document.php
+++ b/models/Document.php
@@ -920,6 +920,7 @@ class Document extends Element\AbstractElement
 
     public function setPublished(bool $published): static
     {
+        $this->markFieldDirty('published');
         $this->published = $published;
 
         return $this;


### PR DESCRIPTION
As a follow up to the discussion in https://github.com/pimcore/pimcore/pull/16828, the dirty state of Concretes and Documents is changed to dirty, when being set.
