### PR TITLE
[Bugfix] Fix typo in @param phpdoc

### DIFF
--- a/models/DataObject/Traits/FieldDefinitionEnrichmentDataTrait.php
+++ b/models/DataObject/Traits/FieldDefinitionEnrichmentDataTrait.php
@@ -27,7 +27,7 @@ trait FieldDefinitionEnrichmentDataTrait
     use FieldDefinitionEnrichmentModelTrait;
 
     /**
-     * @params array<string, Data> $fields
+     * @param array<string, Data> $fields
      *
      * @return array<string, Data>
      */


### PR DESCRIPTION
This was the error when using php8.3

```
[Semantical Error] The annotation "@params" in method Pimcore\Model\DataObject\ClassDefinition\Data\Localizedfields::doGetFieldDefinitions() was never imported. Did you maybe forget to add a "use" statement for this annotation?
```
  

## Changes in this pull request  
- Fix `@param` phpdoc since `@params` is a typo
