### PR TITLE
[Task]: Avoid superfluous thumbnail directory delete calls 

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1008,7 +1008,7 @@ class Asset extends Element\AbstractElement
                     '/../') && $this->getKey() !== '.' && $this->getKey() !== '..') {
                     $this->deletePhysicalFile();
                 }
-                
+
                 //remove target parent folder preview thumbnails
                 $this->clearFolderThumbnails($this);
             }

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1008,12 +1008,13 @@ class Asset extends Element\AbstractElement
                     '/../') && $this->getKey() !== '.' && $this->getKey() !== '..') {
                     $this->deletePhysicalFile();
                 }
+                
+                //remove target parent folder preview thumbnails
+                $this->clearFolderThumbnails($this);
             }
 
             $this->clearThumbnails(true);
 
-            //remove target parent folder preview thumbnails
-            $this->clearFolderThumbnails($this);
         } catch (Exception $e) {
             try {
                 $this->rollBack();


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.3`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Casually noticed this potential issue, given that 
- the clearing of the thumbnails of the current item and children (recursively) are simply covered by [$this->clearThumbnails(true)](https://github.com/pimcore/pimcore/pull/17518/files#diff-867a334e4cc9a097b215afcb2b1f4949910cb2f2103a2cd997d8699d4d414fc9R1016)
- the `clearFolderThumbnails()` which does a while loop on the item parents folders until root 

clearFolderThumbnails should be done once by having the initial element (whom `$isNested` is `false`) as a starting point rather than be done from each nested children recursively to root, as most of the (deleted) folder in between would be not relevant(covered by first bullet point) and the in-common parents above are the same and need to be done just once. 

It may have likely affected when deleting a folder that contained sub-folders, not sure if they are orphanized first and exit the while loop, but from logical pov looks like it should be applied as the PR