### PR TITLE
Check for valid admin UI classic bundle in SearchBackendListener

### DIFF
--- a/bundles/SimpleBackendSearchBundle/src/EventListener/SearchBackendListener.php
+++ b/bundles/SimpleBackendSearchBundle/src/EventListener/SearchBackendListener.php
@@ -57,7 +57,7 @@ class SearchBackendListener implements EventSubscriberInterface
         ];
 
         // used when admin UI classic bundle is installed
-        if (class_exists(AdminEvents::class)) {
+        if (class_exists(AdminEvents::class) && defined(AdminEvents::class . '::OBJECT_LIST_HANDLE_FULLTEXT_QUERY')) {
             $events[AdminEvents::OBJECT_LIST_HANDLE_FULLTEXT_QUERY] = 'onHandleFulltextQuery';
         }
 


### PR DESCRIPTION
This is a follow up to #17105.

As we decided to maybe not add a conflict for admin ui classic bundle <1.5 to the composer.json I added this to double check if the constant exists.