### PR TITLE
[Improvement] Prevent db errors on index updates on classes rebuild

### DIFF
--- a/models/DataObject/ClassDefinition/Helper/Dao.php
+++ b/models/DataObject/ClassDefinition/Helper/Dao.php
@@ -190,7 +190,7 @@ trait Dao
     protected function indexExists(string $table, string $prefix, mixed $columnName): bool
     {
         $exist = $this->db->fetchFirstColumn(
-            "SELECT COUNT(*) FROM information_schema.statistics WHERE table_name = '${table}' and index_name = '${prefix}${columnName}' and table_schema = database();"
+            "SELECT COUNT(*) FROM information_schema.statistics WHERE table_name = '${table}' AND index_name = '${prefix}${columnName}' AND table_schema = DATABASE();"
         );
 
         return \count($exist) > 0 && '1' === $exist[0];

--- a/models/DataObject/ClassDefinition/Helper/Dao.php
+++ b/models/DataObject/ClassDefinition/Helper/Dao.php
@@ -52,7 +52,7 @@ trait Dao
                                 $columnName .= ',`fieldname`';
                             }
                         }
-                        if ($this->indexDoesNotExist($table, $prefix, $columnName)) {
+                        if ($this->indexDoesNotExist($table, $prefix, $indexName)) {
                             $this->db->executeQuery('ALTER TABLE `' . $table . '` ADD ' . $uniqueStr . 'INDEX `' . $prefix . $indexName . '` (' . $columnName . ');');
                         }
                     }
@@ -67,7 +67,7 @@ trait Dao
                             $columnName .= ',`fieldname`';
                         }
                     }
-                    if ($this->indexDoesNotExist($table, $prefix, $columnName)) {
+                    if ($this->indexDoesNotExist($table, $prefix, $indexName)) {
                         $this->db->executeQuery('ALTER TABLE `' . $table . '` ADD ' . $uniqueStr . 'INDEX `' . $prefix . $indexName . '` (' . $columnName . ');');
                     }
                 }
@@ -176,7 +176,7 @@ trait Dao
         if ($columnsToRemove) {
             $lowerCaseColumns = array_map('strtolower', $protectedColumns);
             foreach ($columnsToRemove as $value) {
-                if (!in_array(strtolower($value), $lowerCaseColumns) && $this->indexExists($table, 'p_index_', $value)) {
+                if (!in_array(strtolower($value), $lowerCaseColumns) && $this->indexExists($table, 'u_index_', $value)) {
                     $this->db->executeQuery('ALTER TABLE `'.$table.'` DROP INDEX `u_index_'. $value . '`;');
                 }
             }
@@ -187,17 +187,17 @@ trait Dao
     /**
      * For MariaDB, it would be possible to use 'ADD/DROP INDEX IF EXISTS' but this is not supported by MySQL
      */
-    protected function indexExists(string $table, string $prefix, mixed $columnName): bool
+    protected function indexExists(string $table, string $prefix, mixed $indexName): bool
     {
         $exist = $this->db->fetchFirstColumn(
-            "SELECT COUNT(*) FROM information_schema.statistics WHERE table_name = '${table}' AND index_name = '${prefix}${columnName}' AND table_schema = DATABASE();"
+            "SELECT COUNT(*) FROM information_schema.statistics WHERE table_name = '${table}' AND index_name = '${prefix}${indexName}' AND table_schema = DATABASE();"
         );
 
         return \count($exist) > 0 && '1' === $exist[0];
     }
 
-    protected function indexDoesNotExist(string $table, string $prefix, mixed $columnName): bool
+    protected function indexDoesNotExist(string $table, string $prefix, mixed $indexName): bool
     {
-        return !$this->indexExists($table, $prefix, $columnName);
+        return !$this->indexExists($table, $prefix, $indexName);
     }
 }

--- a/models/DataObject/ClassDefinition/Helper/Dao.php
+++ b/models/DataObject/ClassDefinition/Helper/Dao.php
@@ -193,7 +193,7 @@ trait Dao
             "SELECT COUNT(*) FROM information_schema.statistics WHERE table_name = '${table}' AND index_name = '${prefix}${indexName}' AND table_schema = DATABASE();"
         );
 
-        return \count($exist) > 0 && '1' === $exist[0];
+        return (\count($exist) > 0) && (1 === $exist[0]);
     }
 
     protected function indexDoesNotExist(string $table, string $prefix, mixed $indexName): bool

--- a/models/DataObject/ClassDefinition/Helper/Dao.php
+++ b/models/DataObject/ClassDefinition/Helper/Dao.php
@@ -15,8 +15,6 @@
 
 namespace Pimcore\Model\DataObject\ClassDefinition\Helper;
 
-use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
-use Pimcore\Db\Helper;
 use Pimcore\Model\DataObject;
 
 /**

--- a/models/DataObject/ClassDefinition/Helper/Dao.php
+++ b/models/DataObject/ClassDefinition/Helper/Dao.php
@@ -75,16 +75,16 @@ trait Dao
                 if (is_array($columnType)) {
                     // multicolumn field
                     foreach ($columnType as $fkey => $fvalue) {
-                        $columnName = $field->getName().'__'.$fkey;
-                        if ($this->indexExists($table, $prefix, $columnName)) {
-                            $this->db->executeQuery('ALTER TABLE `' . $table . '` DROP INDEX `' . $prefix . $columnName . '`;');
+                        $indexName = $field->getName().'__'.$fkey;
+                        if ($this->indexExists($table, $prefix, $indexName)) {
+                            $this->db->executeQuery('ALTER TABLE `' . $table . '` DROP INDEX `' . $prefix . $indexName . '`;');
                         }
                     }
                 } else {
                     // single -column field
-                    $columnName = $field->getName();
-                    if ($this->indexExists($table, $prefix, $columnName)) {
-                        $this->db->executeQuery('ALTER TABLE `' . $table . '` DROP INDEX `' . $prefix . $columnName . '`;');
+                    $indexName = $field->getName();
+                    if ($this->indexExists($table, $prefix, $indexName)) {
+                        $this->db->executeQuery('ALTER TABLE `' . $table . '` DROP INDEX `' . $prefix . $indexName . '`;');
                     }
                 }
             }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #13195 

Long time ago, i stumbled upon the errors that MySQL based databases throw, when you try to add an index which is already there or to delete an index that is not there:

`An exception occurred while executing a query: SQLSTATE[42000]: Syntax error or access violation: 1091 Can't DROP INDEX 'p_index_name'; check that it exists`

Some explaining can also be found in the connected issue.

This PR add existence checks for those indexes. Advantage: Cleaner solution, Disadvatage: Slightly more time consuming. (See screenshots).

I did not find any good ways to write tests for that, so i tried that on local machine with the setup explained in the [System Requirements Docs](https://pimcore.com/docs/platform/Pimcore/Installation_and_Upgrade/System_Requirements#database-server). Tested with MySQL 8.3.0 and MariDB 10.11.5

## Additional info
I created a Pimcore class `car` with a name and a sku attribute. I updated the class via the Admin backend and looked in the profiler which db queries were executed. Both time without changing the class attributes at all.

Database queries without refactoring
![Bildschirmfoto vom 2024-03-28 09-46-18](https://github.com/pimcore/pimcore/assets/2377363/bf2bff0c-0b1e-439b-af69-0143511c001c)

Database queries with refactoring
![Bildschirmfoto vom 2024-03-28 13-06-32](https://github.com/pimcore/pimcore/assets/2377363/fbdfdd93-4a96-4801-81a1-5c1d15c3a35b)
