### PR TITLE
[Bug]: Fix QuantityRangeValue validation failed on empty field

### DIFF
--- a/models/DataObject/ClassDefinition/Data/QuantityValueRange.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValueRange.php
@@ -288,7 +288,7 @@ class QuantityValueRange extends Data implements ResourcePersistenceAwareInterfa
 
         $minimum = $data->getMinimum();
         $maximum = $data->getMaximum();
-        
+
         if ($omitMandatoryCheck === false && $this->getMandatory()
             && ($data === null
                 || $minimum === null

--- a/models/DataObject/ClassDefinition/Data/QuantityValueRange.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValueRange.php
@@ -286,22 +286,20 @@ class QuantityValueRange extends Data implements ResourcePersistenceAwareInterfa
             throw new ValidationException('Expected an instance of QuantityValueRange');
         }
 
+        $minimum = $data->getMinimum();
+        $maximum = $data->getMaximum();
+        
         if ($omitMandatoryCheck === false && $this->getMandatory()
             && ($data === null
-                || $data->getMinimum() === null
-                || $data->getMaximum() === null
+                || $minimum === null
+                || $maximum === null
                 || $data->getUnitId() === null
             )
         ) {
             throw new ValidationException(sprintf('Empty mandatory field [ %s ]', $fieldName));
         }
 
-        $minimum = $data?->getMinimum();
-        $maximum = $data?->getMaximum();
-
         if ($minimum || $maximum) {
-            $minimum = $data->getMinimum();
-            $maximum = $data->getMaximum();
 
             if (!is_numeric($minimum) || !is_numeric($maximum)) {
                 throw new ValidationException(sprintf('Invalid dimension unit data: %s', $fieldName));

--- a/models/DataObject/ClassDefinition/Data/QuantityValueRange.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValueRange.php
@@ -296,7 +296,10 @@ class QuantityValueRange extends Data implements ResourcePersistenceAwareInterfa
             throw new ValidationException(sprintf('Empty mandatory field [ %s ]', $fieldName));
         }
 
-        if (!empty($data)) {
+        $minimum = $data?->getMinimum();
+        $maximum = $data?->getMaximum();
+
+        if ($minimum || $maximum) {
             $minimum = $data->getMinimum();
             $maximum = $data->getMaximum();
 


### PR DESCRIPTION
 ## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/17286

## Additional info
`!empty($data)` is not ideal here, $data is always truthy and it would be like

`Pimcore\Model\DataObject\Data\QuantityValueRange Object ( [unitId:protected] => [unit:protected] => [_owner:protected] => [_fieldname:protected] => [_language:protected] => [minimum:protected] => [maximum:protected] => )`