### PR TITLE
[Search / Object selector] Sort class names + Search in whole class name (not only from beginning)

### DIFF
--- a/bundles/SimpleBackendSearchBundle/public/js/pimcore/element/selector/object.js
+++ b/bundles/SimpleBackendSearchBundle/public/js/pimcore/element/selector/object.js
@@ -138,6 +138,8 @@ pimcore.bundle.search.element.selector.object = Class.create(pimcore.bundle.sear
             }
         }
 
+        filterClassStore.sort((class1, class2) => class1[1].localeCompare(class2[1]));
+
         var selectedClassValue = selectedClassStore.join(",");
         if(filterClassStore.length > 1) {
             filterClassStore.splice(0,0,[selectedClassValue, t("all_types")]);

--- a/bundles/SimpleBackendSearchBundle/public/js/pimcore/element/selector/object.js
+++ b/bundles/SimpleBackendSearchBundle/public/js/pimcore/element/selector/object.js
@@ -154,6 +154,7 @@ pimcore.bundle.search.element.selector.object = Class.create(pimcore.bundle.sear
             typeAhead: true,
             forceSelection: true,
             selectOnFocus: true,
+            anyMatch: true,
             value: selectedClassValue,
             listeners: {
                 select: this.changeClass.bind(this)


### PR DESCRIPTION
Currently the class names in the search dropdown are not sorted:
<img width="381" alt="Bildschirmfoto 2024-12-12 um 08 12 08" src="https://github.com/user-attachments/assets/5c33d96b-2dcd-4479-9a00-e9f827cc420d" />

With this PR they get sorted (after applying translations):
<img width="333" alt="Bildschirmfoto 2024-12-12 um 08 12 47" src="https://github.com/user-attachments/assets/2e9d6960-609e-44b3-bccf-088a7f6dd753" />

The are 2 causes for this bug:
1. If you use `group`s for your classes, the classes are sorted by those groups (this comes from https://github.com/pimcore/admin-ui-classic-bundle/blob/cb35505def91379c0e243333d57c8ff34f13444b/src/Controller/Admin/DataObject/ClassController.php#L174 which gets used in https://github.com/pimcore/admin-ui-classic-bundle/blob/cb35505def91379c0e243333d57c8ff34f13444b/public/js/pimcore/startup.js#L418-L428 -> this is the store for the classes which gets used in all the different places)
2. The classes get sorted by `name` in https://github.com/pimcore/admin-ui-classic-bundle/blob/cb35505def91379c0e243333d57c8ff34f13444b/src/Controller/Admin/DataObject/ClassController.php#L99 - if you translate those names via admin translations, the order may also become wrong.


Additionally this PR fixes the problem that the class search only matches from the beginning:
Before:
Searching for `coll` does not find the class `SystemCollection`:
<img width="385" alt="Bildschirmfoto 2024-12-12 um 08 24 24" src="https://github.com/user-attachments/assets/b1ef251b-942c-438b-a04b-5fd6f3b1ecda" />

After:
<img width="329" alt="Bildschirmfoto 2024-12-12 um 08 24 53" src="https://github.com/user-attachments/assets/62b80537-1842-4181-bf78-9ae5d9db8265" />
