### PR TITLE
fix(InstallerBundle): Fix importing last chunk of SQL dump

### DIFF
--- a/bundles/InstallBundle/src/Installer.php
+++ b/bundles/InstallBundle/src/Installer.php
@@ -790,7 +790,10 @@ class Installer
                 }
             }
 
-            $db->executeStatement(implode("\n", $batchQueries));
+            // process remaining queries
+            if (count($batchQueries) > 0) {
+                $db->executeStatement(implode("\n", $batchQueries));
+            }
         }
     }
 


### PR DESCRIPTION
The installer processes the SQL queries in chunks. There is a chance that the remainder chunk will contain zero queries and therefore will result in a PDO exception while trying to execute an empty statement.

This fix checks whether there are queries in the remainder chunk.

---

## Additional notes

In our DDEV setup procedure we provide several own SQL dumps to the installer. If the resulting chunk size was by chance exactly 500 queries, the import process broke.