### PR TITLE
Fix fallback language for boolean fields with two fallback languages

### DIFF
--- a/models/DataObject/Localizedfield.php
+++ b/models/DataObject/Localizedfield.php
@@ -469,7 +469,9 @@ final class Localizedfield extends Model\AbstractModel implements
             foreach (Tool::getFallbackLanguagesFor($language) as $l) {
                 // fallback-language may not exist yet for lazy-loaded field (relation)
                 if ($this->languageExists($l) || ($fieldDefinition instanceof LazyLoadingSupportInterface && $fieldDefinition->getLazyLoading())) {
-                    if ($data = $this->getLocalizedValue($name, $l)) {
+                    $data = $this->getLocalizedValue($name, $l);
+
+                    if (!$fieldDefinition->isEmpty($data)) {
                         break;
                     }
                 }


### PR DESCRIPTION
I have a model with a boolean field `active`

Say we have 3 languages, English, Dutch and German and the fallback languages for German are Dutch -> English in this order.

The model looks like this:

| Language | Active  |
|----------|---------|
| English  | `1`      |
| Dutch    | `-1`      |
| German   | `Empty` |

We would expect the `active` value of German to be `-1` because the fallback language of German is Dutch and the value in Dutch is actually filled in

But because of the check on line 472, it thinks the value is falsy so it needs to check the next language

```php
if ($data = $this->getLocalizedValue($name, $l)) {
    break;
}
```

In my proposed change we actually check if the field is empty before checking the next language, like is done on line 468
