### PR TITLE
Improve search performance by otimizing SQL filter conditions, exclud…

### DIFF
--- a/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
+++ b/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
@@ -419,6 +419,7 @@ class SearchController extends UserAwareController
                     //if there is restriction to root path, and not other paths allowed, no need to check further
                     if ($forbiddenPath === '/' && !$allowedPaths) {
                         $forbiddenPathSql = [' false '];
+
                         break;
                     }
                     if ($allowedPaths) {
@@ -432,6 +433,7 @@ class SearchController extends UserAwareController
                     //if user has access to root path, no need to check for other paths and include "fullpath LIKE %" conditions that will slow down the search
                     if ($allowedPaths === '/') {
                         $allowedPathSql = [' true '];
+
                         break;
                     }
                     $allowedPathSql[] = ' fullpath LIKE ' . $db->quote($allowedPaths  . '%');

--- a/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
+++ b/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
@@ -430,7 +430,7 @@ class SearchController extends UserAwareController
                     $forbiddenPathSql[] = ' (fullpath NOT LIKE ' . $db->quote($forbiddenPath . $folderSuffix . '%') . $exceptions . ') ';
                 }
                 foreach ($elementPaths['allowed'] as $allowedPaths) {
-                    //if user has access to root path, no need to check for other paths and include "fullpath LIKE %" conditions that will slow down the search
+                    //has root access, skip 'fullpath LIKE %' as it slows the search; no need to check other paths
                     if ($allowedPaths === '/') {
                         $allowedPathSql = [' true '];
 

--- a/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
+++ b/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
@@ -416,6 +416,11 @@ class SearchController extends UserAwareController
                 foreach ($elementPaths['forbidden'] as $forbiddenPath => $allowedPaths) {
                     $exceptions = '';
                     $folderSuffix = '';
+                    //if there is restriction to root path, and not other paths allowed, no need to check further
+                    if ($forbiddenPath === '/' && !$allowedPaths) {
+                        $forbiddenPathSql = [' false '];
+                        break;
+                    }
                     if ($allowedPaths) {
                         $exceptionsConcat = implode("%' OR fullpath LIKE '", $allowedPaths);
                         $exceptions = " OR (fullpath LIKE '" . $exceptionsConcat . "%')";
@@ -424,6 +429,11 @@ class SearchController extends UserAwareController
                     $forbiddenPathSql[] = ' (fullpath NOT LIKE ' . $db->quote($forbiddenPath . $folderSuffix . '%') . $exceptions . ') ';
                 }
                 foreach ($elementPaths['allowed'] as $allowedPaths) {
+                    //if user has access to root path, no need to check for other paths and include "fullpath LIKE %" conditions that will slow down the search
+                    if ($allowedPaths === '/') {
+                        $allowedPathSql = [' true '];
+                        break;
+                    }
                     $allowedPathSql[] = ' fullpath LIKE ' . $db->quote($allowedPaths  . '%');
                 }
 


### PR DESCRIPTION
Improve search performance by otimizing SQL filter conditions, exclude "fullpath LIKE %" where it is not necessary

If the user has access to root path `/` , it is not necessary to check if it also has access to `/myfolder1/`, `/myfolder2/`...

instead of 
```
((maintype = 'object' AND ((  fullpath LIKE '/%' ) OR (  fullpath LIKE '/myfolder1/%' ) OR  (  fullpath LIKE '/myfolder2/%' ) ) ))
```

we'll have:
```
((maintype = 'object' AND ((  true  ) ) ))
```
in this way we avoid having redundant mysql filter conditions like `fullpath LIKE ' . $db->quote($allowedPaths  . '%'`  thattypically prevents the use of indexes because the % wildcard at the start (or in the middle) requires MySQL to examine each row to see if the condition matches.