### PR TITLE
[Bug] Check lastQuery in combo box on typed phrase

### DIFF
--- a/bundles/CustomReportsBundle/public/js/pimcore/report/custom/report.js
+++ b/bundles/CustomReportsBundle/public/js/pimcore/report/custom/report.js
@@ -282,18 +282,26 @@ pimcore.bundle.customreports.custom.report = Class.create(pimcore.bundle.customr
                 store: drillDownStore,
                 listeners: {
                     select: function(fieldname, combo, record, index) {
-                        var value = combo.getValue();
+                        let value = combo.getValue();
+
+                        const lastQuery = combo.lastQuery;
+                        // check last query
+                        if(value == null && lastQuery && this.store.findExact(fieldname, lastQuery)) {
+                            value = lastQuery;
+                            combo.setValue(value)
+                        }
+
                         this.drillDownFilters[fieldname] = value;
 
-                        var proxy = this.store.getProxy();
+                        const proxy = this.store.getProxy();
                         proxy.extraParams['drillDownFilters[' + fieldname + ']'] = value;
                         if(this.chartStore) {
-                            var chartProxy = this.chartStore.getProxy();
+                            let chartProxy = this.chartStore.getProxy();
                             chartProxy.extraParams['drillDownFilters[' + fieldname + ']'] = value;
                         }
-                        for(var j = 0; j < this.drillDownStores.length; j++) {
+                        for(let j = 0; j < this.drillDownStores.length; j++) {
                             if(this.drillDownStores[j] != combo.getStore()) {
-                                var drillDownProxy = this.drillDownStores[j].getProxy();
+                                let drillDownProxy = this.drillDownStores[j].getProxy();
                                 drillDownProxy.extraParams['drillDownFilters[' + fieldname + ']'] = value;
                             } else {
                                 this.drillDownStores[j].notReload = true;
@@ -304,7 +312,7 @@ pimcore.bundle.customreports.custom.report = Class.create(pimcore.bundle.customr
                     }.bind(this, this.drillDownFilterDefinitions[i]["name"])
                 },
                 valueField: 'value',
-                displayField: 'value'
+                displayField: 'name'
             });
             if(i < this.drillDownFilterDefinitions.length-1) {
                 drillDownFilterComboboxes.push('-');

--- a/bundles/CustomReportsBundle/src/Tool/Adapter/Sql.php
+++ b/bundles/CustomReportsBundle/src/Tool/Adapter/Sql.php
@@ -212,14 +212,14 @@ class Sql extends AbstractAdapter
         $filteredData = [];
         foreach ($data as $d) {
             if (!empty($d[$field]) || $d[$field] === 0) {
-                $filteredData[] = ['value' => $d[$field]];
+                $filteredData[] = ['name' => $d[$field], 'value' => $d[$field]];
             }
         }
 
         return [
             'data' => array_merge(
                 [
-                    ['value' => null],
+                    ['name' => 'empty', 'value' => null],
                 ],
                 $filteredData
             ),


### PR DESCRIPTION
If lastQuery is exact match, set as filter for manual input

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.3`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #2753 

## Additional info
On manual typed phrase set filter if exact match.
If the phrase does not match no elements will be shown.