### PR TITLE
[Doc] Fix Path Formatter example

### DIFF
--- a/doc/05_Objects/01_Object_Classes/05_Class_Settings/50_Path_Formatter.md
+++ b/doc/05_Objects/01_Object_Classes/05_Class_Settings/50_Path_Formatter.md
@@ -50,7 +50,7 @@ class TheFormatter implements PathFormatterInterface
         $context = $params['context'];
 
         foreach ($targets as $key => $item) {
-            $newPath = $item['path'] .  ' - ' . time();
+            $newPath = $item['path'] . ' - ' . time();
             if ($context['language']) {
                 $newPath .= ' ' . $context['language'];
             }

--- a/doc/05_Objects/01_Object_Classes/05_Class_Settings/50_Path_Formatter.md
+++ b/doc/05_Objects/01_Object_Classes/05_Class_Settings/50_Path_Formatter.md
@@ -50,7 +50,7 @@ class TheFormatter implements PathFormatterInterface
         $context = $params['context'];
 
         foreach ($targets as $key => $item) {
-            $newPath = $item['path'] . ' - ' . time();
+            $newPath = ($item['path'] ?? $item['fullpath']) . ' - ' . time();
             if (isset($context['language'])) {
                 $newPath .= ' ' . $context['language'];
             }

--- a/doc/05_Objects/01_Object_Classes/05_Class_Settings/50_Path_Formatter.md
+++ b/doc/05_Objects/01_Object_Classes/05_Class_Settings/50_Path_Formatter.md
@@ -68,7 +68,7 @@ class TheFormatter implements PathFormatterInterface
                     $title = $asset->getMetadata('title');
 
                     if (!$title) {
-                        $title = 'this guy does not have a title, use ' . $newPath . ' instead';
+                        $title = 'this asset does not have a title, use ' . $newPath . ' instead';
                     }
                     if ($fd instanceof Data\ManyToManyRelation) {
                         $newPath = '<img src="' . $asset . '" style="width: 25px; height: 18px;" />' . $title;

--- a/doc/05_Objects/01_Object_Classes/05_Class_Settings/50_Path_Formatter.md
+++ b/doc/05_Objects/01_Object_Classes/05_Class_Settings/50_Path_Formatter.md
@@ -51,7 +51,7 @@ class TheFormatter implements PathFormatterInterface
 
         foreach ($targets as $key => $item) {
             $newPath = $item['path'] . ' - ' . time();
-            if ($context['language']) {
+            if (isset($context['language'])) {
                 $newPath .= ' ' . $context['language'];
             }
 

--- a/doc/05_Objects/01_Object_Classes/05_Class_Settings/50_Path_Formatter.md
+++ b/doc/05_Objects/01_Object_Classes/05_Class_Settings/50_Path_Formatter.md
@@ -45,31 +45,30 @@ class TheFormatter implements PathFormatterInterface
      */
     public function formatPath(array $result, ElementInterface $source, array $targets, array $params): array
     {
-        /** @var  $fd Data */
-        $fd = $params["fd"];
-        $context = $params["context"];
+        /** @var Data $fd */
+        $fd = $params['fd'];
+        $context = $params['context'];
 
         foreach ($targets as $key => $item) {
-            $newPath = $item["fullpath"] .  " - " . time();
-            if ($context["language"]) {
-                $newPath .= " " . $context["language"];
+            $newPath = $item['path'] .  ' - ' . time();
+            if ($context['language']) {
+                $newPath .= ' ' . $context['language'];
             }
 
-            if ($item["type"] == "object") {
-                $targetObject = Concrete::getById($item["id"]);
+            if ($item['type'] === 'object') {
+                $targetObject = Concrete::getById($item['id']);
                 if ($targetObject instanceof News) {
-                    $newPath = $targetObject->getTitle() . " - " . $targetObject->getShortText();
+                    $newPath = $targetObject->getTitle() . ' - ' . $targetObject->getShortText();
                 }  else if ($targetObject instanceof BlogArticle) {
                     $newPath = $targetObject->getTitle();
                 }
-            } elseif ($item["type"] == "asset") {
-                $asset = Asset::getById($item["id"]);
+            } elseif ($item['type'] === 'asset') {
+                $asset = Asset::getById($item['id']);
                 if ($asset) {
-                    $title = $asset->getMetadata("title");
-
+                    $title = $asset->getMetadata('title');
 
                     if (!$title) {
-                        $title = "this guy does not have a title, use " . $newPath . " instead";
+                        $title = 'this guy does not have a title, use ' . $newPath . ' instead';
                     }
                     if ($fd instanceof Data\ManyToManyRelation) {
                         $newPath = '<img src="' . $asset . '" style="width: 25px; height: 18px;" />' . $title;
@@ -80,8 +79,9 @@ class TheFormatter implements PathFormatterInterface
             }
                 
             // don't forget to use the same key, otherwise the matching doesn't work
-            $result[$key]= $newPath;
+            $result[$key] = $newPath;
         }
+
         return $result;
     }
 }

--- a/lib/Tool.php
+++ b/lib/Tool.php
@@ -27,7 +27,6 @@ final class Tool
     /**
      * Sets the current request to use when resolving request at early
      * stages (before container is loaded)
-     *
      */
     private static ?Request $currentRequest = null;
 
@@ -39,7 +38,6 @@ final class Tool
 
     /**
      * Sets the current request to operate on
-     *
      *
      * @internal
      */
@@ -63,9 +61,6 @@ final class Tool
      * configured at all, false otherwise.
      *
      * @static
-     *
-     * @param ?string $language
-     *
      */
     public static function isValidLanguage(?string $language): bool
     {
@@ -159,7 +154,6 @@ final class Tool
      * Returns the default language for this system. If no default is set,
      * returns the first language, or null, if no languages are configured
      * at all.
-     *
      */
     public static function getDefaultLanguage(): ?string
     {
@@ -290,8 +284,6 @@ final class Tool
 
     /**
      * eg. editmode, preview, version preview, always when it is a "frontend-request", but called out of the admin
-     *
-     *
      */
     public static function isFrontendRequestByAdmin(Request $request = null): bool
     {
@@ -308,8 +300,6 @@ final class Tool
 
     /**
      * Verify element request (eg. editmode, preview, version preview) called within admin, with permissions.
-     *
-     *
      */
     public static function isElementRequestByAdmin(Request $request, Element\ElementInterface $element): bool
     {
@@ -324,8 +314,6 @@ final class Tool
 
     /**
      * @internal
-     *
-     *
      */
     public static function useFrontendOutputFilters(Request $request = null): bool
     {
@@ -358,8 +346,6 @@ final class Tool
 
     /**
      * @internal
-     *
-     *
      */
     public static function getHostname(Request $request = null): ?string
     {
@@ -377,7 +363,6 @@ final class Tool
 
     /**
      * @internal
-     *
      */
     public static function getRequestScheme(Request $request = null): string
     {
@@ -394,7 +379,6 @@ final class Tool
      * Returns the host URL
      *
      * @param string|null $useProtocol use a specific protocol
-     *
      */
     public static function getHostUrl(string $useProtocol = null, Request $request = null): string
     {
@@ -434,8 +418,6 @@ final class Tool
 
     /**
      * @internal
-     *
-     *
      */
     public static function getClientIp(Request $request = null): ?string
     {
@@ -463,8 +445,6 @@ final class Tool
 
     /**
      * @internal
-     *
-     *
      */
     public static function getAnonymizedClientIp(Request $request = null): ?string
     {
@@ -480,8 +460,6 @@ final class Tool
     }
 
     /**
-     *
-     *
      * @throws \Exception
      */
     public static function getMail(array|string $recipients = null, string $subject = null): Mail
@@ -549,8 +527,6 @@ final class Tool
     }
 
     /**
-     *
-     *
      * @internal
      */
     public static function classExists(string $class): bool
@@ -559,8 +535,6 @@ final class Tool
     }
 
     /**
-     *
-     *
      * @internal
      */
     public static function interfaceExists(string $class): bool
@@ -569,8 +543,6 @@ final class Tool
     }
 
     /**
-     *
-     *
      * @internal
      */
     public static function traitExists(string $class): bool


### PR DESCRIPTION
## Changes in this pull request  
- Array key `fullpath` only exists in manyToManyRelation fields, the other field types have `path` (Why is this not consistent?)
- Array key `language` only exists in localized relation fields