### PR TITLE
Update KeyConfig.php to prevent access before initialization TypeError

### DIFF
--- a/models/DataObject/Classificationstore/KeyConfig.php
+++ b/models/DataObject/Classificationstore/KeyConfig.php
@@ -61,7 +61,7 @@ final class KeyConfig extends Model\AbstractModel
 
     protected ?int $modificationDate = null;
 
-    protected string $definition;
+    protected string $definition = "[]";
 
     protected bool $enabled;
 

--- a/models/DataObject/Classificationstore/KeyConfig.php
+++ b/models/DataObject/Classificationstore/KeyConfig.php
@@ -61,7 +61,7 @@ final class KeyConfig extends Model\AbstractModel
 
     protected ?int $modificationDate = null;
 
-    protected string $definition = "[]";
+    protected string $definition = '[]';
 
     protected bool $enabled;
 

--- a/models/DataObject/Classificationstore/KeyConfig.php
+++ b/models/DataObject/Classificationstore/KeyConfig.php
@@ -63,7 +63,7 @@ final class KeyConfig extends Model\AbstractModel
 
     protected string $definition = '[]';
 
-    protected bool $enabled;
+    protected bool $enabled = false;
 
     public static function getById(int $id, ?bool $force = false): ?KeyConfig
     {


### PR DESCRIPTION
## Changes in this pull request  
Prevents `Typed property Pimcore\Model\DataObject\Classificationstore\KeyConfig::$definition must not be accessed before initialization` from being thrown randomly when doing other pimcore operations which the ClassificationStore is in use.

## Additional info
