### PR TITLE
Fix: InputQuantityValue toString method now always returns a string instead of null

### DIFF
--- a/models/DataObject/Data/InputQuantityValue.php
+++ b/models/DataObject/Data/InputQuantityValue.php
@@ -50,6 +50,6 @@ class InputQuantityValue extends AbstractQuantityValue
             $value .= ' ' . $translator->trans($this->getUnit()->getAbbreviation(), [], 'admin');
         }
 
-        return $value ? (string)$value : '';
+        return $value ?? '';
     }
 }

--- a/models/DataObject/Data/InputQuantityValue.php
+++ b/models/DataObject/Data/InputQuantityValue.php
@@ -50,6 +50,6 @@ class InputQuantityValue extends AbstractQuantityValue
             $value .= ' ' . $translator->trans($this->getUnit()->getAbbreviation(), [], 'admin');
         }
 
-        return $value;
+        return $value ? (string)$value : '';
     }
 }


### PR DESCRIPTION
The toString method of the InputQuantityValue DataObject is defined to return a string but might return null if the value is null (since getValue has a return type of string|null). This pr fixes this by checking the returned value and returns an empty string instead of null if null is given.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.2`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.2` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves an error when the value of InputQuantityValue is null and the toString method is used.

## Additional info
