### PR TITLE
Skip frame-by-frame saving of gif:s if original

### DIFF
--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -335,11 +335,15 @@ class Processor
                 }
 
                 $tmpFsPath = File::getLocalTempFilePath($fileExtension);
-                $image->save($tmpFsPath, $format, $config->getQuality());
-                $stream = fopen($tmpFsPath, 'rb');
-                $storage->writeStream($storagePath, $stream);
-                if (is_resource($stream)) {
-                    fclose($stream);
+                if ($format === 'original') {
+                    copy($asset->getFullPath(), $storagePath);
+                } else {
+                    $image->save($tmpFsPath, $format, $config->getQuality());
+                    $stream = fopen($tmpFsPath, 'rb');
+                    $storage->writeStream($storagePath, $stream);
+                    if (is_resource($stream)) {
+                        fclose($stream);
+                    }
                 }
 
                 if ($statusCacheEnabled && $asset instanceof Asset\Image) {


### PR DESCRIPTION
It is unecessary to save original/unprocessed gifs by resaving it frame by frame. Moderatly big original gif:s, or gif:s with lots of frames, can create unecessary processing timeouts and unecessary strain on the server.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.3`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info
