### PR TITLE
[Doc]: Improve docs about config location button being grayed out

### DIFF
--- a/doc/21_Deployment/03_Configuration_Environments.md
+++ b/doc/21_Deployment/03_Configuration_Environments.md
@@ -117,7 +117,7 @@ pimcore_static_routes:
 
 #### Production environment with `symfony-config`
 When using `symfony-config` write target, configs are written to Symfony Config files (`yaml`), which are only getting revalidated in debug mode. So if you're
-changing configs in production you won't see any update, because these configs are read only.
+changing configs in production, you won't see any update because these configs are read-only.
 
 If you'd like to allow changes in production, switch to the alternate `settings-store` config storage. 
 You can do so by adding the following to your `symfony-config`. e.g.:
@@ -135,3 +135,13 @@ With `settings-store` target, one can update/change configurations in production
 This is not the case with `symfony-config` write target, as configurations are read-only and deployed from different environment. So we need to explicitly revalidate the generated files either through command or custom script. 
 
 For example, to revalidate image or video thumbnails either run command `pimcore:thumbnails:clear` or call `Asset\Image\Thumbnail\Config::clearTempFiles()` after deploying changes on thumbnail configurations.
+
+
+#### Troubleshooting: save button is grayed out
+
+Please note that the saving button would be disabled (grayed out) under the following conditions:
+
+- when `write_target` is intentionally set to `disabled`
+- as specified above about production enviroment, when set to `symfony-config` and not being in debug mode
+- when the `write_target` is `symfony-config` and the `yaml` file does not exist, or it is not writeable (according to file-system permissions)
+- when the `read_target` is set but it does not match with the `write_target`.


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/service-operations/issues/1

## Additional info
It is something that was frequently asked in the past and is not explicitly documented, adding a paragraph to easily link and cite instead of sharing https://github.com/pimcore/pimcore/blob/a7f3fef2f8368122cb69c75bd1d4bb6726e638cc/lib/Config/LocationAwareConfigRepository.php#L132-L140

See also
https://github.com/orgs/pimcore/discussions/17503