### PR TITLE
[BUG] Imagick: extend clipping path check for images

### DIFF
--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -160,7 +160,8 @@ class Imagick extends Adapter
 
         // according to 8BIM format: https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#50577409_pgfId-1037504
         // we're looking for the resource id 'Name of clipping path' which is 8BIM 2999 (decimal) or 0x0BB7 in hex
-        if (preg_match('/8BIM\x0b\xb7/', $chunk)) {
+        // and the first path information which is 8BIM 2000 (decimal) or 0x07D0 in hex
+        if (preg_match('/8BIM\x0b\xb7/', $chunk) || preg_match('/8BIM\x07\xd0/', $chunk)) {
             return true;
         }
 


### PR DESCRIPTION
## Changes in this pull request 

TIFF Images created by Adobe Photoshop can contain a clipping path, but not in all cases the images contain a clipping path name. therefore I want to extend the clipping path check by adding the check of an existing path information (first one).

Current Behaviour: 
When we use these TIFF images with clipping path (but without clipping path name) for the thumbnail generation, the thumbnails don't contain the clipping path.

Expected behaviour:
The generated thumbnails contain the clipping path.