### PR TITLE
null-safe nullable value of path as third argument of preg_replace

### DIFF
--- a/models/Document.php
+++ b/models/Document.php
@@ -807,7 +807,7 @@ class Document extends Element\AbstractElement
     {
         // check for site, if so rewrite the path for output
         try {
-            if (Tool::isFrontend() && Site::isSiteRequest()) {
+            if ($this->path != null && Tool::isFrontend() && Site::isSiteRequest()) {
                 $site = Site::getCurrentSite();
                 if ($site instanceof Site) {
                     if ($site->getRootDocument() instanceof Document\Page && $site->getRootDocument() !== $this) {

--- a/models/Document.php
+++ b/models/Document.php
@@ -807,7 +807,7 @@ class Document extends Element\AbstractElement
     {
         // check for site, if so rewrite the path for output
         try {
-            if ($this->path != null && Tool::isFrontend() && Site::isSiteRequest()) {
+            if ($this->path && Tool::isFrontend() && Site::isSiteRequest()) {
                 $site = Site::getCurrentSite();
                 if ($site instanceof Site) {
                     if ($site->getRootDocument() instanceof Document\Page && $site->getRootDocument() !== $this) {


### PR DESCRIPTION
As the return type `?string` of `getPath()` states , `$this->path` can be NULL.

This PR solves the error:

> preg_replace(): Argument https://github.com/pimcore/pimcore/pull/3 ($subject) must be of type array|string, null given