### PR TITLE
[Bug]: Fix multisite link 

### DIFF
--- a/lib/Tool/Text.php
+++ b/lib/Tool/Text.php
@@ -82,7 +82,9 @@ class Text
 
                             $site = Frontend::getSiteForDocument($element);
                             if ($site instanceof Site) {
-                                $path = Tool::getRequestScheme() . '://' . $site->getMainDomain() . preg_replace('~^' . preg_quote($site->getRootPath(), '~') . '~', '', $path);
+                                if (preg_match('~^' . preg_quote($site->getRootPath(), '~') . '~', $path)){
+                                    $path = Tool::getRequestScheme() . '://' . $site->getMainDomain() . preg_replace('~^' . preg_quote($site->getRootPath(), '~') . '~', '', $path);
+                                }
                             }
 
                         } elseif ($element instanceof Concrete) {

--- a/lib/Tool/Text.php
+++ b/lib/Tool/Text.php
@@ -82,7 +82,7 @@ class Text
 
                             $site = Frontend::getSiteForDocument($element);
                             if ($site instanceof Site) {
-                                if (preg_match('~^' . preg_quote($site->getRootPath(), '~') . '~', $path)){
+                                if (preg_match('~^' . preg_quote($site->getRootPath(), '~') . '~', $path)) {
                                     $path = Tool::getRequestScheme() . '://' . $site->getMainDomain() . preg_replace('~^' . preg_quote($site->getRootPath(), '~') . '~', '', $path);
                                 }
                             }


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/17473

## Additional info
If the url belonging to another site is hardcoded or already converted to the right domain (eg. absolute url instead of relative), then it was returning wrong urls by be re-appending the site Main domain, resulting in an url as `https://site2.comhttps//site2.com/link/to/path`