### PR TITLE
temporary fix doctrine migrations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -129,6 +129,7 @@
     "umpirsky/country-list": "^2.0.6"
   },
   "conflict": {
+    "doctrine/doctrine-migrations-bundle": "3.4.0",
     "pimcore/admin-ui-classic-bundle": "<1.5",
     "phpstan/phpdoc-parser": ">=2.0",
     "sabre/dav": "4.2.2",


### PR DESCRIPTION


Currently the update of the "doctrine/doctrine-migrations-bundle" to "3.4.0" breakes the gh actions in some bundles
e.g. Statistics Explorer
`
In MetadataStorageError.php line 18:

[Doctrine\Migrations\Exception\MetadataStorageError]
The metadata storage is not initialized, please run the sync-metadata-stora
ge command to fix this issue.
`
We need to investigate further on this.
