### PR TITLE
Suppress emergency logging on duplicates

### DIFF
--- a/lib/Model/AbstractModel.php
+++ b/lib/Model/AbstractModel.php
@@ -232,7 +232,7 @@ abstract class AbstractModel implements ModelInterface
             } catch (\Doctrine\DBAL\Exception\UniqueConstraintViolationException $e) {
                 // no logs on duplicates
                 throw $e;
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 // log any other issue
                 Logger::emergency((string) $e);
 

--- a/lib/Model/AbstractModel.php
+++ b/lib/Model/AbstractModel.php
@@ -229,7 +229,11 @@ abstract class AbstractModel implements ModelInterface
                 $r = call_user_func_array([$this->getDao(), $method], $args);
 
                 return $r;
-            } catch (Exception $e) {
+            } catch (\Doctrine\DBAL\Exception\UniqueConstraintViolationException $e) {
+                // no logs on duplicates
+                throw $e;
+            } catch (\Exception $e) {
+                // log any other issue
                 Logger::emergency((string) $e);
 
                 throw $e;


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.2`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.2` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Skip `UniqueConstraintViolationException` log on creating DataObject duplicate, other exceptions still logged.

## Additional info
Resolves log spam on `Doctrine\DBAL\Exception\UniqueConstraintViolationException` ,this exception seems to be a higher logical level and developer should decide what to do with it in his `catch` section.
Now it's pollute logs with emergency messages.
Any other exceptions are more technical (low level) and could be logged in a old way.

I'm importing a lot of objects every day (up to few millions) with simple logic:
```
try {
   create();
} catch (UniqueConstraintViolationException $e) {
   update();
} catch (Exception $e) {
   fail();
}
```
If object exist, there is a emergency message dropped to logs anyway.

In my case, for each DataObject it will take less SQL queries, than if I would check existence like that every time:

```
try {
   if (isExist()) {
      update();
   } else {
      create();
   }
} catch (Exception $e) {
   fail();
}
```

Amount of SQL queries for 100 objects:
Create, update on exception - if no duplicates just 100 creates, if all duplicates 100 creates + 100 updates = min 100, max 200 
Check, crate or update - 100 checks + 100 actions = always 200
Less queries, faster import.

But my logs are bloated with messages like `EMERGENCY [pimcore] PDOException: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '*********' for key 'object_store_*********' in /var/www/html/vendor/doctrine/dbal/src/Driver/PDO/Statement.php:130`

Even if I'm catch this exception, the Pimcore already logged it under the hood.

# How to reproduce
Create an DataObject 2 times