### PR TITLE
Fix: Empty glossary line crashes rendering (#17001)

### DIFF
--- a/bundles/GlossaryBundle/src/Tool/Processor.php
+++ b/bundles/GlossaryBundle/src/Tool/Processor.php
@@ -192,6 +192,9 @@ class Processor
         // fix htmlentities issues
         $tmpData = [];
         foreach ($data as $d) {
+            if (!($d['text'])) {
+                continue;
+            }
             $text = htmlentities($d['text'], ENT_COMPAT, 'UTF-8');
             if ($d['text'] !== $text) {
                 $td = $d;


### PR DESCRIPTION
Resolves #17001
