### PR TITLE
Add static to the getValues function

### DIFF
--- a/models/DataObject/SelectOptions/Traits/EnumGetValuesTrait.php
+++ b/models/DataObject/SelectOptions/Traits/EnumGetValuesTrait.php
@@ -21,7 +21,7 @@ trait EnumGetValuesTrait
     /**
      * @return string[]
      */
-    public function getValues(): array
+    public static function getValues(): array
     {
         return array_column(static::cases(), 'value');
     }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.2`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.2` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  

The method must be made static, because you cannot open it through the SelectOptions, because the SelectOptions are an enum, and you cannot create an instance of enums, which is why you can only access the method if you go through a case/value/enum value, but this becomes difficult if the enum does not contain a value because the SelectOptions are empty.

## Additional info
