### PR TITLE
Deprecate key_value_table.html.twig

### DIFF
--- a/bundles/CoreBundle/templates/Profiler/key_value_table.html.twig
+++ b/bundles/CoreBundle/templates/Profiler/key_value_table.html.twig
@@ -1,3 +1,5 @@
+{% deprecated 'The "key_value_table.html.twig" is moved to the personalization bundle and will be removed in pimcore/pimcore 12.' %}
+
 <table class="{{ class|default('') }}">
     <thead>
     <tr>


### PR DESCRIPTION
See https://github.com/pimcore/personalization-bundle/issues/60. The template will be removed in pimcore/pimcore 12 (#17615).