### PR TITLE
Fix date attribute storage when client timezone differs from server timezone

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Date.php
+++ b/models/DataObject/ClassDefinition/Data/Date.php
@@ -131,6 +131,10 @@ class Date extends Data implements ResourcePersistenceAwareInterface, QueryResou
             return $this->getDateFromTimestamp($data / 1000);
         }
 
+        if (is_string($data)) {
+            return Carbon::parse($data);
+        }
+
         return null;
     }
 


### PR DESCRIPTION
Data object date attributes with column type "Date" are not saved corretly when the user timezone differs from the server timezone. For the "Date" column type it's not possible to respect the user's timezone, therefore the date is now transfered to the server as string instead of timestamp (int).

Related to https://github.com/pimcore/admin-ui-classic-bundle/pull/553

(Part of #16184)