### PR TITLE
Feature/Improvement: Make wysiwyg dnd image get custom metadata

### DIFF
--- a/lib/Tool/Text.php
+++ b/lib/Tool/Text.php
@@ -134,9 +134,18 @@ class Text
                         if (!preg_match('/pimcore_disable_thumbnail="([^"]+)*"/', $oldTag)) {
                             if (!empty($config)) {
                                 $path = $element->getThumbnail($config);
+
+                                $imgTagWithCustomMetadata = $path->getImageTag();
+                                preg_match('/alt="([^"]*)"/', $imgTagWithCustomMetadata, $altMatches);
+                                preg_match('/title="([^"]*)"/', $imgTagWithCustomMetadata, $titleMatches);
+                                $alt = $altMatches[1] ?? '';
+                                $title = $titleMatches[1] ?? '';
+
                                 $pathHdpi = $element->getThumbnail(array_merge($config, ['highResolution' => 2]));
                                 $additionalAttributes = [
                                     'srcset' => $path . ' 1x, ' . $pathHdpi . ' 2x',
+                                    'alt' => $alt,
+                                    'title' => $title,
                                 ];
                             } elseif ($element->getWidth() > 2000 || $element->getHeight() > 2000) {
                                 // if the image is too large, size it down to 2000px this is the max. for wysiwyg


### PR DESCRIPTION
When dnd an Asset (Image) to the wysiwyg editor it doesn't get the alt and title tags.
This change adds alt and title attributes to the img-tag that the Thumbnail::getImageTag() builds from the custom metadata-fields.

(Feature improvements suggestion/discussion: Why not use the getImageTag() for all of this speciality code? Perhaps already in the editor.js calling a new function in AssetController that calls Thumbnail::getImageTag instead of returning a binary stream?)
