### PR TITLE
[Bug]: Typecast value passed to `str_starts_with` to `string`

### DIFF
--- a/lib/Tool/Serialize.php
+++ b/lib/Tool/Serialize.php
@@ -82,7 +82,7 @@ final class Serialize
             $propCollection = get_object_vars($clone);
 
             foreach ($propCollection as $name => $propValue) {
-                if (!str_starts_with($name, "\0")) {
+                if (!str_starts_with((string) $name, "\0")) {
                     $clone->$name = self::loopFilterCycles($propValue);
                 }
             }


### PR DESCRIPTION
str_starts_with expects a string and fails otherwise. In some case propCollection may be an unnamed array, meaning $name can be integers and thus failing upon str_starts_wit