### PR TITLE
[Bug]: Fix type error in NumericRange constructor when using decimals

### DIFF
--- a/models/DataObject/ClassDefinition/Data/NumericRange.php
+++ b/models/DataObject/ClassDefinition/Data/NumericRange.php
@@ -240,10 +240,18 @@ class NumericRange extends Data implements
     public function getDataFromResource(mixed $data, DataObject\Concrete $object = null, array $params = []): ?DataObject\Data\NumericRange
     {
         if (isset($data[$this->getName() . '__minimum'], $data[$this->getName() . '__maximum'])) {
-            $numericRange = new DataObject\Data\NumericRange(
-                $data[$this->getName() . '__minimum'],
-                $data[$this->getName() . '__maximum']
-            );
+            $minimum = $data[$this->getName() . '__minimum'];
+            $maximum = $data[$this->getName() . '__maximum'];
+
+            if (is_string($minimum)) {
+                $minimum = (float) $minimum;
+            }
+
+            if (is_string($maximum)) {
+                $maximum = (float) $maximum;
+            }
+
+            $numericRange = new DataObject\Data\NumericRange($minimum, $maximum);
 
             if (isset($params['owner'])) {
                 $numericRange->_setOwner($params['owner']);


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.4`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/` 
- [x] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [x] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #17700

See the linked issue for a reproduction of the error that will be fixed by this PR.
