### PR TITLE
Fix: ClassDefinitionManager->cleanUpDeletedClassDefinitions()

### DIFF
--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -482,7 +482,7 @@ final class ClassDefinition extends Model\AbstractModel implements ClassDefiniti
      */
     public function delete(): void
     {
-        if (!$this->isWritable()) {
+        if (!$this->isWritable() && file_exists($this->getDefinitionFile())) {
             throw new DataObject\Exception\DefinitionWriteException();
         }
         $this->dispatchEvent(new ClassDefinitionEvent($this), DataObjectClassDefinitionEvents::PRE_DELETE);

--- a/models/DataObject/ClassDefinition/Dao.php
+++ b/models/DataObject/ClassDefinition/Dao.php
@@ -241,12 +241,12 @@ class Dao extends Model\Dao\AbstractDao
         $objectDatastoreTableRelation = 'object_relations_' . $this->model->getId();
         $objectMetadataTable = 'object_metadata_' . $this->model->getId();
 
-        $this->db->executeQuery('DROP TABLE `' . $objectTable . '`');
-        $this->db->executeQuery('DROP TABLE `' . $objectDatastoreTable . '`');
-        $this->db->executeQuery('DROP TABLE `' . $objectDatastoreTableRelation . '`');
+        $this->db->executeQuery('DROP TABLE IF EXISTS `' . $objectTable . '`');
+        $this->db->executeQuery('DROP TABLE IF EXISTS `' . $objectDatastoreTable . '`');
+        $this->db->executeQuery('DROP TABLE IF EXISTS `' . $objectDatastoreTableRelation . '`');
         $this->db->executeQuery('DROP TABLE IF EXISTS `' . $objectMetadataTable . '`');
 
-        $this->db->executeQuery('DROP VIEW `object_' . $this->model->getId() . '`');
+        $this->db->executeQuery('DROP VIEW IF EXISTS `object_' . $this->model->getId() . '`');
 
         // delete data
         $this->db->delete('objects', ['classId' => $this->model->getId()]);
@@ -277,7 +277,7 @@ class Dao extends Model\Dao\AbstractDao
         $allTables = $this->db->fetchAllAssociative("SHOW TABLES LIKE 'object\_brick\_%\_" . $this->model->getId() . "'");
         foreach ($allTables as $table) {
             $brickTable = current($table);
-            $this->db->executeQuery('DROP TABLE `'.$brickTable.'`');
+            $this->db->executeQuery('DROP TABLE IF EXISTS `'.$brickTable.'`');
         }
 
         $this->db->executeQuery('DROP TABLE IF EXISTS object_classificationstore_data_'.$this->model->getId());

--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -210,8 +210,14 @@ class Definition extends Model\AbstractModel
         }
     }
 
+    /**
+     * @throws DataObject\Exception\DefinitionWriteException
+     */
     public function delete(): void
     {
+        if (!$this->isWritable() && file_exists($this->getDefinitionFile())) {
+            throw new DataObject\Exception\DefinitionWriteException();
+        }
         @unlink($this->getDefinitionFile());
         @unlink($this->getPhpClassFile());
 

--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -487,9 +487,14 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
 
     /**
      * Delete Brick Definition
+     *
+     * @throws DataObject\Exception\DefinitionWriteException
      */
     public function delete(): void
     {
+        if (!$this->isWritable() && file_exists($this->getDefinitionFile())) {
+            throw new DataObject\Exception\DefinitionWriteException();
+        }
         $this->dispatchEvent(new ObjectbrickDefinitionEvent($this), ObjectbrickDefinitionEvents::PRE_DELETE);
         @unlink($this->getDefinitionFile());
         @unlink($this->getPhpClassFile());


### PR DESCRIPTION

We have local in the development `PIMCORE_CLASS_DEFINITION_WRITABLE=1` and in the production `PIMCORE_CLASS_DEFINITION_WRITABLE=0`
We have also `PIMCORE_CLASS_DEFINITION_DIRECTORY=/var/www/html/config/pimcore/classes`

So we can change the class definitions local and check it into GIT. In production the class definitions are read only.

When we local delete a class definition it came to this error in the build process:
`php bin/console pimcore:deployment:classes-rebuild -c -d -n`
```
11:04:40 CRITICAL  [console] Error thrown while running command "pimcore:deployment:classes-rebuild -c -d -n -v". Message: "Definitions in /var/www/html/config/pimcore folder cannot be overwritten" ["exception" => Pimcore\Model\DataObject\Exception\DefinitionWriteException^ { …},"command" => "pimcore:deployment:classes-rebuild -c -d -n -v","message" => "Definitions in /var/www/html/config/pimcore folder cannot be overwritten"]

In ClassDefinition.php line 580:
                                                                            
  [Pimcore\Model\DataObject\Exception\DefinitionWriteException]             
  Definitions in /var/www/html/config/pimcore folder cannot be overwritten  
                                                                            

Exception trace:
  at /var/www/html/vendor/pimcore/pimcore/models/DataObject/ClassDefinition.php:580
 Pimcore\Model\DataObject\ClassDefinition->delete() at /var/www/html/vendor/pimcore/pimcore/lib/Model/DataObject/ClassDefinition/ClassDefinitionManager.php:50
 Pimcore\Model\DataObject\ClassDefinition\ClassDefinitionManager->cleanUpDeletedClassDefinitions() at /var/www/html/vendor/pimcore/pimcore/bundles/CoreBundle/Command/ClassesRebuildCommand.php:87
 Pimcore\Bundle\CoreBundle\Command\ClassesRebuildCommand->execute() at /var/www/html/vendor/symfony/console/Command/Command.php:298
 Symfony\Component\Console\Command\Command->run() at /var/www/html/vendor/symfony/console/Application.php:1058
 Symfony\Component\Console\Application->doRunCommand() at /var/www/html/vendor/symfony/framework-bundle/Console/Application.php:96
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at /var/www/html/vendor/symfony/console/Application.php:301
 Symfony\Component\Console\Application->doRun() at /var/www/html/vendor/symfony/framework-bundle/Console/Application.php:82
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /var/www/html/vendor/symfony/console/Application.php:171
 Symfony\Component\Console\Application->run() at /var/www/html/bin/console:26

pimcore:deployment:classes-rebuild [-c|--create-classes] [-d|--delete-classes]

Failed to run php bin/console pimcore:deployment:classes-rebuild -c -d -n -v: exit status 1
```

The delete should be allowed if the definiton file is already deleted.
