### PR TITLE
Fix typos in WYSIWYG docs

### DIFF
--- a/doc/03_Documents/01_Editables/40_WYSIWYG.md
+++ b/doc/03_Documents/01_Editables/40_WYSIWYG.md
@@ -8,8 +8,8 @@ Similar to Textarea and Input you can use the WYSIWYG editable in the templates 
 
 | Name           | Type     | Description                                                                                                                               |
 |----------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| `height`       | integer  | Height of the WYSIWYG editable in pixel                                                                           |
-| `width`        | integer  | Width of the WYSIWYG editable in pixel                                                                                                          |
+| `height`       | integer  | Height of the WYSIWYG editable in pixel                                                                                                   |
+| `width`        | integer  | Width of the WYSIWYG editable in pixel                                                                                                    |
 | `class`        | string   | A CSS class that is added to the surrounding container of this element in editmode                                                        |
 | `placeholder`  | string   | A text shown in the field when it is empty to guide the user about the expected type of input.                                            |
 | `defaultValue` | string   | A default value for the available options. Note: This value needs to be saved before calling getData() or use setDataFromResource().      |

--- a/doc/03_Documents/01_Editables/40_WYSIWYG.md
+++ b/doc/03_Documents/01_Editables/40_WYSIWYG.md
@@ -8,8 +8,8 @@ Similar to Textarea and Input you can use the WYSIWYG editable in the templates 
 
 | Name           | Type     | Description                                                                                                                               |
 |----------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| `height`       | bool     | Set true to reload the page in editmode after selecting an item                                                                           |
-| `width`        | integer  | Width of the select box in pixel                                                                                                          |
+| `height`       | integer  | Height of the WYSIWYG editable in pixel                                                                           |
+| `width`        | integer  | Width of the WYSIWYG editable in pixel                                                                                                          |
 | `class`        | string   | A CSS class that is added to the surrounding container of this element in editmode                                                        |
 | `placeholder`  | string   | A text shown in the field when it is empty to guide the user about the expected type of input.                                            |
 | `defaultValue` | string   | A default value for the available options. Note: This value needs to be saved before calling getData() or use setDataFromResource().      |
@@ -21,7 +21,7 @@ Similar to Textarea and Input you can use the WYSIWYG editable in the templates 
 {{ pimcore_wysiwyg("myWYSIWYG", {
     "height": 600,
     "width": 1100,
-    "placeholder": "Enter you content"
+    "placeholder": "Enter your content"
 }) }}
 ```
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Fix typos in docs for WYSIWYG editable
