### PR TITLE
Add target resolution to redirect model

### DIFF
--- a/bundles/SeoBundle/src/Model/Redirect.php
+++ b/bundles/SeoBundle/src/Model/Redirect.php
@@ -156,11 +156,12 @@ final class Redirect extends AbstractModel
         $redirectTarget = $this->target;
         $targetDocumentPath = Document::getById($this->target)?->getFullPath();
 
-        $resolvedPath = ($targetDocumentPath ?? $redirectTarget) ?? "";
+        $resolvedPath = ($targetDocumentPath ?? $redirectTarget) ?? '';
 
-        if(!str_starts_with($resolvedPath, "/")) {
-            return "/".$resolvedPath;
+        if (!str_starts_with($resolvedPath, '/')) {
+            return '/'.$resolvedPath;
         }
+
         return $resolvedPath;
     }
 

--- a/bundles/SeoBundle/src/Model/Redirect.php
+++ b/bundles/SeoBundle/src/Model/Redirect.php
@@ -24,6 +24,7 @@ use Pimcore\Bundle\SeoBundle\Event\RedirectEvents;
 use Pimcore\Event\Traits\RecursionBlockingEventDispatchHelperTrait;
 use Pimcore\Logger;
 use Pimcore\Model\AbstractModel;
+use Pimcore\Model\Document;
 use Pimcore\Model\Exception\NotFoundException;
 use Pimcore\Model\Site;
 use Symfony\Component\HttpFoundation\Request;
@@ -139,6 +140,19 @@ final class Redirect extends AbstractModel
     public function getTarget(): ?string
     {
         return $this->target;
+    }
+
+    public function getTargetPath(): string
+    {
+        $redirectTarget = $this->target;
+        $targetDocumentPath = Document::getById($this->target)?->getFullPath();
+
+        $resolvedPath = ($targetDocumentPath ?? $redirectTarget) ?? "";
+
+        if(!str_starts_with($resolvedPath, "/")) {
+            return "/".$resolvedPath;
+        }
+        return $resolvedPath;
     }
 
     public function setId(int $id): static

--- a/bundles/SeoBundle/src/Model/Redirect.php
+++ b/bundles/SeoBundle/src/Model/Redirect.php
@@ -137,11 +137,20 @@ final class Redirect extends AbstractModel
         return $this->source;
     }
 
+    /**
+     * Target as string, can be target path or document id
+     */
     public function getTarget(): ?string
     {
         return $this->target;
     }
 
+    /**
+     * resolved target path with handling for document ids as `target`
+     *   - tries to resolve the target as document by id and take its full path
+     *   - if no document can be found the target is used as target path
+     *   - ensures a slash at the beginning of the target string
+     */
     public function getTargetPath(): string
     {
         $redirectTarget = $this->target;


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/16896

## Additional info
When working with redirects on a code level there is no "built-in" method to get the actual target path since it could be a document id as well.