### PR TITLE
Fixing regression caused by #17873 in TemplateResolver

### DIFF
--- a/lib/Http/Request/Resolver/TemplateResolver.php
+++ b/lib/Http/Request/Resolver/TemplateResolver.php
@@ -30,7 +30,7 @@ class TemplateResolver extends AbstractRequestResolver
             $request = $this->getCurrentRequest();
         }
 
-        return $request->get(DynamicRouter::CONTENT_TEMPLATE);
+        return $request->attributes->get(DynamicRouter::CONTENT_TEMPLATE);
     }
 
     public function setTemplate(Request $request, string $template): void

--- a/lib/Http/Request/Resolver/TemplateResolver.php
+++ b/lib/Http/Request/Resolver/TemplateResolver.php
@@ -30,7 +30,7 @@ class TemplateResolver extends AbstractRequestResolver
             $request = $this->getCurrentRequest();
         }
 
-        return $request->attributes->getString(DynamicRouter::CONTENT_TEMPLATE);
+        return $request->get(DynamicRouter::CONTENT_TEMPLATE);
     }
 
     public function setTemplate(Request $request, string $template): void


### PR DESCRIPTION
#17873  is causing template attribute  to stop working, e.g. 
https://github.com/pimcore/demo/blob/2024.x/src/Controller/ContentController.php#L33 

