### PR TITLE
Add twig function to get assigned element tags

### DIFF
--- a/doc/02_MVC/02_Template/README.md
+++ b/doc/02_MVC/02_Template/README.md
@@ -76,7 +76,7 @@ generates HTML as otherwise the HTML will be escaped by twig.
 
 ### Functions
 
-#### Loading Objects
+#### Loading elements
 
 The following functions can be used to load Pimcore elements from within a template:
 
@@ -87,6 +87,7 @@ The following functions can be used to load Pimcore elements from within a templ
 * `pimcore_asset_by_path`
 * `pimcore_object`
 * `pimcore_object_by_path`
+* `pimcore_user`
 
 ```twig
 {% set myObject = pimcore_object(123) %}
@@ -103,6 +104,16 @@ For documents, Pimcore also provides a function to handle hardlinks through the 
 See [PimcoreObjectExtension](https://github.com/pimcore/pimcore/blob/11.x/lib/Twig/Extension/PimcoreObjectExtension.php)
 for details.
 
+##### Element helper functions
+
+The following functions can be used to get specific data from Pimcore elements:
+
+| Function                                                                         | Description                                                                                                                       |
+|---------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `pimcore_object_classificationstore_group(id)`                                        | Get classification store group definition by id.                                                                                  |
+| `pimcore_object_classificationstore_get_field_definition_from_json(definition, type)` | Returns the classification store field definition from the given definition JSON, enabling structured access to field properties. |
+| `pimcore_object_brick_definition_key(key)`                                            | Get objectbrick definition by id.                                                                                                 |
+
 
 #### Subrequests
 
@@ -114,7 +125,7 @@ for details.
 See [Template Extensions](./02_Template_Extensions/README.md) for details.
 
 
-#### Templating Extensions
+#### Templating extensions
 
 The following extensions can directly be used on Twig. See [Template Extensions](./02_Template_Extensions/README.md) for a 
 detailed description of every helper:
@@ -154,7 +165,7 @@ Can be used to test if an object is an instance of a given class.
 {% endif %}
 ```
 
-####  Pimcore Specialities
+####  Pimcore specialities
 
 Pimcore provides a few special functionalities to make templates even more powerful. 
 These are explained in following sub chapters:

--- a/doc/02_MVC/02_Template/README.md
+++ b/doc/02_MVC/02_Template/README.md
@@ -108,11 +108,12 @@ for details.
 
 The following functions can be used to get specific data from Pimcore elements:
 
-| Function                                                                         | Description                                                                                                                       |
+| Function                                                                              | Description                                                                                                                       |
 |---------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | `pimcore_object_classificationstore_group(id)`                                        | Get classification store group definition by id.                                                                                  |
 | `pimcore_object_classificationstore_get_field_definition_from_json(definition, type)` | Returns the classification store field definition from the given definition JSON, enabling structured access to field properties. |
 | `pimcore_object_brick_definition_key(key)`                                            | Get objectbrick definition by id.                                                                                                 |
+| `pimcore_element_tags(element, asNameList)`                                           | Returns a list of assigned element tags. Use `true` as the second parameter to receive only the tag names.                        |
 
 
 #### Subrequests

--- a/lib/Twig/Extension/PimcoreObjectExtension.php
+++ b/lib/Twig/Extension/PimcoreObjectExtension.php
@@ -20,6 +20,8 @@ namespace Pimcore\Twig\Extension;
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\Document;
+use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\Tag;
 use Pimcore\Model\Site;
 use Pimcore\Model\User;
 use Twig\Extension\AbstractExtension;
@@ -50,6 +52,7 @@ class PimcoreObjectExtension extends AbstractExtension
             new TwigFunction('pimcore_object_classificationstore_group', [DataObject\Classificationstore\GroupConfig::class, 'getById']),
             new TwigFunction('pimcore_object_classificationstore_get_field_definition_from_json', [$this, 'getFieldDefinitionFromJson']),
             new TwigFunction('pimcore_object_brick_definition_key', [DataObject\Objectbrick\Definition::class, 'getByKey']),
+            new TwigFunction('pimcore_element_tags', [$this, 'getPimcoreElementTags']),
         ];
     }
 
@@ -60,5 +63,20 @@ class PimcoreObjectExtension extends AbstractExtension
         }
 
         return DataObject\Classificationstore\Service::getFieldDefinitionFromJson($definition, $type);
+    }
+
+    public function getPimcoreElementTags(?AbstractElement $element, bool $asNameList): array
+    {
+        if (!$element) {
+            return [];
+        }
+
+        if ($asNameList) {
+            return array_map(function ($tag) {
+                return $tag->getName();
+            }, Tag::getTagsForElement($element->getType(), $element->getId()));
+        }
+
+        return Tag::getTagsForElement($element->getType(), $element->getId());
     }
 }


### PR DESCRIPTION
I've implemented a blog on my website and desiceded to tag a blog post via pimcore tags.

When I tried to output the tags in my tempalte I was faced with a small problem. I didn't know any way to access them on twig side. Neither the documentation as well as the core code provided me with any existing solution.

In the Pimcore demo the "Event" object using a multiselect as tag-solution - but that's not an option for me...

I was wondering why there is no `getTags` method in `Pimcore\Model\Element\AbstractElement`. Is there a reason for this? The data can easily be loaded asynchronously, only when the getter is called, so there is no disadvantage. WDYT?

Because this is unclear to me, and I already implemented a solution that works without core editing - I decided to write a new Twig function and I want to share it here for discussion.

Personally, I prefer it if there would be a `getTags` method.