### PR TITLE
[Custom Reports] Feature: introduce initial sort to sql definition for report - fixes issue 12288

### DIFF
--- a/bundles/CustomReportsBundle/public/js/pimcore/report/custom/definitions/sql.js
+++ b/bundles/CustomReportsBundle/public/js/pimcore/report/custom/definitions/sql.js
@@ -113,6 +113,34 @@ pimcore.bundle.customreports.custom.definition.sql = Class.create({
                     listeners: {
                         keyup: this.onSqlEditorKeyup.bind(this)
                     }
+                },
+                {
+                    xtype: "textarea",
+                    name: "orderby",
+                    fieldLabel: "Initial Order by Field <br /><small>(eg. b, c )</small>",
+                    fieldStyle: 'font-family: monospace',
+                    value: (sourceDefinitionData ? sourceDefinitionData.orderby : ""),
+                    width: 900,
+                    height: 150,
+                    grow: true,
+                    growMax: 200,
+                    enableKeyEvents: true,
+                    listeners: {
+                        keyup: this.onSqlEditorKeyup.bind(this)
+                    }
+                },
+                {
+                    xtype: "combo",
+                    name: "orderbydir",
+                    fieldLabel: "Initial Order by Direction <br />",
+                    fieldStyle: 'font-family: monospace',
+                    queryMode: 'local',
+                    store: ['ASC' , 'DESC'],
+                    value: (sourceDefinitionData ? sourceDefinitionData.orderbydir : ""),
+                    enableKeyEvents: true,
+                    listeners: {
+                        keyup: this.onSqlEditorKeyup.bind(this)
+                    }
                 }
             ]
         });

