### PR TITLE
Fix Multiselect: Version Preview and Version Difference display fix

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Multiselect.php
+++ b/models/DataObject/ClassDefinition/Data/Multiselect.php
@@ -260,7 +260,7 @@ class Multiselect extends Data implements
     {
         if (is_array($data)) {
             return implode(',', array_map(function ($v) {
-                return htmlspecialchars($v, ENT_QUOTES, 'UTF-8');
+                return htmlspecialchars((string)$v, ENT_QUOTES, 'UTF-8');
             }, $data));
         }
 


### PR DESCRIPTION
Fix Version Preview and Version Difference display when the multiselect value is not true string.

<img width="1433" alt="image" src="https://github.com/pimcore/pimcore/assets/10167719/10da230f-478d-458a-8fd5-999fcaa87ae6">

This should be same as Select

<img width="1436" alt="image" src="https://github.com/pimcore/pimcore/assets/10167719/71997333-efaa-4d6f-86b3-addf24a5b6cb">


<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.2`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.2` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info
