### PR TITLE
*.dwg files should be unknown asset type

### DIFF
--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -190,6 +190,9 @@ pimcore:
                         textarea: \Pimcore\Model\Asset\MetaData\ClassDefinition\Data\Textarea
         type_definitions:
             map:
+                unknown:
+                    class: \Pimcore\Model\Asset\Unknown
+                    matching: [ "/\\.dwg/", "/\\.stp$/" ]
                 image:
                     class: \Pimcore\Model\Asset\Image
                     matching: ['/image/', "/\\.eps$/", "/\\.ai$/", "/\\.svgz$/", "/\\.pcx$/", "/\\.iff$/", "/\\.pct$/", "/\\.wmf$/", '/photoshop/']
@@ -210,9 +213,6 @@ pimcore:
                 video:
                    class: \Pimcore\Model\Asset\Video
                    matching: [ "/video/" ]
-                unknown:
-                    class: \Pimcore\Model\Asset\Unknown
-                    matching: [ "/\\.stp$/" ]
 
     objects:
         class_definitions:

--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -192,7 +192,7 @@ pimcore:
             map:
                 unknown:
                     class: \Pimcore\Model\Asset\Unknown
-                    matching: [ "/\\.dwg/", "/\\.stp$/" ]
+                    matching: [ "/\\.dwg$/", "/\\.stp$/" ]
                 image:
                     class: \Pimcore\Model\Asset\Image
                     matching: ['/image/', "/\\.eps$/", "/\\.ai$/", "/\\.svgz$/", "/\\.pcx$/", "/\\.iff$/", "/\\.pct$/", "/\\.wmf$/", '/photoshop/']


### PR DESCRIPTION
## Changes in this pull request  
See https://github.com/orgs/pimcore/discussions/8045#discussioncomment-9827866

A *.dwg file will generate many error logs over and over again because imagick can not generate a thumbnail.
```
00:00:16 ERROR     [pimcore] Unable to load image: /var/www/html/public/var/assets/test.dwg  
00:00:16 ERROR     [pimcore] no decode delegate for this image format `DWG' @ error/constitute.c/ReadImage/564  
```
