### PR TITLE
Fix: Elements deleted by Scheduled Tasks don't appear in Recyclebin

### DIFF
--- a/lib/Maintenance/Tasks/ScheduledTasksTask.php
+++ b/lib/Maintenance/Tasks/ScheduledTasksTask.php
@@ -21,6 +21,7 @@ use Pimcore\Maintenance\TaskInterface;
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\Document;
+use Pimcore\Model\Element\Recyclebin;
 use Pimcore\Model\Schedule\Task\Listing;
 use Pimcore\Model\User;
 use Pimcore\Model\Version;
@@ -70,6 +71,7 @@ class ScheduledTasksTask implements TaskInterface
                             $document->setPublished(false);
                             $document->save();
                         } elseif ($task->getAction() === 'delete' && $document->isAllowed('delete', $taskUser)) {
+                            Recyclebin\Item::create($document);
                             $document->delete();
                         }
                     }
@@ -89,6 +91,7 @@ class ScheduledTasksTask implements TaskInterface
                                 $this->logger->error('Schedule\\Task\\Executor: Version [ '.$task->getVersion().' ] does not exist.');
                             }
                         } elseif ($task->getAction() === 'delete' && $asset->isAllowed('delete', $taskUser)) {
+                            Recyclebin\Item::create($asset);
                             $asset->delete();
                         }
                     }
@@ -115,6 +118,7 @@ class ScheduledTasksTask implements TaskInterface
                             $object->setPublished(false);
                             $object->save();
                         } elseif ($task->getAction() === 'delete' && $object->isAllowed('delete', $taskUser)) {
+                            Recyclebin\Item::create($object);
                             $object->delete();
                         }
                     }


### PR DESCRIPTION
Scheduled deletion events aren't moved to the recycle bin, editors do not expect final deletion.

## Steps to reproduce: 

1. Create any element (Document/Dataobject/Asset)
2. Add a Scheduled Task to delete this element
3. **After task execution:**
- The element is deleted as expected
- The element does NOT appear in the Recyclebin
- The only way to trace the deletion is through the usage log

## Expected Behavior
Deleted elements should appear in the Recyclebin regardless of whether they were deleted manually or by a Scheduled Task

## Changes in this pull request  
Add Recyclebin entry before deleting the element

