### PR TITLE
Asset: hasMetaData must be convert to bool in Dao

### DIFF
--- a/models/Asset/Dao.php
+++ b/models/Asset/Dao.php
@@ -51,6 +51,7 @@ class Dao extends Model\Element\Dao
                 WHERE assets.id = ?", [$id]);
 
         if ($data) {
+            $data['hasMetaData'] = (bool)$data['hasMetaData'];
             $this->assignVariablesToModel($data);
 
             if ($data['hasMetaData']) {


### PR DESCRIPTION
Execute codeception with added missing strict_types declarations (See https://github.com/pimcore/pimcore/pull/15065)

```
In Asset.php line 1390:
                                                                                                                                                                      
  [TypeError]                                                                                                                                                         
  Pimcore\Model\Asset::setHasMetaData(): Argument #1 ($hasMetaData) must be of type bool, int given, called in /var/www/html/lib/Model/AbstractModel.php on line 187 
  
Exception trace:
  at /var/www/html/models/Asset.php:1390
 Pimcore\Model\Asset->setHasMetaData() at /var/www/html/lib/Model/AbstractModel.php:187
 Pimcore\Model\AbstractModel->setValue() at /var/www/html/lib/Model/AbstractModel.php:171
 Pimcore\Model\AbstractModel->setValues() at /var/www/html/lib/Model/Dao/DaoTrait.php:43
 Pimcore\Model\Dao\AbstractDao->assignVariablesToModel() at /var/www/html/models/Asset/Dao.php:55
 Pimcore\Model\Asset\Dao->getById() at /var/www/html/models/Asset.php:278
 Pimcore\Model\Asset::getById() at /var/www/html/tests/Support/Util/TestHelper.php:747
 Pimcore\Tests\Support\Util\TestHelper::cleanUp() at /var/www/html/tests/Support/Helper/AbstractDefinitionHelper.php:52
 Pimcore\Tests\Support\Helper\AbstractDefinitionHelper->_afterSuite() at /var/www/html/vendor/codeception/codeception/src/Codeception/Subscriber/Module.php:59
 Codeception\Subscriber\Module->afterSuite() at /var/www/html/vendor/symfony/event-dispatcher/EventDispatcher.php:220
 Symfony\Component\EventDispatcher\EventDispatcher->callListeners() at /var/www/html/vendor/symfony/event-dispatcher/EventDispatcher.php:56
 Symfony\Component\EventDispatcher\EventDispatcher->dispatch() at /var/www/html/vendor/codeception/codeception/src/Codeception/SuiteManager.php:153
 Codeception\SuiteManager->run() at /var/www/html/vendor/codeception/codeception/src/Codeception/Codecept.php:260
 Codeception\Codecept->runSuite() at /var/www/html/vendor/codeception/codeception/src/Codeception/Codecept.php:216
 Codeception\Codecept->run() at /var/www/html/vendor/codeception/codeception/src/Codeception/Command/Run.php:646
 Codeception\Command\Run->runSuites() at /var/www/html/vendor/codeception/codeception/src/Codeception/Command/Run.php:467
 Codeception\Command\Run->execute() at /var/www/html/vendor/symfony/console/Command/Command.php:326
 Symfony\Component\Console\Command\Command->run() at /var/www/html/vendor/symfony/console/Application.php:1078
 Symfony\Component\Console\Application->doRunCommand() at /var/www/html/vendor/symfony/console/Application.php:324
 Symfony\Component\Console\Application->doRun() at /var/www/html/vendor/symfony/console/Application.php:175
 Symfony\Component\Console\Application->run() at /var/www/html/vendor/codeception/codeception/src/Codeception/Application.php:112
 Codeception\Application->run() at /var/www/html/vendor/codeception/codeception/app.php:45
 {closure}() at /var/www/html/vendor/codeception/codeception/app.php:46
 require() at /var/www/html/vendor/codeception/codeception/codecept:7
 include() at /var/www/html/vendor/bin/codecept:119

```