### PR TITLE
[Bug]: Initial sort to sql definition for report does not work

### DIFF
--- a/bundles/CustomReportsBundle/public/js/pimcore/report/custom/definitions/sql.js
+++ b/bundles/CustomReportsBundle/public/js/pimcore/report/custom/definitions/sql.js
@@ -139,7 +139,7 @@ pimcore.bundle.customreports.custom.definition.sql = Class.create({
                     value: (sourceDefinitionData ? sourceDefinitionData.orderbydir : ""),
                     enableKeyEvents: true,
                     listeners: {
-                        keyup: this.onSqlEditorKeyup.bind(this)
+                        change: this.onSqlEditorKeyup.bind(this)
                     }
                 }
             ]
@@ -205,6 +205,17 @@ pimcore.bundle.customreports.custom.definition.sql = Class.create({
                     sqlText += "<br>GROUP BY ";
                 }
                 sqlText += values.groupby;
+            }
+
+            if(values.orderby) {
+                if(values.orderby.trim().indexOf("ORDER BY") !== 0) {
+                    sqlText += "<br>ORDER BY ";
+                }
+                sqlText += values.orderby;
+
+                if(values.orderbydir) {
+                    sqlText += " " + values.orderbydir;
+                }
             }
 
             this.sqlText.setValue(sqlText);


### PR DESCRIPTION
## Changes in this pull request  
Resolves #17213 

## Additional info
The order by and direction worked basically, but the sql statement wasnt visually updated in the UI
