### PR TITLE
Gracefully handle cases in which the storage adapter fails to calculate a file's checksum.

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1156,7 +1156,7 @@ class Asset extends Element\AbstractElement
     {
         try {
             $this->setCustomSetting('checksum', Storage::get('asset')->checksum($this->getRealFullPath()));
-        } catch(UnableToProvideChecksum $e) {
+        } catch (UnableToProvideChecksum $e) {
             // There are circumstances in which the adapter is unable to calculate the checksum for a given file.
             // In those cases, we ignore the exception.
             Logger::error((string) $e);

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1156,7 +1156,7 @@ class Asset extends Element\AbstractElement
     {
         try {
             $this->setCustomSetting('checksum', Storage::get('asset')->checksum($this->getRealFullPath()));
-        } catch(UnableToProvideChecksum $e){
+        } catch(UnableToProvideChecksum $e) {
             // There are circumstances in which the adapter is unable to calculate the checksum for a given file.
             // In those cases, we ignore the exception.
             return;

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1160,6 +1160,7 @@ class Asset extends Element\AbstractElement
             // There are circumstances in which the adapter is unable to calculate the checksum for a given file.
             // In those cases, we ignore the exception.
             Logger::error((string) $e);
+
             return;
         }
         $this->getDao()->updateCustomSettings();

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1159,6 +1159,7 @@ class Asset extends Element\AbstractElement
         } catch(UnableToProvideChecksum $e) {
             // There are circumstances in which the adapter is unable to calculate the checksum for a given file.
             // In those cases, we ignore the exception.
+            Logger::error((string) $e);
             return;
         }
         $this->getDao()->updateCustomSettings();


### PR DESCRIPTION
@fashxp @brusch @cuca24 

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.3`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #17438

## Additional info
I chose not to widen the return type of `getChecksum`. Alternatively it could be changed to return `string | null` and then to handle the null in the one location that calls `getChecksum`.