### PR TITLE
Image processing: possibility to configure the image adapter

### DIFF
--- a/bundles/CoreBundle/src/DependencyInjection/Compiler/ImageAdapterAliasPass.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Compiler/ImageAdapterAliasPass.php
@@ -16,7 +16,8 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler;
 
-use Pimcore\Image;
+use Pimcore\Image\Adapter\Imagick;
+use Pimcore\Image\Adapter\GD;
 use Pimcore\Image\AdapterInterface;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -36,11 +37,11 @@ final class ImageAdapterAliasPass implements CompilerPassInterface
             $container->getAlias(AdapterInterface::class)->setPublic(true);
         } else {
             if (extension_loaded('imagick')) {
-                $alias = new Alias(Image\Adapter\Imagick::class, true);
-                $container->setAlias(Image::class, $alias);
+                $alias = new Alias(Imagick::class, true);
+                $container->setAlias(AdapterInterface::class, $alias);
             } else {
-                $alias = new Alias(Image\Adapter\GD::class, true);
-                $container->setAlias(Image::class, $alias);
+                $alias = new Alias(GD::class, true);
+                $container->setAlias(AdapterInterface::class, $alias);
             }
         }
     }

--- a/bundles/CoreBundle/src/DependencyInjection/Compiler/ImageAdapterAliasPass.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Compiler/ImageAdapterAliasPass.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler;
 
 use Pimcore\Image;
