### PR TITLE
[Bug] Panel layout getLayout can return null

### DIFF
--- a/models/DataObject/ClassDefinition/Layout/Panel.php
+++ b/models/DataObject/ClassDefinition/Layout/Panel.php
@@ -52,7 +52,7 @@ class Panel extends Model\DataObject\ClassDefinition\Layout
         return $this;
     }
 
-    public function getLayout(): string
+    public function getLayout(): ?string
     {
         return $this->layout;
     }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.4`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves Pimcore\Model\DataObject\ClassDefinition\Layout\Panel layout can be null
