### PR TITLE
[Bug]: Check if host is set after `parse_url`

### DIFF
--- a/models/Document/Service.php
+++ b/models/Document/Service.php
@@ -421,12 +421,12 @@ class Service extends Model\Element\Service
             $document = Document::getByPath($urlParts['path']);
 
             // search for a page in a site
-            if (!$document) {
+            if (!$document && isset($urlParts['host'])) {
                 $sitesList = new Model\Site\Listing();
                 $sitesObjects = $sitesList->load();
 
                 foreach ($sitesObjects as $site) {
-                    if ($site->getRootDocument() && isset($urlParts['host']) && (in_array($urlParts['host'], $site->getDomains()) || $site->getMainDomain() == $urlParts['host'])) {
+                    if ($site->getRootDocument() && (in_array($urlParts['host'], $site->getDomains()) || $site->getMainDomain() == $urlParts['host'])) {
                         if ($document = Document::getByPath($site->getRootDocument() . $urlParts['path'])) {
                             break;
                         }

--- a/models/Document/Service.php
+++ b/models/Document/Service.php
@@ -426,7 +426,7 @@ class Service extends Model\Element\Service
                 $sitesObjects = $sitesList->load();
 
                 foreach ($sitesObjects as $site) {
-                    if ($site->getRootDocument() && (in_array($urlParts['host'], $site->getDomains()) || $site->getMainDomain() == $urlParts['host'])) {
+                    if ($site->getRootDocument() && isset($urlParts['host']) && (in_array($urlParts['host'], $site->getDomains()) || $site->getMainDomain() == $urlParts['host'])) {
                         if ($document = Document::getByPath($site->getRootDocument() . $urlParts['path'])) {
                             break;
                         }


### PR DESCRIPTION
When given a $url = "12345_" parse_url will not deliver a host entry in its result.

![image](https://github.com/pimcore/pimcore/assets/14984260/39f29957-a76c-4068-8687-ca208af945ab)