### PR TITLE
Fix code example for how to create a brick in documentation

### DIFF
--- a/doc/03_Documents/01_Editables/02_Areablock/02_Bricks.md
+++ b/doc/03_Documents/01_Editables/02_Areablock/02_Bricks.md
@@ -181,18 +181,18 @@ brick metadata.
     <div>
         <h2>IFrame</h2>
         <div>
-            URL: {{ urlField }}
+            URL: {{ urlField|raw }}
         </div>
         <br/>
         <b>Advanced Configuration</b>
         <div>
-            Width: {{ widthField }}px (default: 100%)
+            Width: {{ widthField|raw }}px (default: 100%)
         </div>
         <div>
-            Height: {{ heightField }}px (default: 400px)
+            Height: {{ heightField|raw }}px (default: 400px)
         </div>
         <div>
-            Transparent: {{ transparentField }} (default: false)
+            Transparent: {{ transparentField|raw }} (default: false)
         </div>
     </div>
 {% else %}


### PR DESCRIPTION
The example Twig template for creating a brick didn't work properly in editmode.
If the return of pimcore_input, pimcore_numeric (and so on) is stored in a variable, that variable needs to be output raw for the field to be rendered as html.