### PR TITLE
[Bug]: Fix classification store group table type with no width issue

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Table.php
+++ b/models/DataObject/ClassDefinition/Data/Table.php
@@ -29,7 +29,9 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
     use DataObject\Traits\SimpleComparisonTrait;
     use DataObject\Traits\SimpleNormalizerTrait;
     use DataObject\Traits\DataHeightTrait;
-    use DataObject\Traits\DataWidthTrait;
+    use DataObject\Traits\DataWidthTrait{
+        setWidth as protected setWidthTrait;
+    }
 
     /**
      * @internal
@@ -71,6 +73,11 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
      *
      */
     public array $columnConfig = [];
+
+    public function setWidth(int|string|null $width): static
+    {
+        return $this->setWidthTrait($width ?: 320);
+    }
 
     public function getCols(): ?int
     {

--- a/models/DataObject/ClassDefinition/Data/Table.php
+++ b/models/DataObject/ClassDefinition/Data/Table.php
@@ -75,9 +75,8 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
     public array $columnConfig = [];
 
     /**
-     * @return $this
-     *
      * @internal
+     *
      */
     public function setWidth(int|string|null $width): static
     {

--- a/models/DataObject/ClassDefinition/Data/Table.php
+++ b/models/DataObject/ClassDefinition/Data/Table.php
@@ -74,6 +74,11 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
      */
     public array $columnConfig = [];
 
+    /**
+     * @return $this
+     *
+     * @internal
+     */
     public function setWidth(int|string|null $width): static
     {
         return $this->setWidthTrait($width ?: 320);


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/admin-ui-classic-bundle/issues/737

The initial issue seems reproducible by leaving the width empty

320px is because somehow covers the minimum width for the table toolbar to be fully shown, see
![image](https://github.com/user-attachments/assets/5a1ca82f-7e23-41e5-a23f-d1db462a6a91)
