### PR TITLE
escape columns in inheritance helper

### DIFF
--- a/models/DataObject/Concrete/Dao/InheritanceHelper.php
+++ b/models/DataObject/Concrete/Dao/InheritanceHelper.php
@@ -242,7 +242,7 @@ class InheritanceHelper
                 $originalEntry = $originalEntryTmp;
                 foreach ($missingIds as $id) {
                     $originalEntry["`" .$this->idField . "`"] = $id;
-                    $this->db->insert($this->querytable, $originalEntry);
+                    $this->db->insert("`" . $this->querytable  . "`", $originalEntry);
                 }
             }
         }

--- a/models/DataObject/Concrete/Dao/InheritanceHelper.php
+++ b/models/DataObject/Concrete/Dao/InheritanceHelper.php
@@ -234,8 +234,14 @@ class InheritanceHelper
 
                 // create entries for children that don't have an entry yet
                 $originalEntry = $this->db->fetchAssociative('SELECT * FROM ' . $this->querytable . ' WHERE ' . $this->idField . ' = ?', [$oo_id]);
+
+                $originalEntryTmp = [];
+                foreach ($originalEntry as $key => $entry) {
+                    $originalEntryTmp["`" . $key . "`"] = $entry;
+                }
+                $originalEntry = $originalEntryTmp;
                 foreach ($missingIds as $id) {
-                    $originalEntry[$this->idField] = $id;
+                    $originalEntry["`" .$this->idField . "`"] = $id;
                     $this->db->insert($this->querytable, $originalEntry);
                 }
             }

--- a/models/DataObject/Concrete/Dao/InheritanceHelper.php
+++ b/models/DataObject/Concrete/Dao/InheritanceHelper.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Pimcore\Model\DataObject\Concrete\Dao;
 
 use Doctrine\DBAL\Connection;
+use Pimcore\Db\Helper;
 use Pimcore\Model\DataObject;
 
 /**
@@ -233,16 +234,11 @@ class InheritanceHelper
                 $missingIds = $this->db->fetchFirstColumn($query);
 
                 // create entries for children that don't have an entry yet
-                $originalEntry = $this->db->fetchAssociative('SELECT * FROM ' . $this->querytable . ' WHERE ' . $this->idField . ' = ?', [$oo_id]);
+                $originalEntry = Helper::quoteDataIdentifiers($this->db, $this->db->fetchAssociative('SELECT * FROM ' . $this->querytable . ' WHERE ' . $this->idField . ' = ?', [$oo_id]));
 
-                $originalEntryTmp = [];
-                foreach ($originalEntry as $key => $entry) {
-                    $originalEntryTmp["`" . $key . "`"] = $entry;
-                }
-                $originalEntry = $originalEntryTmp;
                 foreach ($missingIds as $id) {
-                    $originalEntry["`" .$this->idField . "`"] = $id;
-                    $this->db->insert("`" . $this->querytable  . "`", $originalEntry);
+                    $originalEntry[$this->db->quoteIdentifier($this->idField)] = $id;
+                    $this->db->insert($this->db->quoteIdentifier($this->querytable), $originalEntry);
                 }
             }
         }


### PR DESCRIPTION
in case of having a reserved keyword as field on an objectbrick (e.g "use") the inheritance helper fails to update a child that does not have a brick that is set on the parent. 

since this helper is called upon save of an object, this leads to the obect save throwing an exception in the backend. the dbal insert function states:
"Table expression and columns are not escaped and are not safe for user-input."%


the same might also apply for localized fields.

