### PR TITLE
Update 24_Numeric.md

### DIFF
--- a/doc/03_Documents/01_Editables/24_Numeric.md
+++ b/doc/03_Documents/01_Editables/24_Numeric.md
@@ -18,7 +18,7 @@ The numeric editable is very similar to the [input editable](./16_Input.md), but
 
 | Name        | Return      | Description                                                                  |
 |-------------|-------------|------------------------------------------------------------------------------|
-| `getData()` | int,float   | Value of the numeric field, this is useful to get the value even in editmode |
+| `getData()` | string,null | Value of the numeric field, this is useful to get the value even in editmode |
 | `isEmpty()` | boolean     | Whether the editable is empty or not                                         |
 
 ## Examples


### PR DESCRIPTION
## Changes in this pull request  
While `Pimcore\Model\Document\Editable\Numeric::getData()` has a return type of `mixed`, it directly returns the value of its `$number` property, which is `string|null`.