### PR TITLE
Update 01_Image_Thumbnails.md document

### DIFF
--- a/doc/04_Assets/03_Working_with_Thumbnails/01_Image_Thumbnails.md
+++ b/doc/04_Assets/03_Working_with_Thumbnails/01_Image_Thumbnails.md
@@ -23,7 +23,7 @@ Click on _+_ to add a new transformation, so that it look like that for example:
 in the configuration above. If you first round the corners this would be performed on the original image,
 and then the image will get resized, so the rounded corners are also resized which is not intended.
 
-To retrieve a thumbnail from an asses simply call `$asset->getThumbnail("thumbnail-name")` on the asset object, which will return
+To retrieve a thumbnail from an asset simply call `$asset->getThumbnail("thumbnail-name")` on the asset object, which will return
 an `\Pimcore\Model\Asset\Image\Thumbnail` object. The thumbnail object's `__toString()` method returns the path to the thumbnail file, for example:
 `/Car%20Images/ac%20cars/68/image-thumb__68__content/automotive-car-classic-149813.jpg`
 


### PR DESCRIPTION
Documentation say it is possible to retrieve a thumbnail from an ass using the getThumbnail function, but I could not retrieve it from my own. I think it's supposed to mean from an "asset"

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info
