### PR TITLE
Conflict with Twig >= 3.9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -132,7 +132,8 @@
   "conflict": {
     "symfony/symfony": "*",
     "sabre/dav": "4.2.2",
-    "thecodingmachine/safe": "<2.0"
+    "thecodingmachine/safe": "<2.0",
+    "twig/twig": ">=3.9.0"
   },
   "require-dev": {
     "codeception/codeception": "^5.0.3",


### PR DESCRIPTION
## Changes in this pull request  
Conflict with Twig `>=3.9.0` because `rybakit/twig-deferred-extension` is incompatible with it. 

## Additional info
See: https://github.com/rybakit/twig-deferred-extension/issues/20