### PR TITLE
[Bug] Fix thumbnail generation if asset or config is null

### DIFF
--- a/models/Asset/Document/ImageThumbnail.php
+++ b/models/Asset/Document/ImageThumbnail.php
@@ -76,14 +76,15 @@ final class ImageThumbnail implements ImageThumbnailInterface
      */
     public function generate(bool $deferredAllowed = true): void
     {
-        if (!$this->checkAllowedFormats($this->config->getFormat(), $this->asset)) {
-            throw new ThumbnailFormatNotSupportedException();
-        }
-
         $deferred = $deferredAllowed && $this->deferred;
         $generated = false;
 
         if ($this->asset && empty($this->pathReference)) {
+
+            if (!$this->checkAllowedFormats($this->config->getFormat(), $this->asset)) {
+                throw new ThumbnailFormatNotSupportedException();
+            }
+
             $config = $this->getConfig();
             $cacheFileStream = null;
             $config->setFilenameSuffix('page-' . $this->page);

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -112,14 +112,6 @@ final class Thumbnail implements ThumbnailInterface
      */
     public function generate(bool $deferredAllowed = true): void
     {
-        if (!$this->checkAllowedFormats($this->config->getFormat(), $this->asset)) {
-            throw new ThumbnailFormatNotSupportedException();
-        }
-
-        if (!$this->checkMaxScalingFactor($this->config->getHighResolution())) {
-            throw new ThumbnailMaxScalingFactorException();
-        }
-
         $deferred = false;
         $generated = false;
 
@@ -131,6 +123,15 @@ final class Thumbnail implements ThumbnailInterface
                     'src' => $this->asset->getRealFullPath(),
                 ];
             } else {
+
+                if (!$this->checkAllowedFormats($this->config->getFormat(), $this->asset)) {
+                    throw new ThumbnailFormatNotSupportedException();
+                }
+
+                if (!$this->checkMaxScalingFactor($this->config->getHighResolution())) {
+                    throw new ThumbnailMaxScalingFactorException();
+                }
+
                 try {
                     $deferred = $deferredAllowed && $this->deferred;
                     $this->pathReference = Thumbnail\Processor::process($this->asset, $this->config, null, $deferred, $generated);

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -117,14 +117,13 @@ final class Thumbnail implements ThumbnailInterface
 
         if ($this->asset && empty($this->pathReference)) {
 
-            if($this->config) {
-                if (!$this->checkAllowedFormats($this->config->getFormat(), $this->asset)) {
-                    throw new ThumbnailFormatNotSupportedException();
-                }
 
-                if (!$this->checkMaxScalingFactor($this->config->getHighResolution())) {
-                    throw new ThumbnailMaxScalingFactorException();
-                }
+            if ($this->config && !$this->checkAllowedFormats($this->config->getFormat(), $this->asset)) {
+                throw new ThumbnailFormatNotSupportedException();
+            }
+
+            if ($this->config && !$this->checkMaxScalingFactor($this->config->getHighResolution())) {
+                throw new ThumbnailMaxScalingFactorException();
             }
 
             // if no correct thumbnail config is given use the original image as thumbnail

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -116,14 +116,8 @@ final class Thumbnail implements ThumbnailInterface
         $generated = false;
 
         if ($this->asset && empty($this->pathReference)) {
-            // if no correct thumbnail config is given use the original image as thumbnail
-            if (!$this->config) {
-                $this->pathReference = [
-                    'type' => 'asset',
-                    'src' => $this->asset->getRealFullPath(),
-                ];
-            } else {
 
+            if($this->config) {
                 if (!$this->checkAllowedFormats($this->config->getFormat(), $this->asset)) {
                     throw new ThumbnailFormatNotSupportedException();
                 }
@@ -131,7 +125,15 @@ final class Thumbnail implements ThumbnailInterface
                 if (!$this->checkMaxScalingFactor($this->config->getHighResolution())) {
                     throw new ThumbnailMaxScalingFactorException();
                 }
+            }
 
+            // if no correct thumbnail config is given use the original image as thumbnail
+            if (!$this->config) {
+                $this->pathReference = [
+                    'type' => 'asset',
+                    'src' => $this->asset->getRealFullPath(),
+                ];
+            } else {
                 try {
                     $deferred = $deferredAllowed && $this->deferred;
                     $this->pathReference = Thumbnail\Processor::process($this->asset, $this->config, null, $deferred, $generated);

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -434,7 +434,7 @@ trait ImageThumbnailTrait
     {
         $format = strtolower($format);
         if($asset) {
-            $original = pathinfo($asset->getRealFullPath(), PATHINFO_EXTENSION);
+            $original = strtolower(pathinfo($asset->getRealFullPath(), PATHINFO_EXTENSION));
             if ($format === $original || $format === 'source') {
                 return true;
             }

--- a/models/Asset/Video/ImageThumbnail.php
+++ b/models/Asset/Video/ImageThumbnail.php
@@ -77,20 +77,21 @@ final class ImageThumbnail implements ImageThumbnailInterface
     }
 
     /**
-     * @throws Exception
+     * @throws Exception|\League\Flysystem\FilesystemException|ThumbnailFormatNotSupportedException
      *
      * @internal
      */
     public function generate(bool $deferredAllowed = true): void
     {
-        if (!$this->checkAllowedFormats($this->config->getFormat(), $this->asset)) {
-            throw new ThumbnailFormatNotSupportedException();
-        }
-
         $deferred = $deferredAllowed && $this->deferred;
         $generated = false;
 
         if ($this->asset && empty($this->pathReference)) {
+
+            if (!$this->checkAllowedFormats($this->config->getFormat(), $this->asset)) {
+                throw new ThumbnailFormatNotSupportedException();
+            }
+
             $cs = $this->asset->getCustomSetting('image_thumbnail_time');
             $im = $this->asset->getCustomSetting('image_thumbnail_asset');
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.2`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.2` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Error images do not need an asset or config. Move checks to certain conditions