### PR TITLE
[Bug]: Error from Migrations - call on null $this->container

### DIFF
--- a/bundles/CoreBundle/src/Migrations/Version20231127124738.php
+++ b/bundles/CoreBundle/src/Migrations/Version20231127124738.php
@@ -20,6 +20,7 @@ namespace Pimcore\Bundle\CoreBundle\Migrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 use Exception;
+use Pimcore;
 use Pimcore\DataObject\ClassBuilder\PHPClassDumperInterface;
 use Pimcore\DataObject\ClassBuilder\PHPFieldCollectionClassDumperInterface;
 use Pimcore\DataObject\ClassBuilder\PHPObjectBrickClassDumperInterface;
@@ -52,10 +53,10 @@ final class Version20231127124738 extends AbstractMigration implements Container
      */
     private function regenerate(): void
     {
-        $classDumper = $this->container->get(PHPClassDumperInterface::class);
-        $brickClassDumper = $this->container->get(PHPObjectBrickClassDumperInterface::class);
-        $brickContainerClassDumper = $this->container->get(PHPObjectBrickContainerClassDumperInterface::class);
-        $collectionClassDumper = $this->container->get(PHPFieldCollectionClassDumperInterface::class);
+        $classDumper = Pimcore::getContainer()->get(PHPClassDumperInterface::class);
+        $brickClassDumper = Pimcore::getContainer()->get(PHPObjectBrickClassDumperInterface::class);
+        $brickContainerClassDumper = Pimcore::getContainer()->get(PHPObjectBrickContainerClassDumperInterface::class);
+        $collectionClassDumper = Pimcore::getContainer()->get(PHPFieldCollectionClassDumperInterface::class);
 
         $listing = new DataObject\ClassDefinition\Listing();
         foreach ($listing->getClasses() as $class) {


### PR DESCRIPTION
## Changes in this pull request  
Potentially resolves https://pimcore.atlassian.net/browse/PEES-436

## Additional info
This PR should avoid this error
![image](https://github.com/user-attachments/assets/4b99bebe-ca5d-49b8-8fb5-c7dbcf439905)

By looking at some other migration
https://github.com/pimcore/pimcore/blob/3ffaeac8d9f07f877ea4f469015be1774de447b9/bundles/CoreBundle/src/Migrations/Version20221028115803.php#L53
which leads to 
https://github.com/pimcore/pimcore/blob/3ffaeac8d9f07f877ea4f469015be1774de447b9/models/DataObject/ClassDefinition.php#L418
