### PR TITLE
Fix error when deleting unique field in FieldCollection

### DIFF
--- a/models/DataObject/Fieldcollection/Definition/Dao.php
+++ b/models/DataObject/Fieldcollection/Definition/Dao.php
@@ -98,6 +98,7 @@ class Dao extends Model\Dao\AbstractDao
             }
         }
 
+        $this->removeIndices($table, $columnsToRemove, $protectedColums);
         $this->removeUnusedColumns($table, $columnsToRemove, $protectedColums);
         $this->tableDefinitions = [];
     }


### PR DESCRIPTION
## Changes in this pull request  
Fix error when deleting unique field in FieldCollection

## Additional info
From what we understand of the bug, it is a problem with an index which is not deleted before the SQL column is deleted

To reproduce:
- Create a unique field in a field Collection on server A
- Deploy the code on server B
- Run classes-rebuild on server B
- Everything is OK
- Remove unique field from fieldCollection on server A
- Deploy on server B
- Run classes-rebuild on server B
- Crash with a non-explicit error
![image](https://github.com/user-attachments/assets/af3bef76-3761-462c-bb97-1b01a479c5b4)

Note: Re-open of #17234 since I have completly blew up my old PR (Sorry)
