### PR TITLE
Added check if data changed on editor before dispatching pimcore.even…

### DIFF
--- a/bundles/TinymceBundle/public/js/editor.js
+++ b/bundles/TinymceBundle/public/js/editor.js
@@ -129,6 +129,7 @@ pimcore.bundle.tinymce.editor = Class.create({
                     if (!changedContent) {
                         return;
                     }
+                    changedContent = false;
                     document.dispatchEvent(new CustomEvent(pimcore.events.changeWysiwyg, {
                         detail: {
                             e: eChange,

--- a/bundles/TinymceBundle/public/js/editor.js
+++ b/bundles/TinymceBundle/public/js/editor.js
@@ -86,6 +86,7 @@ pimcore.bundle.tinymce.editor = Class.create({
         }
 
         const maxChars = this.maxChars;
+        let changedContent = false;
 
         tinymce.init(Object.assign({
             selector: `#${this.textareaId}`,
@@ -121,7 +122,13 @@ pimcore.bundle.tinymce.editor = Class.create({
                         }
                     }));
                 }.bind(this));
+                editor.on('change', function (eChange) {
+                    changedContent = true;
+                }.bind(this));
                 editor.on('blur', function (eChange) {
+                    if (!changedContent) {
+                        return;
+                    }
                     document.dispatchEvent(new CustomEvent(pimcore.events.changeWysiwyg, {
                         detail: {
                             e: eChange,


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.2`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.2` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #
#16890 

## Additional info
In tinymce editor event pimcore.events.changeWysiwyg is always triggered on bluer (removing focus from editor). The data is then set into changeDetectorInitData which is being checked each second checkForChanges. This PR adds event listener on tinymce change event and sets bool variable if change really happen. This variable is then check before triggering event pimcore.events.changeWysiwyg