### PR TITLE
[Task]: Optimize `tags` queries via runtime cache

### DIFF
--- a/lib/Tool.php
+++ b/lib/Tool.php
@@ -64,7 +64,6 @@ final class Tool
      *
      * @static
      *
-     * @param ?string $language
      *
      */
     public static function isValidLanguage(?string $language): bool

--- a/models/Element/Tag.php
+++ b/models/Element/Tag.php
@@ -359,7 +359,14 @@ final class Tag extends Model\AbstractModel
     {
         $this->dispatchEvent(new TagEvent($this), TagEvents::PRE_DELETE);
 
-        $this->getDao()->delete();
+        $deletedTagIds = $this->getDao()->delete();
+
+        foreach ($deletedTagIds as $removeId) {
+            $cacheKey = 'tags_' . $removeId;
+            if (RuntimeCache::isRegistered($cacheKey)) {
+                RuntimeCache::getInstance()->offsetUnset($cacheKey);
+            }
+        }
 
         $this->dispatchEvent(new TagEvent($this), TagEvents::POST_DELETE);
     }

--- a/models/Element/Tag.php
+++ b/models/Element/Tag.php
@@ -73,6 +73,7 @@ final class Tag extends Model\AbstractModel
     public static function getById(int $id): ?Tag
     {
         $cacheKey = 'tags_' . $id;
+
         try {
             $tag = RuntimeCache::get($cacheKey);
         } catch (\Exception $ex) {
@@ -84,6 +85,7 @@ final class Tag extends Model\AbstractModel
                 return null;
             }
         }
+
         return $tag;
     }
 

--- a/models/Element/Tag/Dao.php
+++ b/models/Element/Tag/Dao.php
@@ -15,7 +15,6 @@
 
 namespace Pimcore\Model\Element\Tag;
 
-use Pimcore\Cache\RuntimeCache;
 use Pimcore\Db\Helper;
 use Pimcore\Model;
 use Pimcore\Model\Element\Tag;

--- a/models/Element/Tag/Dao.php
+++ b/models/Element/Tag/Dao.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Model\Element\Tag;
 
+use Pimcore\Cache\RuntimeCache;
 use Pimcore\Db\Helper;
 use Pimcore\Model;
 use Pimcore\Model\Element\Tag;
@@ -113,6 +114,11 @@ class Dao extends Model\Dao\AbstractDao
             $this->db->rollBack();
 
             throw $e;
+        }
+
+        $cacheKey = 'tags_' . $this->model->getId();
+        if (RuntimeCache::isRegistered($cacheKey)) {
+            RuntimeCache::getInstance()->offsetUnset($cacheKey);
         }
     }
 

--- a/models/Element/Tag/Dao.php
+++ b/models/Element/Tag/Dao.php
@@ -106,14 +106,14 @@ class Dao extends Model\Dao\AbstractDao
             $this->db->delete('tags_assignment', ['tagid' => $this->model->getId()]);
             $this->db->executeStatement('DELETE FROM tags_assignment WHERE ' . Helper::quoteInto($this->db, 'tagid IN (SELECT id FROM tags WHERE idPath LIKE ?)', Helper::escapeLike($this->model->getIdPath()) . $this->model->getId() . '/%'));
 
-            $toRemoveTagIds = $this->db->fetchAllAssociative('SELECT id FROM tags WHERE ' . Helper::quoteInto($this->db, 'idPath LIKE ?', Helper::escapeLike($this->model->getIdPath()) . $this->model->getId() . '/%'));
-            $toRemoveTagIds[] = ['id' => $this->model->getId()];
+            $toRemoveTagIds = $this->db->fetchFirstColumn('SELECT id FROM tags WHERE ' . Helper::quoteInto($this->db, 'idPath LIKE ?', Helper::escapeLike($this->model->getIdPath()) . $this->model->getId() . '/%'));
+            $toRemoveTagIds[] = $this->model->getId();
 
-            $this->db->executeStatement('DELETE FROM tags WHERE id IN (' . implode(',', array_column($toRemoveTagIds, 'id')) . ')');
+            $this->db->executeStatement('DELETE FROM tags WHERE id IN (' . implode(',', $toRemoveTagIds) . ')');
             $this->db->commit();
 
             foreach ($toRemoveTagIds as $removeId) {
-                $cacheKey = 'tags_' . $removeId['id'];
+                $cacheKey = 'tags_' . $removeId;
                 if (RuntimeCache::isRegistered($cacheKey)) {
                     RuntimeCache::getInstance()->offsetUnset($cacheKey);
                 }

--- a/models/Element/Tag/Dao.php
+++ b/models/Element/Tag/Dao.php
@@ -98,27 +98,20 @@ class Dao extends Model\Dao\AbstractDao
      *
      * @throws \Exception
      */
-    public function delete(): void
+    public function delete(): array
     {
         $this->db->beginTransaction();
 
         try {
-            $this->db->delete('tags_assignment', ['tagid' => $this->model->getId()]);
-            $this->db->executeStatement('DELETE FROM tags_assignment WHERE ' . Helper::quoteInto($this->db, 'tagid IN (SELECT id FROM tags WHERE idPath LIKE ?)', Helper::escapeLike($this->model->getIdPath()) . $this->model->getId() . '/%'));
-
             $toRemoveTagIds = $this->db->fetchFirstColumn('SELECT id FROM tags WHERE ' . Helper::quoteInto($this->db, 'idPath LIKE ?', Helper::escapeLike($this->model->getIdPath()) . $this->model->getId() . '/%'));
             $toRemoveTagIds[] = $this->model->getId();
+            $implodedTagIds = implode(',', $toRemoveTagIds);
 
-            $this->db->executeStatement('DELETE FROM tags WHERE id IN (' . implode(',', $toRemoveTagIds) . ')');
+            $this->db->executeStatement('DELETE FROM tags_assignment WHERE tagid IN (' . $implodedTagIds . ')');
+            $this->db->executeStatement('DELETE FROM tags WHERE id IN (' . $implodedTagIds . ')');
             $this->db->commit();
 
-            foreach ($toRemoveTagIds as $removeId) {
-                $cacheKey = 'tags_' . $removeId;
-                if (RuntimeCache::isRegistered($cacheKey)) {
-                    RuntimeCache::getInstance()->offsetUnset($cacheKey);
-                }
-            }
-
+            return $toRemoveTagIds;
         } catch (\Exception $e) {
             $this->db->rollBack();
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/admin-ui-classic-bundle/issues/627

## Additional info
By caching the element, it should reduce the queries of the same element

`setParentId()` calls `correctPath` which ends up calling the same parents multiple time via `self::getById($parentId);`
https://github.com/pimcore/pimcore/blob/6c69fbaae3f2a853d5c1445267c5925b28042a55/models/Element/Tag.php#L250
https://github.com/pimcore/pimcore/blob/6c69fbaae3f2a853d5c1445267c5925b28042a55/models/Element/Tag.php#L338-L341
https://github.com/pimcore/pimcore/blob/6c69fbaae3f2a853d5c1445267c5925b28042a55/models/Element/Tag.php#L255-L259