### PR TITLE
[Docs] Run "composer dump autoload -o" after "pimcore:deployment:classes-rebuild --create-classes"

### DIFF
--- a/doc/21_Deployment/05_Deployment_Tools.md
+++ b/doc/21_Deployment/05_Deployment_Tools.md
@@ -51,7 +51,7 @@ To create new classes from your configuration files in the database you can use 
 
 If you use [Composer's autoloader optimization](https://getcomposer.org/doc/articles/autoloader-optimization.md), you have to register the newly created classes via:
 ```bash
-composer dump-autoload -o
+composer dump-autoload --optimize
 ```
 
 As an alternative also class export to json-files and the class import commands can be used.

--- a/doc/21_Deployment/05_Deployment_Tools.md
+++ b/doc/21_Deployment/05_Deployment_Tools.md
@@ -49,6 +49,11 @@ To create new classes from your configuration files in the database you can use 
 ./bin/console pimcore:deployment:classes-rebuild --create-classes
 ```
 
+If you use [Composer's autoloader optimization](https://getcomposer.org/doc/articles/autoloader-optimization.md), you have to register the newly created classes via:
+```bash
+composer dump-autoload -o
+```
+
 As an alternative also class export to json-files and the class import commands can be used.
 
 ```bash


### PR DESCRIPTION
When running `bin/console pimcore:deployment:classes-rebuild --create-classes` or `bin/console pimcore:build:classes`, you have to run `composer dump-autoload -o` if [Composer's autoloader optimization](https://getcomposer.org/doc/articles/autoloader-optimization.md) gets used (which is the case when using [pimcore/skeleton](https://github.com/pimcore/skeleton/blob/bd95bf70edaad61cf9626867ef1858d1ded7f920/composer.json#L6C6-L6C25)) - otherwise the generated PHP classes will not get added to `vendor/composer/autoload_classmap.php` and thus cannot be found.