### PR TITLE
[DOC] Update 01_Dynamic_Text_Labels.md

### DIFF
--- a/bundles/ApplicationLoggerBundle/src/Controller/LogController.php
+++ b/bundles/ApplicationLoggerBundle/src/Controller/LogController.php
@@ -77,7 +77,7 @@ class LogController extends UserAwareController implements KernelControllerEvent
         }
 
         $priority = $request->get('priority');
-        if(!empty($priority)) {
+        if (!empty($priority)) {
             $qb->andWhere($qb->expr()->eq('priority', ':priority'));
             $qb->setParameter('priority', $priority);
         }

--- a/bundles/CoreBundle/src/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/src/Controller/PublicServicesController.php
@@ -49,7 +49,7 @@ class PublicServicesController extends Controller
 
         try {
             $response = Asset\Service::getStreamedResponseForThumbnail($config, $request->getPathInfo());
-            if($response) {
+            if ($response) {
                 return $response;
             }
 

--- a/bundles/CoreBundle/src/Migrations/Version20230320131322.php
+++ b/bundles/CoreBundle/src/Migrations/Version20230320131322.php
@@ -37,12 +37,12 @@ final class Version20230320131322 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $classDefinitionListing = new Listing();
-        foreach($classDefinitionListing->getClasses() as $classDefinition) {
+        foreach ($classDefinitionListing->getClasses() as $classDefinition) {
             $relations = Db::get()->fetchAllAssociative('SELECT src_id, ownername, fieldname, position FROM object_relations_'.$classDefinition->getId().' WHERE ownertype=\'localizedfield\' AND ownername LIKE \'/objectbrick~%\'');
-            foreach($relations as $relationItem) {
-                if(preg_match('/^\/objectbrick~([^\/]+)/', $relationItem['ownername'], $match)) {
+            foreach ($relations as $relationItem) {
+                if (preg_match('/^\/objectbrick~([^\/]+)/', $relationItem['ownername'], $match)) {
                     $object = Concrete::getById($relationItem['src_id']);
-                    if(!$object instanceof Concrete) {
+                    if (!$object instanceof Concrete) {
                         continue;
                     }
                     $objectBrickContainerField = $match[1];
@@ -52,17 +52,17 @@ final class Version20230320131322 extends AbstractMigration
                     $brickContainer = $object->$brickGetter();
 
                     /** @var AbstractData $objectBrick */
-                    foreach($brickContainer->getItems() as $objectBrick) {
+                    foreach ($brickContainer->getItems() as $objectBrick) {
                         $brickDefinition = $objectBrick->getDefinition();
                         $localizedFieldDefinition = $brickDefinition->getFieldDefinition('localizedfields');
-                        if($localizedFieldDefinition instanceof Localizedfields) {
-                            if($localizedFieldDefinition->getFieldDefinition($relationItem['fieldname'])) {
+                        if ($localizedFieldDefinition instanceof Localizedfields) {
+                            if ($localizedFieldDefinition->getFieldDefinition($relationItem['fieldname'])) {
                                 $fieldGetter = 'get'.$relationItem['fieldname'];
                                 $fieldSetter = 'set'.$relationItem['fieldname'];
                                 $objectBrick->$fieldSetter($objectBrick->$fieldGetter($relationItem['position']), $relationItem['position']);
                                 $objectBrick->markFieldDirty('localizedfields');
                                 $objectBrick->markFieldDirty($relationItem['fieldname']);
-                                if(!method_exists($objectBrick, 'getLocalizedfields')) {
+                                if (!method_exists($objectBrick, 'getLocalizedfields')) {
                                     // this cannot happen, because we already checked that there are localized fields via $brickDefinition->getFieldDefinition('localizedfields') but PhpStan complains...
                                     continue;
                                 }

--- a/bundles/CoreBundle/src/Migrations/Version20230424084415.php
+++ b/bundles/CoreBundle/src/Migrations/Version20230424084415.php
@@ -28,7 +28,7 @@ class Version20230424084415 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        if($schema->hasTable('documents_editables')) {
+        if ($schema->hasTable('documents_editables')) {
             $db = Db::get();
             $db->executeStatement('SET foreign_key_checks = 0');
 

--- a/bundles/CoreBundle/src/Migrations/Version20240222143211.php
+++ b/bundles/CoreBundle/src/Migrations/Version20240222143211.php
@@ -36,8 +36,8 @@ final class Version20240222143211 extends AbstractMigration
     {
         $this->addSql('SET foreign_key_checks = 0');
 
-        foreach($schema->getTables() as $table) {
-            if($table->hasColumn('id')) {
+        foreach ($schema->getTables() as $table) {
+            if ($table->hasColumn('id')) {
                 $tableName = $table->getName();
 
                 if (
@@ -64,8 +64,8 @@ final class Version20240222143211 extends AbstractMigration
     {
         $this->addSql('SET foreign_key_checks = 0');
 
-        foreach($schema->getTables() as $table) {
-            if($table->hasColumn('id')) {
+        foreach ($schema->getTables() as $table) {
+            if ($table->hasColumn('id')) {
                 $tableName = $table->getName();
 
                 if (

--- a/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
+++ b/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
@@ -276,7 +276,7 @@ class CustomReportController extends UserAwareController
         $items = $list->getDao()->loadForGivenUser($this->getPimcoreUser());
 
         foreach ($items as $report) {
-            if($report->getDataSourceConfig() !== null) {
+            if ($report->getDataSourceConfig() !== null) {
                 $reports[] = [
                     'name' => htmlspecialchars($report->getName()),
                     'niceName' => htmlspecialchars($report->getNiceName()),
@@ -486,7 +486,7 @@ class CustomReportController extends UserAwareController
      */
     public function isValidConfigName(string $configName): void
     {
-        if(!preg_match('/^[a-zA-Z0-9_\-]+$/', $configName)) {
+        if (!preg_match('/^[a-zA-Z0-9_\-]+$/', $configName)) {
             throw new Exception('The customer report name is invalid');
         }
     }
@@ -497,7 +497,7 @@ class CustomReportController extends UserAwareController
         $sortingSettings = null;
         $sort = null;
         $dir = null;
-        if(class_exists('\Pimcore\Bundle\AdminBundle\Helper\QueryParams')) {
+        if (class_exists('\Pimcore\Bundle\AdminBundle\Helper\QueryParams')) {
             $sortingSettings = \Pimcore\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings(array_merge($request->request->all(), $request->query->all()));
         }
         if (is_array($sortingSettings) && $sortingSettings['orderKey']) {

--- a/bundles/GenericExecutionEngineBundle/src/Agent/JobExecutionAgent.php
+++ b/bundles/GenericExecutionEngineBundle/src/Agent/JobExecutionAgent.php
@@ -151,9 +151,9 @@ final class JobExecutionAgent implements JobExecutionAgentInterface
     private function getSelectionProcessingModeFromJobRun(JobRun $jobRun): SelectionProcessingMode
     {
         $steps = $jobRun->getJob()?->getSteps();
-        if($steps !== null) {
+        if ($steps !== null) {
             $step = $steps[$jobRun->getCurrentStep()] ?? null;
-            if($step) {
+            if ($step) {
                 return $step->getSelectionProcessingMode();
             }
         }
@@ -266,7 +266,7 @@ final class JobExecutionAgent implements JobExecutionAgentInterface
         JobRun $jobRun,
         SelectionProcessingMode $selectionProcessingMode
     ): ErrorHandlingMode {
-        if($selectionProcessingMode === SelectionProcessingMode::ONCE) {
+        if ($selectionProcessingMode === SelectionProcessingMode::ONCE) {
             return ErrorHandlingMode::STOP_ON_FIRST_ERROR;
         }
 
@@ -416,15 +416,15 @@ final class JobExecutionAgent implements JobExecutionAgentInterface
             $jobRun->getCurrentStep()
         );
 
-        if(count($logs) === $jobRun->getTotalElements()) {
+        if (count($logs) === $jobRun->getTotalElements()) {
             $jobRun->setState(JobRunStates::FAILED);
             $message = 'gee_job_failed';
-        } elseif(count($logs) > 0) {
+        } elseif (count($logs) > 0) {
             $jobRun->setState(JobRunStates::FINISHED_WITH_ERRORS);
             $message = 'gee_job_finished_with_errors';
         }
 
-        if(empty($logs)) {
+        if (empty($logs)) {
             $jobRun->setCurrentMessage(null);
             $jobRun->setState(JobRunStates::FINISHED);
             $message = 'gee_job_finished';

--- a/bundles/GenericExecutionEngineBundle/src/Extractor/JobRunExtractor.php
+++ b/bundles/GenericExecutionEngineBundle/src/Extractor/JobRunExtractor.php
@@ -147,7 +147,7 @@ final class JobRunExtractor implements JobRunExtractorInterface
                 $elementDescriptor->getId(),
                 $types
             );
-            if($element !== null) {
+            if ($element !== null) {
                 $elementsToProcess[] = $element;
             }
         }

--- a/bundles/GenericExecutionEngineBundle/src/Messenger/Handler/AbstractAutomationActionHandler.php
+++ b/bundles/GenericExecutionEngineBundle/src/Messenger/Handler/AbstractAutomationActionHandler.php
@@ -164,10 +164,10 @@ abstract class AbstractAutomationActionHandler
         array $variables
     ): mixed {
         /** @var $matches array */
-        if(!preg_match_all("/job_env\('([^']*)'\)/", $value, $matches)) {
+        if (!preg_match_all("/job_env\('([^']*)'\)/", $value, $matches)) {
             return $value;
         }
-        if(empty($matches[1])) {
+        if (empty($matches[1])) {
             return $value;
         }
         $envVariableKey = $matches[1][0];
@@ -188,7 +188,7 @@ abstract class AbstractAutomationActionHandler
         }
 
         $value = $config[$key];
-        if(is_string($value)) {
+        if (is_string($value)) {
             $value = $this->replaceConfigValueWithEnvVariable(
                 $value,
                 $this->getEnvironmentVariables($message)

--- a/bundles/GenericExecutionEngineBundle/src/Repository/JobRunErrorLogRepository.php
+++ b/bundles/GenericExecutionEngineBundle/src/Repository/JobRunErrorLogRepository.php
@@ -61,7 +61,7 @@ final class JobRunErrorLogRepository implements JobRunErrorLogRepositoryInterfac
         int $offset = 0
     ): array {
         $criteria = ['jobRunId' => $jobRunId];
-        if($step !== null && $step >= 0) {
+        if ($step !== null && $step >= 0) {
             $criteria['step'] = $step;
         }
 

--- a/bundles/GlossaryBundle/src/Model/Glossary/Dao.php
+++ b/bundles/GlossaryBundle/src/Model/Glossary/Dao.php
@@ -13,7 +13,7 @@
  *  @license    http://www.pimcore.org/license     GPLv3 and PCL
  */
 
-namespace  Pimcore\Bundle\GlossaryBundle\Model\Glossary;
+namespace Pimcore\Bundle\GlossaryBundle\Model\Glossary;
 
 use Exception;
 use Pimcore\Bundle\GlossaryBundle\Model\Glossary;

--- a/bundles/GlossaryBundle/src/Model/Glossary/Listing.php
+++ b/bundles/GlossaryBundle/src/Model/Glossary/Listing.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  *  @license    http://www.pimcore.org/license     GPLv3 and PCL
  */
 
-namespace  Pimcore\Bundle\GlossaryBundle\Model\Glossary;
+namespace Pimcore\Bundle\GlossaryBundle\Model\Glossary;
 
 use Pimcore\Bundle\GlossaryBundle\Model\Glossary;
 use Pimcore\Model\Listing\AbstractListing;

--- a/bundles/GlossaryBundle/src/Model/Glossary/Listing/Dao.php
+++ b/bundles/GlossaryBundle/src/Model/Glossary/Listing/Dao.php
@@ -13,7 +13,7 @@
  *  @license    http://www.pimcore.org/license     GPLv3 and PCL
  */
 
-namespace  Pimcore\Bundle\GlossaryBundle\Model\Glossary\Listing;
+namespace Pimcore\Bundle\GlossaryBundle\Model\Glossary\Listing;
 
 use Exception;
 use Pimcore\Bundle\GlossaryBundle\Model\Glossary;

--- a/bundles/InstallBundle/src/Command/InstallCommand.php
+++ b/bundles/InstallBundle/src/Command/InstallCommand.php
@@ -445,7 +445,7 @@ class InstallCommand extends Command
     {
         $installableBundleKeys = array_keys($bundleSetupEvent->getBundles());
         $recommendedBundles = [];
-        foreach($bundleSetupEvent->getRecommendedBundles() as $recBundle) {
+        foreach ($bundleSetupEvent->getRecommendedBundles() as $recBundle) {
             $recommendedBundles[] = array_search($recBundle, $installableBundleKeys);
         }
 

--- a/bundles/InstallBundle/src/Installer.php
+++ b/bundles/InstallBundle/src/Installer.php
@@ -394,7 +394,7 @@ class Installer
         $errors = [];
         $stepsToRun = $this->getRunInstallSteps();
 
-        if(in_array('write_database_config', $stepsToRun)) {
+        if (in_array('write_database_config', $stepsToRun)) {
             $this->dispatchStepEvent('create_config_files');
 
             unset($dbConfig['driver']);
@@ -438,16 +438,16 @@ class Installer
 
         $kernel = new $kernel($environment, true);
 
-        if(in_array('clear_cache', $stepsToRun)) {
+        if (in_array('clear_cache', $stepsToRun)) {
             $this->clearKernelCacheDir($kernel);
         }
 
-        if(in_array('clear_cache', $stepsToRun) || in_array('install_assets', $stepsToRun)) {
+        if (in_array('clear_cache', $stepsToRun) || in_array('install_assets', $stepsToRun)) {
             Pimcore::setKernel($kernel);
             $kernel->boot();
         }
 
-        if(in_array('setup_database', $stepsToRun)) {
+        if (in_array('setup_database', $stepsToRun)) {
             $this->dispatchStepEvent('setup_database');
 
             $errors = $this->setupDatabase($db, $userCredentials, $errors);
@@ -465,7 +465,7 @@ class Installer
             }
         }
 
-        if(in_array('install_assets', $stepsToRun)) {
+        if (in_array('install_assets', $stepsToRun)) {
             $this->dispatchStepEvent('install_assets');
             $this->installAssets($kernel);
         }
@@ -475,12 +475,12 @@ class Installer
             $this->installBundles();
         }
 
-        if(in_array('install_classes', $stepsToRun)) {
+        if (in_array('install_classes', $stepsToRun)) {
             $this->dispatchStepEvent('install_classes');
             $this->installClasses();
         }
 
-        if(in_array('mark_migrations_as_done', $stepsToRun)) {
+        if (in_array('mark_migrations_as_done', $stepsToRun)) {
             $this->dispatchStepEvent('install_classes');
             $this->installClasses();
 
@@ -488,7 +488,7 @@ class Installer
             $this->markMigrationsAsDone();
         }
 
-        if(in_array('clear_cache', $stepsToRun)) {
+        if (in_array('clear_cache', $stepsToRun)) {
             $this->clearKernelCacheDir($kernel);
         }
 
@@ -583,7 +583,7 @@ class Installer
         $bundlesToInstall = $this->bundlesToInstall;
         $availableBundles = $this->availableBundles;
 
-        if(!empty($this->excludeFromBundlesPhp)) {
+        if (!empty($this->excludeFromBundlesPhp)) {
             $bundlesToInstall = array_diff($bundlesToInstall, array_values($this->excludeFromBundlesPhp));
             $availableBundles = array_diff($availableBundles, $this->excludeFromBundlesPhp);
         }
@@ -724,7 +724,7 @@ class Installer
 
         // close connections and collection garbage ... in order to avoid too many connections error
         // when installing demos
-        if(Pimcore::getKernel() instanceof \Pimcore\Kernel) {
+        if (Pimcore::getKernel() instanceof \Pimcore\Kernel) {
             Pimcore::collectGarbage();
         }
 

--- a/bundles/SeoBundle/src/Sitemap/Document/DocumentTreeGenerator.php
+++ b/bundles/SeoBundle/src/Sitemap/Document/DocumentTreeGenerator.php
@@ -77,7 +77,7 @@ class DocumentTreeGenerator extends AbstractElementGenerator
         if ($this->options['handleMainDomain'] && (null === $section || $section === 'default')) {
             $rootDocument = Document::getById($this->options['rootId']);
 
-            if($rootDocument instanceof Document) {
+            if ($rootDocument instanceof Document) {
                 $this->populateCollection($urlContainer, $rootDocument, 'default');
             }
         }

--- a/bundles/StaticRoutesBundle/src/Model/Staticroute.php
+++ b/bundles/StaticRoutesBundle/src/Model/Staticroute.php
@@ -491,7 +491,7 @@ final class Staticroute extends AbstractModel
     {
         if (is_string($methods)) {
             $methods = strlen($methods) ? explode(',', $methods) : [];
-            foreach($methods as $key => $method) {
+            foreach ($methods as $key => $method) {
                 $methods[$key] = trim($method);
             }
         }

--- a/doc/05_Objects/01_Object_Classes/03_Layout_Elements/01_Dynamic_Text_Labels.md
+++ b/doc/05_Objects/01_Object_Classes/03_Layout_Elements/01_Dynamic_Text_Labels.md
@@ -24,18 +24,18 @@ Here is an example for a rendering class.
 
 namespace App\Helpers;
 
-use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\ClassDefinition\Layout\DynamicTextLabelInterface;
 
 class CustomRenderer implements DynamicTextLabelInterface
 {
     /**
      * @param string $data as provided in the class definition
      */
-    public function renderLayoutText(string $data, ?Concrete $object, array $params): string
+    public function renderLayoutText($data, $object, $params): string
     {
         $text = '<h1 style="color: #F00;">Last reload: ' . date('c') . '</h1>' .
             '<h2>Additional Data: ' . $data . '</h2>';
-
+       
         if ($object) {
             $text .= '<h3>BTW, my fullpath is: ' . $object->getFullPath() . ' and my ID is ' . $object->getId() . '</h3>';
         }

--- a/lib/Composer.php
+++ b/lib/Composer.php
@@ -164,7 +164,7 @@ class Composer
         $phpFinder = new PhpExecutableFinder();
         $arguments = $phpFinder->findArguments();
 
-        if(!empty($_SERVER['COMPOSER_ORIGINAL_INIS'])) {
+        if (!empty($_SERVER['COMPOSER_ORIGINAL_INIS'])) {
             $paths = explode(PATH_SEPARATOR, $_SERVER['COMPOSER_ORIGINAL_INIS']);
             $ini = array_shift($paths);
         } else {
@@ -185,11 +185,11 @@ class Composer
     {
         $options = array_merge(static::$options, $event->getComposer()->getPackage()->getExtra());
 
-        if(!empty($_SERVER['SYMFONY_ASSETS_INSTALL'])) {
+        if (!empty($_SERVER['SYMFONY_ASSETS_INSTALL'])) {
             $options['symfony-assets-install'] = $_SERVER['SYMFONY_ASSETS_INSTALL'];
         }
 
-        if(!empty($_SERVER['SYMFONY_CACHE_WARMUP'])) {
+        if (!empty($_SERVER['SYMFONY_CACHE_WARMUP'])) {
             $options['symfony-cache-warmup'] = $_SERVER['SYMFONY_CACHE_WARMUP'];
         }
 

--- a/lib/Config/LocationAwareConfigRepository.php
+++ b/lib/Config/LocationAwareConfigRepository.php
@@ -71,7 +71,7 @@ class LocationAwareConfigRepository
         $dataSource = null;
 
         $loadType = $this->getReadTargets()[0] ?? null;
-        if($loadType === null) {
+        if ($loadType === null) {
             // try to load from container config
             $data = $this->getDataFromContainerConfig($key, $dataSource);
 
@@ -80,7 +80,7 @@ class LocationAwareConfigRepository
                 $data = $this->getDataFromSettingsStore($key, $dataSource);
             }
         } else {
-            if($loadType === self::LOCATION_SYMFONY_CONFIG) {
+            if ($loadType === self::LOCATION_SYMFONY_CONFIG) {
                 $data = $this->getDataFromContainerConfig($key, $dataSource);
             } elseif ($loadType === self::LOCATION_SETTINGS_STORE) {
                 $data = $this->getDataFromSettingsStore($key, $dataSource);
@@ -292,7 +292,7 @@ class LocationAwareConfigRepository
         $writeTargetConf = $containerConfig[self::CONFIG_LOCATION][$configKey][self::WRITE_TARGET];
 
         $configDir = null;
-        if($readTargetConf !== null) {
+        if ($readTargetConf !== null) {
             if ($readTargetConf[self::TYPE] === LocationAwareConfigRepository::LOCATION_SETTINGS_STORE ||
                 ($readTargetConf[self::TYPE] !== LocationAwareConfigRepository::LOCATION_SYMFONY_CONFIG && $writeTargetConf[self::TYPE] !== LocationAwareConfigRepository::LOCATION_SYMFONY_CONFIG)
             ) {

--- a/lib/Document/Renderer/DocumentRenderer.php
+++ b/lib/Document/Renderer/DocumentRenderer.php
@@ -93,10 +93,10 @@ class DocumentRenderer implements DocumentRendererInterface
         } catch (Exception $e) {
 
             $host = null;
-            if($site = Frontend::getSiteForDocument($document)) {
+            if ($site = Frontend::getSiteForDocument($document)) {
                 Site::setCurrentSite($site);
                 $host = $site->getMainDomain();
-            } elseif($systemMainDomain = Tool::getHostname()) {
+            } elseif ($systemMainDomain = Tool::getHostname()) {
                 $host = $systemMainDomain;
             }
 
@@ -105,7 +105,7 @@ class DocumentRenderer implements DocumentRendererInterface
 
         if ($attributes['pimcore_static_page_generator'] ?? false) {
             $headers = \Pimcore\Config::getSystemConfiguration('documents')['static_page_generator']['headers'];
-            foreach($headers as $header) {
+            foreach ($headers as $header) {
                 $request->headers->set($header['name'], $header['value']);
             }
         }

--- a/lib/Document/StaticPageGenerator.php
+++ b/lib/Document/StaticPageGenerator.php
@@ -52,7 +52,7 @@ class StaticPageGenerator
             $mainDomain = '/' . $systemConfig['general']['domain'];
             $returnPath = '';
             $pathInfo = pathinfo($path);
-            if($pathInfo['dirname'] != '') {
+            if ($pathInfo['dirname'] != '') {
                 $directories = explode('/', $pathInfo['dirname']);
                 $directories = array_filter($directories);
                 $pathString = '';

--- a/lib/Helper/GotenbergHelper.php
+++ b/lib/Helper/GotenbergHelper.php
@@ -46,14 +46,14 @@ class GotenbergHelper
 
         /** @var GotenbergAPI|object $chrome */
         $chrome = GotenbergAPI::chromium(Config::getSystemConfiguration('gotenberg')['base_url']);
-        if(method_exists($chrome, 'html')) {
+        if (method_exists($chrome, 'html')) {
             // gotenberg/gotenberg-php API Client v1
             $request = $chrome->html(Stream::string('dummy.html', '<body></body>'));
-        } elseif(method_exists($chrome, 'screenshot')) {
+        } elseif (method_exists($chrome, 'screenshot')) {
             $request = $chrome->screenshot()->html(Stream::string('dummy.html', '<body></body>'));
         }
 
-        if($request) {
+        if ($request) {
             try {
                 GotenbergAPI::send($request);
                 self::$validPing = true;

--- a/lib/Image/HtmlToImage.php
+++ b/lib/Image/HtmlToImage.php
@@ -41,7 +41,7 @@ class HtmlToImage
 
     private static function getSupportedAdapter(): string
     {
-        if(self::$supportedAdapter !== null) {
+        if (self::$supportedAdapter !== null) {
             return self::$supportedAdapter;
         }
 
@@ -50,7 +50,7 @@ class HtmlToImage
         if (GotenbergHelper::isAvailable()) {
             /** @var GotenbergAPI|object $chrome */
             $chrome = GotenbergAPI::chromium(Config::getSystemConfiguration('gotenberg')['base_url']);
-            if(method_exists($chrome, 'screenshot')) {
+            if (method_exists($chrome, 'screenshot')) {
                 // only v2 of Gotenberg lib is supported
                 self::$supportedAdapter = 'gotenberg';
             }
@@ -60,7 +60,7 @@ class HtmlToImage
             $chromiumUri = \Pimcore\Config::getSystemConfiguration('chromium')['uri'];
             if (!empty($chromiumUri)) {
                 try {
-                    if((new Connection($chromiumUri))->connect()) {
+                    if ((new Connection($chromiumUri))->connect()) {
                         self::$supportedAdapter = 'chromium';
                     }
                 } catch (Exception $e) {
@@ -69,7 +69,7 @@ class HtmlToImage
                 }
             }
 
-            if(self::getChromiumBinary()) {
+            if (self::getChromiumBinary()) {
                 self::$supportedAdapter = 'chromium';
             }
         }
@@ -95,7 +95,7 @@ class HtmlToImage
     public static function convert(string $url, string $outputFile, ?string $sessionName = null, ?string $sessionId = null, string $windowSize = '1280,1024'): bool
     {
         $adapter = self::getSupportedAdapter();
-        if($adapter === 'gotenberg') {
+        if ($adapter === 'gotenberg') {
             return self::convertGotenberg(...func_get_args());
         } elseif ($adapter === 'chromium') {
             return self::convertChromium(...func_get_args());
@@ -112,7 +112,7 @@ class HtmlToImage
         try {
             /** @var GotenbergAPI|object $request */
             $request = GotenbergAPI::chromium(Config::getSystemConfiguration('gotenberg')['base_url']);
-            if(method_exists($request, 'screenshot')) {
+            if (method_exists($request, 'screenshot')) {
                 $sizes = explode(',', $windowSize);
                 $urlResponse = $request->screenshot()
                     ->width((int) $sizes[0])

--- a/lib/Kernel.php
+++ b/lib/Kernel.php
@@ -103,7 +103,7 @@ abstract class Kernel extends SymfonyKernel
                 $readTargetConf = $containerConfig[LocationAwareConfigRepository::CONFIG_LOCATION][$configKey][LocationAwareConfigRepository::READ_TARGET] ?? null;
 
                 $configDir = null;
-                if($readTargetConf !== null) {
+                if ($readTargetConf !== null) {
                     if ($readTargetConf[LocationAwareConfigRepository::TYPE] === LocationAwareConfigRepository::LOCATION_SETTINGS_STORE ||
                         ($readTargetConf[LocationAwareConfigRepository::TYPE] !== LocationAwareConfigRepository::LOCATION_SYMFONY_CONFIG && $writeTargetConf[LocationAwareConfigRepository::TYPE] !== LocationAwareConfigRepository::LOCATION_SYMFONY_CONFIG)
                     ) {
@@ -115,7 +115,7 @@ abstract class Kernel extends SymfonyKernel
                     }
                 }
 
-                if($configDir === null) {
+                if ($configDir === null) {
                     $configDir = rtrim($writeTargetConf[LocationAwareConfigRepository::OPTIONS][LocationAwareConfigRepository::DIRECTORY], '/\\');
                 }
                 $configDir = "$configDir/";

--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -163,7 +163,7 @@ class Mail extends Email
      */
     public function init(string $type = 'email', ?array $config = null): void
     {
-        if(empty($config)) {
+        if (empty($config)) {
             $config = Config::getSystemConfiguration($type);
         }
 

--- a/lib/Mail/Mailer.php
+++ b/lib/Mail/Mailer.php
@@ -41,7 +41,7 @@ class Mailer implements MailerInterface
             $this->redirectPlugin->beforeSendPerformed($message);
         }
 
-        if($message instanceof Message && !$message->getHeaders()->has('X-Transport')) {
+        if ($message instanceof Message && !$message->getHeaders()->has('X-Transport')) {
             $message->getHeaders()->addTextHeader('X-Transport', 'main');
         }
 

--- a/lib/Maintenance/Tasks/DataObject/CleanupBrickTablesTaskHelper.php
+++ b/lib/Maintenance/Tasks/DataObject/CleanupBrickTablesTaskHelper.php
@@ -39,7 +39,7 @@ class CleanupBrickTablesTaskHelper implements ConcreteTaskHelperInterface
         $collectionNames =
             $this->helper->getCollectionNames(self::PIMCORE_OBJECTBRICK_CLASS_DIRECTORY);
 
-        if(empty($collectionNames)) {
+        if (empty($collectionNames)) {
             return;
         }
 

--- a/lib/Maintenance/Tasks/DataObject/CleanupFieldcollectionTablesTaskHelper.php
+++ b/lib/Maintenance/Tasks/DataObject/CleanupFieldcollectionTablesTaskHelper.php
@@ -39,7 +39,7 @@ class CleanupFieldcollectionTablesTaskHelper implements ConcreteTaskHelperInterf
         $collectionNames =
             $this->helper->getCollectionNames(self::PIMCORE_FIELDCOLLECTION_CLASS_DIRECTORY);
 
-        if(empty($collectionNames)) {
+        if (empty($collectionNames)) {
             return;
         }
 

--- a/lib/Security/SecurityHelper.php
+++ b/lib/Security/SecurityHelper.php
@@ -24,7 +24,7 @@ class SecurityHelper
 {
     public static function convertHtmlSpecialChars(?string $text): ?string
     {
-        if(is_string($text)) {
+        if (is_string($text)) {
             return htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8', false);
         }
 

--- a/lib/SystemSettingsConfig.php
+++ b/lib/SystemSettingsConfig.php
@@ -75,7 +75,7 @@ class SystemSettingsConfig
         // If the read target is settings-store and no data is found there,
         // load the data from the container config
         // Please see https://github.com/pimcore/pimcore/issues/15596 for more information
-        if(!$data && $loadType === $repository::LOCATION_SETTINGS_STORE) {
+        if (!$data && $loadType === $repository::LOCATION_SETTINGS_STORE) {
             $data = self::getConfigValuesFromContainer()['config'];
             $data['writeable'] = $repository->isWriteable();
         }

--- a/lib/Tool/AssetsInstaller.php
+++ b/lib/Tool/AssetsInstaller.php
@@ -133,11 +133,11 @@ class AssetsInstaller
             }
         }
 
-        if(in_array($_SERVER['SYMFONY_ASSETS_INSTALL'] ?? null, ['symlink', 'relative'])) {
+        if (in_array($_SERVER['SYMFONY_ASSETS_INSTALL'] ?? null, ['symlink', 'relative'])) {
             $defaults['symlink'] = true;
         }
 
-        if(($_SERVER['SYMFONY_ASSETS_INSTALL'] ?? null) === 'relative') {
+        if (($_SERVER['SYMFONY_ASSETS_INSTALL'] ?? null) === 'relative') {
             $defaults['relative'] = true;
         }
 

--- a/lib/Tool/Requirements.php
+++ b/lib/Tool/Requirements.php
@@ -415,7 +415,7 @@ final class Requirements
 
         // LibreOffice BIN
         $libreofficeGotenberg = GotenbergHelper::isAvailable();
-        if(!$libreofficeGotenberg) {
+        if (!$libreofficeGotenberg) {
             try {
                 $libreofficeGotenberg = (bool)\Pimcore\Document\Adapter\LibreOffice::getLibreOfficeCli();
             } catch (Exception $e) {

--- a/lib/Twig/Extension/Templating/HeadScript.php
+++ b/lib/Twig/Extension/Templating/HeadScript.php
@@ -465,7 +465,7 @@ class HeadScript extends CacheBusterAware implements RuntimeExtensionInterface
         $container = Pimcore::getContainer();
 
         //@phpstan-ignore-next-line
-        if($container->has('pimcore_admin_bundle.content_security_policy_handler')) {
+        if ($container->has('pimcore_admin_bundle.content_security_policy_handler')) {
             $cspHandler = $container->get('pimcore_admin_bundle.content_security_policy_handler');
             $attrString .= $cspHandler->getNonceHtmlAttribute();
         }

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -174,7 +174,7 @@ class Asset extends Element\AbstractElement
             // for caching asset
             $blockedVars = array_merge($blockedVars, ['children', 'properties']);
 
-            if($this->customSettingsCanBeCached === false) {
+            if ($this->customSettingsCanBeCached === false) {
                 $blockedVars[] = 'customSettings';
             }
         }
@@ -185,7 +185,7 @@ class Asset extends Element\AbstractElement
     public function __sleep(): array
     {
         $blockedVars = parent::__sleep();
-        if(in_array('customSettings', $blockedVars)) {
+        if (in_array('customSettings', $blockedVars)) {
             $this->customSettingsNeedRefresh = true;
         }
 
@@ -1264,7 +1264,7 @@ class Asset extends Element\AbstractElement
 
     private function refreshCustomSettings(): void
     {
-        if($this->customSettingsNeedRefresh === true) {
+        if ($this->customSettingsNeedRefresh === true) {
             $customSettings = $this->getDao()->getCustomSettings();
             $this->setCustomSettings($customSettings);
             $this->customSettingsNeedRefresh = false;
@@ -1308,7 +1308,7 @@ class Asset extends Element\AbstractElement
     public function setCustomSettings(mixed $customSettings): static
     {
         if (is_string($customSettings)) {
-            if(strlen($customSettings) > 10e6) {
+            if (strlen($customSettings) > 10e6) {
                 $this->customSettingsCanBeCached = false;
             }
 
@@ -1601,7 +1601,7 @@ class Asset extends Element\AbstractElement
             $this->renewInheritedProperties();
         }
 
-        if(!$this->isInDumpState() && $this->customSettingsCanBeCached === false) {
+        if (!$this->isInDumpState() && $this->customSettingsCanBeCached === false) {
             $this->customSettingsNeedRefresh = true;
         }
 

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -462,7 +462,7 @@ final class Thumbnail implements ThumbnailInterface
      */
     private function validate(): void
     {
-        if(!$this->asset || !$this->config) {
+        if (!$this->asset || !$this->config) {
             return;
         }
         if (!$this->checkAllowedFormats($this->config->getFormat(), $this->asset)) {

--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -440,7 +440,7 @@ class Service extends Model\Element\Service
                         }
                     }
 
-                    if(!empty($thumbnailFormats[$config['file_extension']]['quality'] ?? null)) {
+                    if (!empty($thumbnailFormats[$config['file_extension']]['quality'] ?? null)) {
                         $thumbnailConfig->setQuality($thumbnailFormats[$config['file_extension']]['quality']);
                     }
                 }
@@ -562,7 +562,7 @@ class Service extends Model\Element\Service
         $storagePath = urldecode($uri);
 
         $prefix = \Pimcore\Config::getSystemConfiguration('assets')['frontend_prefixes']['thumbnail'];
-        if($prefix) {
+        if ($prefix) {
             $storagePath = preg_replace('/^' . preg_quote($prefix, '/') . '/', '', $storagePath);
         }
 

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -434,7 +434,7 @@ trait ImageThumbnailTrait
     private function checkAllowedFormats(string $format, ?Asset $asset = null): bool
     {
         $format = strtolower($format);
-        if($asset) {
+        if ($asset) {
             if (
                 $format === 'original' ||
                 $format === 'source'

--- a/models/DataObject/ClassDefinition/Data/DateRange.php
+++ b/models/DataObject/ClassDefinition/Data/DateRange.php
@@ -360,7 +360,7 @@ class DateRange extends Data implements
      */
     public function setColumnType(string|array $columnType): void
     {
-        if(is_array($columnType)) {
+        if (is_array($columnType)) {
             $this->columnType = $columnType;
         } else {
             $this->columnType = [

--- a/models/DataObject/ClassDefinition/Data/Input.php
+++ b/models/DataObject/ClassDefinition/Data/Input.php
@@ -200,7 +200,7 @@ class Input extends Data implements
 
     public function checkValidity(mixed $data, bool $omitMandatoryCheck = false, array $params = []): void
     {
-        if(is_string($data)) {
+        if (is_string($data)) {
             if (!$omitMandatoryCheck && $this->getRegex() && $data !== '') {
                 $throwException = false;
                 if (in_array('g', $this->getRegexFlags())) {

--- a/models/DataObject/ClassDefinition/Data/Password.php
+++ b/models/DataObject/ClassDefinition/Data/Password.php
@@ -75,7 +75,7 @@ class Password extends Data implements ResourcePersistenceAwareInterface, QueryR
      */
     public function setAlgorithm(string $algorithm): void
     {
-        if($algorithm !== self::HASH_FUNCTION_PASSWORD_HASH) {
+        if ($algorithm !== self::HASH_FUNCTION_PASSWORD_HASH) {
             trigger_deprecation(
                 'pimcore/pimcore',
                 '11.2',
@@ -138,7 +138,7 @@ class Password extends Data implements ResourcePersistenceAwareInterface, QueryR
         }
 
         // is already a hashed string? Then do not re-hash
-        if($this->getAlgorithm() === self::HASH_FUNCTION_PASSWORD_HASH) {
+        if ($this->getAlgorithm() === self::HASH_FUNCTION_PASSWORD_HASH) {
             $info = password_get_info($data);
             if ($info['algo'] !== null && $info['algo'] !== 0) {
                 return $data;

--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -76,7 +76,7 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
                     return null;
                 }
                 $class = DataObject\ClassDefinition::getById($this->ownerClassId);
-                if($class instanceof DataObject\ClassDefinition) {
+                if ($class instanceof DataObject\ClassDefinition) {
                     $this->ownerClassName = $class->getName();
                 }
             } catch (Exception $e) {
@@ -205,7 +205,7 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
 
     public function getClasses(): array
     {
-        if($this->getOwnerClassId()) {
+        if ($this->getOwnerClassId()) {
             return Model\Element\Service::fixAllowedTypes([$this->ownerClassName], 'classes');
         }
 

--- a/models/DataObject/ClassDefinition/Data/UrlSlug.php
+++ b/models/DataObject/ClassDefinition/Data/UrlSlug.php
@@ -142,7 +142,7 @@ class UrlSlug extends Data implements CustomResourcePersistingInterface, LazyLoa
                         throw new Model\Element\ValidationException('Slug must be at least 2 characters long and start with slash');
                     }
 
-                    if(preg_match_all('([?#])', $item->getSlug(), $matches)) {
+                    if (preg_match_all('([?#])', $item->getSlug(), $matches)) {
                         throw new Model\Element\ValidationException('Slug contains reserved characters! [' . implode(' ', array_unique($matches[0])) . ']');
                     }
                 }

--- a/models/DataObject/Classificationstore.php
+++ b/models/DataObject/Classificationstore.php
@@ -95,7 +95,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     public function getItems(): array
     {
         $doGetInheritedValues = Model\DataObject::doGetInheritedValues();
-        if(!$doGetInheritedValues) {
+        if (!$doGetInheritedValues) {
             return $this->items;
         }
 
@@ -258,7 +258,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     public function getActiveGroups(): array
     {
         $doGetInheritedValues = Model\DataObject::doGetInheritedValues();
-        if(!$doGetInheritedValues) {
+        if (!$doGetInheritedValues) {
             return $this->activeGroups;
         }
 
@@ -409,7 +409,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     public function getGroupCollectionMappings(): array
     {
         $doGetInheritedValues = Model\DataObject::doGetInheritedValues();
-        if(!$doGetInheritedValues) {
+        if (!$doGetInheritedValues) {
             return $this->groupCollectionMapping;
         }
 
@@ -487,9 +487,9 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
 
     private function mergeArrays(array $a1, array $a2): array
     {
-        foreach($a1 as $key => $value) {
-            if(array_key_exists($key, $a2)) {
-                if(is_array($value)) {
+        foreach ($a1 as $key => $value) {
+            if (array_key_exists($key, $a2)) {
+                if (is_array($value)) {
                     $a2[$key] = $this->mergeArrays($a2[$key], $value);
                 } else {
                     $a2[$key] = $value;

--- a/models/Document/Editable/Wysiwyg.php
+++ b/models/Document/Editable/Wysiwyg.php
@@ -132,7 +132,7 @@ class Wysiwyg extends Model\Document\Editable implements IdRewriterInterface, Ed
 
     public function save(): void
     {
-        if(is_string($this->text)) {
+        if (is_string($this->text)) {
             $helper = self::getWysiwygSanitizer();
             $this->text = $helper->sanitizeFor('body', $this->text);
         }

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -164,7 +164,7 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
 
     public function setModificationDate(int $modificationDate): static
     {
-        if($this->modificationDate != $modificationDate) {
+        if ($this->modificationDate != $modificationDate) {
             $this->markFieldDirty('modificationDate');
             $this->modificationDate = $modificationDate;
         }

--- a/models/Property/Dao.php
+++ b/models/Property/Dao.php
@@ -45,9 +45,9 @@ class Dao extends Model\Dao\AbstractDao
         }
 
         $cpath = $this->model->getCpath();
-        if(empty($cpath)) {
+        if (empty($cpath)) {
             $element = Model\Element\Service::getElementById($this->model->getCtype(), $this->model->getCid());
-            if($element instanceof Model\Element\ElementInterface) {
+            if ($element instanceof Model\Element\ElementInterface) {
                 $cpath = $element->getRealFullPath();
             }
         }

--- a/models/User.php
+++ b/models/User.php
@@ -469,7 +469,7 @@ final class User extends User\UserRole implements UserInterface
                 $targetFile = File::getLocalTempFilePath('png');
 
                 $image = \Pimcore\Image::getInstance();
-                if($image->load($localFile)) {
+                if ($image->load($localFile)) {
                     $image->cover($width, $height);
                     $image->save($targetFile, 'png');
                     $storage->write($this->getThumbnailImageStoragePath(), file_get_contents($targetFile));


### PR DESCRIPTION
## Additional info

Fix CustomRenderer class implementation to match the correct interface and method signature

This PR addresses an issue in the `CustomRenderer` class where the implementation did not correctly match the `DynamicTextLabelInterface` as required by Pimcore. Specifically:

- Updated the `use` statement to correctly reference `Pimcore\Model\DataObject\ClassDefinition\Layout\DynamicTextLabelInterface` instead of the incorrect `Pimcore\Model\DataObject\Concrete`.
- Corrected the method signature of `renderLayoutText` to remove type hints for the parameters `$data`, `$object`, and `$params` as the interface does not specify them.
- Ensured that the method returns a string with the correct HTML structure, including additional data and object information if available.

