### PR TITLE
[Data Objects] Select data-types: do not configure dynamic options in __set_state() when not in admin mode

### DIFF
--- a/models/DataObject/ClassDefinition/Data/AbstractQuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/AbstractQuantityValue.php
@@ -215,7 +215,9 @@ abstract class AbstractQuantityValue extends Data implements ResourcePersistence
     {
         $obj = parent::__set_state($data);
 
-        $obj->configureOptions();
+        if (Pimcore::inAdmin()) {
+            $obj->configureOptions();
+        }
 
         return $obj;
     }

--- a/models/DataObject/ClassDefinition/Data/Language.php
+++ b/models/DataObject/ClassDefinition/Data/Language.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
+use Pimcore;
 use Pimcore\Model;
 use Pimcore\Model\DataObject\ClassDefinition\Service;
 use Pimcore\Tool;
@@ -70,7 +71,10 @@ class Language extends Model\DataObject\ClassDefinition\Data\Select
     public static function __set_state(array $data): static
     {
         $obj = parent::__set_state($data);
-        $obj->configureOptions();
+
+        if (Pimcore::inAdmin()) {
+            $obj->configureOptions();
+        }
 
         return $obj;
     }

--- a/models/DataObject/ClassDefinition/Data/Languagemultiselect.php
+++ b/models/DataObject/ClassDefinition/Data/Languagemultiselect.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
 use Exception;
+use Pimcore;
 use Pimcore\Model;
 use Pimcore\Model\DataObject\ClassDefinition\Service;
 use Pimcore\Tool;
@@ -73,7 +74,10 @@ class Languagemultiselect extends Model\DataObject\ClassDefinition\Data\Multisel
     public static function __set_state(array $data): static
     {
         $obj = parent::__set_state($data);
-        $obj->configureOptions();
+
+        if (Pimcore::inAdmin()) {
+            $obj->configureOptions();
+        }
 
         return $obj;
     }

--- a/models/DataObject/ClassDefinition/Data/QuantityValueRange.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValueRange.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
 use Exception;
+use Pimcore;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\Element\ValidationException;
@@ -335,7 +336,10 @@ class QuantityValueRange extends Data implements ResourcePersistenceAwareInterfa
     public static function __set_state(array $data): static
     {
         $obj = parent::__set_state($data);
-        $obj->configureOptions();
+
+        if (Pimcore::inAdmin()) {
+            $obj->configureOptions();
+        }
 
         return $obj;
     }


### PR DESCRIPTION
Resolves #17959

Options are only required in admin so it should be fine to do not configure options when not in admin mode. 