### PR TITLE
[Bug]: Hotspotimage cannot save object with empty relational field inside marker

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Hotspotimage.php
+++ b/models/DataObject/ClassDefinition/Data/Hotspotimage.php
@@ -248,7 +248,7 @@ class Hotspotimage extends Data implements ResourcePersistenceAwareInterface, Qu
                 if (array_key_exists('data', $element) && is_array($element['data']) && count($element['data']) > 0) {
                     foreach ($element['data'] as &$metaData) {
                         $metaData = new Element\Data\MarkerHotspotItem($metaData);
-                        if (in_array($metaData['type'], ['object', 'asset', 'document']) && !empty($metaData->getValue())) {
+                        if (in_array($metaData['type'], ['object', 'asset', 'document']) && $metaData->getValue()) {
                             $el = Element\Service::getElementByPath($metaData['type'], $metaData->getValue());
                             $metaData['value'] = $el;
                         }

--- a/models/DataObject/ClassDefinition/Data/Hotspotimage.php
+++ b/models/DataObject/ClassDefinition/Data/Hotspotimage.php
@@ -248,7 +248,7 @@ class Hotspotimage extends Data implements ResourcePersistenceAwareInterface, Qu
                 if (array_key_exists('data', $element) && is_array($element['data']) && count($element['data']) > 0) {
                     foreach ($element['data'] as &$metaData) {
                         $metaData = new Element\Data\MarkerHotspotItem($metaData);
-                        if (in_array($metaData['type'], ['object', 'asset', 'document'])) {
+                        if (in_array($metaData['type'], ['object', 'asset', 'document']) && !empty($metaData->getValue())) {
                             $el = Element\Service::getElementByPath($metaData['type'], $metaData->getValue());
                             $metaData['value'] = $el;
                         }

--- a/models/Element/Data/MarkerHotspotItem.php
+++ b/models/Element/Data/MarkerHotspotItem.php
@@ -85,7 +85,7 @@ class MarkerHotspotItem implements \ArrayAccess
     public function offsetGet($offset): mixed
     {
         if ($this->offsetExists($offset)) {
-            if ($offset === 'value' && in_array($this->type, ['object', 'asset', 'document']) && !empty($this->value)) {
+            if ($offset === 'value' && in_array($this->type, ['object', 'asset', 'document']) && $this->value) {
                 return Model\Element\Service::getElementById($this->type, $this->value);
             }
 

--- a/models/Element/Data/MarkerHotspotItem.php
+++ b/models/Element/Data/MarkerHotspotItem.php
@@ -85,7 +85,7 @@ class MarkerHotspotItem implements \ArrayAccess
     public function offsetGet($offset): mixed
     {
         if ($this->offsetExists($offset)) {
-            if ($offset === 'value' && in_array($this->type, ['object', 'asset', 'document'])) {
+            if ($offset === 'value' && in_array($this->type, ['object', 'asset', 'document']) && !empty($this->value)) {
                 return Model\Element\Service::getElementById($this->type, $this->value);
             }
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.2`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.2` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  

Added checks if the values is not empty before calling Model\Element\Service::getElementById 

Resolves #17486

## Additional info
