### PR TITLE
Migration to rebuild classes was renamed and updated

### DIFF
--- a/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
+++ b/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
@@ -213,7 +213,7 @@ bin/console pimcore:assets:remove-custom-setting disableImageFeatureAutoDetectio
 ### Rebuild classes, objectBricks, fieldCollections and customLayouts
 Make sure you ran the following commands to rebuild the classes, objectBricks, fieldCollections and customLayouts:
 ```bash
-bin/console doctrine:migration:exec 'Pimcore\Bundle\CoreBundle\Migrations\Version20230412105530'
+bin/console doctrine:migration:exec 'Pimcore\Bundle\CoreBundle\Migrations\Version20240708083500'
 ```
 
 ### Additional Cleanups 


### PR DESCRIPTION
In version 11.3.1 migration Version20230412105530.php was removed and replaced by Version20240708083500. 
Yet the documentation was not updated to reflect this change. Which causes confusion when upgrading to Pimcore 11 as you get an error that this migration is not found.

![image](https://github.com/user-attachments/assets/3e8e92a2-1d9c-498b-ae61-29134c334e52)

