### PR TITLE
Fix: Task::setDate(): Argument #1 ($date) must be of type int, null given

### DIFF
--- a/models/Schedule/Task.php
+++ b/models/Schedule/Task.php
@@ -141,7 +141,7 @@ class Task extends Model\AbstractModel
     /**
      * @return $this
      */
-    public function setDate(int $date): static
+    public function setDate(?int $date): static
     {
         $this->date = $date;
 


### PR DESCRIPTION
1. Open Schedule Tab in Admin interface
2. Add new Task
3. Empty date field
![image](https://github.com/user-attachments/assets/ae974b72-f9a0-4a0a-9447-c9f1c2336690)
