### PR TITLE
Fix property changes are not a recognised

### DIFF
--- a/models/Property.php
+++ b/models/Property.php
@@ -93,6 +93,13 @@ final class Property extends AbstractModel
         return $this;
     }
 
+    public function save(): void
+    {
+        $this->getDao()->save();
+
+        \Pimcore\Cache::remove($this->getCtype() . '_properties_' . $this->getCid());
+    }
+
     public function getCid(): ?int
     {
         return $this->cid;

--- a/models/Property/Dao.php
+++ b/models/Property/Dao.php
@@ -63,6 +63,5 @@ class Dao extends Model\Dao\AbstractDao
         ];
 
         Helper::upsert($this->db, 'properties', $saveData, $this->getPrimaryKey('properties'));
-        \Pimcore\Cache::remove($this->model->getCtype() . '_properties_' . $this->model->getCid());
     }
 }

--- a/models/Property/Dao.php
+++ b/models/Property/Dao.php
@@ -63,5 +63,6 @@ class Dao extends Model\Dao\AbstractDao
         ];
 
         Helper::upsert($this->db, 'properties', $saveData, $this->getPrimaryKey('properties'));
+        \Pimcore\Cache::remove($this->model->getCtype() . '_properties_' . $this->model->getCid());
     }
 }


### PR DESCRIPTION
I implemented a Like button for my blog that allows each user to trigger a Like once per blog post.

I store this like counter as a property on the object and not inside a data field. Because I personally do not see a change by a visitor on the object field level.

To keep the whole thing cleanly separate, I only save the property (not the object), here is an example:

```php
            if (!$blog->hasProperty('likes')) {
                $blog->setProperty('likes', 'text', 0);
            }

            $likesProperty = $blog->getProperty('likes', true);
            $likesProperty->setData($likesProperty->getData() + 1);
            $likesProperty->save();
```

But saving the property alone has no direct effect, because the properties are cached in the Pimcore cache. This pull request involves clearing the associated cache entry when saving a property.

# Steps to reproduce
 - Create a property
 - Use the code snippet above to change the property value
 - Reload the property tab in Pimcore admin -> no effect
