### PR TITLE
[Bug] Implicit float to int conversion on image crop

### DIFF
--- a/lib/Image/Adapter.php
+++ b/lib/Image/Adapter.php
@@ -208,7 +208,7 @@ abstract class Adapter
         }
 
         if ($cropX !== null && $cropY !== null) {
-            $this->crop($cropX, $cropY, $width, $height);
+            $this->crop((int)$cropX, (int)$cropY, $width, $height);
         } else {
             Logger::error('Cropping not processed, because X or Y is not defined or null, proceeding with next step');
         }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #11799

## Additional info
https://github.com/pimcore/pimcore/blob/fcedfd356ba726ba238996aa4777b2178366367d/lib/Image/Adapter/Imagick.php#L530
$x/$y are not always provided as integers, sometimes an implicit conversion from float to integer occurs. This leads to a deprecation warning.