### PR TITLE
[Docs] Removed info about HTML sanitizer max length 

### DIFF
--- a/doc/03_Documents/01_Editables/40_WYSIWYG.md
+++ b/doc/03_Documents/01_Editables/40_WYSIWYG.md
@@ -80,5 +80,3 @@ If you want to adapt this configuration please have a look at the [symfony docum
 
 > Note: When using API to set WYSIWYG data, please pass encoded characters for html entities e.g. `<`,`>`, `&` etc.
 > The data is encoded by the sanitizer before persisting into db and the same encoded data will be returned by the API.
-
-> Note: By default, HTML sanitizer truncates content at 20.000 characters. To change that, see [symfony documentation](https://symfony.com/doc/current/html_sanitizer.html#max-input-length). 


### PR DESCRIPTION
partly reverts #16451 - follow up of #16297
