### PR TITLE
Fix add overlay image over a gif image

### DIFF
--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -758,7 +758,13 @@ class Imagick extends Adapter
             }
 
             $newImage->evaluateImage(\Imagick::EVALUATE_MULTIPLY, $alpha, \Imagick::CHANNEL_ALPHA);
-            $this->resource->compositeImage($newImage, constant('Imagick::' . $composite), (int)$x, (int)$y);
+            if ($this->checkPreserveAnimation()) {
+                foreach ($this->resource as $i => $frame) {
+                    $frame->compositeImage($newImage, constant('Imagick::' . $composite), (int)$x, (int)$y);
+                }
+            } else {
+                $this->resource->compositeImage($newImage, constant('Imagick::' . $composite), (int)$x, (int)$y);
+            }
         }
 
         $this->postModify();

--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -774,17 +774,21 @@ class Imagick extends Adapter
         switch ($origin) {
             case 'top-right':
                 $x = $imageWidth - $newImageWidth - $x;
+
                 break;
             case 'bottom-left':
                 $y = $imageHeight - $newImageHeight - $y;
+
                 break;
             case 'bottom-right':
                 $x = $imageWidth - $newImageWidth - $x;
                 $y = $imageHeight - $newImageHeight - $y;
+
                 break;
             case 'center':
                 $x = round($imageWidth / 2 - $newImageWidth / 2) + $x;
                 $y = round($imageHeight / 2 - $newImageHeight / 2) + $y;
+
                 break;
         }
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.2`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.2` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #
When applying transformation: `Add Overlay (Imagick)` over a gif image, it is applied only to the first frame:
<img width="503" alt="Screenshot 2024-08-01 at 12 56 44" src="https://github.com/user-attachments/assets/0b79443e-9500-440e-b8ce-ea048a640026">


Wrong:
![wrong](https://github.com/user-attachments/assets/9710da29-05b9-456f-83e8-cc21775b6826)

Right:
![right](https://github.com/user-attachments/assets/5a4dddf1-0202-4408-816a-1c61883e8442)



## Additional info
