### PR TITLE
[BUG] fix glossary preg_replace greediness

### DIFF
--- a/bundles/GlossaryBundle/src/Tool/Processor.php
+++ b/bundles/GlossaryBundle/src/Tool/Processor.php
@@ -236,9 +236,9 @@ class Processor
 
             // add PCRE delimiter and modifiers
             if ($d['exactmatch']) {
-                $d['text'] = '/<a.*\/a>(*SKIP)(*FAIL)|(?<!\w)' . preg_quote($d['text'], '/') . '(?!\w)/';
+                $d['text'] = '/<a.*?\/a>(*SKIP)(*FAIL)|(?<!\w)' . preg_quote($d['text'], '/') . '(?!\w)/';
             } else {
-                $d['text'] = '/<a.*\/a>(*SKIP)(*FAIL)|' . preg_quote($d['text'], '/') . '/';
+                $d['text'] = '/<a.*?\/a>(*SKIP)(*FAIL)|' . preg_quote($d['text'], '/') . '/';
             }
 
             if (!$d['casesensitive']) {


### PR DESCRIPTION
The glossary has a bug where it does not replace the text when there are multiple links in a text.

For instance when a text is something like `<a href="/some-link">some link</a>and some text with sources and <a href="/another">another link</a>` and the glossary looks for 'sources', the search input on preg_replace will be `/<a.*\/a>(*SKIP)(*FAIL)|sources/i`, now the replacement will not happen as the .* makes the preg_replace greedy and skip everything between the two links.

The fix is to use .*?, which is the change in this PR.