### PR TITLE
null-safe path value as third argument for preg_replace

### DIFF
--- a/models/Document.php
+++ b/models/Document.php
@@ -822,7 +822,7 @@ class Document extends Element\AbstractElement
                     if ($site->getRootDocument() instanceof Document\Page && $site->getRootDocument() !== $this) {
                         $rootPath = $site->getRootPath();
                         $rootPath = preg_quote($rootPath, '@');
-                        $link = preg_replace('@^' . $rootPath . '@', '', $this->path);
+                        $link = preg_replace('@^' . $rootPath . '@', '', $this->path ?? '');
 
                         return $link;
                     }

--- a/models/Document.php
+++ b/models/Document.php
@@ -822,6 +822,7 @@ class Document extends Element\AbstractElement
                     if ($site->getRootDocument() instanceof Document\Page && $site->getRootDocument() !== $this) {
                         $rootPath = $site->getRootPath();
                         $rootPath = preg_quote($rootPath, '@');
+                        // $this->path can be null since return type is `?string`
                         $link = preg_replace('@^' . $rootPath . '@', '', $this->path ?? '');
 
                         return $link;


### PR DESCRIPTION
fix error "preg_replace(): Argument #3 ($subject) must be of type array|string, null given"

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.2`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.2` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info
