### PR TITLE
[Bug,EC] Video Editable HTML Output ampersand

### DIFF
--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -740,7 +740,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
             }
 
             $code .= '<div id="pimcore_video_' . $this->getName() . '" class="pimcore_editable_video '. ($config['class'] ?? '') .'">
-                <iframe src="https://player.vimeo.com/video/' . $vimeoId . '?dnt=1&title=0&amp;byline=0&amp;portrait=0' . $additionalParams . '" width="' . $width . '" height="' . $height . '" title="Vimeo video" allow="fullscreen" data-type="pimcore_video_editable"></iframe>
+                <iframe src="https://player.vimeo.com/video/' . $vimeoId . '?dnt=1&amp;title=0&amp;byline=0&amp;portrait=0' . $additionalParams . '" width="' . $width . '" height="' . $height . '" title="Vimeo video" allow="fullscreen" data-type="pimcore_video_editable"></iframe>
             </div>';
 
             return $code;

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -650,12 +650,12 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
                 if (in_array($key, $validYoutubeParams)) {
                     if (is_bool($value)) {
                         if ($value) {
-                            $additionalParams .= '&'.$key.'=1';
+                            $additionalParams .= '&amp;'.$key.'=1';
                         } else {
-                            $additionalParams .= '&'.$key.'=0';
+                            $additionalParams .= '&amp;'.$key.'=0';
                         }
                     } else {
-                        $additionalParams .= '&'.$key.'='.$value;
+                        $additionalParams .= '&amp;'.$key.'='.$value;
                     }
                 }
             }
@@ -728,12 +728,12 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
                     if (in_array($key, $validVimeoParams)) {
                         if (is_bool($value)) {
                             if ($value) {
-                                $additionalParams .= '&'.$key.'=1';
+                                $additionalParams .= '&amp;'.$key.'=1';
                             } else {
-                                $additionalParams .= '&'.$key.'=0';
+                                $additionalParams .= '&amp;'.$key.'=0';
                             }
                         } else {
-                            $additionalParams .= '&'.$key.'='.$value;
+                            $additionalParams .= '&amp;'.$key.'='.$value;
                         }
                     }
                 }
@@ -800,12 +800,12 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
                     if (in_array($key, $validDailymotionParams)) {
                         if (is_bool($value)) {
                             if ($value) {
-                                $additionalParams .= '&'.$key.'=1';
+                                $additionalParams .= '&amp;'.$key.'=1';
                             } else {
-                                $additionalParams .= '&'.$key.'=0';
+                                $additionalParams .= '&amp;'.$key.'=0';
                             }
                         } else {
-                            $additionalParams .= '&'.$key.'='.$value;
+                            $additionalParams .= '&amp;'.$key.'='.$value;
                         }
                     }
                 }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.4`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://pimcore.atlassian.net/browse/PEES-430

## Additional info
When trying to pass the output to `DOMDocument->loadHtml()`, the `&` could trigger a  `DOMDocument::loadHTML(): htmlParseEntityRef: expecting ';' in Entity`
Not using [libxml_use_internal_errors(true)](http://www.php.net/manual/en/function.libxml-use-internal-errors.php) to avoid "hiding" other errors