### PR TITLE
[Improvement]: Add possibility to define date time locale on user basis

### DIFF
--- a/bundles/ApplicationLoggerBundle/public/js/log/admin.js
+++ b/bundles/ApplicationLoggerBundle/public/js/log/admin.js
@@ -270,28 +270,28 @@ pimcore.bundle.applicationlogger.log.admin = Class.create({
             this.fromDate = new Ext.form.DateField({
                 name: 'from_date',
                 width: 130,
-                format: "Y-m-d",
+                format: pimcore.helpers.intlDateFormatFromLocale("Y-m-d"),
                 xtype: 'datefield'
             });
 
             this.fromTime = new Ext.form.TimeField({
                 name: 'from_time',
                 width: 100,
-                format: "H:i",
+                format: pimcore.helpers.intlTimeFormatFromLocale("H:i"),
                 xtype: 'timefield'
             });
 
             this.toDate = new Ext.form.DateField({
                 name: 'to_date',
                 width: 130,
-                format: "Y-m-d",
+                format: pimcore.helpers.intlDateFormatFromLocale("Y-m-d"),
                 xtype: 'datefield'
             });
 
             this.toTime = new Ext.form.TimeField({
                 name: 'to_time',
                 width: 100,
-                format: "H:i",
+                format: pimcore.helpers.intlTimeFormatFromLocale("H:i"),
                 xtype: 'timefield'
             });
 

--- a/bundles/ApplicationLoggerBundle/public/js/log/admin.js
+++ b/bundles/ApplicationLoggerBundle/public/js/log/admin.js
@@ -182,7 +182,8 @@ pimcore.bundle.applicationlogger.log.admin = Class.create({
                     align: 'left',
                     sortable: true,
                     renderer: function (d) {
-                        return Ext.Date.format(new Date(d*1000), "Y-m-d H:i:s");
+                        const localeDateTime = pimcore.globalmanager.get('localeDateTime');
+                        return Ext.Date.format(new Date(d*1000), localeDateTime.getDateTimeFormat());
                     }
                 },{
                     text: t("log_pid"),
@@ -270,28 +271,24 @@ pimcore.bundle.applicationlogger.log.admin = Class.create({
             this.fromDate = new Ext.form.DateField({
                 name: 'from_date',
                 width: 130,
-                format: pimcore.helpers.intlDateFormatFromLocale("Y-m-d"),
                 xtype: 'datefield'
             });
 
             this.fromTime = new Ext.form.TimeField({
                 name: 'from_time',
                 width: 100,
-                format: pimcore.helpers.intlTimeFormatFromLocale("H:i"),
                 xtype: 'timefield'
             });
 
             this.toDate = new Ext.form.DateField({
                 name: 'to_date',
                 width: 130,
-                format: pimcore.helpers.intlDateFormatFromLocale("Y-m-d"),
                 xtype: 'datefield'
             });
 
             this.toTime = new Ext.form.TimeField({
                 name: 'to_time',
                 width: 100,
-                format: pimcore.helpers.intlTimeFormatFromLocale("H:i"),
                 xtype: 'timefield'
             });
 

--- a/bundles/CoreBundle/src/Migrations/Version20240606165618.php
+++ b/bundles/CoreBundle/src/Migrations/Version20240606165618.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240606165618 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Adds the Date Time Locale column to the Users table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if (!$schema->getTable('users')->hasColumn('datetimeLocale')) {
+            $this->addSql('ALTER TABLE `users` ADD COLUMN `datetimeLocale` varchar(10) AFTER `language`;');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if ($schema->getTable('users')->hasColumn('datetimeLocale')) {
+            $this->addSql('ALTER TABLE `users` DROP COLUMN `datetimeLocale`;');
+        }
+    }
+}

--- a/bundles/CoreBundle/src/Migrations/Version20240606165618.php
+++ b/bundles/CoreBundle/src/Migrations/Version20240606165618.php
@@ -7,9 +7,6 @@ namespace Pimcore\Bundle\CoreBundle\Migrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 final class Version20240606165618 extends AbstractMigration
 {
     public function getDescription(): string

--- a/bundles/CoreBundle/src/Migrations/Version20240606165618.php
+++ b/bundles/CoreBundle/src/Migrations/Version20240606165618.php
@@ -6,9 +6,12 @@ namespace Pimcore\Bundle\CoreBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
+use Pimcore\Cache;
+use Pimcore\Cache\RuntimeCache;
 
 final class Version20240606165618 extends AbstractMigration
 {
+    const CACHEKEY = 'system_resource_columns_';
     public function getDescription(): string
     {
         return 'Adds the Date Time Locale column to the Users table.';
@@ -18,6 +21,7 @@ final class Version20240606165618 extends AbstractMigration
     {
         if (!$schema->getTable('users')->hasColumn('datetimeLocale')) {
             $this->addSql('ALTER TABLE `users` ADD COLUMN `datetimeLocale` varchar(10) AFTER `language`;');
+            $this->resetValidTableColumnsCache('users');
         }
     }
 
@@ -25,6 +29,17 @@ final class Version20240606165618 extends AbstractMigration
     {
         if ($schema->getTable('users')->hasColumn('datetimeLocale')) {
             $this->addSql('ALTER TABLE `users` DROP COLUMN `datetimeLocale`;');
+            $this->resetValidTableColumnsCache('users');
         }
     }
+
+    public function resetValidTableColumnsCache(string $table): void
+    {
+        $cacheKey = self::CACHEKEY . $table;
+        if (RuntimeCache::isRegistered($cacheKey)) {
+            RuntimeCache::getInstance()->offsetUnset($cacheKey);
+        }
+        Cache::clearTags(['system', 'resource']);
+    }
+
 }

--- a/bundles/InstallBundle/dump/install.sql
+++ b/bundles/InstallBundle/dump/install.sql
@@ -461,6 +461,7 @@ CREATE TABLE `users` (
   `lastname` varchar(255) DEFAULT NULL,
   `email` varchar(255) DEFAULT NULL,
   `language` varchar(10) DEFAULT 'en',
+  `datetimeLocale` varchar(10) DEFAULT '',
   `contentLanguages` LONGTEXT NULL,
   `admin` tinyint(1) unsigned DEFAULT '0',
   `active` tinyint(1) unsigned DEFAULT '1',

--- a/lib/Tool.php
+++ b/lib/Tool.php
@@ -214,6 +214,49 @@ final class Tool
         return $languageOptions;
     }
 
+    /**
+     * Trying to get BCP 47 format
+     *
+     * @return array<string, string>
+     *
+     * @throws \Exception
+     */
+    public static function getSupportedJSLocales(): array
+    {
+        $localeService = \Pimcore::getContainer()->get(LocaleServiceInterface::class);
+        $locale = $localeService->findLocale();
+
+        $cacheKey = 'system_supported_js_locales_' . strtolower((string)$locale);
+        if (!$languageOptions = Cache::load($cacheKey)) {
+            $languages = $localeService->getLocaleList();
+
+            $languageOptions = [];
+            foreach ($languages as $code) {
+                if (substr_count($code, '_') > 1) {
+                    continue;
+                }
+                $codeBCP = str_replace('_', '-', $code);
+
+                $displayName = \Locale::getDisplayName($code, $locale);
+                $displayRegion = \Locale::getDisplayRegion($code, $locale);
+
+                if ($displayRegion) {
+                    $translation = $displayRegion . ' [' . $codeBCP . ']';
+                } else {
+                    $translation = $displayName . ' [' . $codeBCP . ']';
+                }
+
+                $languageOptions[$codeBCP] = $translation;
+            }
+
+            asort($languageOptions);
+
+            Cache::save($languageOptions, $cacheKey, ['system']);
+        }
+
+        return $languageOptions;
+    }
+
     private static function resolveRequest(Request $request = null): ?Request
     {
         if (null === $request) {

--- a/models/User.php
+++ b/models/User.php
@@ -43,6 +43,8 @@ final class User extends User\UserRole implements UserInterface
 
     protected string $language = 'en';
 
+    protected ?string $datetimeLocale = null;
+
     protected bool $admin = false;
 
     protected bool $active = true;
@@ -727,5 +729,16 @@ final class User extends User\UserRole implements UserInterface
     protected function getFallbackImage(): string
     {
         return PIMCORE_WEB_ROOT . '/bundles/pimcoreadmin/img/avatar.png';
+    }
+
+    public function getDatetimeLocale(): ?string
+    {
+        return $this->datetimeLocale;
+    }
+
+    public function setDatetimeLocale(?string $datetimeLocale): static
+    {
+        $this->datetimeLocale = $datetimeLocale;
+        return $this;
     }
 }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.2`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.2` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Related https://github.com/pimcore/pimcore/issues/14658
Works best with https://github.com/pimcore/admin-ui-classic-bundle/pull/554

## Additional info
opening a draft as i faced some challenges: 

- [x] there is no straightforward way to get the locale format BCP 47 (`en-US`), getting the ones from PHP Intl and replacing `_` with `-` and ignore the "longer" variants AND filter out valid ones by [Intl.DateTimeFormat.supportedLocalesOf](https://github.com/pimcore/admin-ui-classic-bundle/pull/554/files#diff-7891cb6faa7b3cb767562da702a095253f9a4844d6f7e3bf64ca1e9d2af9c3ddR309) in frontend
- [x] todo: the config is missing under `My Profile`
- [x] unusual combination? Austria `en-AT`?
![image](https://github.com/pimcore/pimcore/assets/6014195/5b2f3101-91ac-4c9f-8414-73483fc4f772)
uses slashes as date separator, while `de-AT` is with dots

