### PR TITLE
Added grid preview for field collections

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Fieldcollections.php
+++ b/models/DataObject/ClassDefinition/Data/Fieldcollections.php
@@ -487,7 +487,10 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
                 }
             }
 
-            $dataForGrid[$collectionDef->getKey()] = $itemData;
+            $dataForGrid[] = [
+                'type' => $collectionDef->getKey(),
+                'data' => $itemData
+            ];
         }
 
         return $dataForGrid;

--- a/models/DataObject/ClassDefinition/Data/Fieldcollections.php
+++ b/models/DataObject/ClassDefinition/Data/Fieldcollections.php
@@ -452,9 +452,45 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
      * @param DataObject\Concrete|null $object
      *
      */
-    public function getDataForGrid(?DataObject\Fieldcollection $data, Concrete $object = null, array $params = []): string
+    public function getDataForGrid(?DataObject\Fieldcollection $data, DataObject\Concrete $object = null, array $params = []): ?array
     {
-        return 'NOT SUPPORTED';
+        if (null === $data) {
+            return null;
+        }
+
+        $dataForGrid = [];
+
+        foreach ($data as $item) {
+            if (!$item instanceof DataObject\Fieldcollection\Data\AbstractData) {
+                continue;
+            }
+
+            $itemData = [];
+            $collectionDef = DataObject\Fieldcollection\Definition::getByKey($item->getType());
+            if ($collectionDef instanceof DataObject\Fieldcollection\Definition) {
+                foreach ($collectionDef->getFieldDefinitions() as $fd) {
+                    if ($fd instanceof DataObject\ClassDefinition\Data\Localizedfields) {
+                        foreach ($fd->getFieldDefinitions() as $localizedFieldDefinition) {
+                            $getter = 'get'.ucfirst($localizedFieldDefinition->getName());
+                            $itemData[$localizedFieldDefinition->getName()] = [
+                                'title' => $localizedFieldDefinition->getTitle(),
+                                'value' => $localizedFieldDefinition->getVersionPreview($item->$getter(), $object, $params)
+                            ];
+                        }
+                    } else {
+                        $getter = 'get'.ucfirst($fd->getName());
+                        $itemData[$fd->getName()] = [
+                            'title' => $fd->getTitle(),
+                            'value' => $fd->getVersionPreview($item->$getter(), $object, $params)
+                        ];
+                    }
+                }
+            }
+
+            $dataForGrid[$collectionDef->getKey()] = $itemData;
+        }
+
+        return $dataForGrid;
     }
 
     public function getGetterCode(DataObject\Objectbrick\Definition|DataObject\ClassDefinition|DataObject\Fieldcollection\Definition $class): string

--- a/models/DataObject/ClassDefinition/Data/Fieldcollections.php
+++ b/models/DataObject/ClassDefinition/Data/Fieldcollections.php
@@ -448,10 +448,6 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
         return $data;
     }
 
-    /**
-     * @param DataObject\Concrete|null $object
-     *
-     */
     public function getDataForGrid(?DataObject\Fieldcollection $data, DataObject\Concrete $object = null, array $params = []): ?array
     {
         if (null === $data) {
@@ -474,14 +470,14 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
                             $getter = 'get'.ucfirst($localizedFieldDefinition->getName());
                             $itemData[$localizedFieldDefinition->getName()] = [
                                 'title' => $localizedFieldDefinition->getTitle(),
-                                'value' => $localizedFieldDefinition->getVersionPreview($item->$getter(), $object, $params)
+                                'value' => $localizedFieldDefinition->getVersionPreview($item->$getter(), $object, $params),
                             ];
                         }
                     } else {
                         $getter = 'get'.ucfirst($fd->getName());
                         $itemData[$fd->getName()] = [
                             'title' => $fd->getTitle(),
-                            'value' => $fd->getVersionPreview($item->$getter(), $object, $params)
+                            'value' => $fd->getVersionPreview($item->$getter(), $object, $params),
                         ];
                     }
                 }
@@ -489,7 +485,7 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
 
             $dataForGrid[] = [
                 'type' => $collectionDef->getKey(),
-                'data' => $itemData
+                'data' => $itemData,
             ];
         }
 


### PR DESCRIPTION
alternative approach to https://github.com/pimcore/pimcore/pull/16444

- no HTML generated in Data\Fioeldcollections
- collection names and field names are translated

![image](https://github.com/user-attachments/assets/5edc419b-8e6f-4c72-8748-166dd2eb0574)


corresponding frontend PR: https://github.com/pimcore/admin-ui-classic-bundle/pull/663