### PR TITLE
Datatype input regex validates always instead of save and publish

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Input.php
+++ b/models/DataObject/ClassDefinition/Data/Input.php
@@ -198,7 +198,7 @@ class Input extends Data implements
     public function checkValidity(mixed $data, bool $omitMandatoryCheck = false, array $params = []): void
     {
         if(is_string($data)) {
-            if ($this->getRegex() && $data !== '') {
+            if (!$omitMandatoryCheck && $this->getRegex() && $data !== '') {
                 $throwException = false;
                 if (in_array('g', $this->getRegexFlags())) {
                     $flags = str_replace('g', '', implode('', $this->getRegexFlags()));


### PR DESCRIPTION
The Regular Expression Validation on input dataType validates the regular expression always instead of only on Save And Publish. This results in validation errors when trying to save a draft or when unpublishing.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.2`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.2` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Restoring !$omitMandatoryCheck to checkValidity of Input Classdefinition resolves this issue.