### PR TITLE
[Bug]: Follow-up Gotenberg, remove extra headers

### DIFF
--- a/lib/Image/HtmlToImage.php
+++ b/lib/Image/HtmlToImage.php
@@ -109,7 +109,7 @@ class HtmlToImage
     /**
      * @throws \Exception
      */
-    public static function convertGotenberg(string $url, string $outputFile, ?string $sessionName = null, ?string $sessionId = null, string $windowSize = '1920,1024'): bool
+    public static function convertGotenberg(string $url, string $outputFile, ?string $sessionName = null, ?string $sessionId = null, string $windowSize = '1280,1024'): bool
     {
         try {
             /** @var GotenbergAPI|object $request */

--- a/lib/Image/HtmlToImage.php
+++ b/lib/Image/HtmlToImage.php
@@ -109,24 +109,14 @@ class HtmlToImage
     /**
      * @throws \Exception
      */
-    public static function convertGotenberg(string $url, string $outputFile, ?string $sessionName = null, ?string $sessionId = null, string $windowSize = '1280,1024'): bool
+    public static function convertGotenberg(string $url, string $outputFile, ?string $sessionName = null, ?string $sessionId = null, string $windowSize = '1920,1024'): bool
     {
         try {
-
-            $extraHeaders = [
-                'X-Foo' => 'Bar', // required, as extraHttpHeaders() requires at least one entry
-            ];
-
-            if (null !== $sessionId && null !== $sessionName) {
-                $extraHeaders['Cookie'] = $sessionName . '=' . $sessionId;
-            }
-
             /** @var GotenbergAPI|object $request */
             $request = GotenbergAPI::chromium(Config::getSystemConfiguration('gotenberg')['base_url']);
             if(method_exists($request, 'screenshot')) {
                 $urlResponse = $request->screenshot()
                     ->png()
-                    ->extraHttpHeaders($extraHeaders)
                     ->url($url);
 
                 $file = GotenbergAPI::save($urlResponse, PIMCORE_SYSTEM_TEMP_DIRECTORY);


### PR DESCRIPTION
## Changes in this pull request  
Resolves: https://github.com/pimcore/pimcore/issues/16858

It seems that with the extra headers, the external css files are not properly loaded.

Before PR:
![image](https://github.com/pimcore/pimcore/assets/6014195/67342cf7-7c86-4b55-a81c-d86e3e8c41ed)

After PR:
![image](https://github.com/pimcore/pimcore/assets/6014195/26c9da97-aa05-485f-a3eb-0cb1ca7ecaa1)

In this case, the bootstrap and google fonts were some not loaded.
