### PR TITLE
QuantityValueRange - Allowing for smaller differences between min and max without throwing

### DIFF
--- a/models/DataObject/Data/QuantityValueRange.php
+++ b/models/DataObject/Data/QuantityValueRange.php
@@ -64,8 +64,19 @@ class QuantityValueRange extends AbstractQuantityValue
         $this->markMeDirty();
     }
 
-    public function getRange(int $step = 1): array
+    public function getRange(int|float $step = 1): array
     {
+        $delta = $this->getMaximum() - $this->getMinimum();
+
+        // range throws when used with $step greater then $delta
+        if (abs($step) > abs($delta)) {
+            if ($step > 0) {
+                return [$this->minimum, $this->maximum];
+            } else {
+                return [$this->maximum, $this->minimum];
+            }
+        }
+
         return range($this->getMinimum(), $this->getMaximum(), $step);
     }
 


### PR DESCRIPTION
Recreation the issue:
```php
/////////////////////////////
// Preparation
/*
 * Store
 */
$storeConfig = Classificationstore\StoreConfig::create();
$storeConfig->setName("Bug");
$storeConfig->save();

/*
 * key
 */
$keyConfig = new Classificationstore\KeyConfig();
$keyConfig->setStoreId($storeConfig->getId());
$keyConfig->setName("Bug Key");
$keyConfig->setTitle("Bug Key");
$keyConfig->setEnabled(true);


$keyDefinitionConfig = new QuantityValueRange();

$keyDefinitionConfig->setName("Bug Key");
$keyDefinitionConfig->setTitle("Bug Key");


$keyConfig->setType($keyDefinitionConfig->getFieldType());
$keyConfig->setDefinition(json_encode($keyDefinitionConfig));

$keyConfig->save();

/*
 * Group
 */
$groupConfig = new Classificationstore\GroupConfig();

$groupConfig->setStoreId($storeConfig->getId());
$groupConfig->setName("Bug Group");
$groupConfig->setDescription("Bug Group");

$groupConfig->save();

/*
 * Key:Group
 */
$keyGroupRelation = new KeyGroupRelation();

$keyGroupRelation->setKeyId($keyConfig->getId());
$keyGroupRelation->setGroupId($groupConfig->getId());

$keyGroupRelation->save();

/*
 * Collection
 */
$collectionConfig = new Classificationstore\CollectionConfig();
$collectionConfig->setStoreId($storeConfig->getId());
$collectionConfig->setName("Bug Collection");
$collectionConfig->setDescription("Bug Collection");

$collectionConfig->save();

/*
 * Group:Collection
 */
$collectionGroupRelation = new Classificationstore\CollectionGroupRelation();

$collectionGroupRelation->setGroupId($groupConfig->getId());
$collectionGroupRelation->setColId($collectionConfig->getId());

$collectionGroupRelation->save();

/////////////////////////////
// Bug
/** @var Classificationstore $store */
$store = /* get from some data object the classification store */;

$store->setLocalizedKeyValue($groupConfig->getId(), $keyConfig->getId(), new \Pimcore\Model\DataObject\Data\QuantityValueRange(2.7, 3.6, null));

/*
 * range(): Argument #3 ($step) must be less than the range spanned by argument #1 ($start) and argument #2 ($end)
 */
$store->save();
```

(Hope I complied with everything in CONTRIBUTING.md, please give feedback if I forgot something)
 
## Changes in this pull request  
When `DataObject/Data/QuantityValueRange.php:getRange()` is called with a $step greater than the difference between `$minimum` and `$maximum`, it now returns an optimized version of `range($this->getMinimum(), $this->getMaximum(), $this->getMaximum() - $this->getMinimum())`, including support for negative `$step` values.

## Additional info
