### PR TITLE
Remove fallback sender email address

### DIFF
--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -496,9 +496,8 @@ class Mail extends Email
             }
         }
 
-        if (empty($this->getFrom()) && $hostname = Tool::getHostname()) {
-            // set default "from" address
-            $this->from('no-reply@' . $hostname);
+        if (empty($this->getFrom())) {
+            $sendingFailedException = new \Exception('Missing mandatory mail parameter: From.');
         }
 
         $event = new MailEvent($this, [


### PR DESCRIPTION
## Changes in this pull request 
Throw expection if sender email adress is not configured.

It is not the task of a CMS to guess an email address based on the current host. In the case of the current host not matching the actual email domain, this can lead to sending many emails from "wrong" email adress without anyone noticing, as there is no error.

If this throws an error with a clear message, which is displayed in the Pimcore Backend, the problem becomes clear to everybody. 