### PR TITLE
fix overwritten loop variable in a nested loop in brick class dumper

### DIFF
--- a/lib/DataObject/ClassBuilder/PHPObjectBrickContainerClassDumper.php
+++ b/lib/DataObject/ClassBuilder/PHPObjectBrickContainerClassDumper.php
@@ -63,7 +63,7 @@ class PHPObjectBrickContainerClassDumper implements PHPObjectBrickContainerClass
                 }
 
                 foreach ($cd as $fieldname => $brickKeys) {
-                    $cd = $this->classBuilder->buildContainerClass($definition, $class, $fieldname, $brickKeys);
+                    $containerClass = $this->classBuilder->buildContainerClass($definition, $class, $fieldname, $brickKeys);
                     $folder = $definition->getContainerClassFolder($class->getName());
 
                     if (!is_dir($folder)) {
@@ -71,7 +71,7 @@ class PHPObjectBrickContainerClassDumper implements PHPObjectBrickContainerClass
                     }
 
                     $file = $folder . '/' . ucfirst($fieldname) . '.php';
-                    $this->filesystem->dumpFile($file, $cd);
+                    $this->filesystem->dumpFile($file, $containerClass);
                 }
             }
         }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #
$cd comes from the foreach in line 52 and is an array. the foreach in line 65 uses this variable as iterable, though immediately overwrites it with a string. on the second run this fails since a string is not an iterable.

## Additional info
error was introduced with https://github.com/pimcore/pimcore/commit/6706dba38446ab23ca2ea1a704cae261eac45fbf.

i stumbled uppon this problem when this (https://github.com/pimcore/pimcore/blob/11.3/bundles/CoreBundle/src/Migrations/Version20240708083500.php) migrations was executed and the Bricks in our project were saved. `APP_DEBUG=true` was set and warning were handled as errors, we got following error

```
[notice] Saving class: ...
...
[notice] Saving object brick: Brick1
[error] Migration Pimcore\Bundle\CoreBundle\Migrations\Version20240708083500 failed during Execution. Error: "Warning: foreach() argument must be of type array|object, string given"

In PHPObjectBrickContainerClassDumper.php line 65:
                                                                          
  Warning: foreach() argument must be of type array|object, string given  
```

