### PR TITLE
Fix WebsiteSetting::getById()

### DIFF
--- a/models/WebsiteSetting/Dao.php
+++ b/models/WebsiteSetting/Dao.php
@@ -17,16 +17,16 @@ namespace Pimcore\Model\WebsiteSetting;
 
 use Pimcore\Model;
 use Pimcore\Model\Exception\NotFoundException;
+use Pimcore\Model\WebsiteSetting;
 
 /**
  * @internal
  *
- * @property \Pimcore\Model\WebsiteSetting $model
+ * @property WebsiteSetting $model
  */
 class Dao extends Model\Dao\AbstractDao
 {
     /**
-     *
      * @throws NotFoundException
      */
     public function getById(int $id = null): void
@@ -36,9 +36,8 @@ class Dao extends Model\Dao\AbstractDao
         }
 
         $data = $this->db->fetchAssociative('SELECT * FROM website_settings WHERE id = ?', [$this->model->getId()]);
-        $this->assignVariablesToModel($data);
 
-        if (!empty($data['id'])) {
+        if ($data) {
             $this->assignVariablesToModel($data);
         } else {
             throw new NotFoundException('Website Setting with id: ' . $this->model->getId() . ' does not exist');
@@ -46,7 +45,6 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     *
      * @throws NotFoundException
      */
     public function getByName(string $name = null, int $siteId = null, string $language = null): void
@@ -72,7 +70,7 @@ class Dao extends Model\Dao\AbstractDao
             [$this->model->getName(), $siteId, $language]
         );
 
-        if (!empty($data['id'])) {
+        if ($data) {
             $this->assignVariablesToModel($data);
         } else {
             throw new NotFoundException('Website Setting with name: ' . $this->model->getName() . ' does not exist');


### PR DESCRIPTION
## Changes in this pull request  
Error when you try to load a non existing WebsiteSetting:
```
Pimcore\Model\Dao\AbstractDao::assignVariablesToModel(): Argument #1 ($data) must be of type array, bool given, called in /var/www/html/vendor/pimcore/pimcore/models/WebsiteSetting/Dao.php on line 39
```

But should return `null`.

TestCommand:
```
<?php

namespace App\Command;

use Pimcore\Console\AbstractCommand;
use Pimcore\Model\WebsiteSetting;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;

class TestCommand extends AbstractCommand
{
    protected function configure(): void
    {
        $this->setName('app:test');
    }

    protected function execute(InputInterface $input, OutputInterface $output): int
    {
        WebsiteSetting::getById(234);

        return 0;
    }
}
```