### PR TITLE
Fix: change sorting column from `path` to `key` to ensure correct order

### DIFF
--- a/lib/Tool/Frontend.php
+++ b/lib/Tool/Frontend.php
@@ -86,7 +86,10 @@ final class Frontend
         if (!$siteMapping) {
             $siteMapping = [];
             $sites = new Site\Listing();
-            $sites->setOrderKey('(SELECT LENGTH(`path`) FROM documents WHERE documents.id = sites.rootId) DESC', false);
+            $sites->setOrderKey(
+                '(SELECT LENGTH(CONCAT(`path`, `key`)) FROM documents WHERE documents.id = sites.rootId) DESC',
+                false
+            );
             $sites = $sites->load();
             foreach ($sites as $site) {
                 $siteMapping[$site->getRootPath()] = $site->getId();

--- a/tests/Model/Tool/TextTest.php
+++ b/tests/Model/Tool/TextTest.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Tests\Model\Tool;
+
+use Pimcore\Cache\RuntimeCache;
+use Pimcore\Model\Document;
+use Pimcore\Model\Site;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+use Pimcore\Tool\Text;
+
+class TextTest extends ModelTestCase
+{
+    private Document\Page $testingDocument;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $site1 = $this->createSite('site', 'example.com');
+        $site2 = $this->createSite('site2', 'example2.com');
+        $this->testingDocument = $this->createDocument('testing', $site2->getRootDocument()->getId());
+    }
+
+    protected function needsDb(): bool
+    {
+        return true;
+    }
+
+    public function testWysiwygText(): void
+    {
+        RuntimeCache::clear();
+
+        $text = sprintf(
+            'Link to a document <a href="%s" pimcore_id="%s" pimcore_type="document">The link</a>',
+            $this->testingDocument->getFullPath(),
+            $this->testingDocument->getId()
+        );
+        $expected = sprintf(
+            'Link to a document <a href="http://example2.com/testing" pimcore_id="%s" pimcore_type="document">The link</a>',
+            $this->testingDocument->getId()
+        );
+
+        $this->assertEquals($expected, Text::wysiwygText($text));
+    }
+
+    private function createDocument(string $key, int $parentId): Document\Page
+    {
+        $document = new Document\Page();
+        $document->setKey($key);
+        $document->setPublished(true);
+        $document->setParentId($parentId);
+        $document->setUserOwner(1);
+        $document->setUserModification(1);
+        $document->setCreationDate(time());
+        $document->save();
+
+        return $document;
+    }
+
+    private function createSite(string $key, string $mainDomain): Site
+    {
+        $site = new Site();
+        $site->setRootDocument($this->createDocument($key, 1));
+        $site->setMainDomain($mainDomain);
+        $site->setRootPath('/');
+        $site->save();
+
+        return $site;
+    }
+}


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.4`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves the issue with broken links in Wysiwyg editable.

## Additional info
When `Wysiwyg` editable is being rendered it's contents is being passed to `Pimcore\Tool\Text::wysiwygText` which calls `Pimcore\Tool\Frontend::getSiteForDocument` which calls `Pimcore\Tool\Frontend::getSiteMapping`.

For a multi-site environment where there are multiple sites where one site key starts with the key of another, e.g. `mysite` and `mysite2`, `getSiteMapping` method will always resolve to the first one (or random) since it is sorting the sites based on a length of path which is always the same (`'/'`) and hence without any effect.

~~My assumption (supported by using the patch in a production environment) is that this sorting should use the length of the `key` instead. It's also the only sorting argument that makes sense in this context~~.
EDIT: I've realized there's a possibility to have nested sites which was not our case and the fix is solving the issue only for root sites (path = `'/'`).

Without it the link replacement in Wysiwyg editable becomes broken and ends up generating invalid links.

Here's a simple how-to reproduce:
- install Pimcore demo
- create 2 sites, `mysite` with main domain **mysite.com** and `mysite2` with main domain **mysite2.com**
- publish a document directly in `mysite2` (`mysite2/first-document`)
- publish second document anywhere, add Wysiwyg editable, select some text and drag&drop first document onto it to create a link
- preview second document - the link will look like **http://mysite.com/mysite2/first-document** while it should be **http://mysite2.com/first-document**