+use Pimcore\Image\AdapterInterface;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -29,10 +30,10 @@ final class ImageAdapterAliasPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        if ($container->hasDefinition(Image::class)) {
-            $container->getDefinition(Image::class)->setPublic(true)->setShared(false);
-        } elseif ($container->hasAlias(Image::class)) {
-            $container->getAlias(Image::class)->setPublic(true);
+        if ($container->hasDefinition(AdapterInterface::class)) {
+            $container->getDefinition(AdapterInterface::class)->setPublic(true)->setShared(false);
+        } elseif ($container->hasAlias(AdapterInterface::class)) {
+            $container->getAlias(AdapterInterface::class)->setPublic(true);
         } else {
             if (extension_loaded('imagick')) {
                 $alias = new Alias(Image\Adapter\Imagick::class, true);

--- a/bundles/CoreBundle/src/DependencyInjection/Compiler/ImageAdapterAliasPass.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Compiler/ImageAdapterAliasPass.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler;
+
+use Pimcore\Image;
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use function extension_loaded;
+
+/**
+ * @internal
+ */
+final class ImageAdapterAliasPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if($container->hasDefinition(Image::class)) {
+            $container->getDefinition(Image::class)->setPublic(true)->setShared(false);
+        } elseif ($container->hasAlias(Image::class)) {
+            $container->getAlias(Image::class)->setPublic(true);
+        } else {
+            if (extension_loaded('imagick')) {
+                $alias = new Alias(Image\Adapter\Imagick::class, true);
+                $container->setAlias(Image::class, $alias);
+            } else {
+                $alias = new Alias(Image\Adapter\GD::class, true);
+                $container->setAlias(Image::class, $alias);
+            }
+        }
+    }
+}

--- a/bundles/CoreBundle/src/DependencyInjection/Compiler/ImageAdapterAliasPass.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Compiler/ImageAdapterAliasPass.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler;
 
-use Pimcore\Image\Adapter\Imagick;
 use Pimcore\Image\Adapter\GD;
+use Pimcore\Image\Adapter\Imagick;
 use Pimcore\Image\AdapterInterface;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/bundles/CoreBundle/src/DependencyInjection/Compiler/ImageAdapterAliasPass.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Compiler/ImageAdapterAliasPass.php
@@ -29,7 +29,7 @@ final class ImageAdapterAliasPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        if($container->hasDefinition(Image::class)) {
+        if ($container->hasDefinition(Image::class)) {
             $container->getDefinition(Image::class)->setPublic(true)->setShared(false);
         } elseif ($container->hasAlias(Image::class)) {
             $container->getAlias(Image::class)->setPublic(true);

--- a/bundles/CoreBundle/src/PimcoreCoreBundle.php
+++ b/bundles/CoreBundle/src/PimcoreCoreBundle.php
@@ -19,6 +19,7 @@ namespace Pimcore\Bundle\CoreBundle;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\AreabrickPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\CacheFallbackPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\HtmlSanitizerPass;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\ImageAdapterAliasPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\LongRunningHelperPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\MessageBusPublicPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\MonologPsrLogMessageProcessorPass;
@@ -65,6 +66,7 @@ class PimcoreCoreBundle extends Bundle
         $container->addCompilerPass(new HtmlSanitizerPass());
         $container->addCompilerPass(new TranslationSanitizerPass());
         $container->addCompilerPass(new SerializerPass());
+        $container->addCompilerPass(new ImageAdapterAliasPass());
     }
 
     public function getPath(): string

--- a/doc/04_Assets/03_Working_with_Thumbnails/01_Image_Thumbnails.md
+++ b/doc/04_Assets/03_Working_with_Thumbnails/01_Image_Thumbnails.md
@@ -8,7 +8,7 @@ which are not stored as an asset inside Pimcore.
 
 > **IMPORTANT**  
 > Use Imagick PECL extension for best results, GDlib is just a fallback with limited functionality
-> (only PNG, JPG, GIF) and less quality!
+> (only PNG, JPG, GIF) and less quality! If Imagick is available it will be the default, otherwise falling back to GD.
 > Using ImageMagick Pimcore can support hundreds of formats including: AI, EPS, TIFF, PNG, JPG, GIF, PSD, etc.
 > Not all formats are allowed out of the box. To extend the list [see](./README.md#allowed-formats).
 
@@ -507,3 +507,18 @@ pimcore:
             thumbnails:
                 auto_formats: null
 ```
+
+## Manually specify the used image processing adapter (Imagick or GD)
+It is possible to manually specify the used image processing adapter by Pimcore. 
+You can choose from `Imagick` or `GD`, the default is auto-detected, based on the availability of `imagick` PECL extension. 
+It is also possible to implement your own adapter, by implementing `Pimcore\Image\AdapterInterface`.
+
+To specify the used image adapter, please use the following service configuration: 
+
+```yaml
+services: 
+    Pimcore\Image\AdapterInterface:
+        alias: Pimcore\Image\Adapter\GD
+        public: true
+```
+Please be aware that the adapter service needs to be public. 

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -27,7 +27,7 @@ final class Image
      */
     public static function getInstance(): AdapterInterface
     {
-        return Pimcore::getContainer()->get(AdapterInterface::class);
+        return \Pimcore::getContainer()->get(AdapterInterface::class);
     }
 
     /**
@@ -38,6 +38,6 @@ final class Image
      */
     public static function create(): AdapterInterface
     {
-        return Pimcore::getContainer()->get(AdapterInterface::class);
+        return \Pimcore::getContainer()->get(AdapterInterface::class);
     }
 }

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -30,15 +30,4 @@ final class Image
     {
         return Pimcore::getContainer()->get(AdapterInterface::class);
     }
-
-    /**
-     *
-     * @throws Exception
-     *
-     * @internal
-     */
-    public static function create(): AdapterInterface
-    {
-        return Pimcore::getContainer()->get(AdapterInterface::class);
-    }
 }

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -26,12 +26,9 @@ final class Image
      *
      * @throws Exception
      */
-    public static function getInstance(): Adapter\GD|Adapter\Imagick|null
+    public static function getInstance(): Adapter\GD|Adapter\Imagick
     {
-        //@TODO should be configured on the container
-        $adapter = self::create();
-
-        return $adapter;
+        return Pimcore::getContainer()->get(self::class);
     }
 
     /**
@@ -40,18 +37,8 @@ final class Image
      *
      * @internal
      */
-    public static function create(): Adapter\GD|Adapter\Imagick|null
+    public static function create(): Adapter\GD|Adapter\Imagick
     {
-        try {
-            if (extension_loaded('imagick')) {
-                return Pimcore::getContainer()->get(Adapter\Imagick::class);
-            } else {
-                return Pimcore::getContainer()->get(Adapter\GD::class);
-            }
-        } catch (Exception $e) {
-            Logger::crit('Unable to load image extensions: ' . $e->getMessage());
-
-            throw $e;
-        }
+        return Pimcore::getContainer()->get(self::class);
     }
 }

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Pimcore;
 
 use Exception;
+use Pimcore;
 use Pimcore\Image\AdapterInterface;
 
 final class Image
@@ -27,7 +28,7 @@ final class Image
      */
     public static function getInstance(): AdapterInterface
     {
-        return \Pimcore::getContainer()->get(AdapterInterface::class);
+        return Pimcore::getContainer()->get(AdapterInterface::class);
     }
 
     /**
@@ -38,6 +39,6 @@ final class Image
      */
     public static function create(): AdapterInterface
     {
-        return \Pimcore::getContainer()->get(AdapterInterface::class);
+        return Pimcore::getContainer()->get(AdapterInterface::class);
     }
 }

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -17,8 +17,7 @@ declare(strict_types=1);
 namespace Pimcore;
 
 use Exception;
-use Pimcore;
-use Pimcore\Image\Adapter;
+use Pimcore\Image\AdapterInterface;
 
 final class Image
 {
@@ -26,9 +25,9 @@ final class Image
      *
      * @throws Exception
      */
-    public static function getInstance(): Adapter\GD|Adapter\Imagick
+    public static function getInstance(): AdapterInterface
     {
-        return Pimcore::getContainer()->get(self::class);
+        return Pimcore::getContainer()->get(AdapterInterface::class);
     }
 
     /**
@@ -37,8 +36,8 @@ final class Image
      *
      * @internal
      */
-    public static function create(): Adapter\GD|Adapter\Imagick
+    public static function create(): AdapterInterface
     {
-        return Pimcore::getContainer()->get(self::class);
+        return Pimcore::getContainer()->get(AdapterInterface::class);
     }
 }

--- a/lib/Image/Adapter.php
+++ b/lib/Image/Adapter.php
@@ -370,12 +370,14 @@ abstract class Adapter implements AdapterInterface
 
     /**
      * @deprecated Provided by AdapterInterface::load() instead
+     *
      * @return $this|false
      */
     abstract public function load(string $imagePath, array $options = []): static|false;
 
     /**
      * @deprecated Provided by AdapterInterface::save() instead
+     *
      * @return $this
      */
     abstract public function save(string $path, string $format = null, int $quality = null): static;
@@ -384,12 +386,12 @@ abstract class Adapter implements AdapterInterface
 
     /**
      * @deprecated Provided by AdapterInterface::getContentOptimizedFormat() instead
-     * @return string
      */
     abstract public function getContentOptimizedFormat(): string;
 
     /**
      * @deprecated Provided by AdapterInterface::supportsFormat() instead
+     *
      * @internal
      */
     abstract public function supportsFormat(string $format, bool $force = false): bool;

--- a/lib/Image/Adapter.php
+++ b/lib/Image/Adapter.php
@@ -41,9 +41,6 @@ abstract class Adapter implements AdapterInterface
 
     protected mixed $resource = null;
 
-    /**
-     * @return $this
-     */
     public function setHeight(int $height): static
     {
         $this->height = $height;
@@ -56,9 +53,6 @@ abstract class Adapter implements AdapterInterface
         return $this->height;
     }
 
-    /**
-     * @return $this
-     */
     public function setWidth(int $width): static
     {
         $this->width = $width;
@@ -95,17 +89,11 @@ abstract class Adapter implements AdapterInterface
         return [$r, $g, $b, 'type' => 'RGB'];
     }
 
-    /**
-     * @return $this
-     */
     public function resize(int $width, int $height): static
     {
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function scaleByWidth(int $width, bool $forceResize = false): static
     {
         if ($forceResize || $width <= $this->getWidth() || $this->isVectorGraphic()) {
@@ -116,9 +104,6 @@ abstract class Adapter implements AdapterInterface
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function scaleByHeight(int $height, bool $forceResize = false): static
     {
         if ($forceResize || $height < $this->getHeight() || $this->isVectorGraphic()) {
@@ -129,9 +114,6 @@ abstract class Adapter implements AdapterInterface
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function contain(int $width, int $height, bool $forceResize = false): static
     {
         $x = $this->getWidth() / $width;
@@ -147,9 +129,6 @@ abstract class Adapter implements AdapterInterface
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function cover(int $width, int $height, array|string|null $orientation = 'center', bool $forceResize = false): static
     {
         if (!$orientation) {
@@ -216,91 +195,56 @@ abstract class Adapter implements AdapterInterface
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function frame(int $width, int $height, bool $forceResize = false): static
     {
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function trim(int $tolerance): static
     {
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function rotate(int $angle): static
     {
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function crop(int $x, int $y, int $width, int $height): static
     {
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function setBackgroundColor(string $color): static
     {
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function setBackgroundImage(string $image): static
     {
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function roundCorners(int $width, int $height): static
     {
         return $this;
     }
 
-    /**
-     * @param string $origin Origin of the X and Y coordinates (top-left, top-right, bottom-left, bottom-right or center)
-     *
-     * @return $this
-     */
     public function addOverlay(mixed $image, int $x = 0, int $y = 0, int $alpha = 100, string $composite = 'COMPOSITE_DEFAULT', string $origin = 'top-left'): static
     {
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function addOverlayFit(string $image, string $composite = 'COMPOSITE_DEFAULT'): static
     {
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function applyMask(string $image): static
     {
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function cropPercent(int $width, int $height, int $x, int $y): static
     {
         if ($this->isVectorGraphic()) {
@@ -320,49 +264,31 @@ abstract class Adapter implements AdapterInterface
         return $this->crop($xPixel, $yPixel, $widthPixel, $heightPixel);
     }
 
-    /**
-     * @return $this
-     */
     public function grayscale(): static
     {
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function sepia(): static
     {
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function sharpen(): static
     {
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function mirror(string $mode): static
     {
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function gaussianBlur(int $radius = 0, float $sigma = 1.0): static
     {
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function brightnessSaturation(int $brightness = 100, int $saturation = 100, int $hue = 100): static
     {
         return $this;
@@ -370,15 +296,11 @@ abstract class Adapter implements AdapterInterface
 
     /**
      * @deprecated Provided by AdapterInterface::load() instead
-     *
-     * @return $this|false
      */
     abstract public function load(string $imagePath, array $options = []): static|false;
 
     /**
      * @deprecated Provided by AdapterInterface::save() instead
-     *
-     * @return $this
      */
     abstract public function save(string $path, string $format = null, int $quality = null): static;
 
@@ -391,7 +313,6 @@ abstract class Adapter implements AdapterInterface
 
     /**
      * @deprecated Provided by AdapterInterface::supportsFormat() instead
-     *
      * @internal
      */
     abstract public function supportsFormat(string $format, bool $force = false): bool;
@@ -449,9 +370,6 @@ abstract class Adapter implements AdapterInterface
         ];
     }
 
-    /**
-     * @return $this
-     */
     public function setColorspace(string $type = 'RGB'): static
     {
         return $this;

--- a/lib/Image/Adapter.php
+++ b/lib/Image/Adapter.php
@@ -17,7 +17,7 @@ namespace Pimcore\Image;
 
 use Pimcore\Logger;
 
-abstract class Adapter
+abstract class Adapter implements AdapterInterface
 {
     protected int $width;
 
@@ -369,21 +369,27 @@ abstract class Adapter
     }
 
     /**
+     * @deprecated Provided by AdapterInterface::load() instead
      * @return $this|false
      */
     abstract public function load(string $imagePath, array $options = []): static|false;
 
     /**
-     *
+     * @deprecated Provided by AdapterInterface::save() instead
      * @return $this
      */
     abstract public function save(string $path, string $format = null, int $quality = null): static;
 
     abstract protected function destroy(): void;
 
+    /**
+     * @deprecated Provided by AdapterInterface::getContentOptimizedFormat() instead
+     * @return string
+     */
     abstract public function getContentOptimizedFormat(): string;
 
     /**
+     * @deprecated Provided by AdapterInterface::supportsFormat() instead
      * @internal
      */
     abstract public function supportsFormat(string $format, bool $force = false): bool;

--- a/lib/Image/Adapter.php
+++ b/lib/Image/Adapter.php
@@ -313,6 +313,7 @@ abstract class Adapter implements AdapterInterface
 
     /**
      * @deprecated Provided by AdapterInterface::supportsFormat() instead
+     *
      * @internal
      */
     abstract public function supportsFormat(string $format, bool $force = false): bool;

--- a/lib/Image/AdapterInterface.php
+++ b/lib/Image/AdapterInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * Pimcore

--- a/lib/Image/AdapterInterface.php
+++ b/lib/Image/AdapterInterface.php
@@ -94,6 +94,7 @@ interface AdapterInterface
 
     /**
      * @param string $origin Origin of the X and Y coordinates (top-left, top-right, bottom-left, bottom-right or center)
+     *
      * @return $this
      */
     public function addOverlay(mixed $image, int $x = 0, int $y = 0, int $alpha = 100, string $composite = 'COMPOSITE_DEFAULT', string $origin = 'top-left'): static;

--- a/lib/Image/AdapterInterface.php
+++ b/lib/Image/AdapterInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Image;
+
+interface AdapterInterface
+{
+    public function getHeight(): int;
+    public function setHeight(int $height): static;
+    public function getWidth(): int;
+    public function setWidth(int $width): static;
+    public function resize(int $width, int $height): static;
+    public function scaleByWidth(int $width, bool $forceResize = false): static;
+    public function scaleByHeight(int $height, bool $forceResize = false): static;
+    public function contain(int $width, int $height, bool $forceResize = false): static;
+    public function cover(int $width, int $height, array|string|null $orientation = 'center', bool $forceResize = false): static;
+    public function frame(int $width, int $height, bool $forceResize = false): static;
+    public function trim(int $tolerance): static;
+    public function rotate(int $angle): static;
+    public function crop(int $x, int $y, int $width, int $height): static;
+    public function setBackgroundColor(string $color): static;
+    public function setBackgroundImage(string $image): static;
+    public function roundCorners(int $width, int $height): static;
+    public function addOverlay(mixed $image, int $x = 0, int $y = 0, int $alpha = 100, string $composite = 'COMPOSITE_DEFAULT', string $origin = 'top-left'): static;
+    public function addOverlayFit(string $image, string $composite = 'COMPOSITE_DEFAULT'): static;
+    public function applyMask(string $image): static;
+    public function cropPercent(int $width, int $height, int $x, int $y): static;
+    public function grayscale(): static;
+    public function sepia(): static;
+    public function sharpen(): static;
+    public function mirror(string $mode): static;
+    public function gaussianBlur(int $radius = 0, float $sigma = 1.0): static;
+    public function brightnessSaturation(int $brightness = 100, int $saturation = 100, int $hue = 100): static;
+    public function load(string $imagePath, array $options = []): static|false;
+    public function save(string $path, string $format = null, int $quality = null): static;
+    public function getContentOptimizedFormat(): string;
+    public function supportsFormat(string $format, bool $force = false): bool;
+    public function isVectorGraphic(): bool;
+}

--- a/lib/Image/AdapterInterface.php
+++ b/lib/Image/AdapterInterface.php
@@ -50,6 +50,9 @@ interface AdapterInterface
 
     public function roundCorners(int $width, int $height): static;
 
+    /**
+     * @param string $origin Origin of the X and Y coordinates (top-left, top-right, bottom-left, bottom-right or center)
+     */
     public function addOverlay(mixed $image, int $x = 0, int $y = 0, int $alpha = 100, string $composite = 'COMPOSITE_DEFAULT', string $origin = 'top-left'): static;
 
     public function addOverlayFit(string $image, string $composite = 'COMPOSITE_DEFAULT'): static;

--- a/lib/Image/AdapterInterface.php
+++ b/lib/Image/AdapterInterface.php
@@ -18,34 +18,64 @@ namespace Pimcore\Image;
 interface AdapterInterface
 {
     public function getHeight(): int;
+
     public function setHeight(int $height): static;
+
     public function getWidth(): int;
+
     public function setWidth(int $width): static;
+
     public function resize(int $width, int $height): static;
+
     public function scaleByWidth(int $width, bool $forceResize = false): static;
+
     public function scaleByHeight(int $height, bool $forceResize = false): static;
+
     public function contain(int $width, int $height, bool $forceResize = false): static;
+
     public function cover(int $width, int $height, array|string|null $orientation = 'center', bool $forceResize = false): static;
+
     public function frame(int $width, int $height, bool $forceResize = false): static;
+
     public function trim(int $tolerance): static;
+
     public function rotate(int $angle): static;
+
     public function crop(int $x, int $y, int $width, int $height): static;
+
     public function setBackgroundColor(string $color): static;
+
     public function setBackgroundImage(string $image): static;
+
     public function roundCorners(int $width, int $height): static;
+
     public function addOverlay(mixed $image, int $x = 0, int $y = 0, int $alpha = 100, string $composite = 'COMPOSITE_DEFAULT', string $origin = 'top-left'): static;
+
     public function addOverlayFit(string $image, string $composite = 'COMPOSITE_DEFAULT'): static;
+
     public function applyMask(string $image): static;
+
     public function cropPercent(int $width, int $height, int $x, int $y): static;
+
     public function grayscale(): static;
+
     public function sepia(): static;
+
     public function sharpen(): static;
+
     public function mirror(string $mode): static;
+
     public function gaussianBlur(int $radius = 0, float $sigma = 1.0): static;
+
     public function brightnessSaturation(int $brightness = 100, int $saturation = 100, int $hue = 100): static;
+
     public function load(string $imagePath, array $options = []): static|false;
+
     public function save(string $path, string $format = null, int $quality = null): static;
+
     public function getContentOptimizedFormat(): string;
+
     public function supportsFormat(string $format, bool $force = false): bool;
+
     public function isVectorGraphic(): bool;
 }

--- a/lib/Image/AdapterInterface.php
+++ b/lib/Image/AdapterInterface.php
@@ -20,61 +20,137 @@ interface AdapterInterface
 {
     public function getHeight(): int;
 
+    /**
+     * @return $this
+     */
     public function setHeight(int $height): static;
 
     public function getWidth(): int;
 
+    /**
+     * @return $this
+     */
     public function setWidth(int $width): static;
 
+    /**
+     * @return $this
+     */
     public function resize(int $width, int $height): static;
 
+    /**
+     * @return $this
+     */
     public function scaleByWidth(int $width, bool $forceResize = false): static;
 
+    /**
+     * @return $this
+     */
     public function scaleByHeight(int $height, bool $forceResize = false): static;
 
+    /**
+     * @return $this
+     */
     public function contain(int $width, int $height, bool $forceResize = false): static;
 
+    /**
+     * @return $this
+     */
     public function cover(int $width, int $height, array|string|null $orientation = 'center', bool $forceResize = false): static;
 
+    /**
+     * @return $this
+     */
     public function frame(int $width, int $height, bool $forceResize = false): static;
 
+    /**
+     * @return $this
+     */
     public function trim(int $tolerance): static;
 
+    /**
+     * @return $this
+     */
     public function rotate(int $angle): static;
 
+    /**
+     * @return $this
+     */
     public function crop(int $x, int $y, int $width, int $height): static;
 
+    /**
+     * @return $this
+     */
     public function setBackgroundColor(string $color): static;
 
+    /**
+     * @return $this
+     */
     public function setBackgroundImage(string $image): static;
 
+    /**
+     * @return $this
+     */
     public function roundCorners(int $width, int $height): static;
 
     /**
      * @param string $origin Origin of the X and Y coordinates (top-left, top-right, bottom-left, bottom-right or center)
+     * @return $this
      */
     public function addOverlay(mixed $image, int $x = 0, int $y = 0, int $alpha = 100, string $composite = 'COMPOSITE_DEFAULT', string $origin = 'top-left'): static;
 
+    /**
+     * @return $this
+     */
     public function addOverlayFit(string $image, string $composite = 'COMPOSITE_DEFAULT'): static;
 
+    /**
+     * @return $this
+     */
     public function applyMask(string $image): static;
 
+    /**
+     * @return $this
+     */
     public function cropPercent(int $width, int $height, int $x, int $y): static;
 
+    /**
+     * @return $this
+     */
     public function grayscale(): static;
 
+    /**
+     * @return $this
+     */
     public function sepia(): static;
 
+    /**
+     * @return $this
+     */
     public function sharpen(): static;
 
+    /**
+     * @return $this
+     */
     public function mirror(string $mode): static;
 
+    /**
+     * @return $this
+     */
     public function gaussianBlur(int $radius = 0, float $sigma = 1.0): static;
 
+    /**
+     * @return $this
+     */
     public function brightnessSaturation(int $brightness = 100, int $saturation = 100, int $hue = 100): static;
 
+    /**
+     * @return $this|false
+     */
     public function load(string $imagePath, array $options = []): static|false;
 
+    /**
+     * @return $this
+     */
     public function save(string $path, string $format = null, int $quality = null): static;
 
     public function getContentOptimizedFormat(): string;


### PR DESCRIPTION
This change makes it possible to manually specify the image adapter to be used (`Imagick` or `GD`). 

Example: 
```yaml
services: 
    Pimcore\Image\AdapterInterface:
        alias: Pimcore\Image\Adapter\GD
        public: true
```