--- a/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
+++ b/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
@@ -492,10 +492,10 @@ class CustomReportController extends UserAwareController
      */
     protected function getSortAndFilters(Request $request, \stdClass $configuration): array
     {
-        $sortingSettings = \Pimcore\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings(array_merge($request->request->all(), $request->query->all()));
+        if(class_exists('\Pimcore\Bundle\AdminBundle\Helper\QueryParams')) $sortingSettings = \Pimcore\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings(array_merge($request->request->all(), $request->query->all()));
         $sort = null;
         $dir = null;
-        if ($sortingSettings['orderKey']) {
+        if (is_array($sortingSettings) && $sortingSettings['orderKey']) {
             $sort = $sortingSettings['orderKey'];
             $dir = $sortingSettings['order'];
         }

--- a/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
+++ b/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
@@ -327,7 +327,10 @@ class CustomReportController extends UserAwareController
         $configuration = $config->getDataSourceConfig();
 
         $adapter = Tool\Config::getAdapter($configuration, $config);
-
+        if($sort === null && $dir === null && property_exists($configuration, 'orderby') && $configuration->orderby !== ''){
+            $sort = $configuration->orderby;
+            $dir = $configuration->orderbydir;
+        }
         $result = $adapter->getData($filters, $sort, $dir, $offset, $limit, null, $drillDownFilters);
 
         return $this->jsonResponse([
@@ -387,6 +390,10 @@ class CustomReportController extends UserAwareController
         $configuration = $config->getDataSourceConfig();
 
         $adapter = Tool\Config::getAdapter($configuration, $config);
+        if($sort === null && $dir === null && property_exists($configuration, 'orderby') && $configuration->orderby !== ''){
+            $sort = $configuration->orderby;
+            $dir = $configuration->orderbydir;
+        }
         $result = $adapter->getData($filters, $sort, $dir, null, null, null, $drillDownFilters);
 
         return $this->jsonResponse([

--- a/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
+++ b/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
@@ -490,12 +490,14 @@ class CustomReportController extends UserAwareController
     /*
      * gets the sort, direction, filters, drilldownfilters from grid or initial config
      */
-    protected function getSortAndFilters(Request $request, \stdClass $configuration): array
+    private function getSortAndFilters(Request $request, \stdClass $configuration): array
     {
         $sortingSettings = null;
         $sort = null;
         $dir = null;
-        if(class_exists('\Pimcore\Bundle\AdminBundle\Helper\QueryParams')) $sortingSettings = \Pimcore\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings(array_merge($request->request->all(), $request->query->all()));
+        if(class_exists('\Pimcore\Bundle\AdminBundle\Helper\QueryParams')) {
+        $sortingSettings = \Pimcore\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings(array_merge($request->request->all(), $request->query->all()));
+        }
         if (is_array($sortingSettings) && $sortingSettings['orderKey']) {
             $sort = $sortingSettings['orderKey'];
             $dir = $sortingSettings['order'];

--- a/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
+++ b/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
@@ -492,9 +492,10 @@ class CustomReportController extends UserAwareController
      */
     protected function getSortAndFilters(Request $request, \stdClass $configuration): array
     {
-        if(class_exists('\Pimcore\Bundle\AdminBundle\Helper\QueryParams')) $sortingSettings = \Pimcore\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings(array_merge($request->request->all(), $request->query->all()));
+        $sortingSettings = null;
         $sort = null;
         $dir = null;
+        if(class_exists('\Pimcore\Bundle\AdminBundle\Helper\QueryParams')) $sortingSettings = \Pimcore\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings(array_merge($request->request->all(), $request->query->all()));
         if (is_array($sortingSettings) && $sortingSettings['orderKey']) {
             $sort = $sortingSettings['orderKey'];
             $dir = $sortingSettings['order'];

--- a/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
+++ b/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
@@ -496,7 +496,7 @@ class CustomReportController extends UserAwareController
         $sort = null;
         $dir = null;
         if(class_exists('\Pimcore\Bundle\AdminBundle\Helper\QueryParams')) {
-        $sortingSettings = \Pimcore\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings(array_merge($request->request->all(), $request->query->all()));
+            $sortingSettings = \Pimcore\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings(array_merge($request->request->all(), $request->query->all()));
         }
         if (is_array($sortingSettings) && $sortingSettings['orderKey']) {
             $sort = $sortingSettings['orderKey'];

--- a/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
+++ b/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
@@ -301,38 +301,19 @@ class CustomReportController extends UserAwareController
     public function dataAction(Request $request): JsonResponse
     {
         $this->checkPermission('reports');
-
         if (!class_exists(\Pimcore\Bundle\AdminBundle\Helper\QueryParams::class)) {
             throw new AdminClassicBundleNotFoundException('This action requires package "pimcore/admin-ui-classic-bundle" to be installed.');
         }
-
         $offset = (int) $request->get('start', 0);
         $limit = (int) $request->get('limit', 40);
-        $sortingSettings = \Pimcore\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings(array_merge($request->request->all(), $request->query->all()));
-        $sort = null;
-        $dir = null;
-        if ($sortingSettings['orderKey']) {
-            $sort = $sortingSettings['orderKey'];
-            $dir = $sortingSettings['order'];
-        }
-
-        $filters = ($request->get('filter') ? json_decode($request->get('filter'), true) : null);
-
-        $drillDownFilters = $request->get('drillDownFilters', null);
-
         $config = Tool\Config::getByName($request->get('name'));
         if (!$config) {
             throw $this->createNotFoundException();
         }
         $configuration = $config->getDataSourceConfig();
-
         $adapter = Tool\Config::getAdapter($configuration, $config);
-        if($sort === null && $dir === null && property_exists($configuration, 'orderby') && $configuration->orderby !== ''){
-            $sort = $configuration->orderby;
-            $dir = $configuration->orderbydir;
-        }
-        $result = $adapter->getData($filters, $sort, $dir, $offset, $limit, null, $drillDownFilters);
-
+        $sortFilters = $this->getSortAndFilters($request , $configuration);
+        $result = $adapter->getData($sortFilters['filters'], $sortFilters['sort'], $sortFilters['dir'], $offset, $limit, null, $sortFilters['drillDownFilters']);
         return $this->jsonResponse([
             'success' => true,
             'data' => $result['data'],
@@ -376,26 +357,14 @@ class CustomReportController extends UserAwareController
     public function chartAction(Request $request): JsonResponse
     {
         $this->checkPermission('reports');
-
-        $sort = $request->get('sort');
-        $dir = $request->get('dir');
-        $filters = ($request->get('filter') ? json_decode($request->get('filter'), true) : null);
-        $drillDownFilters = $request->get('drillDownFilters', null);
-
         $config = Tool\Config::getByName($request->get('name'));
         if (!$config) {
             throw $this->createNotFoundException();
         }
-
         $configuration = $config->getDataSourceConfig();
-
         $adapter = Tool\Config::getAdapter($configuration, $config);
-        if($sort === null && $dir === null && property_exists($configuration, 'orderby') && $configuration->orderby !== ''){
-            $sort = $configuration->orderby;
-            $dir = $configuration->orderbydir;
-        }
-        $result = $adapter->getData($filters, $sort, $dir, null, null, null, $drillDownFilters);
-
+        $sortFilters = $this->getSortAndFilters($request , $configuration);
+        $result = $adapter->getData($sortFilters['filters'], $sortFilters['sort'], $sortFilters['dir'], null, null, null, $sortFilters['drillDownFilters']);
         return $this->jsonResponse([
             'success' => true,
             'data' => $result['data'],
@@ -516,5 +485,26 @@ class CustomReportController extends UserAwareController
         if(!preg_match('/^[a-zA-Z0-9_\-]+$/', $configName)) {
             throw new \Exception('The customer report name is invalid');
         }
+    }
+
+    /*
+     * gets the sort, direction, filters, drilldownfilters from grid or initial config
+     */
+    protected function getSortAndFilters(Request $request, \stdClass $configuration): array
+    {
+        $sortingSettings = \Pimcore\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings(array_merge($request->request->all(), $request->query->all()));
+        $sort = null;
+        $dir = null;
+        if ($sortingSettings['orderKey']) {
+            $sort = $sortingSettings['orderKey'];
+            $dir = $sortingSettings['order'];
+        }
+        $filters = ($request->get('filter') ? json_decode($request->get('filter'), true) : null);
+        $drillDownFilters = $request->get('drillDownFilters', null);
+        if ($sort === null && $dir === null && property_exists($configuration, 'orderby') && $configuration->orderby !== '' && $configuration->orderbydir !== '') {
+            $sort = $configuration->orderby;
+            $dir = $configuration->orderbydir;
+        }
+        return array('sort' => $sort, 'dir' => $dir, 'filters' => $filters, 'drillDownFilters' => $drillDownFilters);
     }
 }


### PR DESCRIPTION
adds the ability to supply an inital Order By to Grid and chart in Custom Report

Should be sufficent for most cases that use Chart because chart does not update with changing sort in Data
