### PR TITLE
[Improvement] Minor extension of last example in 15_Classification_Store.md

### DIFF
--- a/doc/05_Objects/01_Object_Classes/01_Data_Types/15_Classification_Store.md
+++ b/doc/05_Objects/01_Object_Classes/01_Data_Types/15_Classification_Store.md
@@ -179,6 +179,7 @@ $definition->setName("height");
 $definition->setTitle("Height");
 
 $keyConfig = new \Pimcore\Model\DataObject\Classificationstore\KeyConfig();
+$keyConfig->setStoreId($storeId);
 $keyConfig->setName($name);
 $keyConfig->setDescription($description);
 $keyConfig->setEnabled(true);
@@ -188,19 +189,27 @@ $keyConfig->save();
 
 // Group
 $groupConfig = new \Pimcore\Model\DataObject\Classificationstore\GroupConfig();
+$groupConfig->setStoreId($storeId);
 $groupConfig->setName($name);
 $groupConfig->setDescription($description);
 $groupConfig->save();
 
 // Collection
 $collectionConfig = new \Pimcore\Model\DataObject\Classificationstore\CollectionConfig();
+$collectionConfig->setStoreId($storeId);
 $collectionConfig->setName($name);
 $collectionConfig->setDescription($description);
 $collectionConfig->save();
 
+// Add a key to group
+$keyRel = new \Pimcore\Model\DataObject\Classificationstore\KeyGroupRelation();
+$keyRel->setGroupId($groupConfig->getId());
+$keyRel->setKeyId($keyConfig->getId());
+$keyRel->save();
+
 // Add a group to a collection
-$rel = new CollectionGroupRelation();
-$rel->setGroupId($groupConfig->getId());
-$rel->setColId($collectionConfig->getId());
-$rel->save();
+$groupRel = new \Pimcore\Model\DataObject\Classificationstore\CollectionGroupRelation();
+$groupRel->setGroupId($groupConfig->getId());
+$groupRel->setColId($collectionConfig->getId());
+$groupRel->save();
 ```


### PR DESCRIPTION
Added the KeyGroupRelation and `setStoreId`.

<!--
## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/` 
- [x] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.3` (see Readme.md for the list of supported versions)
- [x] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  
## Changes in this pull request  
- Set the classification store ID.
- Added the Key Group Relation use-case.

## Additional info
I noticed that the last example was not working because I forgot to set the store ID. While I quickly realized this, I believe it would be helpful if the documentation explicitly mentioned the need to set the store ID.