### PR TITLE
Fix fallback mechanism for ICU translations

### DIFF
--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -284,10 +284,11 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
                 }
 
                 if ($fallbackValue && $normalizedId != $fallbackValue) {
+                    $isIntl = $catalogue->defines($normalizedId, $domain . $catalogue::INTL_DOMAIN_SUFFIX);
                     // update fallback value in original catalogue otherwise multiple calls to the same id will not work
-                    $this->getCatalogue($locale)->set($normalizedId, $fallbackValue, $domain);
+                    $this->getCatalogue($locale)->set($normalizedId, $fallbackValue, $domain . ($isIntl ? $catalogue::INTL_DOMAIN_SUFFIX : ''));
 
-                    return strtr($fallbackValue, $parameters);
+                    return $this->translator->trans($normalizedId, $parameters, $domain, $locale);
                 }
             }
         }


### PR DESCRIPTION
 

## Changes in this pull request  
Fixes the fallback mechanism for ICU translations.  

## Steps to reproduce
1. Define fallback language for one of the locales, for example `de` fallbacks to `en`
2. Create ICU translation; set value for the fallback language (`en`) and leave empty for the language having the fallback (`de`)
    - example CSV:  
    ```
   "key";"de";"en"
   "someKey";"";"{count, plural, one {One} other {Other} }"
   ```
4. Execute this Twig code
```
<div>{{ 'someKey'|trans({count: 1}, null, 'en') }}</div> // output: "One"
<div>{{ 'someKey'|trans({count: 1}, null, 'de') }}</div> // output: "{1, plural, one {One} other {Other} }"
```

The fallback mechanism works but partially.  
**The displayed string is unformatted** - that's why we have to use Symfony's translator to return correctly formatted string.

## Steps to reproduce
I discovered this issue on Pimcore v10.6.9.  
Tested this issue on the latest Pimcore Demo docker image.