### PR TITLE
FieldDefinition: Add missing forbidden names

### DIFF
--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -85,7 +85,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         'objectvar', 'objectvars', 'omitmandatorycheck', 'parent', 'parentclass', 'parentid', 'path', 'permissions',
         'permissionsforuser', 'properties', 'property', 'published', 'realfullpath', 'realpath', 'relationdata',
         'resource', 'scheduledtasks', 'siblings', 'type', 'types', 'usermodification', 'userowner', 'userpermissions',
-        'value', 'valueforfieldname', 'valuefromparent', 'values', 'versioncount', 'versions',
+        'validtablecolumns', 'value', 'valueforfieldname', 'valuefromparent', 'values', 'versioncount', 'versions',
     ];
 
     /**

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -80,7 +80,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         'childrensortorder', 'childs', 'class', 'classid', 'classname', 'classtitle', 'closestparentofclass',
         'creationdate', 'dao', 'data', 'definition', 'dependencies', 'dirtyfields', 'dirtylanguages', 'fieldname',
         'fullpath', 'haschildren', 'hassiblings', 'id', 'idpath', 'index', 'key', 'language', 'latestversion',
-        'lazyloadedfieldnames', 'list', 'localizedfields', 'locked', 'modificationdate', 'nextparentforinheritance',
+        'lazyloadedfieldnames', 'list', 'locked', 'modificationdate', 'nextparentforinheritance',
         'object', 'omitmandatorycheck', 'parent', 'parentclass', 'parentid', 'path', 'permissions',
         'permissionsforuser', 'properties', 'property', 'published', 'relationdata', 'resource', 'scheduledtasks',
         'siblings', 'type', 'usermodification', 'userowner', 'userpermissions', 'value', 'valueforfieldname',

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -82,10 +82,10 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         'dirtyfields', 'dirtylanguages', 'fieldname', 'fullpath', 'getinheritedvalues', 'haschildren', 'hassiblings',
         'hideunpublished', 'id', 'idpath', 'index', 'key', 'language', 'latestversion', 'lazyloadedfieldnames', 'list',
         'listingcachekey', 'locked', 'modelfactory', 'modificationdate', 'nextparentforinheritance', 'object',
-        'omitmandatorycheck', 'parent', 'parentclass', 'parentid', 'path', 'permissions', 'permissionsforuser',
-        'properties', 'property', 'published', 'realfullpath', 'realpath', 'relationdata', 'resource',
-        'scheduledtasks', 'siblings', 'type', 'types', 'usermodification', 'userowner', 'userpermissions', 'value',
-        'valueforfieldname', 'valuefromparent', 'values', 'versioncount', 'versions',
+        'objectvar', 'objectvars', 'omitmandatorycheck', 'parent', 'parentclass', 'parentid', 'path', 'permissions',
+        'permissionsforuser', 'properties', 'property', 'published', 'realfullpath', 'realpath', 'relationdata',
+        'resource', 'scheduledtasks', 'siblings', 'type', 'types', 'usermodification', 'userowner', 'userpermissions',
+        'value', 'valueforfieldname', 'valuefromparent', 'values', 'versioncount', 'versions',
     ];
 
     /**

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -76,15 +76,16 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
      * @var string[]
      */
     protected const FORBIDDEN_NAMES = [
-        'apipluginbroker', 'byid', 'bypath', 'cachetag', 'cachetags', 'childamount', 'children', 'childrensortby',
-        'childrensortorder', 'childs', 'class', 'classid', 'classname', 'classtitle', 'closestparentofclass',
-        'creationdate', 'dao', 'data', 'definition', 'dependencies', 'dirtyfields', 'dirtylanguages', 'fieldname',
-        'fullpath', 'haschildren', 'hassiblings', 'id', 'idpath', 'index', 'key', 'language', 'latestversion',
-        'lazyloadedfieldnames', 'list', 'locked', 'modificationdate', 'nextparentforinheritance',
-        'object', 'omitmandatorycheck', 'parent', 'parentclass', 'parentid', 'path', 'permissions',
-        'permissionsforuser', 'properties', 'property', 'published', 'relationdata', 'resource', 'scheduledtasks',
-        'siblings', 'type', 'usermodification', 'userowner', 'userpermissions', 'value', 'valueforfieldname',
-        'valuefromparent', 'values', 'versioncount', 'versions',
+        'apipluginbroker', 'byid', 'bypath', 'cachetag', 'cachetags', 'childamount', 'childpermissions', 'children',
+        'childrensortby', 'childrensortorder', 'childs', 'class', 'classid', 'classname', 'classtitle',
+        'closestparentofclass', 'creationdate', 'currentfullpath', 'dao', 'data', 'definition', 'dependencies',
+        'dirtyfields', 'dirtylanguages', 'fieldname', 'fullpath', 'getinheritedvalues', 'haschildren', 'hassiblings',
+        'hideunpublished', 'id', 'idpath', 'index', 'key', 'language', 'latestversion', 'lazyloadedfieldnames', 'list',
+        'locked', 'modificationdate', 'nextparentforinheritance', 'object', 'omitmandatorycheck', 'parent',
+        'parentclass', 'parentid', 'path', 'permissions', 'permissionsforuser', 'properties', 'property', 'published',
+        'realfullpath', 'realpath', 'relationdata', 'resource', 'scheduledtasks', 'siblings', 'type', 'types',
+        'usermodification', 'userowner', 'userpermissions', 'value', 'valueforfieldname', 'valuefromparent', 'values',
+        'versioncount', 'versions',
     ];
 
     /**

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -76,16 +76,16 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
      * @var string[]
      */
     protected const FORBIDDEN_NAMES = [
-        'apipluginbroker', 'byid', 'bypath', 'cachetag', 'cachetags', 'childamount', 'childpermissions', 'children',
-        'childrensortby', 'childrensortorder', 'childs', 'class', 'classid', 'classname', 'classtitle',
+        'apipluginbroker', 'byid', 'bypath', 'cachekey', 'cachetag', 'cachetags', 'childamount', 'childpermissions',
+        'children', 'childrensortby', 'childrensortorder', 'childs', 'class', 'classid', 'classname', 'classtitle',
         'closestparentofclass', 'creationdate', 'currentfullpath', 'dao', 'data', 'definition', 'dependencies',
         'dirtyfields', 'dirtylanguages', 'fieldname', 'fullpath', 'getinheritedvalues', 'haschildren', 'hassiblings',
         'hideunpublished', 'id', 'idpath', 'index', 'key', 'language', 'latestversion', 'lazyloadedfieldnames', 'list',
-        'locked', 'modificationdate', 'nextparentforinheritance', 'object', 'omitmandatorycheck', 'parent',
-        'parentclass', 'parentid', 'path', 'permissions', 'permissionsforuser', 'properties', 'property', 'published',
-        'realfullpath', 'realpath', 'relationdata', 'resource', 'scheduledtasks', 'siblings', 'type', 'types',
-        'usermodification', 'userowner', 'userpermissions', 'value', 'valueforfieldname', 'valuefromparent', 'values',
-        'versioncount', 'versions',
+        'listingcachekey', 'locked', 'modificationdate', 'nextparentforinheritance', 'object', 'omitmandatorycheck',
+        'parent', 'parentclass', 'parentid', 'path', 'permissions', 'permissionsforuser', 'properties', 'property',
+        'published', 'realfullpath', 'realpath', 'relationdata', 'resource', 'scheduledtasks', 'siblings', 'type',
+        'types', 'usermodification', 'userowner', 'userpermissions', 'value', 'valueforfieldname', 'valuefromparent',
+        'values', 'versioncount', 'versions',
     ];
 
     /**

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -1319,7 +1319,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
     public function isForbiddenName(): bool
     {
         $name = $this->getName();
-        if ($name === null) {
+        if ($name === null || $name === '') {
             return true;
         }
         $lowerCasedName = strtolower($name);

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -81,11 +81,11 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         'closestparentofclass', 'creationdate', 'currentfullpath', 'dao', 'data', 'definition', 'dependencies',
         'dirtyfields', 'dirtylanguages', 'fieldname', 'fullpath', 'getinheritedvalues', 'haschildren', 'hassiblings',
         'hideunpublished', 'id', 'idpath', 'index', 'key', 'language', 'latestversion', 'lazyloadedfieldnames', 'list',
-        'listingcachekey', 'locked', 'modificationdate', 'nextparentforinheritance', 'object', 'omitmandatorycheck',
-        'parent', 'parentclass', 'parentid', 'path', 'permissions', 'permissionsforuser', 'properties', 'property',
-        'published', 'realfullpath', 'realpath', 'relationdata', 'resource', 'scheduledtasks', 'siblings', 'type',
-        'types', 'usermodification', 'userowner', 'userpermissions', 'value', 'valueforfieldname', 'valuefromparent',
-        'values', 'versioncount', 'versions',
+        'listingcachekey', 'locked', 'modelfactory', 'modificationdate', 'nextparentforinheritance', 'object',
+        'omitmandatorycheck', 'parent', 'parentclass', 'parentid', 'path', 'permissions', 'permissionsforuser',
+        'properties', 'property', 'published', 'realfullpath', 'realpath', 'relationdata', 'resource',
+        'scheduledtasks', 'siblings', 'type', 'types', 'usermodification', 'userowner', 'userpermissions', 'value',
+        'valueforfieldname', 'valuefromparent', 'values', 'versioncount', 'versions',
     ];
 
     /**

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -82,7 +82,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         'versions', 'properties', 'permissions', 'permissionsforuser', 'childamount', 'apipluginbroker', 'resource',
         'parentClass', 'definition', 'locked', 'language', 'omitmandatorycheck', 'idpath', 'object', 'fieldname',
         'property', 'parentid', 'scheduledtasks', 'latestVersion', 'haschildren', 'siblings', 'hassiblings',
-        'childrenSortby', 'childrensortorder', 'versioncount', 'dirtylanguages', 'dirtyfields', 'classTitle',
+        'childrensortby', 'childrensortorder', 'versioncount', 'dirtylanguages', 'dirtyfields', 'classtitle', 'classid',
     ];
 
     /**
@@ -1352,7 +1352,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
     public function isForbiddenName(): bool
     {
-        return in_array($this->getName(), self::FORBIDDEN_NAMES);
+        return in_array(strtolower($this->getName() ?? ''), self::FORBIDDEN_NAMES);
     }
 
     public function jsonSerialize(): mixed

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -76,13 +76,15 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
      * @var string[]
      */
     protected const FORBIDDEN_NAMES = [
-        'id', 'key', 'path', 'type', 'index', 'classname', 'creationdate', 'userowner', 'value', 'class', 'list',
-        'fullpath', 'childs', 'children', 'values', 'cachetag', 'cachetags', 'parent', 'published', 'valuefromparent',
-        'userpermissions', 'dependencies', 'modificationdate', 'usermodification', 'byid', 'bypath', 'data',
-        'versions', 'properties', 'permissions', 'permissionsforuser', 'childamount', 'apipluginbroker', 'resource',
-        'parentClass', 'definition', 'locked', 'language', 'omitmandatorycheck', 'idpath', 'object', 'fieldname',
-        'property', 'parentid', 'scheduledtasks', 'latestVersion', 'haschildren', 'siblings', 'hassiblings',
-        'childrensortby', 'childrensortorder', 'versioncount', 'dirtylanguages', 'dirtyfields', 'classtitle', 'classid',
+        'apipluginbroker', 'byid', 'bypath', 'cachetag', 'cachetags', 'childamount', 'children', 'childrensortby',
+        'childrensortorder', 'childs', 'class', 'classid', 'classname', 'classtitle', 'closestparentofclass',
+        'creationdate', 'dao', 'data', 'definition', 'dependencies', 'dirtyfields', 'dirtylanguages', 'fieldname',
+        'fullpath', 'haschildren', 'hassiblings', 'id', 'idpath', 'index', 'key', 'language', 'latestversion',
+        'lazyloadedfieldnames', 'list', 'localizedfields', 'locked', 'modificationdate', 'nextparentforinheritance',
+        'object', 'omitmandatorycheck', 'parent', 'parentclass', 'parentid', 'path', 'permissions',
+        'permissionsforuser', 'properties', 'property', 'published', 'relationdata', 'resource', 'scheduledtasks',
+        'siblings', 'type', 'usermodification', 'userowner', 'userpermissions', 'value', 'valueforfieldname',
+        'valuefromparent', 'values', 'versioncount', 'versions',
     ];
 
     /**

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -89,21 +89,16 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
     /**
      * Returns the data for the editmode
-     *
-     *
      */
     abstract public function getDataForEditmode(mixed $data, DataObject\Concrete $object = null, array $params = []): mixed;
 
     /**
      * Converts data from editmode to internal eg. Image-Id to Asset\Image object
-     *
-     *
      */
     abstract public function getDataFromEditmode(mixed $data, DataObject\Concrete $object = null, array $params = []): mixed;
 
     /**
      * Checks if data is valid for current data field
-     *
      *
      * @throws \Exception
      */
