### PR TITLE
Fix issue with cropping gif images with focal points

### DIFF
--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -527,8 +527,15 @@ class Imagick extends Adapter
     {
         $this->preModify();
 
-        $this->resource->cropImage($width, $height, $x, $y);
-        $this->resource->setImagePage($width, $height, 0, 0);
+        if ($this->checkPreserveAnimation()) {
+            foreach ($this->resource as $i => $frame) {
+                $frame->cropImage($width, $height, $x, $y);
+                $frame->setImagePage($width, $height, 0, 0);
+            }
+        } else {
+            $this->resource->cropImage($width, $height, $x, $y);
+            $this->resource->setImagePage($width, $height, 0, 0);
+        }
 
         $this->setWidth($width);
         $this->setHeight($height);


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.2`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.2` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #
This PR fixes the crop method for GIF images. When focal points are used on a GIF image to create a cover-thumb thumbnail while preserving the animation, the cropping is currently applied correctly only to the first frame. As a result, the correct cropping with focal points is only applied to the first frame of the GIF. As you can see in example below the first frame is cropped with focal points, but the rest frames not, attaching transformed gif so you can see glitching(jumping).

As fix I've used the same logic from the same Imagick class from resize/createCompositeImageFromResource methods, we check if `$this->checkPreserveAnimation()` and then apply transformation for all frames.

I hope I have described everything correctly. Thanks.

<img width="459" alt="image" src="https://github.com/pimcore/pimcore/assets/17313784/54ef075d-bec4-4d5d-9971-94c2ceed9c21">

## Additional info
![downloaded](https://github.com/pimcore/pimcore/assets/17313784/a7c0d20a-4bdd-4d73-8043-2675e9ae88a2)

