### PR TITLE
Allow "_" in object brick / field collection class names

### DIFF
--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -348,7 +348,7 @@ final class ClassDefinition extends Model\AbstractModel implements ClassDefiniti
             $this->setId((string) $maxId);
         }
 
-        if (!preg_match('/[a-zA-Z][a-zA-Z0-9_]+/', $this->getName())) {
+        if (!preg_match('/[a-zA-Z]\w+/', $this->getName())) {
             throw new Exception(sprintf('Invalid name for class definition: %s', $this->getName()));
         }
 

--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -305,7 +305,7 @@ class Definition extends Model\AbstractModel
         if ($key === null || $key === '') {
             return true;
         }
-        if (!preg_match('/^[a-zA-Z][a-zA-Z0-9]*$/', $key)) {
+        if (!preg_match('/^[a-zA-Z][a-zA-Z0-9_]*$/', $key)) {
             return true;
         }
 

--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -305,7 +305,7 @@ class Definition extends Model\AbstractModel
         if ($key === null || $key === '') {
             return true;
         }
-        if (!preg_match('/^[a-zA-Z][a-zA-Z0-9_]*$/', $key)) {
+        if (!preg_match('/^[a-zA-Z]\w*$/', $key)) {
             return true;
         }
 


### PR DESCRIPTION
For data object classes it is allowed to use `_` in class names:
https://github.com/pimcore/pimcore/blob/679e2f23243c8544e754b3cde3da59b7b07c5ce9/models/DataObject/ClassDefinition.php#L351-L353

But for object brick and field collection classes, this is currently not the case. From technical perspective this does not seem to have a valid reason - even for some features like column sorting / filtering in the grid, `_` is not used as separator between brick and field name (instead there `~` is used which is fine because this is not a valid character for PHP class names).

So to be consistent, this PR adds support for `_` also for object brick and field collection class names.

Note: I replaced `[a-zA-Z0-9_]` with `\w` in the regular expression because of your SonarCube rule:
> Use concise character class syntax '\w' instead of '[a-zA-Z0-9_]'.