### PR TITLE
Fix Task setCid and setCtype methods

### DIFF
--- a/models/Schedule/Task.php
+++ b/models/Schedule/Task.php
@@ -121,7 +121,7 @@ class Task extends Model\AbstractModel
     /**
      * @return $this
      */
-    public function setCid(int $cid): static
+    public function setCid(?int $cid): static
     {
         $this->cid = $cid;
 
@@ -131,7 +131,7 @@ class Task extends Model\AbstractModel
     /**
      * @return $this
      */
-    public function setCtype(string $ctype): static
+    public function setCtype(?string $ctype): static
     {
         $this->ctype = $ctype;
 


### PR DESCRIPTION
Task $cid and $ctype are nullable, also in database these columns allow null

<img width="301" alt="Screenshot 2024-09-27 at 17 28 46" src="https://github.com/user-attachments/assets/07d6caf4-6418-4ad1-b2ea-24a029ac1453">
<img width="282" alt="Screenshot 2024-09-27 at 17 29 11" src="https://github.com/user-attachments/assets/309eed55-4593-43a5-86b1-46686bb4cef5">


However setter methods for them does not allow null