### PR TITLE
[Docs]: Add mention of `getCount()` method in Document PHP API Documentation

### DIFF
--- a/doc/03_Documents/09_Working_with_PHP_API.md
+++ b/doc/03_Documents/09_Working_with_PHP_API.md
@@ -119,7 +119,8 @@ If you'd like to get also all the unpublished documents, set the following flag:
 
 | Method                  | Arguments                           | Description                                                                                 |
 |-------------------------|-------------------------------------|---------------------------------------------------------------------------------------------|
-| `getTotalCount()`       |                                     | Returns total number of selected rows.                                                      |
+| `getCount()`            |                                     | Returns total number of selected rows.                                                      |
+| `getTotalCount()`       |                                     | Returns total number of selected rows (excluding offset and limit).                         |
 | `getPaginatorAdapter()` |                                     | List implements `\Iterator`, you could use the list as a paginator.                         |
 | `getItems()`            | int $offset, int $itemsCountPerPage | as arguments you have to specify the limit of rows and the offset.                          |
 | `loadIdList()`          |                                     | Returns complete array with id as a row.                                                    |


### PR DESCRIPTION
Describe the difference between getCount() and getTotalCount()

Resolves #17618

Sorry for the duplicate of PR #17620 - messed up the rebase...
