### PR TITLE
Add conflicting bundles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -131,6 +131,9 @@
   "conflict": {
     "doctrine/doctrine-migrations-bundle": "3.4.0",
     "pimcore/admin-ui-classic-bundle": "<1.5",
+    "pimcore/output-data-config-toolkit-bundle": "<5.0",
+    "pimcore/translations-provider-interfaces": "<3.0",
+    "pimcore/web2print-tools-bundle": "<5.0",
     "phpstan/phpdoc-parser": ">=2.0",
     "sabre/dav": "4.2.2",
     "symfony/symfony": "*",


### PR DESCRIPTION
Add following conflicts:

    "pimcore/output-data-config-toolkit-bundle": "<5.0",
    "pimcore/translations-provider-interfaces": "<3.0",
    "pimcore/web2print-tools-bundle": "<5.0",
  
They have some very old version which do not require pimcore/pimcore and woud install instead of the latest dev-x.

