### PR TITLE
TestDataHelper::createHotspots() - seed can't be null

### DIFF
--- a/tests/Support/Helper/DataType/TestDataHelper.php
+++ b/tests/Support/Helper/DataType/TestDataHelper.php
@@ -397,7 +397,7 @@ class TestDataHelper extends AbstractTestDataHelper
         $this->assertEquals($expected->getHotspots(), $value->getHotspots());
     }
 
-    private function createHotspots(?int $idx = null, ?int $seed = 0): array
+    private function createHotspots(?int $idx = null, int $seed = 0): array
     {
         $result = [];
 


### PR DESCRIPTION
Followup to https://github.com/pimcore/pimcore/pull/17985