### PR TITLE
Data Object: HTML in version preview should be rendered properly for wysiwyg data type

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Extension/Text.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Text.php
@@ -39,10 +39,7 @@ trait Text
     }
 
     /**
-     *
-     *
      * @see Data::getVersionPreview
-     *
      */
     public function getVersionPreview(mixed $data, Model\DataObject\Concrete $object = null, array $params = []): string
     {

--- a/models/DataObject/ClassDefinition/Data/Wysiwyg.php
+++ b/models/DataObject/ClassDefinition/Data/Wysiwyg.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
+use Pimcore;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\Element;
@@ -302,5 +303,13 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
     public function getFieldType(): string
     {
         return 'wysiwyg';
+    }
+
+    /**
+     * @see Data::getVersionPreview
+     */
+    public function getVersionPreview(mixed $data, DataObject\Concrete $object = null, array $params = []): string
+    {
+        return self::getWysiwygSanitizer()->sanitizeFor('body', (string) $data);
     }
 }


### PR DESCRIPTION
Currently content of WYSIWYG fields is getting escaped and therefore looks like this

![image](https://github.com/user-attachments/assets/18dbb0e6-45d6-4d57-bfe6-ab4e5dd7db0c)


This PR fixes this, while keeping it secure against XSS by using the HTML Sanitizer. 