### PR TITLE
Fix MySql Error 'Syntax error or access violation: 1061 Duplicate key name' when unique key consists of at least 2 columns

### DIFF
--- a/models/DataObject/ClassDefinition/Helper/Dao.php
+++ b/models/DataObject/ClassDefinition/Helper/Dao.php
@@ -199,7 +199,7 @@ trait Dao
             ]
         );
 
-        return (\count($exist) > 0) && (1 === $exist[0]);
+        return (\count($exist) > 0) && ($exist[0] > 0);
     }
 
     protected function indexDoesNotExist(string $table, string $prefix, string $indexName): bool


### PR DESCRIPTION
Fix MySql Error 'Syntax error or access violation: 1061 Duplicate key name' when unique key consists of at least 2 columns

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.2`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.2` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #
Error when migrating Pimcore\Bundle\CoreBundle\Migrations\Version20240708083500
If there are are field collection we receive error:
<img width="1056" alt="Screenshot 2024-07-19 at 12 34 38" src="https://github.com/user-attachments/assets/61390289-c6e5-454a-b918-fd443961492e">

Error happens because of this logic:
```
protected function indexExists(string $table, string $prefix, string $indexName): bool
    {
        $exist = $this->db->fetchFirstColumn(
            'SELECT COUNT(*)
            FROM information_schema.statistics
            WHERE table_name = ?
                AND index_name = ?
                AND table_schema = DATABASE();',
            [
                $table,
                $prefix . $indexName,
            ]
        );

        return (\count($exist) > 0) && (1 === $exist[0]);
    }
```
For field collection unique key consists of 2 columns:
<img width="1279" alt="Screenshot 2024-07-19 at 12 33 49" src="https://github.com/user-attachments/assets/fabe4ba0-87ce-42e0-9413-e4bc696c4390">

<img width="603" alt="Screenshot 2024-07-19 at 12 33 05" src="https://github.com/user-attachments/assets/a1d289be-fbaf-4967-9380-6f6868d2459e">

and because  `$exist[0] is equal to 2` it does not fulfill condition `1 === $exist[0]` and it returns false, which is not correct
   


## Additional info
