### PR TITLE
Fix sitemaps doc

### DIFF
--- a/doc/18_Tools_and_Features/39_Sitemaps.md
+++ b/doc/18_Tools_and_Features/39_Sitemaps.md
@@ -23,7 +23,7 @@ for details).
 
 ```yaml
 PrestaSitemapBundle:
-    resource: "@PrestaSitemapBundle/config/routing.yaml"
+    resource: "@PrestaSitemapBundle/config/routing.yml"
     prefix:   /
 ```
 


### PR DESCRIPTION
The routing config of the PrestaSitemapBundle is `@PrestaSitemapBundle/config/routing.yml`
See: https://github.com/prestaconcept/PrestaSitemapBundle/blob/3.x/config/routing.yml