### PR TITLE
Make allowed thumbnail formats case-insensitive

### DIFF
--- a/models/Asset/Image/Thumbnail/Config.php
+++ b/models/Asset/Image/Thumbnail/Config.php
@@ -259,7 +259,7 @@ final class Config extends Model\AbstractModel
                 'mode' => 'asTexture',
             ]);
             $thumbnail->setQuality(60);
-            $thumbnail->setFormat('PJPEG');
+            $thumbnail->setFormat('pjpeg');
         }
 
         $thumbnail->setHighResolution(2);

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -442,10 +442,9 @@ trait ImageThumbnailTrait
 
         $assetConfig = PimcoreConfig::getSystemConfiguration('assets');
 
-        return in_array(
+        return in_arrayi(
             $format,
-            $assetConfig['thumbnails']['allowed_formats'],
-            true
+            $assetConfig['thumbnails']['allowed_formats']
         );
     }
 


### PR DESCRIPTION
Since this commit Pimcore checks if a thumbnail definition provides a valid format:

https://github.com/pimcore/pimcore/commit/a6821a16ea38086bf6012e682e1743488244bd85

This is done in a case-sensitive way therefore the Pimcore preview thumbnail config does not work anymore (as there the format is 'PJPEG'). 

This PR solves this problem in 2 ways:

1. Change 'PJPEG' to lowercase in the preview thumbnail config.
2. Make the thumbnail config format check case-insensitive.