### PR TITLE
[Command "pimcore:locale:delete-unused-tables"] Do not delete localized query tables and views with lower_case_table_names = 1

### DIFF
--- a/bundles/CoreBundle/src/Command/DeleteUnusedLocaleDataCommand.php
+++ b/bundles/CoreBundle/src/Command/DeleteUnusedLocaleDataCommand.php
@@ -77,7 +77,7 @@ class DeleteUnusedLocaleDataCommand extends AbstractCommand
             //delete data from object_localized_data_classID tables
             foreach ($result as $res) {
                 $language = $res['language'];
-                if (!in_array($language, $skipLocales) && !in_array($language, $validLanguages)) {
+                if (!in_arrayi($language, $skipLocales) && !in_arrayi($language, $validLanguages)) {
                     $sqlDeleteData = 'Delete FROM object_localized_data_' . $classId  . ' WHERE `language` = ' . $db->quote($language);
                     $printLine = true;
                     if (!$this->isDryRun()) {
@@ -95,7 +95,7 @@ class DeleteUnusedLocaleDataCommand extends AbstractCommand
                 $localizedView = current($existingView);
                 $existingLanguage = str_replace('object_localized_'.$classId.'_', '', $localizedView);
 
-                if (!in_array($existingLanguage, $validLanguages)) {
+                if (!in_arrayi($existingLanguage, $validLanguages)) {
                     $sqlDropView = 'DROP VIEW IF EXISTS object_localized_' . $classId . '_' .$existingLanguage;
                     $printLine = true;
 
@@ -114,7 +114,7 @@ class DeleteUnusedLocaleDataCommand extends AbstractCommand
                 $localizedTable = current($existingTable);
                 $existingLanguage = str_replace('object_localized_query_'.$classId.'_', '', $localizedTable);
 
-                if (!in_array($existingLanguage, $validLanguages)) {
+                if (!in_arrayi($existingLanguage, $validLanguages)) {
                     $sqlDropTable = 'DROP TABLE IF EXISTS object_localized_query_' . $classId . '_' .$existingLanguage;
                     $printLine = true;
 


### PR DESCRIPTION
Assume we have added system languages like `de_DE`, `en_GB` or any other country-specific locale.
With MySQL setting [lower_case_table_names](https://dev.mysql.com/doc/refman/8.3/en/identifier-case-sensitivity.html) the localized query tables and views get created all lower-case, e.g.:
<img width="182" alt="Bildschirmfoto 2024-04-17 um 09 26 36" src="https://github.com/pimcore/pimcore/assets/8749138/066b7432-2bca-4b86-b027-84237cf4e63f">

In normal usage this is not a problem because table names get compared case-insensitive with `lower_case_table_names = 1`. 
But the cleanup command `pimcore:locale:delete-unused-tables` fetches all localized table names / views, extracts the locale and tries to remove the ones which do not exist as Pimcore system languages. And this comparison is case-sensitive. So from database the table name locale de_de gets extracted in but this does not exist as Pimcore language (only de_DE does) and so the views and query tables get deleted. 

Explanation in code:
1. All configured system languages get fetched in 
    https://github.com/pimcore/pimcore/blob/177a8604c06831da6bb5889931342512659fef53/bundles/CoreBundle/src/Command/DeleteUnusedLocaleDataCommand.php#L62-L65
    Here the correct locales get fetched into `$validLanguages`, e.g. `de_DE`
2. https://github.com/pimcore/pimcore/blob/177a8604c06831da6bb5889931342512659fef53/bundles/CoreBundle/src/Command/DeleteUnusedLocaleDataCommand.php#L92-L96
    Here the locales get extracted from the table names. With `lower_case_table_names = 1` this leads to `$existingLanguage = de_de`
3. https://github.com/pimcore/pimcore/blob/177a8604c06831da6bb5889931342512659fef53/bundles/CoreBundle/src/Command/DeleteUnusedLocaleDataCommand.php#L98-L99
    Here `$existingLanguage` gets compared to `$validLanguages` in a case-sensitive manner. As `de_de` will not get found, the view `object_localized_1_de_de` will get dropped.

And the same applies to the  `object_localized_query_*` tables in https://github.com/pimcore/pimcore/blob/177a8604c06831da6bb5889931342512659fef53/bundles/CoreBundle/src/Command/DeleteUnusedLocaleDataCommand.php#L112-L128

This PR resolved the problem by making the lookup case-insensitive, if the locale in the table / view name matches the PImcore languages.