### PR TITLE
[Bug]: Change twig/twig conflict to support 3.14.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -135,7 +135,7 @@
     "sabre/dav": "4.2.2",
     "symfony/symfony": "*",
     "thecodingmachine/safe": "<2.0",
-    "twig/twig": ">=3.9.0"
+    "twig/twig": ">=3.9.0 <3.14.0"
   },
   "require-dev": {
     "codeception/codeception": "^5.0.3",

--- a/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
+++ b/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
@@ -213,7 +213,7 @@ bin/console pimcore:assets:remove-custom-setting disableImageFeatureAutoDetectio
 ### Rebuild classes, objectBricks, fieldCollections and customLayouts
 Make sure you ran the following commands to rebuild the classes, objectBricks, fieldCollections and customLayouts:
 ```bash
-bin/console doctrine:migration:exec 'Pimcore\Bundle\CoreBundle\Migrations\Version20230412105530'
+bin/console doctrine:migration:exec 'Pimcore\Bundle\CoreBundle\Migrations\Version20240708083500'
 ```
 
 ### Additional Cleanups 


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/17582

## Additional info
When `rybakit/twig-deferred-extension` is not in use, it would opt for the ^3.14