### PR TITLE
FIX : ApplicationLogger -> Stop TaskManager on tab destroy

### DIFF
--- a/bundles/ApplicationLoggerBundle/public/js/log/admin.js
+++ b/bundles/ApplicationLoggerBundle/public/js/log/admin.js
@@ -394,6 +394,10 @@ pimcore.bundle.applicationlogger.log.admin = Class.create({
                 this.store.load();
             }
             pimcore.layout.refresh();
+
+            this.panel.on("destroy", function () {
+                Ext.TaskManager.stop(this.autoRefreshTask);
+            }.bind(this));
         }
         return this.panel;
     },


### PR DESCRIPTION
When enabling the auto refresh on ApplicationLogger, the task to refresh the grid is never stopped even when we close ApplicationLogger.

This PR resolve this issue.