### PR TITLE
[Data Objects] Fixed removing a field with an index

### DIFF
--- a/models/DataObject/ClassDefinition/Helper/Dao.php
+++ b/models/DataObject/ClassDefinition/Helper/Dao.php
@@ -121,6 +121,7 @@ trait Dao
             //if (!in_array($value, $protectedColumns)) {
             if (!in_array(strtolower($value), array_map('strtolower', $protectedColumns))) {
                 $dropColumns[] = 'DROP COLUMN `' . $value . '`';
+                $this->removeIndices($table, [$value], []);
             }
         }
         if ($dropColumns) {


### PR DESCRIPTION
Currently it's not possible to remove a field from a class definition, field collection, ... when it has an unique index. The index needs to be removed first, so that the column can be dropped. 

Related to #17374 