### PR TITLE
Add mysql 8.4 to codeception matrix

### DIFF
--- a/.github/workflows/codeception.yaml
+++ b/.github/workflows/codeception.yaml
@@ -47,6 +47,7 @@ jobs:
                     - { php-version: 8.2, database: "mariadb:10.11", dependencies: highest, experimental: true, storage: local, symfony: "6.4.x-dev", composer-options: "" }
                     - { php-version: 8.1, database: "mariadb:10.7", dependencies: highest, experimental: false, storage: local, symfony: "", composer-options: "" }
                     - { php-version: 8.1, database: "mysql:8.0", dependencies: lowest, experimental: false, storage: local, symfony: "", composer-options: "" }
+                    - { php-version: 8.1, database: "mysql:8.4", dependencies: lowest, experimental: false, storage: local, symfony: "", composer-options: "" }
                     - { php-version: 8.1, database: "percona:8.0", dependencies: lowest, experimental: false, storage: minio, symfony: "", composer-options: "" }
 
         services:


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
_did not create an issue for this - when required, I'm more than happy to create one._

## Additional info
I noticed that the system requirements mention `mysql >= 8.0` but 8.4 is not covered in the tests yet. 
We use MySQL 8.4 for a new Pimcore project and I'd like to have the core tests running against this ;-) 