### PR TITLE
UrlSlug: Fix return type

### DIFF
--- a/models/DataObject/ClassDefinition/Data/UrlSlug.php
+++ b/models/DataObject/ClassDefinition/Data/UrlSlug.php
@@ -552,12 +552,12 @@ class UrlSlug extends Data implements CustomResourcePersistingInterface, LazyLoa
 
     public function getReturnTypeDeclaration(): ?string
     {
-        return '?array';
+        return 'array';
     }
 
     public function getPhpdocInputType(): ?string
     {
-        return '\\' . Model\DataObject\Data\UrlSlug::class . '[]';
+        return '\\' . Model\DataObject\Data\UrlSlug::class . '[]|null';
     }
 
     public function getPhpdocReturnType(): ?string


### PR DESCRIPTION
## Changes in this pull request  
Follow up to https://github.com/pimcore/pimcore/pull/17281, https://github.com/pimcore/pimcore/pull/17363

I think only the parameter type is a BC break. Maybe this should also be nullable in Pimcore 12 (possibly making #17364 unnecessary), because of #17368.

