### PR TITLE
FrontendController: Fix PhpDoc

### DIFF
--- a/lib/Controller/FrontendController.php
+++ b/lib/Controller/FrontendController.php
@@ -100,9 +100,9 @@ abstract class FrontendController extends Controller
     {
         if (null === $document) {
             $document = $this->document;
-        }
-        if (!$document instanceof Document\PageSnippet) {
-            throw new \Exception('getDocumentEditable needs a Document\PageSnippet instance');
+            if (!$document instanceof Document\PageSnippet) {
+                throw new \Exception('FrontendController::getDocumentEditable() needs a Document\PageSnippet instance');
+            }
         }
 
         return $this->container->get(EditableRenderer::class)->getEditable($document, $type, $inputName, $options);

--- a/lib/Controller/FrontendController.php
+++ b/lib/Controller/FrontendController.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * @property Document $document
+ * @property Document|null $document
  * @property bool $editmode
  */
 abstract class FrontendController extends Controller
@@ -100,6 +100,9 @@ abstract class FrontendController extends Controller
     {
         if (null === $document) {
             $document = $this->document;
+        }
+        if (!$document instanceof Document\PageSnippet) {
+            throw new \Exception('getDocumentEditable needs a Document\PageSnippet instance');
         }
 
         return $this->container->get(EditableRenderer::class)->getEditable($document, $type, $inputName, $options);

--- a/lib/Controller/FrontendController.php
+++ b/lib/Controller/FrontendController.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * @property Document\PageSnippet $document
+ * @property Document $document
  * @property bool $editmode
  */
 abstract class FrontendController extends Controller
@@ -47,7 +47,6 @@ abstract class FrontendController extends Controller
     /**
      * document and editmode as properties and proxy them to request attributes through
      * their resolvers.
-     *
      *
      * @return mixed
      */
@@ -80,7 +79,6 @@ abstract class FrontendController extends Controller
     /**
      * We don't have a response object at this point, but we can add headers here which will be
      * set by the ResponseHeaderListener which reads and adds this headers in the kernel.response event.
-     *
      */
     protected function addResponseHeader(string $key, array|string $values, bool $replace = false, Request $request = null): void
     {
@@ -95,8 +93,6 @@ abstract class FrontendController extends Controller
      * Loads a document editable
      *
      * e.g. `$this->getDocumentEditable('input', 'foobar')`
-     *
-     *
      *
      * @throws \Exception
      */


### PR DESCRIPTION
## Changes in this pull request  

DocumentResolver accept also other Document types instead of PageSnippet. 

For example Link: If you call a DataObject with a Link Document as Prefix.