### PR TITLE
Prematurely exit pimcore:bundle:install with success code if bundle is already installed

### DIFF
--- a/bundles/CoreBundle/src/Command/Bundle/InstallCommand.php
+++ b/bundles/CoreBundle/src/Command/Bundle/InstallCommand.php
@@ -49,7 +49,7 @@ class InstallCommand extends AbstractBundleCommand
     {
         $bundle = $this->getBundle();
 
-        if (!$this->bundleManager->canBeInstalled($bundle) || $this->bundleManager->isInstalled($bundle)) {
+        if ($this->bundleManager->isInstalled($bundle)) {
             $this->io->success(sprintf('Bundle "%s" is already installed', $bundle->getName()));
             return 0;
         }

--- a/bundles/CoreBundle/src/Command/Bundle/InstallCommand.php
+++ b/bundles/CoreBundle/src/Command/Bundle/InstallCommand.php
@@ -22,6 +22,7 @@ use Pimcore\Extension\Bundle\PimcoreBundleManager;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Command\Command;
 
 /**
  * @internal
@@ -51,7 +52,7 @@ class InstallCommand extends AbstractBundleCommand
 
         if ($this->bundleManager->isInstalled($bundle)) {
             $this->io->success(sprintf('Bundle "%s" is already installed', $bundle->getName()));
-            return 0;
+            return Command::SUCCESS;
         }
 
         // sets up installer with console output writer
@@ -70,6 +71,6 @@ class InstallCommand extends AbstractBundleCommand
             $this->getApplication()->getKernel()->getEnvironment()
         );
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/bundles/CoreBundle/src/Command/Bundle/InstallCommand.php
+++ b/bundles/CoreBundle/src/Command/Bundle/InstallCommand.php
@@ -49,6 +49,11 @@ class InstallCommand extends AbstractBundleCommand
     {
         $bundle = $this->getBundle();
 
+        if (!$this->bundleManager->canBeInstalled($bundle) || $this->bundleManager->isInstalled($bundle)) {
+            $this->io->success(sprintf('Bundle "%s" is already installed', $bundle->getName()));
+            return 0;
+        }
+
         // sets up installer with console output writer
         $this->setupInstaller($bundle);
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.2`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/` 
- [x] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.2` (see Readme.md for the list of supported versions)
- [x] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #https://github.com/pimcore/pimcore/issues/17029

## Additional info
Choosing to first check if the given bundle is already installed, and if true prematurely exit with success. If it is preferred to provide an optional "ignore" flag instead, this PR can be closed in favour of that solution.
