### PR TITLE
HTML sanitizer: Allow img class attribute and hr element

### DIFF
--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -100,7 +100,8 @@ framework:
                     s: [ 'class', 'id' ]
                     iframe: [ 'frameborder', 'height', 'longdesc', 'name', 'sandbox', 'scrolling', 'src', 'title', 'width' ]
                     br: ''
-                    img: [ 'alt', 'style', 'src' ]
+                    img: [ 'class', 'alt', 'style', 'src' ]
+                    hr: ''
             pimcore.translation_sanitizer:
                 allow_attributes:
                     pimcore_type: '*'


### PR DESCRIPTION
## Changes in this pull request  

- Allow class attribute for img element (classes can be added via image_class_list config in the tinymce editor)
- Allow hr element

## Additional info
Split from #17319 for branch 11.3