### PR TITLE
Optimize Asset Document ImageThumbnail generation

### DIFF
--- a/models/Asset/Document/ImageThumbnail.php
+++ b/models/Asset/Document/ImageThumbnail.php
@@ -144,8 +144,9 @@ final class ImageThumbnail implements ImageThumbnailInterface
                 try {
                     $converter = \Pimcore\Document::getInstance();
                     $converter->load($this->asset);
-                    $converter->saveImage($tempFile, $this->page);
-                    $storage->write($cacheFilePath, file_get_contents($tempFile));
+                    if (false !== $converter->saveImage($tempFile, $this->page)) {
+                        $storage->write($cacheFilePath, file_get_contents($tempFile));
+                    }
                 } finally {
                     $lock->release();
                 }


### PR DESCRIPTION
In certain cases, it can happen that the Document Thumbnail Generator fails (eg. ghostscript problems). Pimcore then tries to access a file that does not exist.
