### PR TITLE
[BUG] type error on multiselect unmarshal

### DIFF
--- a/lib/DataObject/ClassificationstoreDataMarshaller/Multiselect.php
+++ b/lib/DataObject/ClassificationstoreDataMarshaller/Multiselect.php
@@ -34,7 +34,7 @@ class Multiselect implements MarshallerInterface
 
     public function unmarshal(mixed $value, array $params = []): mixed
     {
-        if (is_array($value) && strlen($value['value']) > 0) {
+        if (!empty($value['value'])) {
             return explode(',', $value['value']);
         }
 

--- a/lib/DataObject/ClassificationstoreDataMarshaller/Multiselect.php
+++ b/lib/DataObject/ClassificationstoreDataMarshaller/Multiselect.php
@@ -34,7 +34,7 @@ class Multiselect implements MarshallerInterface
 
     public function unmarshal(mixed $value, array $params = []): mixed
     {
-        if (is_array($value) && strlen($value['value']) > 0) {
+        if (is_array($value) && strlen($value['value'] ?? '') > 0)  {
             return explode(',', $value['value']);
         }
 

--- a/lib/DataObject/ClassificationstoreDataMarshaller/Multiselect.php
+++ b/lib/DataObject/ClassificationstoreDataMarshaller/Multiselect.php
@@ -34,7 +34,7 @@ class Multiselect implements MarshallerInterface
 
     public function unmarshal(mixed $value, array $params = []): mixed
     {
-        if (!empty($value['value']) && is_string($value['value'])) {
+        if (is_array($value) && strlen($value['value']) > 0) {
             return explode(',', $value['value']);
         }
 

--- a/lib/DataObject/ClassificationstoreDataMarshaller/Multiselect.php
+++ b/lib/DataObject/ClassificationstoreDataMarshaller/Multiselect.php
@@ -34,7 +34,7 @@ class Multiselect implements MarshallerInterface
 
     public function unmarshal(mixed $value, array $params = []): mixed
     {
-        if (!empty($value['value'])) {
+        if (!empty($value['value']) && is_string($value['value'])) {
             return explode(',', $value['value']);
         }
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.2`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.2` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves : A type error thrown by strlen if $value['value'] is NULL

Provide a stricter condition to avoid exception in grid view.

## Additional info

We have not yet figured out which circumstances lead to the exect status so that $value['value'] is NULL. What we can say is that the exception occurs in the "grid view" while we where searching for a specific product (on the articleNumber attribute col with the filter function of the col).

```
Timestamp: Fri May 17 2024 12:36:56 GMT+0200 (Mitteleuropäische Sommerzeit)
Status: 500 | 
URL: /admin/object/grid-proxy?classId=Product&folderId=38784&xaction=read&_dc=1715942216818
Method: POST
Message: strlen(): Argument #1 ($string) must be of type string, null given
Trace: 
in /var/www/html/vendor/pimcore/pimcore/lib/DataObject/ClassificationstoreDataMarshaller/Multiselect.php:37
#0 /var/www/html/vendor/pimcore/pimcore/lib/DataObject/ClassificationstoreDataMarshaller/Multiselect.php(37): strlen(NULL)
#1 /var/www/html/vendor/pimcore/pimcore/models/DataObject/Classificationstore/Dao.php(252): Pimcore\DataObject\ClassificationstoreDataMarshaller\Multiselect->unmarshal(Array, Array)
#2 [internal function]: Pimcore\Model\DataObject\Classificationstore\Dao->load()
#3 /var/www/html/vendor/pimcore/pimcore/lib/Model/AbstractModel.php(220): call_user_func_array(Array, Array)
#4 /var/www/html/vendor/pimcore/pimcore/models/DataObject/ClassDefinition/Data/Classificationstore.php(491): Pimcore\Model\AbstractModel->__call('load', Array)
#5 /var/www/html/vendor/pimcore/pimcore/models/DataObject/Concrete/Dao.php(152): Pimcore\Model\DataObject\ClassDefinition\Data\Classificationstore->load(Object(Pimcore\Model\DataObject\Product), Array)
#6 /var/www/html/vendor/pimcore/pimcore/models/DataObject/Concrete/Dao.php(69): Pimcore\Model\DataObject\Concrete\Dao->getData()
#7 /var/www/html/vendor/pimcore/pimcore/models/DataObject/AbstractObject.php(243): Pimcore\Model\DataObject\Concrete\Dao->getById(48225)
#8 /var/www/html/vendor/pimcore/pimcore/models/DataObject/Listing/Dao.php(66): Pimcore\Model\DataObject\AbstractObject::getById(48225)
#9 [internal function]: Pimcore\Model\DataObject\Listing\Dao->load()
#10 /var/www/html/vendor/pimcore/pimcore/lib/Model/AbstractModel.php(220): call_user_func_array(Array, Array)
#11 /var/www/html/vendor/pimcore/admin-ui-classic-bundle/src/Controller/Admin/DataObject/DataObjectActionsTrait.php(120): Pimcore\Model\AbstractModel->__call('load', Array)
#12 /var/www/html/vendor/pimcore/admin-ui-classic-bundle/src/Controller/Admin/DataObject/DataObjectController.php(1761): Pimcore\Bundle\AdminBundle\Controller\Admin\DataObject\DataObjectController->gridProxy(Array, 'object', Object(Symfony\Component\HttpFoundation\Request), Object(Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher), Object(Pimcore\Bundle\AdminBundle\Helper\GridHelperService), Object(Pimcore\Localization\LocaleService))
#13 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(181): Pimcore\Bundle\AdminBundle\Controller\Admin\DataObject\DataObjectController->gridProxyAction(Object(Symfony\Component\HttpFoundation\Request), Object(Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher), Object(Pimcore\Bundle\AdminBundle\Helper\GridHelperService), Object(Pimcore\Localization\LocaleService), Object(Pimcore\Bundle\AdminBundle\Security\CsrfProtectionHandler))
#14 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(76): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#15 /var/www/html/vendor/symfony/http-kernel/Kernel.php(197): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#16 /var/www/html/public/index.php(36): Symfony\Component\HttpKernel\Kernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#17 {main}
```

The exception points to the method we fixed in this merge request. Obviously this code missed some stricter conditions.