@@ -129,8 +124,6 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
     /**
      * converts object data to a simple string value or CSV Export
-     *
-     *
      *
      * @internal
      */
@@ -369,9 +362,6 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
     /**
      * returns sql query statement to filter according to this data types value(s)
-     *
-     *
-     *
      */
     public function getFilterCondition(mixed $value, string $operator, array $params = []): string
     {
@@ -388,7 +378,6 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
      * returns sql query statement to filter according to this data types value(s)
      *
      * @param array $params optional params used to change the behavior
-     *
      */
     public function getFilterConditionExt(mixed $value, string $operator, array $params = []): string
     {
@@ -492,8 +481,6 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
     /**
      * Creates getter code which is used for generation of php file for object classes using this data type
-     *
-     *
      */
     public function getGetterCode(DataObject\ClassDefinition|DataObject\Objectbrick\Definition|DataObject\Fieldcollection\Definition $class): string
     {
@@ -543,8 +530,6 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
     /**
      * Creates setter code which is used for generation of php file for object classes using this data type
-     *
-     *
      */
     public function getSetterCode(DataObject\Objectbrick\Definition|DataObject\ClassDefinition|DataObject\Fieldcollection\Definition $class): string
     {
@@ -631,8 +616,6 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
     /**
      * Creates getter code which is used for generation of php file for object brick classes using this data type
-     *
-     *
      */
     public function getGetterCodeObjectbrick(DataObject\Objectbrick\Definition $brickClass): string
     {
@@ -680,8 +663,6 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
     /**
      * Creates setter code which is used for generation of php file for object brick classes using this data type
-     *
-     *
      */
     public function getSetterCodeObjectbrick(DataObject\Objectbrick\Definition $brickClass): string
     {
@@ -763,8 +744,6 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
     /**
      * Creates getter code which is used for generation of php file for fieldcollectionk classes using this data type
-     *
-     *
      */
     public function getGetterCodeFieldcollection(DataObject\Fieldcollection\Definition $fieldcollectionDefinition): string
     {
@@ -804,8 +783,6 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
     /**
      * Creates setter code which is used for generation of php file for fieldcollection classes using this data type
-     *
-     *
      */
     public function getSetterCodeFieldcollection(DataObject\Fieldcollection\Definition $fieldcollectionDefinition): string
     {
@@ -876,8 +853,6 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
     /**
      * Creates getter code which is used for generation of php file for localized fields in classes using this data type
-     *
-     *
      */
     public function getGetterCodeLocalizedfields(DataObject\Objectbrick\Definition|DataObject\ClassDefinition|DataObject\Fieldcollection\Definition $class): string
     {
@@ -916,8 +891,6 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
     /**
      * Creates setter code which is used for generation of php file for localized fields in classes using this data type
-     *
-     *
      */
     public function getSetterCodeLocalizedfields(DataObject\Objectbrick\Definition|DataObject\ClassDefinition|DataObject\Fieldcollection\Definition $class): string
     {
@@ -997,7 +970,6 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
     /**
      * Creates filter method code for listing classes
-     *
      */
     public function getFilterCode(): string
     {
@@ -1085,8 +1057,6 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
      *  - "field" => the name of (this) field
      *  - "key" => the key of the data element
      *  - "data" => the data
-     *
-     *
      */
     public function getDiffDataFromEditmode(array $data, DataObject\Concrete $object = null, array $params = []): mixed
     {
@@ -1106,9 +1076,6 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
      *                          and will not be touched by the editor in any way.
      *      - "disabled" => whether the data element can be edited or not
      *      - "title" => pretty name describing the data element
-     *
-     *
-     *
      */
     public function getDiffDataForEditMode(mixed $data, DataObject\Concrete $object = null, array $params = []): ?array
     {
@@ -1140,8 +1107,6 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
     }
 
     /**
-     *
-     *
      * @throws \Exception
      */
     protected function getDataFromObjectParam(DataObject\Localizedfield|DataObject\Fieldcollection\Data\AbstractData|DataObject\Objectbrick\Data\AbstractData|DataObject\Concrete $object, array $params = []): mixed
@@ -1314,7 +1279,6 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
     /**
      * Returns if datatype supports data inheritance
-     *
      */
     public function supportsInheritance(): bool
     {
@@ -1335,7 +1299,6 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
     /**
      * Returns if datatype supports listing filters: getBy, filterBy
-     *
      */
     public function isFilterable(): bool
     {
@@ -1345,7 +1308,6 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
     /**
      * @param string|int|float|array|Model\Element\ElementInterface $data comparison data, can be scalar or array (if operator is e.g. "IN (?)")
      * @param string $operator SQL comparison operator, e.g. =, <, >= etc. You can use "?" as placeholder, e.g. "IN (?)"
-     *
      */
     public function addListingFilter(DataObject\Listing $listing, float|array|int|string|Model\Element\ElementInterface $data, string $operator = '='): DataObject\Listing
     {
@@ -1354,7 +1316,15 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
     public function isForbiddenName(): bool
     {
-        return in_array(strtolower($this->getName() ?? ''), self::FORBIDDEN_NAMES);
+        $name = $this->getName();
+        if ($name === null) {
+            return true;
+        }
+        if ($name === 'localizedfields' && !$this instanceof DataObject\ClassDefinition\Data\Localizedfields) {
+            return true;
+        }
+
+        return in_array(strtolower($name), self::FORBIDDEN_NAMES);
     }
 
     public function jsonSerialize(): mixed

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -76,16 +76,17 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
      * @var string[]
      */
     protected const FORBIDDEN_NAMES = [
-        'apipluginbroker', 'byid', 'bypath', 'cachekey', 'cachetag', 'cachetags', 'childamount', 'childpermissions',
-        'children', 'childrensortby', 'childrensortorder', 'childs', 'class', 'classid', 'classname', 'classtitle',
-        'closestparentofclass', 'creationdate', 'currentfullpath', 'dao', 'data', 'definition', 'dependencies',
-        'dirtyfields', 'dirtylanguages', 'fieldname', 'fullpath', 'getinheritedvalues', 'haschildren', 'hassiblings',
-        'hideunpublished', 'id', 'idpath', 'index', 'key', 'language', 'latestversion', 'lazyloadedfieldnames', 'list',
-        'listingcachekey', 'locked', 'modelfactory', 'modificationdate', 'nextparentforinheritance', 'object',
-        'objectvar', 'objectvars', 'omitmandatorycheck', 'parent', 'parentclass', 'parentid', 'path', 'permissions',
-        'permissionsforuser', 'properties', 'property', 'published', 'realfullpath', 'realpath', 'relationdata',
-        'resource', 'scheduledtasks', 'siblings', 'type', 'types', 'usermodification', 'userowner', 'userpermissions',
-        'validtablecolumns', 'value', 'valueforfieldname', 'valuefromparent', 'values', 'versioncount', 'versions',
+        'apipluginbroker', 'baseobject', 'byid', 'bypath', 'cachekey', 'cachetag', 'cachetags', 'childamount',
+        'childpermissions', 'children', 'childrensortby', 'childrensortorder', 'childs', 'class', 'classid',
+        'classname', 'classtitle', 'closestparentofclass', 'creationdate', 'currentfullpath', 'dao', 'data',
+        'definition', 'dependencies', 'dirtyfields', 'dirtylanguages', 'dodelete', 'fieldname', 'fullpath',
+        'getinheritedvalues', 'haschildren', 'hassiblings', 'hideunpublished', 'id', 'idpath', 'index', 'key',
+        'language', 'latestversion', 'lazyloadedfieldnames', 'list', 'listingcachekey', 'locked', 'modelfactory',
+        'modificationdate', 'nextparentforinheritance', 'object', 'objectvar', 'objectvars', 'omitmandatorycheck',
+        'parent', 'parentclass', 'parentid', 'path', 'permissions', 'permissionsforuser', 'properties', 'property',
+        'published', 'realfullpath', 'realpath', 'relationdata', 'resource', 'scheduledtasks', 'siblings', 'type',
+        'types', 'usermodification', 'userowner', 'userpermissions', 'validtablecolumns', 'value', 'valueforfieldname',
+        'valuefromparent', 'values', 'versioncount', 'versions',
     ];
 
     /**

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -1320,11 +1320,15 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         if ($name === null) {
             return true;
         }
-        if ($name === 'localizedfields' && !$this instanceof DataObject\ClassDefinition\Data\Localizedfields) {
+        $lowerCasedName = strtolower($name);
+        if (
+            !$this instanceof DataObject\ClassDefinition\Data\Localizedfields &&
+            $lowerCasedName === 'localizedfields'
+        ) {
             return true;
         }
 
-        return in_array(strtolower($name), self::FORBIDDEN_NAMES);
+        return in_array($lowerCasedName, self::FORBIDDEN_NAMES);
     }
 
     public function jsonSerialize(): mixed

--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -123,7 +123,7 @@ class Definition extends Model\AbstractModel
             throw new \Exception('A field-collection needs a key to be saved!');
         }
 
-        if (!preg_match('/^[a-zA-Z][a-zA-Z0-9]*$/', $this->getKey()) || $this->isForbiddenName()) {
+        if ($this->isForbiddenName()) {
             throw new \Exception(sprintf('Invalid key for field-collection: %s', $this->getKey()));
         }
 
@@ -272,6 +272,9 @@ class Definition extends Model\AbstractModel
     {
         $key = $this->getKey();
         if ($key === null || $key === '') {
+            return true;
+        }
+        if (!preg_match('/^[a-zA-Z][a-zA-Z0-9]*$/', $key)) {
             return true;
         }
 

--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -41,8 +41,8 @@ class Definition extends Model\AbstractModel
      * @var array
      */
     protected const FORBIDDEN_NAMES = [
-        'abstract', 'class', 'data', 'folder', 'list', 'permissions', 'resource', 'dao', 'concrete', 'items',
-        'object', 'interface', 'default',
+        'abstract', 'class', 'concrete', 'dao', 'data', 'default', 'folder', 'interface', 'items', 'list', 'object',
+        'permissions', 'resource',
     ];
 
     protected function doEnrichFieldDefinition(Data $fieldDefinition, array $context = []): Data

--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -271,7 +271,7 @@ class Definition extends Model\AbstractModel
     public function isForbiddenName(): bool
     {
         $key = $this->getKey();
-        if ($key === null) {
+        if ($key === null || $key === '') {
             return true;
         }
 

--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -58,7 +58,6 @@ class Definition extends Model\AbstractModel
 
     /**
      * @internal
-     *
      */
     protected function extractDataDefinitions(DataObject\ClassDefinition\Data|DataObject\ClassDefinition\Layout $def): void
     {
@@ -84,8 +83,6 @@ class Definition extends Model\AbstractModel
     }
 
     /**
-     *
-     *
      * @throws \Exception
      */
     public static function getByKey(string $key): ?Definition
@@ -118,7 +115,6 @@ class Definition extends Model\AbstractModel
     }
 
     /**
-     *
      * @throws \Exception
      */
     public function save(bool $saveDefinitionFile = true): void
@@ -166,7 +162,6 @@ class Definition extends Model\AbstractModel
     }
 
     /**
-     *
      * @throws \Exception
      * @throws DataObject\Exception\DefinitionWriteException
      *
@@ -240,8 +235,6 @@ class Definition extends Model\AbstractModel
     }
 
     /**
-     *
-     *
      * @internal
      */
     public function getDefinitionFile(string $key = null): string
@@ -251,7 +244,6 @@ class Definition extends Model\AbstractModel
 
     /**
      * @internal
-     *
      */
     public function getPhpClassFile(): string
     {
@@ -260,7 +252,6 @@ class Definition extends Model\AbstractModel
 
     /**
      * @internal
-     *
      */
     protected function getInfoDocBlock(): string
     {

--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -270,6 +270,11 @@ class Definition extends Model\AbstractModel
 
     public function isForbiddenName(): bool
     {
-        return in_array($this->getKey(), self::FORBIDDEN_NAMES);
+        $key = $this->getKey();
+        if ($key === null) {
+            return true;
+        }
+
+        return in_array(strtolower($key), self::FORBIDDEN_NAMES);
     }
 }

--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -38,7 +38,7 @@ class Definition extends Model\AbstractModel
     use Model\DataObject\ClassDefinition\Helper\VarExport;
 
     /**
-     * @var array
+     * @var string[]
      */
     protected const FORBIDDEN_NAMES = [
         'abstract', 'class', 'concrete', 'dao', 'data', 'default', 'folder', 'interface', 'items', 'list', 'object',

--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -41,8 +41,8 @@ class Definition extends Model\AbstractModel
      * @var string[]
      */
     protected const FORBIDDEN_NAMES = [
-        'abstract', 'class', 'concrete', 'dao', 'data', 'default', 'folder', 'interface', 'items', 'list', 'object',
-        'permissions', 'resource',
+        'abstract', 'abstractdata', 'class', 'concrete', 'dao', 'data', 'default', 'folder', 'interface', 'items',
+        'list', 'object', 'permissions', 'resource',
     ];
 
     protected function doEnrichFieldDefinition(Data $fieldDefinition, array $context = []): Data

--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -150,7 +150,7 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
             throw new \Exception('A object-brick needs a key to be saved!');
         }
 
-        if (!preg_match('/^[a-zA-Z][a-zA-Z0-9]*$/', $this->getKey()) || $this->isForbiddenName()) {
+        if ($this->isForbiddenName()) {
             throw new \Exception(sprintf('Invalid key for object-brick: %s', $this->getKey()));
         }
 


### PR DESCRIPTION
`Fatal error: Declaration of Pimcore\Model\DataObject\Test::setClassId(?string $classId) must be compatible with Pimcore\Model\DataObject\Concrete::setClassId($o_classId) in /var/www/html/var/classes/DataObject/Test.php on line 188`

See also https://github.com/pimcore/admin-ui-classic-bundle/pull/545