### PR TITLE
[FIX] Allow strings to have escaped quotes

### DIFF
--- a/lib/Model/Listing/AbstractListing.php
+++ b/lib/Model/Listing/AbstractListing.php
@@ -189,7 +189,7 @@ abstract class AbstractListing extends AbstractModel implements \Iterator, \Coun
         $condition = '('.$condition.')';
         $ignoreParameter = true;
 
-        $conditionWithoutQuotedStrings = preg_replace('/["\'][^"\']*?["\']/', '', $condition);
+        $conditionWithoutQuotedStrings = preg_replace('/((?<![\\\\])[\'\"])((?:.(?!(?<![\\\\])\\1))*.?)\\1/', '', $condition);
         if (str_contains($conditionWithoutQuotedStrings, '?') || str_contains($conditionWithoutQuotedStrings, ':')) {
             $ignoreParameter = false;
         }


### PR DESCRIPTION
When a condition in `AbstractListing::addConditionParam` had escaped quotes in it (eg. `xyz.key = 'This is a \"test\" string'`) it was matched weirdly which led to unexpected behaviour in my case.

![image](https://github.com/pimcore/pimcore/assets/12415466/cd0d856e-0481-40a1-9be9-df5b88b62f7a)


The new Regex matches it as intended:
![image](https://github.com/pimcore/pimcore/assets/12415466/dc5cc826-838d-490d-85b1-bcd63e608cd9)

The Regex was taken from https://www.metaltoad.com/blog/regex-quoted-string-escapable-quotes