### PR TITLE
[Data Objects] Fix revert to previous global inheritance state in DAO

### DIFF
--- a/models/DataObject/Concrete/Dao.php
+++ b/models/DataObject/Concrete/Dao.php
@@ -202,6 +202,7 @@ class Dao extends Model\DataObject\AbstractObject\Dao
         }
 
         $inheritedValues = DataObject::doGetInheritedValues();
+
         try {
             DataObject::setGetInheritedValues(false);
 

--- a/models/DataObject/Concrete/Dao.php
+++ b/models/DataObject/Concrete/Dao.php
@@ -202,181 +202,183 @@ class Dao extends Model\DataObject\AbstractObject\Dao
         }
 
         $inheritedValues = DataObject::doGetInheritedValues();
-        DataObject::setGetInheritedValues(false);
+        try {
+            DataObject::setGetInheritedValues(false);
 
-        $data = [];
-        $data['oo_id'] = $this->model->getId();
-        foreach ($fieldDefinitions as $fieldName => $fd) {
-            $getter = 'get' . ucfirst($fieldName);
+            $data = [];
+            $data['oo_id'] = $this->model->getId();
+            foreach ($fieldDefinitions as $fieldName => $fd) {
+                $getter = 'get' . ucfirst($fieldName);
 
-            if ($fd instanceof CustomResourcePersistingInterface
-                && $fd instanceof DataObject\ClassDefinition\Data) {
-                // for fieldtypes which have their own save algorithm eg. fieldcollections, relational data-types, ...
-                $saveParams = ['isUntouchable' => in_array($fd->getName(), $untouchable),
-                    'isUpdate' => $isUpdate,
-                    'context' => [
-                        'containerType' => 'object',
-                    ],
-                    'owner' => $this->model,
-                    'fieldname' => $fieldName,
-                ]
-                ;
-                if ($this->model instanceof Model\Element\DirtyIndicatorInterface) {
-                    $saveParams['newParent'] = $this->model->isFieldDirty('parentId');
-                }
-                $fd->save($this->model, $saveParams);
-            }
-            if ($fd instanceof ResourcePersistenceAwareInterface) {
-                // pimcore saves the values with getDataForResource
-
-                $fieldDefinitionParams = [
-                    'isUpdate' => $isUpdate,
-                    'owner' => $this->model,
-                    'fieldname' => $fieldName,
-                ];
-                if (is_array($fd->getColumnType())) {
-                    $insertDataArray = $fd->getDataForResource($this->model->$getter(), $this->model, $fieldDefinitionParams);
-                    if (is_array($insertDataArray)) {
-                        $data = array_merge($data, $insertDataArray);
-                        $this->model->set($fieldName, $fd->getDataFromResource($insertDataArray, $this->model, $fieldDefinitionParams));
+                if ($fd instanceof CustomResourcePersistingInterface
+                    && $fd instanceof DataObject\ClassDefinition\Data) {
+                    // for fieldtypes which have their own save algorithm eg. fieldcollections, relational data-types, ...
+                    $saveParams = ['isUntouchable' => in_array($fd->getName(), $untouchable),
+                        'isUpdate' => $isUpdate,
+                        'context' => [
+                            'containerType' => 'object',
+                        ],
+                        'owner' => $this->model,
+                        'fieldname' => $fieldName,
+                    ]
+                    ;
+                    if ($this->model instanceof Model\Element\DirtyIndicatorInterface) {
+                        $saveParams['newParent'] = $this->model->isFieldDirty('parentId');
                     }
-                } else {
-                    $insertData = $fd->getDataForResource($this->model->$getter(), $this->model, $fieldDefinitionParams);
-                    $data[$fieldName] = $insertData;
-                    $this->model->set($fieldName, $fd->getDataFromResource($insertData, $this->model, $fieldDefinitionParams));
+                    $fd->save($this->model, $saveParams);
                 }
+                if ($fd instanceof ResourcePersistenceAwareInterface) {
+                    // pimcore saves the values with getDataForResource
 
-                if ($this->model instanceof Model\Element\DirtyIndicatorInterface) {
-                    $this->model->markFieldDirty($fieldName, false);
-                }
-            }
-        }
-        $tableName = 'object_store_' . $this->model->getClassId();
-        if ($isUpdate) {
-            Helper::upsert($this->db, $tableName, $data, $this->getPrimaryKey($tableName));
-        } else {
-            $this->db->insert('object_store_' . $this->model->getClassId(), Helper::quoteDataIdentifiers($this->db, $data));
-        }
-
-        // get data for query table
-        $data = [];
-        $this->getInheritanceHelper()->resetFieldsToCheck();
-        $oldData = $this->db->fetchAssociative('SELECT * FROM object_query_' . $this->model->getClassId() . ' WHERE oo_id = ?', [$this->model->getId()]);
-
-        $inheritanceEnabled = $this->model->getClass()->getAllowInherit();
-        $parentData = null;
-        if ($inheritanceEnabled) {
-            // get the next suitable parent for inheritance
-            $parentForInheritance = $this->model->getNextParentForInheritance();
-            if ($parentForInheritance) {
-                // we don't use the getter (built in functionality to get inherited values) because we need to avoid race conditions
-                // we cannot DataObject::setGetInheritedValues(true); and then $this->model->$method();
-                // so we select the data from the parent object using FOR UPDATE, which causes a lock on this row
-                // so the data of the parent cannot be changed while this transaction is on progress
-                $parentData = $this->db->fetchAssociative('SELECT * FROM object_query_' . $this->model->getClassId() . ' WHERE oo_id = ? FOR UPDATE', [$parentForInheritance->getId()]);
-            }
-        }
-
-        foreach ($fieldDefinitions as $key => $fd) {
-            if ($fd instanceof QueryResourcePersistenceAwareInterface
-                && $fd instanceof DataObject\ClassDefinition\Data) {
-                //exclude untouchables if value is not an array - this means data has not been loaded
-                if (!in_array($key, $untouchable)) {
-                    $method = 'get' . $key;
-                    $fieldValue = $this->model->$method();
-                    $insertData = $fd->getDataForQueryResource($fieldValue, $this->model,
-                        [
-                            'isUpdate' => $isUpdate,
-                            'owner' => $this->model,
-                            'fieldname' => $key,
-                        ]);
-                    $isEmpty = $fd->isEmpty($fieldValue);
-
-                    if (is_array($insertData)) {
-                        $columnNames = array_keys($insertData);
-                        $data = array_merge($data, $insertData);
+                    $fieldDefinitionParams = [
+                        'isUpdate' => $isUpdate,
+                        'owner' => $this->model,
+                        'fieldname' => $fieldName,
+                    ];
+                    if (is_array($fd->getColumnType())) {
+                        $insertDataArray = $fd->getDataForResource($this->model->$getter(), $this->model, $fieldDefinitionParams);
+                        if (is_array($insertDataArray)) {
+                            $data = array_merge($data, $insertDataArray);
+                            $this->model->set($fieldName, $fd->getDataFromResource($insertDataArray, $this->model, $fieldDefinitionParams));
+                        }
                     } else {
-                        $columnNames = [$key];
-                        $data[$key] = $insertData;
+                        $insertData = $fd->getDataForResource($this->model->$getter(), $this->model, $fieldDefinitionParams);
+                        $data[$fieldName] = $insertData;
+                        $this->model->set($fieldName, $fd->getDataFromResource($insertData, $this->model, $fieldDefinitionParams));
                     }
 
-                    // if the current value is empty and we have data from the parent, we just use it
-                    if ($isEmpty && $parentData) {
-                        foreach ($columnNames as $columnName) {
-                            if (array_key_exists($columnName, $parentData)) {
-                                $data[$columnName] = $parentData[$columnName];
-                                if (is_array($insertData)) {
-                                    $insertData[$columnName] = $parentData[$columnName];
-                                } else {
-                                    $insertData = $parentData[$columnName];
-                                }
-                            }
-                        }
+                    if ($this->model instanceof Model\Element\DirtyIndicatorInterface) {
+                        $this->model->markFieldDirty($fieldName, false);
                     }
-
-                    if ($inheritanceEnabled && $fd->supportsInheritance()) {
-                        //get changed fields for inheritance
-                        if ($fd->isRelationType()) {
-                            if (is_array($insertData)) {
-                                $doInsert = false;
-                                foreach ($insertData as $insertDataKey => $insertDataValue) {
-                                    $oldDataValue = $oldData[$insertDataKey] ?? null;
-                                    $parentDataValue = $parentData[$insertDataKey] ?? null;
-                                    if ($isEmpty && $oldDataValue == $parentDataValue) {
-                                        // do nothing, ... value is still empty and parent data is equal to current data in query table
-                                    } elseif ($oldDataValue != $insertDataValue) {
-                                        $doInsert = true;
-
-                                        break;
-                                    }
-                                }
-
-                                if ($doInsert) {
-                                    $this->getInheritanceHelper()->addRelationToCheck($key, $fd, array_keys($insertData));
-                                }
-                            } else {
-                                $oldDataValue = $oldData[$key] ?? null;
-                                $parentDataValue = $parentData[$key] ?? null;
-                                if ($isEmpty && $oldDataValue == $parentDataValue) {
-                                    // do nothing, ... value is still empty and parent data is equal to current data in query table
-                                } elseif ($oldDataValue != $insertData) {
-                                    $this->getInheritanceHelper()->addRelationToCheck($key, $fd);
-                                }
-                            }
-                        } else {
-                            if (is_array($insertData)) {
-                                foreach ($insertData as $insertDataKey => $insertDataValue) {
-                                    $oldDataValue = $oldData[$insertDataKey] ?? null;
-                                    $parentDataValue = $parentData[$insertDataKey] ?? null;
-                                    if ($isEmpty && $oldDataValue == $parentDataValue) {
-                                        // do nothing, ... value is still empty and parent data is equal to current data in query table
-                                    } elseif ($oldDataValue != $insertDataValue) {
-                                        $this->getInheritanceHelper()->addFieldToCheck($insertDataKey, $fd);
-                                    }
-                                }
-                            } else {
-                                $oldDataValue = $oldData[$key] ?? null;
-                                $parentDataValue = $parentData[$key] ?? null;
-                                if ($isEmpty && $oldDataValue == $parentDataValue) {
-                                    // do nothing, ... value is still empty and parent data is equal to current data in query table
-                                } elseif ($oldDataValue != $insertData) {
-                                    // data changed, do check and update
-                                    $this->getInheritanceHelper()->addFieldToCheck($key, $fd);
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    Logger::debug('Excluding untouchable query value for object [ ' . $this->model->getId() . " ]  key [ $key ] because it has not been loaded");
                 }
             }
+            $tableName = 'object_store_' . $this->model->getClassId();
+            if ($isUpdate) {
+                Helper::upsert($this->db, $tableName, $data, $this->getPrimaryKey($tableName));
+            } else {
+                $this->db->insert('object_store_' . $this->model->getClassId(), Helper::quoteDataIdentifiers($this->db, $data));
+            }
+
+            // get data for query table
+            $data = [];
+            $this->getInheritanceHelper()->resetFieldsToCheck();
+            $oldData = $this->db->fetchAssociative('SELECT * FROM object_query_' . $this->model->getClassId() . ' WHERE oo_id = ?', [$this->model->getId()]);
+
+            $inheritanceEnabled = $this->model->getClass()->getAllowInherit();
+            $parentData = null;
+            if ($inheritanceEnabled) {
+                // get the next suitable parent for inheritance
+                $parentForInheritance = $this->model->getNextParentForInheritance();
+                if ($parentForInheritance) {
+                    // we don't use the getter (built in functionality to get inherited values) because we need to avoid race conditions
+                    // we cannot DataObject::setGetInheritedValues(true); and then $this->model->$method();
+                    // so we select the data from the parent object using FOR UPDATE, which causes a lock on this row
+                    // so the data of the parent cannot be changed while this transaction is on progress
+                    $parentData = $this->db->fetchAssociative('SELECT * FROM object_query_' . $this->model->getClassId() . ' WHERE oo_id = ? FOR UPDATE', [$parentForInheritance->getId()]);
+                }
+            }
+
+            foreach ($fieldDefinitions as $key => $fd) {
+                if ($fd instanceof QueryResourcePersistenceAwareInterface
+                    && $fd instanceof DataObject\ClassDefinition\Data) {
+                    //exclude untouchables if value is not an array - this means data has not been loaded
+                    if (!in_array($key, $untouchable)) {
+                        $method = 'get' . $key;
+                        $fieldValue = $this->model->$method();
+                        $insertData = $fd->getDataForQueryResource($fieldValue, $this->model,
+                            [
+                                'isUpdate' => $isUpdate,
+                                'owner' => $this->model,
+                                'fieldname' => $key,
+                            ]);
+                        $isEmpty = $fd->isEmpty($fieldValue);
+
+                        if (is_array($insertData)) {
+                            $columnNames = array_keys($insertData);
+                            $data = array_merge($data, $insertData);
+                        } else {
+                            $columnNames = [$key];
+                            $data[$key] = $insertData;
+                        }
+
+                        // if the current value is empty and we have data from the parent, we just use it
+                        if ($isEmpty && $parentData) {
+                            foreach ($columnNames as $columnName) {
+                                if (array_key_exists($columnName, $parentData)) {
+                                    $data[$columnName] = $parentData[$columnName];
+                                    if (is_array($insertData)) {
+                                        $insertData[$columnName] = $parentData[$columnName];
+                                    } else {
+                                        $insertData = $parentData[$columnName];
+                                    }
+                                }
+                            }
+                        }
+
+                        if ($inheritanceEnabled && $fd->supportsInheritance()) {
+                            //get changed fields for inheritance
+                            if ($fd->isRelationType()) {
+                                if (is_array($insertData)) {
+                                    $doInsert = false;
+                                    foreach ($insertData as $insertDataKey => $insertDataValue) {
+                                        $oldDataValue = $oldData[$insertDataKey] ?? null;
+                                        $parentDataValue = $parentData[$insertDataKey] ?? null;
+                                        if ($isEmpty && $oldDataValue == $parentDataValue) {
+                                            // do nothing, ... value is still empty and parent data is equal to current data in query table
+                                        } elseif ($oldDataValue != $insertDataValue) {
+                                            $doInsert = true;
+
+                                            break;
+                                        }
+                                    }
+
+                                    if ($doInsert) {
+                                        $this->getInheritanceHelper()->addRelationToCheck($key, $fd, array_keys($insertData));
+                                    }
+                                } else {
+                                    $oldDataValue = $oldData[$key] ?? null;
+                                    $parentDataValue = $parentData[$key] ?? null;
+                                    if ($isEmpty && $oldDataValue == $parentDataValue) {
+                                        // do nothing, ... value is still empty and parent data is equal to current data in query table
+                                    } elseif ($oldDataValue != $insertData) {
+                                        $this->getInheritanceHelper()->addRelationToCheck($key, $fd);
+                                    }
+                                }
+                            } else {
+                                if (is_array($insertData)) {
+                                    foreach ($insertData as $insertDataKey => $insertDataValue) {
+                                        $oldDataValue = $oldData[$insertDataKey] ?? null;
+                                        $parentDataValue = $parentData[$insertDataKey] ?? null;
+                                        if ($isEmpty && $oldDataValue == $parentDataValue) {
+                                            // do nothing, ... value is still empty and parent data is equal to current data in query table
+                                        } elseif ($oldDataValue != $insertDataValue) {
+                                            $this->getInheritanceHelper()->addFieldToCheck($insertDataKey, $fd);
+                                        }
+                                    }
+                                } else {
+                                    $oldDataValue = $oldData[$key] ?? null;
+                                    $parentDataValue = $parentData[$key] ?? null;
+                                    if ($isEmpty && $oldDataValue == $parentDataValue) {
+                                        // do nothing, ... value is still empty and parent data is equal to current data in query table
+                                    } elseif ($oldDataValue != $insertData) {
+                                        // data changed, do check and update
+                                        $this->getInheritanceHelper()->addFieldToCheck($key, $fd);
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        Logger::debug('Excluding untouchable query value for object [ ' . $this->model->getId() . " ]  key [ $key ] because it has not been loaded");
+                    }
+                }
+            }
+            $data['oo_id'] = $this->model->getId();
+
+            $tableName = 'object_query_' . $this->model->getClassId();
+            Helper::upsert($this->db, $tableName, $data, $this->getPrimaryKey($tableName));
+        } finally {
+            DataObject::setGetInheritedValues($inheritedValues);
         }
-        $data['oo_id'] = $this->model->getId();
-
-        $tableName = 'object_query_' . $this->model->getClassId();
-        Helper::upsert($this->db, $tableName, $data, $this->getPrimaryKey($tableName));
-
-        DataObject::setGetInheritedValues($inheritedValues);
     }
 
     public function saveChildData(): void

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -147,6 +147,7 @@ class Dao extends Model\Dao\AbstractDao
             }
 
             $inheritedValues = DataObject::doGetInheritedValues();
+
             try {
                 DataObject::setGetInheritedValues(false);
 

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -147,119 +147,79 @@ class Dao extends Model\Dao\AbstractDao
             }
 
             $inheritedValues = DataObject::doGetInheritedValues();
-            DataObject::setGetInheritedValues(false);
+            try {
+                DataObject::setGetInheritedValues(false);
 
-            $insertData = [
-                'ooo_id' => $this->model->getObject()->getId(),
-                'language' => $language,
-            ];
+                $insertData = [
+                    'ooo_id' => $this->model->getObject()->getId(),
+                    'language' => $language,
+                ];
 
-            if ($container instanceof DataObject\Objectbrick\Definition || $container instanceof DataObject\Fieldcollection\Definition) {
-                $insertData['fieldname'] = $context['fieldname'];
-                $insertData['index'] = $context['index'] ?? 0;
-            }
+                if ($container instanceof DataObject\Objectbrick\Definition || $container instanceof DataObject\Fieldcollection\Definition) {
+                    $insertData['fieldname'] = $context['fieldname'];
+                    $insertData['index'] = $context['index'] ?? 0;
+                }
 
-            foreach ($fieldDefinitions as $fieldName => $fd) {
-                if ($fd instanceof CustomResourcePersistingInterface) {
-                    // for fieldtypes which have their own save algorithm eg. relational data types, ...
-                    $context = $this->model->getContext() ? $this->model->getContext() : [];
-                    if (isset($context['containerType']) && ($context['containerType'] === 'fieldcollection' || $context['containerType'] === 'objectbrick')) {
-                        $context['subContainerType'] = 'localizedfield';
-                    }
+                foreach ($fieldDefinitions as $fieldName => $fd) {
+                    if ($fd instanceof CustomResourcePersistingInterface) {
+                        // for fieldtypes which have their own save algorithm eg. relational data types, ...
+                        $context = $this->model->getContext() ? $this->model->getContext() : [];
+                        if (isset($context['containerType']) && ($context['containerType'] === 'fieldcollection' || $context['containerType'] === 'objectbrick')) {
+                            $context['subContainerType'] = 'localizedfield';
+                        }
 
-                    $isUpdate = isset($params['isUpdate']) && $params['isUpdate'];
-                    $childParams = $this->getFieldDefinitionParams($fieldName, $language, ['isUpdate' => $isUpdate, 'context' => $context]);
+                        $isUpdate = isset($params['isUpdate']) && $params['isUpdate'];
+                        $childParams = $this->getFieldDefinitionParams($fieldName, $language, ['isUpdate' => $isUpdate, 'context' => $context]);
 
-                    if ($fd instanceof DataObject\ClassDefinition\Data\Relations\AbstractRelations) {
-                        $saveLocalizedRelations = $forceUpdate || ($params['saveRelationalData']['saveLocalizedRelations'] ?? false);
-                        if (($saveLocalizedRelations && $container instanceof DataObject\Fieldcollection\Definition)
-                            || (((!$container instanceof DataObject\Fieldcollection\Definition || $container instanceof DataObject\Objectbrick\Definition)
-                                    && $this->model->isLanguageDirty($language))
-                                || $saveLocalizedRelations)) {
-                            if ($saveLocalizedRelations) {
-                                $childParams['forceSave'] = true;
+                        if ($fd instanceof DataObject\ClassDefinition\Data\Relations\AbstractRelations) {
+                            $saveLocalizedRelations = $forceUpdate || ($params['saveRelationalData']['saveLocalizedRelations'] ?? false);
+                            if (($saveLocalizedRelations && $container instanceof DataObject\Fieldcollection\Definition)
+                                || (((!$container instanceof DataObject\Fieldcollection\Definition || $container instanceof DataObject\Objectbrick\Definition)
+                                        && $this->model->isLanguageDirty($language))
+                                    || $saveLocalizedRelations)) {
+                                if ($saveLocalizedRelations) {
+                                    $childParams['forceSave'] = true;
+                                }
+                                $fd->save($this->model, $childParams);
                             }
+                        } else {
                             $fd->save($this->model, $childParams);
                         }
-                    } else {
-                        $fd->save($this->model, $childParams);
+                    }
+                    if ($fd instanceof ResourcePersistenceAwareInterface
+                        && $fd instanceof DataObject\ClassDefinition\Data) {
+                        if (is_array($fd->getColumnType())) {
+                            $fieldDefinitionParams = $this->getFieldDefinitionParams($fieldName, $language, ['isUpdate' => ($params['isUpdate'] ?? false)]);
+                            $insertDataArray = $fd->getDataForResource(
+                                $this->model->getLocalizedValue($fieldName, $language, true),
+                                $object,
+                                $fieldDefinitionParams
+                            );
+                            $insertData = array_merge($insertData, $insertDataArray);
+                            $this->model->setLocalizedValue($fieldName, $fd->getDataFromResource($insertDataArray, $object, $fieldDefinitionParams), $language, false);
+                        } else {
+                            $fieldDefinitionParams = $this->getFieldDefinitionParams($fieldName, $language, ['isUpdate' => ($params['isUpdate'] ?? false)]);
+                            $insertData[$fd->getName()] = $fd->getDataForResource(
+                                $this->model->getLocalizedValue($fieldName, $language, true),
+                                $object,
+                                $fieldDefinitionParams
+                            );
+                            $this->model->setLocalizedValue($fieldName, $fd->getDataFromResource($insertData[$fd->getName()], $object, $fieldDefinitionParams), $language, false);
+                        }
                     }
                 }
-                if ($fd instanceof ResourcePersistenceAwareInterface
-                    && $fd instanceof DataObject\ClassDefinition\Data) {
-                    if (is_array($fd->getColumnType())) {
-                        $fieldDefinitionParams = $this->getFieldDefinitionParams($fieldName, $language, ['isUpdate' => ($params['isUpdate'] ?? false)]);
-                        $insertDataArray = $fd->getDataForResource(
-                            $this->model->getLocalizedValue($fieldName, $language, true),
-                            $object,
-                            $fieldDefinitionParams
-                        );
-                        $insertData = array_merge($insertData, $insertDataArray);
-                        $this->model->setLocalizedValue($fieldName, $fd->getDataFromResource($insertDataArray, $object, $fieldDefinitionParams), $language, false);
-                    } else {
-                        $fieldDefinitionParams = $this->getFieldDefinitionParams($fieldName, $language, ['isUpdate' => ($params['isUpdate'] ?? false)]);
-                        $insertData[$fd->getName()] = $fd->getDataForResource(
-                            $this->model->getLocalizedValue($fieldName, $language, true),
-                            $object,
-                            $fieldDefinitionParams
-                        );
-                        $this->model->setLocalizedValue($fieldName, $fd->getDataFromResource($insertData[$fd->getName()], $object, $fieldDefinitionParams), $language, false);
+
+                $storeTable = $this->getTableName();
+                $queryTable = $this->getQueryTableName().'_'.$language;
+
+                try {
+                    if ((isset($params['newParent']) && $params['newParent']) || !isset($params['isUpdate']) || !$params['isUpdate'] || $this->model->isLanguageDirty(
+                        $language
+                    )) {
+                        Helper::upsert($this->db, $storeTable, $insertData, $this->getPrimaryKey($storeTable));
                     }
-                }
-            }
-
-            $storeTable = $this->getTableName();
-            $queryTable = $this->getQueryTableName().'_'.$language;
-
-            try {
-                if ((isset($params['newParent']) && $params['newParent']) || !isset($params['isUpdate']) || !$params['isUpdate'] || $this->model->isLanguageDirty(
-                    $language
-                )) {
-                    Helper::upsert($this->db, $storeTable, $insertData, $this->getPrimaryKey($storeTable));
-                }
-            } catch (TableNotFoundException $e) {
-                // if the table doesn't exist -> create it! deferred creation for object bricks ...
-                try {
-                    $this->db->rollBack();
-                } catch (Exception $er) {
-                    // PDO adapter throws exceptions if rollback fails
-                    Logger::info((string) $er);
-                }
-
-                $this->createUpdateTable();
-
-                // throw exception which gets caught in AbstractObject::save() -> retry saving
-                throw new LanguageTableDoesNotExistException('missing table created, start next run ... ;-)');
-            }
-
-            if ($container instanceof DataObject\ClassDefinition || $container instanceof DataObject\Objectbrick\Definition) {
-                // query table
-                $data = [];
-                $data['ooo_id'] = $this->model->getObject()->getId();
-                $data['language'] = $language;
-
-                $this->inheritanceHelper = new DataObject\Concrete\Dao\InheritanceHelper(
-                    $object->getClassId(),
-                    'ooo_id',
-                    $storeTable,
-                    $queryTable
-                );
-                $this->inheritanceHelper->resetFieldsToCheck();
-                $sql = 'SELECT * FROM '.$queryTable.' WHERE ooo_id = '.$object->getId(
-                )." AND language = '".$language."'";
-
-                $oldData = [];
-
-                try {
-                    $oldData = $this->db->fetchAssociative($sql);
                 } catch (TableNotFoundException $e) {
-                    // if the table doesn't exist -> create it!
-
-                    // the following is to ensure consistent data and atomic transactions, while having the flexibility
-                    // to add new languages on the fly without saving all classes having localized fields
-
-                    // first we need to roll back all modifications, because otherwise they would be implicitly committed
-                    // by the following DDL
+                    // if the table doesn't exist -> create it! deferred creation for object bricks ...
                     try {
                         $this->db->rollBack();
                     } catch (Exception $er) {
@@ -267,160 +227,202 @@ class Dao extends Model\Dao\AbstractDao
                         Logger::info((string) $er);
                     }
 
-                    // this creates the missing table
                     $this->createUpdateTable();
 
-                    // at this point we throw an exception so that the transaction gets repeated in DataObject::save()
+                    // throw exception which gets caught in AbstractObject::save() -> retry saving
                     throw new LanguageTableDoesNotExistException('missing table created, start next run ... ;-)');
                 }
 
-                // get fields which shouldn't be updated
-                $untouchable = [];
+                if ($container instanceof DataObject\ClassDefinition || $container instanceof DataObject\Objectbrick\Definition) {
+                    // query table
+                    $data = [];
+                    $data['ooo_id'] = $this->model->getObject()->getId();
+                    $data['language'] = $language;
 
-                // @TODO: currently we do not support lazyloading in localized fields
+                    $this->inheritanceHelper = new DataObject\Concrete\Dao\InheritanceHelper(
+                        $object->getClassId(),
+                        'ooo_id',
+                        $storeTable,
+                        $queryTable
+                    );
+                    $this->inheritanceHelper->resetFieldsToCheck();
+                    $sql = 'SELECT * FROM '.$queryTable.' WHERE ooo_id = '.$object->getId(
+                    )." AND language = '".$language."'";
 
-                $inheritanceEnabled = $object->getClass()->getAllowInherit();
-                $parentData = null;
-                if ($inheritanceEnabled) {
-                    // get the next suitable parent for inheritance
-                    $parentForInheritance = $object->getNextParentForInheritance();
-                    if ($parentForInheritance) {
-                        // we don't use the getter (built in functionality to get inherited values) because we need to avoid race conditions
-                        // we cannot DataObject\AbstractObject::setGetInheritedValues(true); and then $this->model->getLocalizedValue($key, $language)
-                        // so we select the data from the parent object using FOR UPDATE, which causes a lock on this row
-                        // so the data of the parent cannot be changed while this transaction is on progress
-                        $parentData = $this->db->fetchAssociative(
-                            'SELECT * FROM '.$queryTable.' WHERE ooo_id = ? AND language = ? FOR UPDATE',
-                            [$parentForInheritance->getId(), $language]
-                        );
+                    $oldData = [];
+
+                    try {
+                        $oldData = $this->db->fetchAssociative($sql);
+                    } catch (TableNotFoundException $e) {
+                        // if the table doesn't exist -> create it!
+
+                        // the following is to ensure consistent data and atomic transactions, while having the flexibility
+                        // to add new languages on the fly without saving all classes having localized fields
+
+                        // first we need to roll back all modifications, because otherwise they would be implicitly committed
+                        // by the following DDL
+                        try {
+                            $this->db->rollBack();
+                        } catch (Exception $er) {
+                            // PDO adapter throws exceptions if rollback fails
+                            Logger::info((string) $er);
+                        }
+
+                        // this creates the missing table
+                        $this->createUpdateTable();
+
+                        // at this point we throw an exception so that the transaction gets repeated in DataObject::save()
+                        throw new LanguageTableDoesNotExistException('missing table created, start next run ... ;-)');
                     }
-                }
 
-                foreach ($fieldDefinitions as $fd) {
-                    if ($fd instanceof QueryResourcePersistenceAwareInterface
-                        &&  $fd instanceof DataObject\ClassDefinition\Data) {
-                        $key = $fd->getName();
+                    // get fields which shouldn't be updated
+                    $untouchable = [];
 
-                        // exclude untouchables if value is not an array - this means data has not been loaded
-                        if (!in_array($key, $untouchable)) {
-                            $localizedValue = $this->model->getLocalizedValue($key, $language, $ignoreLocalizedQueryFallback);
-                            $insertData = $fd->getDataForQueryResource(
-                                $localizedValue,
-                                $object,
-                                $this->getFieldDefinitionParams($key, $language)
-                            );
-                            $isEmpty = $fd->isEmpty($localizedValue);
+                    // @TODO: currently we do not support lazyloading in localized fields
 
-                            if (is_array($insertData)) {
-                                $columnNames = array_keys($insertData);
-                                $data = array_merge($data, $insertData);
-                            } else {
-                                $columnNames = [$key];
-                                $data[$key] = $insertData;
-                            }
-
-                            // if the current value is empty and we have data from the parent, we just use it
-                            if ($isEmpty && $parentData) {
-                                foreach ($columnNames as $columnName) {
-                                    if (array_key_exists($columnName, $parentData)) {
-                                        $data[$columnName] = $parentData[$columnName];
-                                        if (is_array($insertData)) {
-                                            $insertData[$columnName] = $parentData[$columnName];
-                                        } else {
-                                            $insertData = $parentData[$columnName];
-                                        }
-                                    }
-                                }
-                            }
-
-                            if ($inheritanceEnabled && $fd->getFieldType() != 'calculatedValue') {
-                                //get changed fields for inheritance
-                                if ($fd->isRelationType()) {
-                                    if (is_array($insertData)) {
-                                        $doInsert = false;
-                                        foreach ($insertData as $insertDataKey => $insertDataValue) {
-                                            $oldDataValue = $oldData[$insertDataKey] ?? null;
-                                            $parentDataValue = $parentData[$insertDataKey] ?? null;
-                                            if ($isEmpty && $oldDataValue == $parentDataValue) {
-                                                // do nothing, ... value is still empty and parent data is equal to current data in query table
-                                            } elseif ($oldDataValue != $insertDataValue) {
-                                                $doInsert = true;
-
-                                                break;
-                                            }
-                                        }
-
-                                        if ($doInsert) {
-                                            $this->inheritanceHelper->addRelationToCheck(
-                                                $key,
-                                                $fd,
-                                                array_keys($insertData)
-                                            );
-                                        }
-                                    } else {
-                                        $oldDataValue = $oldData[$key] ?? null;
-                                        $parentDataValue = $parentData[$key] ?? null;
-                                        if ($isEmpty && $oldDataValue == $parentDataValue) {
-                                            // do nothing, ... value is still empty and parent data is equal to current data in query table
-                                        } elseif ($oldDataValue != $insertData) {
-                                            $this->inheritanceHelper->addRelationToCheck($key, $fd);
-                                        }
-                                    }
-                                } else {
-                                    if (is_array($insertData)) {
-                                        foreach ($insertData as $insertDataKey => $insertDataValue) {
-                                            $oldDataValue = $oldData[$insertDataKey] ?? null;
-                                            $parentDataValue = $parentData[$insertDataKey] ?? null;
-                                            if ($isEmpty && $oldDataValue == $parentDataValue) {
-                                                // do nothing, ... value is still empty and parent data is equal to current data in query table
-                                            } elseif ($oldDataValue != $insertDataValue) {
-                                                $this->inheritanceHelper->addFieldToCheck($insertDataKey, $fd);
-                                            }
-                                        }
-                                    } else {
-                                        $oldDataValue = $oldData[$key] ?? null;
-                                        $parentDataValue = $parentData[$key] ?? null;
-                                        if ($isEmpty && $oldDataValue == $parentDataValue) {
-                                            // do nothing, ... value is still empty and parent data is equal to current data in query table
-                                        } elseif ($oldDataValue != $insertData) {
-                                            // data changed, do check and update
-                                            $this->inheritanceHelper->addFieldToCheck($key, $fd);
-                                        }
-                                    }
-                                }
-                            }
-                        } else {
-                            Logger::debug(
-                                'Excluding untouchable query value for object [ '.$this->model->getObjectId() ." ]  key [ $key ] because it has not been loaded"
+                    $inheritanceEnabled = $object->getClass()->getAllowInherit();
+                    $parentData = null;
+                    if ($inheritanceEnabled) {
+                        // get the next suitable parent for inheritance
+                        $parentForInheritance = $object->getNextParentForInheritance();
+                        if ($parentForInheritance) {
+                            // we don't use the getter (built in functionality to get inherited values) because we need to avoid race conditions
+                            // we cannot DataObject\AbstractObject::setGetInheritedValues(true); and then $this->model->getLocalizedValue($key, $language)
+                            // so we select the data from the parent object using FOR UPDATE, which causes a lock on this row
+                            // so the data of the parent cannot be changed while this transaction is on progress
+                            $parentData = $this->db->fetchAssociative(
+                                'SELECT * FROM '.$queryTable.' WHERE ooo_id = ? AND language = ? FOR UPDATE',
+                                [$parentForInheritance->getId(), $language]
                             );
                         }
                     }
-                }
 
-                $queryTable = $this->getQueryTableName().'_'.$language;
-                Helper::upsert($this->db, $queryTable, $data, $this->getPrimaryKey($queryTable));
-                if ($inheritanceEnabled) {
-                    $context = isset($params['context']) ? $params['context'] : [];
-                    if ($context['containerType'] === 'objectbrick') {
-                        $inheritanceRelationContext = [
-                            'ownertype' => 'localizedfield',
-                            'ownername' => '/objectbrick~' . $context['fieldname'] . '/' . $context['containerKey'] . '/localizedfield~localizedfield',
-                        ];
-                    } else {
-                        $inheritanceRelationContext = [
-                            'ownertype' => 'localizedfield',
-                            'ownername' => 'localizedfield',
-                        ];
+                    foreach ($fieldDefinitions as $fd) {
+                        if ($fd instanceof QueryResourcePersistenceAwareInterface
+                            &&  $fd instanceof DataObject\ClassDefinition\Data) {
+                            $key = $fd->getName();
+
+                            // exclude untouchables if value is not an array - this means data has not been loaded
+                            if (!in_array($key, $untouchable)) {
+                                $localizedValue = $this->model->getLocalizedValue($key, $language, $ignoreLocalizedQueryFallback);
+                                $insertData = $fd->getDataForQueryResource(
+                                    $localizedValue,
+                                    $object,
+                                    $this->getFieldDefinitionParams($key, $language)
+                                );
+                                $isEmpty = $fd->isEmpty($localizedValue);
+
+                                if (is_array($insertData)) {
+                                    $columnNames = array_keys($insertData);
+                                    $data = array_merge($data, $insertData);
+                                } else {
+                                    $columnNames = [$key];
+                                    $data[$key] = $insertData;
+                                }
+
+                                // if the current value is empty and we have data from the parent, we just use it
+                                if ($isEmpty && $parentData) {
+                                    foreach ($columnNames as $columnName) {
+                                        if (array_key_exists($columnName, $parentData)) {
+                                            $data[$columnName] = $parentData[$columnName];
+                                            if (is_array($insertData)) {
+                                                $insertData[$columnName] = $parentData[$columnName];
+                                            } else {
+                                                $insertData = $parentData[$columnName];
+                                            }
+                                        }
+                                    }
+                                }
+
+                                if ($inheritanceEnabled && $fd->getFieldType() != 'calculatedValue') {
+                                    //get changed fields for inheritance
+                                    if ($fd->isRelationType()) {
+                                        if (is_array($insertData)) {
+                                            $doInsert = false;
+                                            foreach ($insertData as $insertDataKey => $insertDataValue) {
+                                                $oldDataValue = $oldData[$insertDataKey] ?? null;
+                                                $parentDataValue = $parentData[$insertDataKey] ?? null;
+                                                if ($isEmpty && $oldDataValue == $parentDataValue) {
+                                                    // do nothing, ... value is still empty and parent data is equal to current data in query table
+                                                } elseif ($oldDataValue != $insertDataValue) {
+                                                    $doInsert = true;
+
+                                                    break;
+                                                }
+                                            }
+
+                                            if ($doInsert) {
+                                                $this->inheritanceHelper->addRelationToCheck(
+                                                    $key,
+                                                    $fd,
+                                                    array_keys($insertData)
+                                                );
+                                            }
+                                        } else {
+                                            $oldDataValue = $oldData[$key] ?? null;
+                                            $parentDataValue = $parentData[$key] ?? null;
+                                            if ($isEmpty && $oldDataValue == $parentDataValue) {
+                                                // do nothing, ... value is still empty and parent data is equal to current data in query table
+                                            } elseif ($oldDataValue != $insertData) {
+                                                $this->inheritanceHelper->addRelationToCheck($key, $fd);
+                                            }
+                                        }
+                                    } else {
+                                        if (is_array($insertData)) {
+                                            foreach ($insertData as $insertDataKey => $insertDataValue) {
+                                                $oldDataValue = $oldData[$insertDataKey] ?? null;
+                                                $parentDataValue = $parentData[$insertDataKey] ?? null;
+                                                if ($isEmpty && $oldDataValue == $parentDataValue) {
+                                                    // do nothing, ... value is still empty and parent data is equal to current data in query table
+                                                } elseif ($oldDataValue != $insertDataValue) {
+                                                    $this->inheritanceHelper->addFieldToCheck($insertDataKey, $fd);
+                                                }
+                                            }
+                                        } else {
+                                            $oldDataValue = $oldData[$key] ?? null;
+                                            $parentDataValue = $parentData[$key] ?? null;
+                                            if ($isEmpty && $oldDataValue == $parentDataValue) {
+                                                // do nothing, ... value is still empty and parent data is equal to current data in query table
+                                            } elseif ($oldDataValue != $insertData) {
+                                                // data changed, do check and update
+                                                $this->inheritanceHelper->addFieldToCheck($key, $fd);
+                                            }
+                                        }
+                                    }
+                                }
+                            } else {
+                                Logger::debug(
+                                    'Excluding untouchable query value for object [ '.$this->model->getObjectId() ." ]  key [ $key ] because it has not been loaded"
+                                );
+                            }
+                        }
                     }
-                    $this->inheritanceHelper->doUpdate($object->getId(), true, [
-                        'language' => $language,
-                        'inheritanceRelationContext' => $inheritanceRelationContext,
-                    ]);
-                }
-                $this->inheritanceHelper->resetFieldsToCheck();
-            }
 
-            DataObject::setGetInheritedValues($inheritedValues);
+                    $queryTable = $this->getQueryTableName().'_'.$language;
+                    Helper::upsert($this->db, $queryTable, $data, $this->getPrimaryKey($queryTable));
+                    if ($inheritanceEnabled) {
+                        $context = isset($params['context']) ? $params['context'] : [];
+                        if ($context['containerType'] === 'objectbrick') {
+                            $inheritanceRelationContext = [
+                                'ownertype' => 'localizedfield',
+                                'ownername' => '/objectbrick~' . $context['fieldname'] . '/' . $context['containerKey'] . '/localizedfield~localizedfield',
+                            ];
+                        } else {
+                            $inheritanceRelationContext = [
+                                'ownertype' => 'localizedfield',
+                                'ownername' => 'localizedfield',
+                            ];
+                        }
+                        $this->inheritanceHelper->doUpdate($object->getId(), true, [
+                            'language' => $language,
+                            'inheritanceRelationContext' => $inheritanceRelationContext,
+                        ]);
+                    }
+                    $this->inheritanceHelper->resetFieldsToCheck();
+                }
+            } finally {
+                DataObject::setGetInheritedValues($inheritedValues);
+            }
         } // foreach language
 
         if (!$ignoreLocalizedQueryFallback) {

--- a/models/DataObject/Objectbrick/Data/Dao.php
+++ b/models/DataObject/Objectbrick/Data/Dao.php
@@ -47,206 +47,208 @@ class Dao extends Model\Dao\AbstractDao
 
         $this->inheritanceHelper = new DataObject\Concrete\Dao\InheritanceHelper($object->getClassId(), 'id', $storetable, $querytable, null, 'id');
 
-        DataObject::setGetInheritedValues(false);
+        try {
+            DataObject::setGetInheritedValues(false);
 
-        $fieldDefinitions = $this->model->getDefinition()->getFieldDefinitions();
+            $fieldDefinitions = $this->model->getDefinition()->getFieldDefinitions();
 
-        $data = [];
-        $data['id'] = $object->getId();
-        $data['fieldname'] = $this->model->getFieldname();
+            $data = [];
+            $data['id'] = $object->getId();
+            $data['fieldname'] = $this->model->getFieldname();
 
-        $dirtyRelations = [];
-        $db = Db::get();
+            $dirtyRelations = [];
+            $db = Db::get();
 
-        if (($params['isUpdate'] ?? false) === false && $this->model->getObject()->getClass()->getAllowInherit()) {
-            // if this is a fresh object, then we don't need the check
-            $isBrickUpdate = false; // used to indicate whether we want to consider the default value
-        } else {
-            // or brick has been added
-            $existsResult = $this->db->fetchOne(
-                'SELECT id FROM ' . $storetable . ' WHERE id = ? LIMIT 1',
-                [$object->getId()]
-            );
+            if (($params['isUpdate'] ?? false) === false && $this->model->getObject()->getClass()->getAllowInherit()) {
+                // if this is a fresh object, then we don't need the check
+                $isBrickUpdate = false; // used to indicate whether we want to consider the default value
+            } else {
+                // or brick has been added
+                $existsResult = $this->db->fetchOne(
+                    'SELECT id FROM ' . $storetable . ' WHERE id = ? LIMIT 1',
+                    [$object->getId()]
+                );
 
-            $isBrickUpdate = (bool)$existsResult; // used to indicate whether we want to consider the default value
-        }
+                $isBrickUpdate = (bool)$existsResult; // used to indicate whether we want to consider the default value
+            }
 
-        foreach ($fieldDefinitions as $fieldName => $fd) {
-            $getter = 'get' . ucfirst($fd->getName());
+            foreach ($fieldDefinitions as $fieldName => $fd) {
+                $getter = 'get' . ucfirst($fd->getName());
 
-            if ($fd instanceof CustomResourcePersistingInterface) {
-                // for fieldtypes which have their own save algorithm eg. relational data-types, ...
-                $fd->save($this->model,
-                    array_merge($params, [
+                if ($fd instanceof CustomResourcePersistingInterface) {
+                    // for fieldtypes which have their own save algorithm eg. relational data-types, ...
+                    $fd->save($this->model,
+                        array_merge($params, [
+                            'context' => [
+                                'containerType' => 'objectbrick',
+                                'containerKey' => $this->model->getType(),
+                                'fieldname' => $this->model->getFieldname(),
+                            ],
+                            'isUpdate' => $isBrickUpdate,
+                            'owner' => $this->model,
+                            'fieldname' => $fieldName,
+                        ]));
+                }
+
+                if ($fd instanceof ResourcePersistenceAwareInterface) {
+                    $fieldDefinitionParams = [
+                        'owner' => $this->model, //\Pimcore\Model\DataObject\Objectbrick\Data\Dao
+                        'fieldname' => $fieldName,
+                        'isUpdate' => $isBrickUpdate,
                         'context' => [
                             'containerType' => 'objectbrick',
                             'containerKey' => $this->model->getType(),
                             'fieldname' => $this->model->getFieldname(),
                         ],
-                        'isUpdate' => $isBrickUpdate,
-                        'owner' => $this->model,
-                        'fieldname' => $fieldName,
-                    ]));
-            }
-
-            if ($fd instanceof ResourcePersistenceAwareInterface) {
-                $fieldDefinitionParams = [
-                    'owner' => $this->model, //\Pimcore\Model\DataObject\Objectbrick\Data\Dao
-                    'fieldname' => $fieldName,
-                    'isUpdate' => $isBrickUpdate,
-                    'context' => [
-                        'containerType' => 'objectbrick',
-                        'containerKey' => $this->model->getType(),
-                        'fieldname' => $this->model->getFieldname(),
-                    ],
-                ];
-                if (is_array($fd->getColumnType())) {
-                    $insertDataArray = $fd->getDataForResource($this->model->$getter(), $object, $fieldDefinitionParams);
-                    $data = array_merge($data, $insertDataArray);
-                    $this->model->set($fieldName, $fd->getDataFromResource($insertDataArray, $object, $fieldDefinitionParams));
-                } else {
-                    $insertData = $fd->getDataForResource($this->model->$getter(), $object, $fieldDefinitionParams);
-                    $data[$fieldName] = $insertData;
-                    $this->model->set($fieldName, $fd->getDataFromResource($insertData, $object, $fieldDefinitionParams));
-                }
-
-                if ($this->model instanceof Model\Element\DirtyIndicatorInterface) {
-                    $this->model->markFieldDirty($fieldName, false);
-                }
-            }
-        }
-
-        if ($isBrickUpdate) {
-            $this->db->update($storetable, Helper::quoteDataIdentifiers($this->db, $data), ['id'=> $object->getId()]);
-        } else {
-            $this->db->insert($storetable, Helper::quoteDataIdentifiers($this->db, $data));
-        }
-
-        // get data for query table
-        // $tableName = $this->model->getDefinition()->getTableName($object->getClass(), true);
-        // this is special because we have to call each getter to get the inherited values from a possible parent object
-
-        $data = [];
-        $data['id'] = $object->getId();
-        $data['fieldname'] = $this->model->getFieldname();
-
-        $this->inheritanceHelper->resetFieldsToCheck();
-        $oldData = $this->db->fetchAssociative('SELECT * FROM ' . $querytable . ' WHERE id = ?', [$object->getId()]);
-
-        $inheritanceEnabled = $object->getClass()->getAllowInherit();
-        $parentData = null;
-        if ($inheritanceEnabled) {
-            // get the next suitable parent for inheritance
-            $parentForInheritance = $object->getNextParentForInheritance();
-            if ($parentForInheritance) {
-                // we don't use the getter (built in functionality to get inherited values) because we need to avoid race conditions
-                // we cannot DataObject::setGetInheritedValues(true); and then $this->model->$method();
-                // so we select the data from the parent object using FOR UPDATE, which causes a lock on this row
-                // so the data of the parent cannot be changed while this transaction is on progress
-                $parentData = $this->db->fetchAssociative('SELECT * FROM ' . $querytable . ' WHERE id = ? FOR UPDATE', [$parentForInheritance->getId()]);
-            }
-        }
-
-        foreach ($fieldDefinitions as $key => $fd) {
-            if ($fd instanceof QueryResourcePersistenceAwareInterface
-                && $fd instanceof DataObject\ClassDefinition\Data) {
-                $method = 'get' . $key;
-                $fieldValue = $this->model->$method();
-                $insertData = $fd->getDataForQueryResource($fieldValue, $object);
-                $isEmpty = $fd->isEmpty($fieldValue);
-
-                if (is_array($insertData)) {
-                    $columnNames = array_keys($insertData);
-                    $data = array_merge($data, $insertData);
-                } else {
-                    $columnNames = [$key];
-                    $data[$key] = $insertData;
-                }
-
-                // if the current value is empty and we have data from the parent, we just use it
-                if ($isEmpty && $parentData) {
-                    foreach ($columnNames as $columnName) {
-                        if (array_key_exists($columnName, $parentData)) {
-                            $data[$columnName] = $parentData[$columnName];
-                            if (is_array($insertData)) {
-                                $insertData[$columnName] = $parentData[$columnName];
-                            } else {
-                                $insertData = $parentData[$columnName];
-                            }
-                        }
-                    }
-                }
-
-                if ($inheritanceEnabled) {
-                    //get changed fields for inheritance
-                    if ($fd instanceof DataObject\ClassDefinition\Data\CalculatedValue) {
-                        // nothing to do, see https://github.com/pimcore/pimcore/issues/727
-                        continue;
-                    } elseif ($fd->isRelationType()) {
-                        if (is_array($insertData)) {
-                            $doInsert = false;
-                            foreach ($insertData as $insertDataKey => $insertDataValue) {
-                                $oldDataValue = $oldData[$insertDataKey] ?? null;
-                                $parentDataValue = $parentData[$insertDataKey] ?? null;
-                                if ($isEmpty && $oldDataValue == $parentDataValue) {
-                                    // do nothing, ... value is still empty and parent data is equal to current data in query table
-                                } elseif ($oldDataValue != $insertDataValue) {
-                                    $doInsert = true;
-
-                                    break;
-                                }
-                            }
-
-                            if ($doInsert) {
-                                $this->inheritanceHelper->addRelationToCheck($key, $fd, array_keys($insertData));
-                            }
-                        } else {
-                            $oldDataValue = $oldData[$key] ?? null;
-                            $parentDataValue = $parentData[$key] ?? null;
-                            if ($isEmpty && $oldDataValue == $parentDataValue) {
-                                // do nothing, ... value is still empty and parent data is equal to current data in query table
-                            } elseif ($oldDataValue != $insertData) {
-                                $this->inheritanceHelper->addRelationToCheck($key, $fd);
-                            }
-                        }
+                    ];
+                    if (is_array($fd->getColumnType())) {
+                        $insertDataArray = $fd->getDataForResource($this->model->$getter(), $object, $fieldDefinitionParams);
+                        $data = array_merge($data, $insertDataArray);
+                        $this->model->set($fieldName, $fd->getDataFromResource($insertDataArray, $object, $fieldDefinitionParams));
                     } else {
-                        if (is_array($insertData)) {
-                            foreach ($insertData as $insertDataKey => $insertDataValue) {
-                                $oldDataValue = $oldData[$insertDataKey] ?? null;
-                                $parentDataValue = $parentData[$insertDataKey] ?? null;
+                        $insertData = $fd->getDataForResource($this->model->$getter(), $object, $fieldDefinitionParams);
+                        $data[$fieldName] = $insertData;
+                        $this->model->set($fieldName, $fd->getDataFromResource($insertData, $object, $fieldDefinitionParams));
+                    }
+
+                    if ($this->model instanceof Model\Element\DirtyIndicatorInterface) {
+                        $this->model->markFieldDirty($fieldName, false);
+                    }
+                }
+            }
+
+            if ($isBrickUpdate) {
+                $this->db->update($storetable, Helper::quoteDataIdentifiers($this->db, $data), ['id'=> $object->getId()]);
+            } else {
+                $this->db->insert($storetable, Helper::quoteDataIdentifiers($this->db, $data));
+            }
+
+            // get data for query table
+            // $tableName = $this->model->getDefinition()->getTableName($object->getClass(), true);
+            // this is special because we have to call each getter to get the inherited values from a possible parent object
+
+            $data = [];
+            $data['id'] = $object->getId();
+            $data['fieldname'] = $this->model->getFieldname();
+
+            $this->inheritanceHelper->resetFieldsToCheck();
+            $oldData = $this->db->fetchAssociative('SELECT * FROM ' . $querytable . ' WHERE id = ?', [$object->getId()]);
+
+            $inheritanceEnabled = $object->getClass()->getAllowInherit();
+            $parentData = null;
+            if ($inheritanceEnabled) {
+                // get the next suitable parent for inheritance
+                $parentForInheritance = $object->getNextParentForInheritance();
+                if ($parentForInheritance) {
+                    // we don't use the getter (built in functionality to get inherited values) because we need to avoid race conditions
+                    // we cannot DataObject::setGetInheritedValues(true); and then $this->model->$method();
+                    // so we select the data from the parent object using FOR UPDATE, which causes a lock on this row
+                    // so the data of the parent cannot be changed while this transaction is on progress
+                    $parentData = $this->db->fetchAssociative('SELECT * FROM ' . $querytable . ' WHERE id = ? FOR UPDATE', [$parentForInheritance->getId()]);
+                }
+            }
+
+            foreach ($fieldDefinitions as $key => $fd) {
+                if ($fd instanceof QueryResourcePersistenceAwareInterface
+                    && $fd instanceof DataObject\ClassDefinition\Data) {
+                    $method = 'get' . $key;
+                    $fieldValue = $this->model->$method();
+                    $insertData = $fd->getDataForQueryResource($fieldValue, $object);
+                    $isEmpty = $fd->isEmpty($fieldValue);
+
+                    if (is_array($insertData)) {
+                        $columnNames = array_keys($insertData);
+                        $data = array_merge($data, $insertData);
+                    } else {
+                        $columnNames = [$key];
+                        $data[$key] = $insertData;
+                    }
+
+                    // if the current value is empty and we have data from the parent, we just use it
+                    if ($isEmpty && $parentData) {
+                        foreach ($columnNames as $columnName) {
+                            if (array_key_exists($columnName, $parentData)) {
+                                $data[$columnName] = $parentData[$columnName];
+                                if (is_array($insertData)) {
+                                    $insertData[$columnName] = $parentData[$columnName];
+                                } else {
+                                    $insertData = $parentData[$columnName];
+                                }
+                            }
+                        }
+                    }
+
+                    if ($inheritanceEnabled) {
+                        //get changed fields for inheritance
+                        if ($fd instanceof DataObject\ClassDefinition\Data\CalculatedValue) {
+                            // nothing to do, see https://github.com/pimcore/pimcore/issues/727
+                            continue;
+                        } elseif ($fd->isRelationType()) {
+                            if (is_array($insertData)) {
+                                $doInsert = false;
+                                foreach ($insertData as $insertDataKey => $insertDataValue) {
+                                    $oldDataValue = $oldData[$insertDataKey] ?? null;
+                                    $parentDataValue = $parentData[$insertDataKey] ?? null;
+                                    if ($isEmpty && $oldDataValue == $parentDataValue) {
+                                        // do nothing, ... value is still empty and parent data is equal to current data in query table
+                                    } elseif ($oldDataValue != $insertDataValue) {
+                                        $doInsert = true;
+
+                                        break;
+                                    }
+                                }
+
+                                if ($doInsert) {
+                                    $this->inheritanceHelper->addRelationToCheck($key, $fd, array_keys($insertData));
+                                }
+                            } else {
+                                $oldDataValue = $oldData[$key] ?? null;
+                                $parentDataValue = $parentData[$key] ?? null;
                                 if ($isEmpty && $oldDataValue == $parentDataValue) {
                                     // do nothing, ... value is still empty and parent data is equal to current data in query table
-                                } elseif ($oldDataValue != $insertDataValue) {
-                                    $this->inheritanceHelper->addFieldToCheck($insertDataKey, $fd);
+                                } elseif ($oldDataValue != $insertData) {
+                                    $this->inheritanceHelper->addRelationToCheck($key, $fd);
                                 }
                             }
                         } else {
-                            $oldDataValue = $oldData[$key] ?? null;
-                            $parentDataValue = $parentData[$key] ?? null;
-                            if ($isEmpty && $oldDataValue == $parentDataValue) {
-                                // do nothing, ... value is still empty and parent data is equal to current data in query table
-                            } elseif ($oldDataValue != $insertData) {
-                                // data changed, do check and update
-                                $this->inheritanceHelper->addFieldToCheck($key, $fd);
+                            if (is_array($insertData)) {
+                                foreach ($insertData as $insertDataKey => $insertDataValue) {
+                                    $oldDataValue = $oldData[$insertDataKey] ?? null;
+                                    $parentDataValue = $parentData[$insertDataKey] ?? null;
+                                    if ($isEmpty && $oldDataValue == $parentDataValue) {
+                                        // do nothing, ... value is still empty and parent data is equal to current data in query table
+                                    } elseif ($oldDataValue != $insertDataValue) {
+                                        $this->inheritanceHelper->addFieldToCheck($insertDataKey, $fd);
+                                    }
+                                }
+                            } else {
+                                $oldDataValue = $oldData[$key] ?? null;
+                                $parentDataValue = $parentData[$key] ?? null;
+                                if ($isEmpty && $oldDataValue == $parentDataValue) {
+                                    // do nothing, ... value is still empty and parent data is equal to current data in query table
+                                } elseif ($oldDataValue != $insertData) {
+                                    // data changed, do check and update
+                                    $this->inheritanceHelper->addFieldToCheck($key, $fd);
+                                }
                             }
                         }
                     }
                 }
             }
+
+            Helper::upsert($this->db, $querytable, $data, $this->getPrimaryKey($querytable));
+
+            if ($inheritanceEnabled) {
+                $this->inheritanceHelper->doUpdate($object->getId(), true,
+                    ['inheritanceRelationContext' => [
+                        'ownertype' => 'objectbrick',
+                    ]]);
+            }
+            $this->inheritanceHelper->resetFieldsToCheck();
+        } finally {
+            // HACK: see a few lines above!
+            DataObject::setGetInheritedValues($inheritedValues);
         }
-
-        Helper::upsert($this->db, $querytable, $data, $this->getPrimaryKey($querytable));
-
-        if ($inheritanceEnabled) {
-            $this->inheritanceHelper->doUpdate($object->getId(), true,
-                ['inheritanceRelationContext' => [
-                    'ownertype' => 'objectbrick',
-                ]]);
-        }
-        $this->inheritanceHelper->resetFieldsToCheck();
-
-        // HACK: see a few lines above!
-        DataObject::setGetInheritedValues($inheritedValues);
     }
 
     public function delete(DataObject\Concrete $object): void


### PR DESCRIPTION
## Motivation

In a project using the classification store data type and handling data objects in a message consumer I noticed that sometimes objects were handled under the wrong assumption regarding inheritance. It took my a while to figure out that for a few items there was invalid data provided (an object or array instead of a scalar value), and that caused the DataObject's DAO save() method to exit without resetting its altered global state of inheritance. The data objects that were consumed afterwards were handled with inheritance turned off, causing data corruption in the app's business logic.

## Description of the change

In the DAOs save() methods the inheritance is switched off at some point
and the actual save logic happens. After that block the state is reverted.
However, if for some reason an exception is thrown, the method exits
without reverting the global state. This results in inheritance being
still in the altered state for the previous stack frame, potentially
corrupting data in regards to inheritance.

This fix uses the try-finally pattern to safely revert to the previous state.

## Example code to reproduce

* Create a classification store, a key (for type choose integer) and a group.
* Create a DataObject class `Foobar`.
* Add a field `store` of type classification store.
* Run the command below and notice the global state remains in the altered inheritance state.

```php
<?php

namespace App\Command;

use Pimcore\Console\AbstractCommand;
use Pimcore\Model\DataObject;
use Symfony\Component\Console\Attribute\AsCommand;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;

#[AsCommand('app:test')]
class TestCommand extends AbstractCommand
{
    public function execute(InputInterface $input, OutputInterface $output): int
    {
        $this->dump(['getInheritedValues-before' => DataObject\AbstractObject::getGetInheritedValues()]);

        try {
            $foo = new DataObject\Foobar();
            $store = $foo->getStore();

            $store
                ->setLocalizedKeyValue(1, 1, ['status' => 'fatal'])    // add invalid data (here: array) that causes an exception in DAO
                ->setActiveGroups([1 => true]);

            $foo
                ->setKey('test')
                ->setParentId(1)
                ->save();
        } catch (\Throwable $e) {     // in this example a \TypeError is thrown, but in principle it could be any regular \Exception
            $this->writeError($e->getMessage());
        }

        $this->dump(['getInheritedValues-after' => DataObject\AbstractObject::getGetInheritedValues()]);

        // From here on we're having getInheritedValues=false, breaking inheritance...

        return 0;
    }
}
```
