### PR TITLE
Fix return type on getDataForQueryResource for CalculatedValue

### DIFF
--- a/models/DataObject/ClassDefinition/Data/CalculatedValue.php
+++ b/models/DataObject/ClassDefinition/Data/CalculatedValue.php
@@ -138,7 +138,7 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
      *
      * @see QueryResourcePersistenceAwareInterface::getDataForQueryResource
      */
-    public function getDataForQueryResource(mixed $data, DataObject\Concrete $object = null, array $params = []): ?string
+    public function getDataForQueryResource(mixed $data, DataObject\Concrete $object = null, array $params = []): int|null|string
     {
         return $data;
     }

--- a/models/DataObject/ClassDefinition/Data/CalculatedValue.php
+++ b/models/DataObject/ClassDefinition/Data/CalculatedValue.php
@@ -141,8 +141,9 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
     public function getDataForQueryResource(mixed $data, DataObject\Concrete $object = null, array $params = []): ?string
     {
         if ($data !== null) {
-            return (string) $data;   
+            return (string) $data;
         }
+
         return null;
     }
 

--- a/models/DataObject/ClassDefinition/Data/CalculatedValue.php
+++ b/models/DataObject/ClassDefinition/Data/CalculatedValue.php
@@ -138,9 +138,9 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
      *
      * @see QueryResourcePersistenceAwareInterface::getDataForQueryResource
      */
-    public function getDataForQueryResource(mixed $data, DataObject\Concrete $object = null, array $params = []): int|null|string
+    public function getDataForQueryResource(mixed $data, DataObject\Concrete $object = null, array $params = []): ?string
     {
-        return $data;
+        return (string) $data;
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/CalculatedValue.php
+++ b/models/DataObject/ClassDefinition/Data/CalculatedValue.php
@@ -140,7 +140,10 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
      */
     public function getDataForQueryResource(mixed $data, DataObject\Concrete $object = null, array $params = []): ?string
     {
-        return (string) $data;
+        if ($data !== null) {
+            return (string) $data;   
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
Allow for int to be a valid return type
e.g. for:
![image](https://github.com/user-attachments/assets/8cb6d9c6-f07f-444f-a78b-9dee81cecf15)

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.4`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info
Similar fix to #15299
