### PR TITLE
docs: remove version constraint of league/flysystem-aws-s3-v3

### DIFF
--- a/doc/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/03_File_Storage_Setup.md
+++ b/doc/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/03_File_Storage_Setup.md
@@ -86,7 +86,7 @@ like CloudFront for your resources.
 ### Example: AWS S3 Adapter for Assets
 First, install AWS S3 Adapter with command:
 ```
-composer require league/flysystem-aws-s3-v3:^2.0
+composer require league/flysystem-aws-s3-v3
 ````
 
 Next step is to configure AWS S3 client service for class `Aws\S3\S3Client` with following required arguments:


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.4`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  

Removed the version constraint from `league/flysystem-aws-s3-v3` in the docs, since `^2.0` seems to be incompatible with  platform version 2024.3. 

```
composer require league/flysystem-aws-s3-v3:^2.0


./composer.json has been updated
Running composer update league/flysystem-aws-s3-v3
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires league/flysystem-aws-s3-v3 ^2.0 -> satisfiable by league/flysystem-aws-s3-v3[2.0.0, ..., 2.5.0].
    - league/flysystem-aws-s3-v3[2.0.0, ..., 2.5.0] require league/flysystem ^2.0.0 -> found league/flysystem[2.0.0, ..., 2.5.0] but the package is fixed to 3.29.1 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
Composer [require league/flysystem-aws-s3-v3:^2.0] failed, composer command failed: exit status 2. stderr=

```

Removing the version requirement from the `composer require` command solved the issue and I was able to install the package without any issues. 

## Additional info
_I didn't create an issue for this to prevent spam, when required, I'm more than happy to create one after the fact._
