### PR TITLE
[Bug] Fix DateRange.php breaking Version Preview

### DIFF
--- a/models/DataObject/ClassDefinition/Data/DateRange.php
+++ b/models/DataObject/ClassDefinition/Data/DateRange.php
@@ -170,7 +170,7 @@ class DateRange extends Data implements
     public function getVersionPreview(mixed $data, DataObject\Concrete $object = null, array $params = []): string
     {
         if ($data instanceof CarbonPeriod) {
-            return $data->toString();
+            return 'From ' . $data->getStartDate()->toDateString() . ' to ' . $data->getEndDate()->toDateString();
         }
 
         return '';


### PR DESCRIPTION
## Changes in this pull request  
Resolves an error in the Version Preview when using DateRange Datatypes

To reproduce the error:
- Go to https://demo.pimcore.com/admin/ and create a new Dataobject and add a DateRange Datatype to it or an existing Dataobject.
- Save some data in the DateRange
- Check the Version Preview of your newly saved version
![image](https://github.com/pimcore/pimcore/assets/12949620/41d3a823-fa58-4d79-87ab-9d3485e2d0a9)


## Additional info
CarbonPeriods dateInterval property is wrongly set in (un-)Serialization as a standard PHP DateInterval and not as a CarbonInterval as expected from CarbonPeriod class, since CarbonInterval extends DateInterval. This causes an Exception to be thrown:
"Call to undefined method DateInterval::forHumans()")." at preview_version.html.twig line 172

Since the interval is not used afaik maybe this workaround is ok. 

