### PR TITLE
[Bug]: Fix pdf scanner

### DIFF
--- a/lib/Messenger/Handler/AssetUpdateTasksHandler.php
+++ b/lib/Messenger/Handler/AssetUpdateTasksHandler.php
@@ -64,6 +64,9 @@ class AssetUpdateTasksHandler
     private function processDocument(Asset\Document $asset): void
     {
         if ($asset->isPdfScanningEnabled() && $asset->getMimeType() === 'application/pdf' && !$asset->getScanStatus()) {
+            $asset->setCustomSetting($asset::CUSTOM_SETTING_PDF_SCAN_STATUS, PdfScanStatus::IN_PROGRESS->value);
+            $this->saveAsset($asset);
+
             if ($asset->checkIfPdfContainsJS()) {
                 $asset->setCustomSetting($asset::CUSTOM_SETTING_PDF_SCAN_STATUS, PdfScanStatus::SAFE->value);
                 $note = 'safe';

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -500,7 +500,7 @@ class Asset extends Element\AbstractElement
             $parameters['isUpdate'] = $isUpdate; // need for $this->update() for certain types (image, video, document)
 
             if ($this->getDataChanged()) {
-                if ($this->getType() === 'document') {
+                if ($this->getType() === 'document' && $this instanceof Asset\Document) {
                     $this->setCustomSetting($this::CUSTOM_SETTING_PDF_SCAN_STATUS, null);
                 }
             }

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -17,6 +17,7 @@ namespace Pimcore\Model;
 
 use Doctrine\DBAL\Exception\DeadlockException;
 use Exception;
+use Pimcore\Model\Asset\Enum\PdfScanStatus;
 use function in_array;
 use function is_array;
 use League\Flysystem\FilesystemException;
@@ -497,6 +498,12 @@ class Asset extends Element\AbstractElement
             $this->correctPath();
 
             $parameters['isUpdate'] = $isUpdate; // need for $this->update() for certain types (image, video, document)
+
+            if ($this->getDataChanged()) {
+                if ($this->getType() === 'document') {
+                    $this->setCustomSetting($this::CUSTOM_SETTING_PDF_SCAN_STATUS, null);
+                }
+            }
 
             // we wrap the save actions in a loop here, to restart the database transactions in the case it fails
             // if a transaction fails it gets restarted $maxRetries times, then the exception is thrown out

--- a/models/Asset/Document.php
+++ b/models/Asset/Document.php
@@ -167,10 +167,6 @@ class Document extends Model\Asset
 
     public function checkIfPdfContainsJS(): bool
     {
-        if (!$this->isPdfScanningEnabled()) {
-            return false;
-        }
-
         $this->setCustomSetting(
             self::CUSTOM_SETTING_PDF_SCAN_STATUS,
             Model\Asset\Enum\PdfScanStatus::IN_PROGRESS->value
@@ -187,19 +183,9 @@ class Document extends Model\Asset
             }
 
             if (str_contains($chunk, '/JS') || str_contains($chunk, '/JavaScript')) {
-                $this->setCustomSetting(
-                    self::CUSTOM_SETTING_PDF_SCAN_STATUS,
-                    Model\Asset\Enum\PdfScanStatus::UNSAFE->value
-                );
-
-                return true;
+                return false;
             }
         }
-
-        $this->setCustomSetting(
-            self::CUSTOM_SETTING_PDF_SCAN_STATUS,
-            Model\Asset\Enum\PdfScanStatus::SAFE->value
-        );
 
         return true;
     }
@@ -228,7 +214,7 @@ class Document extends Model\Asset
         return Config::getSystemConfiguration('assets')['document']['process_text'];
     }
 
-    private function isPdfScanningEnabled(): bool
+    public function isPdfScanningEnabled(): bool
     {
         return Config::getSystemConfiguration('assets')['document']['scan_pdf'];
     }

--- a/models/Asset/Document.php
+++ b/models/Asset/Document.php
@@ -167,11 +167,6 @@ class Document extends Model\Asset
 
     public function checkIfPdfContainsJS(): bool
     {
-        $this->setCustomSetting(
-            self::CUSTOM_SETTING_PDF_SCAN_STATUS,
-            Model\Asset\Enum\PdfScanStatus::IN_PROGRESS->value
-        );
-
         $chunkSize = 1024;
         $filePointer = $this->getStream();
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.2`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.2` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/16318
Requires https://github.com/pimcore/admin-ui-classic-bundle/pull/498

## Additional info

It seems the problem was that the sanitization would be [re-dispatched](https://github.com/pimcore/admin-ui-classic-bundle/pull/498/files#diff-af41f235287fbe3ee51b1657dd02c7c8b51371fbd4870b5b378f7cca94501b5eR1457) on every reload and at least every 5 seconds, because the [in progress](https://github.com/pimcore/pimcore/pull/16956/files#diff-00881ca8531e9aa6a80427bb435b7fdf2e2e098b0db16b45700c77f4791b1f90L174-L176) is [not saved ](https://github.com/pimcore/pimcore/pull/16956/files#diff-f9779d6bf7f7d2cfcbd48f036980ea510e017943bf93f2edbcc968d60689a020R67-R68) and was always [null](https://github.com/pimcore/admin-ui-classic-bundle/pull/498/files#diff-af41f235287fbe3ee51b1657dd02c7c8b51371fbd4870b5b378f7cca94501b5eL1455-L1456)
Also if [processBackground ](https://github.com/pimcore/admin-ui-classic-bundle/pull/498/files#diff-af41f235287fbe3ee51b1657dd02c7c8b51371fbd4870b5b378f7cca94501b5eR1456) is false, it's appearing as in progress all the time, due to the line above it.