### PR TITLE
Layout: Fix return types of getter methods

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -727,14 +727,13 @@ class Asset extends Element\AbstractElement
                     $storage->delete($dbPath);
                 }
 
-                $this->closeStream(); // set stream to null, so that the source stream isn't used anymore after saving
-
-                try {
-                    $mimeType = $storage->mimeType($path);
-                } catch(UnableToRetrieveMetadata $e) {
+                $mimeType = MimeTypes::getDefault()->guessMimeType($this->getLocalFileFromStream($src));
+                if($mimeType === null) {
                     $mimeType = 'application/octet-stream';
                 }
                 $this->setMimeType($mimeType);
+
+                $this->closeStream(); // set stream to null, so that the source stream isn't used anymore after saving
 
                 // set type
                 $type = self::getTypeFromMimeMapping($mimeType, $this->getFilename());

--- a/models/DataObject/ClassDefinition/Layout.php
+++ b/models/DataObject/ClassDefinition/Layout.php
@@ -91,22 +91,22 @@ class Layout implements Model\DataObject\ClassDefinition\Data\VarExporterInterfa
      */
     public bool $locked = false;
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    public function getType(): string
+    public function getType(): ?string
     {
         return $this->type;
     }
 
-    public function getRegion(): string
+    public function getRegion(): ?string
     {
         return $this->region;
     }
 
-    public function getTitle(): string
+    public function getTitle(): ?string
     {
         return $this->title;
     }
@@ -295,7 +295,7 @@ class Layout implements Model\DataObject\ClassDefinition\Data\VarExporterInterfa
         return $this;
     }
 
-    public function getBodyStyle(): string
+    public function getBodyStyle(): ?string
     {
         return $this->bodyStyle;
     }


### PR DESCRIPTION
Lots of properties of `Pimcore\Model\DataObject\ClassDefinition\Layout` are of type `?string`, e.g.
https://github.com/pimcore/pimcore/blob/cf3482e46750b951c13fd7d338c5b030eba6638d/models/DataObject/ClassDefinition/Layout.php#L30

But the corresponding getter methods which simply return these properties have return type `string`, e.g.
https://github.com/pimcore/pimcore/blob/cf3482e46750b951c13fd7d338c5b030eba6638d/models/DataObject/ClassDefinition/Layout.php#L94

This does not fit together.

Sample code to illustrate the problem:
```php
$layout = new \Pimcore\Model\DataObject\ClassDefinition\Layout();
$layout->getName();
```
This triggers a PHP error 
> Pimcore\Model\DataObject\ClassDefinition\Layout::getName(): Return value must be of type string, null returned