### PR TITLE
QuantityValueRange: Call to a member function getMinimum() on null

### DIFF
--- a/models/DataObject/ClassDefinition/Data/QuantityValueRange.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValueRange.php
@@ -286,8 +286,8 @@ class QuantityValueRange extends Data implements ResourcePersistenceAwareInterfa
             throw new ValidationException('Expected an instance of QuantityValueRange');
         }
 
-        $minimum = $data->getMinimum();
-        $maximum = $data->getMaximum();
+        $minimum = $data?->getMinimum();
+        $maximum = $data?->getMaximum();
 
         if ($omitMandatoryCheck === false && $this->getMandatory()
             && ($data === null


### PR DESCRIPTION
## Changes in this pull request  
Follow up to https://github.com/pimcore/pimcore/pull/17743

Saving a new object with empty QuantityValueRange field:
![image](https://github.com/user-attachments/assets/3389494f-b211-4007-9cd2-2e5f107d3db8)

