### PR TITLE
[Recyclebin] Fix typo in Item:getStorageFile() method name

### DIFF
--- a/models/Element/Recyclebin/Item.php
+++ b/models/Element/Recyclebin/Item.php
@@ -91,7 +91,7 @@ class Item extends Model\AbstractModel
     public function restore(Model\User $user = null): void
     {
         $dummy = null;
-        $raw = Storage::get('recycle_bin')->read($this->getStoreageFile());
+        $raw = Storage::get('recycle_bin')->read($this->getStorageFile());
         $element = Serialize::unserialize($raw);
 
         // check for element with the same name
@@ -175,7 +175,7 @@ class Item extends Model\AbstractModel
         $this->getDao()->save();
 
         $storage = Storage::get('recycle_bin');
-        $storage->write($this->getStoreageFile(), $data);
+        $storage->write($this->getStorageFile(), $data);
 
         $saveBinaryData = function ($element, $rec, self $scope) use ($storage) {
             // assets are kind of special because they can contain massive amount of binary data which isn't serialized, we create separate files for them
@@ -197,7 +197,7 @@ class Item extends Model\AbstractModel
     public function delete(): void
     {
         $storage = Storage::get('recycle_bin');
-        $storage->delete($this->getStoreageFile());
+        $storage->delete($this->getStorageFile());
 
         $files = $storage->listContents($this->getType())->filter(function (StorageAttributes $item) {
             return (bool) strpos($item->path(), '/' . $this->getId() . '_');
@@ -358,9 +358,18 @@ class Item extends Model\AbstractModel
         return $copier->copy($data);
     }
 
-    public function getStoreageFile(): string
+    public function getStorageFile(): string
     {
         return sprintf('%s/%s.psf', $this->getType(), $this->getId());
+    }
+
+    /**
+     * @deprecated since pimcore 11.3 and will be removed in 12.0
+     * @see Item::getStorageFile()
+     */
+    public function getStoreageFile(): string
+    {
+       return $this->getStorageFile();
     }
 
     protected function getStorageFileBinary(Element\ElementInterface $element): string

--- a/tests/Model/Element/RecyclebinTest.php
+++ b/tests/Model/Element/RecyclebinTest.php
@@ -73,10 +73,12 @@ class RecyclebinTest extends ModelTestCase
 
         //recycle asserts
         $recycledItems = new Item\Listing();
-        $this->assertTrue($storage->fileExists($recycledItems->current()->getStoreageFile()));
+        $this->assertTrue($storage->fileExists($recycledItems->current()->getStorageFile()));
 
-        $recycledStorage = unserialize($storage->read($recycledItems->current()->getStoreageFile()));
+        $recycledStorage = unserialize($storage->read($recycledItems->current()->getStorageFile()));
         $this->assertEquals($objectId, $recycledStorage->getId(), 'Recycled Object not found.');
+
+        $this->assertEquals($recycledItems->current()->getStorageFile(), $recycledItems->current()->getStoreageFile());    // deprecated method name
 
         //restore asserts
         $recycledItems->current()->restore();
@@ -114,7 +116,7 @@ class RecyclebinTest extends ModelTestCase
 
         $storage = Storage::get('recycle_bin');
         //recycle bin item storage file
-        $recycledContent = unserialize($storage->read($recycledItems->current()->getStoreageFile()));
+        $recycledContent = unserialize($storage->read($recycledItems->current()->getStorageFile()));
 
         $this->assertEquals($parentId, $recycledContent->getId(), 'Expected recycled parent object ID');
         $this->assertCount(1, $recycledContent->getChildren(DataObject::$types, true)->getData(), 'Expected recycled child object');


### PR DESCRIPTION
Corrected typo in method name `getStoreageFile()` to `getStorageFile()`.

BC is ensured by deprecating the old method name, which calls the corrected method.
