### PR TITLE
Supress warning if getimagesize() is failing becaus it throws an Exception

### DIFF
--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -251,7 +251,7 @@ EOT;
 
         //try to get the dimensions with getimagesize because it is much faster than e.g. the Imagick-Adapter
         if (is_readable($path)) {
-            $imageSize = getimagesize($path);
+            $imageSize = @getimagesize($path);
             if ($imageSize && $imageSize[0] && $imageSize[1]) {
                 $dimensions = [
                     'width' => $imageSize[0],


### PR DESCRIPTION
If we are not in the "prod" environment the call of "getimagesize()" might throw an Notice Exception and therefore the images are / response is not correct when you call e.g. /admin/asset/get-data-by-id?_dc=1716319584225&id=123&type=image

We get an Error like "Notice: getimagesize(): Error reading from /tmp/phpYVyM0A!"
Supressing the Warning fixes this issue as it is also with an "@" sign in multiple other locations like models/Asset/Image.php.

Regards,
Christian
