### PR TITLE
Respect denied workflow permissions in permission checks

### DIFF
--- a/lib/Workflow/Manager.php
+++ b/lib/Workflow/Manager.php
@@ -361,4 +361,40 @@ class Manager
 
         return $definition->getInitialPlaces();
     }
+
+    public function isDeniedInWorkflow(ElementInterface $element, string $permissionType): bool
+    {
+        $userPermissions = $this->getWorkflowUserPermissions($element);
+
+        return ($userPermissions[$permissionType] ?? null) === false;
+    }
+
+    private function getWorkflowUserPermissions(ElementInterface $element): array
+    {
+        $userPermissions = [];
+        foreach ($this->getAllWorkflows() as $workflowName) {
+            $workflow = $this->getWorkflowIfExists($element, $workflowName);
+
+            if (empty($workflow)) {
+                continue;
+            }
+
+            $marking = $workflow->getMarking($element);
+
+            if (!count($marking->getPlaces())) {
+                continue;
+            }
+
+            foreach ($this->getOrderedPlaceConfigs($workflow, $marking) as $placeConfig) {
+                if (!empty($placeConfig->getPermissions($workflow, $element))) {
+                    $userPermissions = array_merge(
+                        $userPermissions,
+                        $placeConfig->getUserPermissions($workflow, $element)
+                    );
+                }
+            }
+        }
+
+        return $userPermissions;
+    }
 }

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -27,6 +27,7 @@ use Pimcore\Messenger\ElementDependenciesMessage;
 use Pimcore\Model;
 use Pimcore\Model\Element\Traits\DirtyIndicatorTrait;
 use Pimcore\Model\User;
+use Pimcore\Workflow\Manager;
 
 /**
  * @method Model\Document\Dao|Model\Asset\Dao|Model\DataObject\AbstractObject\Dao getDao()
@@ -485,10 +486,13 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
 
             return false;
         }
+        /** @var Manager $workflowManager */
+        $workflowManager = Pimcore::getContainer()->get(Manager::class);
+        $isDeniedInWorkflow = $workflowManager->isDeniedInWorkflow($this, $type);
 
-        //everything is allowed for admin
+        //everything is allowed for admin except if it is denied in workflow
         if ($user->isAdmin()) {
-            return true;
+            return !$isDeniedInWorkflow;
         }
 
         if (!$user->isAllowed(Service::getElementType($this) . 's')) {
@@ -496,8 +500,12 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
         }
         $isAllowed = $this->getDao()->isAllowed($type, $user);
 
+        if ($isDeniedInWorkflow) {
+            $isAllowed = false;
+        }
+
         $event = new ElementEvent($this, ['isAllowed' => $isAllowed, 'permissionType' => $type, 'user' => $user]);
-        \Pimcore::getEventDispatcher()->dispatch($event, ElementEvents::ELEMENT_PERMISSION_IS_ALLOWED);
+        Pimcore::getEventDispatcher()->dispatch($event, ElementEvents::ELEMENT_PERMISSION_IS_ALLOWED);
 
         return (bool) $event->getArgument('isAllowed');
     }


### PR DESCRIPTION
When workflows deny certain actions (e.g. saving of an element) currently only the buttons in the UI are hidden which leads to the situation that it is still possible to modifiy or delete the element e.g. via keyboard shortcuts (see #17095).

This PR solves this problem by respecting denied workflow permissions in the permission check.