### PR TITLE
[Bug]: Fix `php: ../../magick/exception.c:1121: ThrowMagickExceptionList: Assertion` error on install

### DIFF
--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -1024,11 +1024,9 @@ class Imagick extends Adapter
     {
         try {
             // we can't use \Imagick::queryFormats() here, because this doesn't consider configured delegates
-            $tmpFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/imagick-format-support-detection-' . uniqid() . '.' . $format;
             $image = new \Imagick();
             $image->newImage(1, 1, new ImagickPixel('red'));
-            $image->writeImage($format . ':' . $tmpFile);
-            unlink($tmpFile);
+            $image->writeImageFile(tmpfile(), $format);
 
             return true;
         } catch (Exception $e) {

--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -1024,11 +1024,6 @@ class Imagick extends Adapter
     {
         try {
             // we can't use \Imagick::queryFormats() here, because this doesn't consider configured delegates
-            $fs = new Filesystem();
-            if (!$fs->exists(PIMCORE_SYSTEM_TEMP_DIRECTORY)) {
-                $fs->mkdir(PIMCORE_SYSTEM_TEMP_DIRECTORY, 0775);
-            }
-
             $tmpFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/imagick-format-support-detection-' . uniqid() . '.' . $format;
             $image = new \Imagick();
             $image->newImage(1, 1, new ImagickPixel('red'));

--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -1024,6 +1024,11 @@ class Imagick extends Adapter
     {
         try {
             // we can't use \Imagick::queryFormats() here, because this doesn't consider configured delegates
+            $fs = new Filesystem();
+            if (!$fs->exists(PIMCORE_SYSTEM_TEMP_DIRECTORY)) {
+                $fs->mkdir(PIMCORE_SYSTEM_TEMP_DIRECTORY, 0775);
+            }
+
             $tmpFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/imagick-format-support-detection-' . uniqid() . '.' . $format;
             $image = new \Imagick();
             $image->newImage(1, 1, new ImagickPixel('red'));

--- a/lib/Tool/Requirements.php
+++ b/lib/Tool/Requirements.php
@@ -675,6 +675,10 @@ final class Requirements
 
         // WebP for active image adapter
         if (extension_loaded('imagick')) {
+            $fs = new Filesystem();
+            if (!$fs->exists(PIMCORE_SYSTEM_TEMP_DIRECTORY)) {
+                $fs->mkdir(PIMCORE_SYSTEM_TEMP_DIRECTORY, 0775);
+            }
             $imageAdapter = new Image\Adapter\Imagick();
         } else {
             $imageAdapter = new Image\Adapter\GD();

--- a/lib/Tool/Requirements.php
+++ b/lib/Tool/Requirements.php
@@ -675,10 +675,6 @@ final class Requirements
 
         // WebP for active image adapter
         if (extension_loaded('imagick')) {
-            $fs = new Filesystem();
-            if (!$fs->exists(PIMCORE_SYSTEM_TEMP_DIRECTORY)) {
-                $fs->mkdir(PIMCORE_SYSTEM_TEMP_DIRECTORY, 0775);
-            }
             $imageAdapter = new Image\Adapter\Imagick();
         } else {
             $imageAdapter = new Image\Adapter\GD();

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -957,3 +957,7 @@ parameters:
 			message: "#^If condition is always false\\.$#"
 			count: 1
 			path: lib/Image/Chromium.php
+		-
+			message: "#^Method Imagick::writeImageFile\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: lib/Image/Adapter/Imagick.php


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/demo/issues/591#issuecomment-2209058294


It was only affected when checking Imagick by 
https://github.com/pimcore/pimcore/blob/61747535f8e58c7cb4a1e4da5b43c6d5a2cd0403/lib/Tool/Requirements.php#L698
with  https://github.com/pimcore/pimcore/blob/61747535f8e58c7cb4a1e4da5b43c6d5a2cd0403/lib/Image/Adapter/Imagick.php#L1027 being perfomed before `MkdirCacheWarmer` and therefore `PIMCORE_SYSTEM_TEMP_DIRECTORY` missing