### PR TITLE
Fix version preview error for Block data type when additional fields are added

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Block.php
+++ b/models/DataObject/ClassDefinition/Data/Block.php
@@ -461,7 +461,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
                     $title = !empty($fieldDefinition->title) ? $fieldDefinition->title : $fieldDefinition->getName();
                     $html .= '<tr><td>&nbsp;</td><td>'.$title.'</td><td>';
 
-                    $blockElement = $item[$fieldDefinition->getName()];
+                    $blockElement = $item[$fieldDefinition->getName()] ?? null;
                     if ($blockElement instanceof DataObject\Data\BlockElement) {
                         $html .= $fieldDefinition->getVersionPreview($blockElement->getData(), $object, $params);
                     } else {


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info
This PR addresses an issue in the getDiffVersionPreview function within models/DataObject/ClassDefinition/Data/Block.php

The issue arises when an additional field is added to a Block data type within an Object. Specifically, the version preview fails to render correctly if the structure of the Block element is modified by adding new fields after the object has already been created and saved. This discrepancy between the saved version's Block structure and the updated class definition leads to errors during the version preview.

## Steps to Reproduce the Issue

### 1. Create a Class with a Block Element
- Go to the Pimcore backend.
- Create a new class (e.g., TestClass).
- Add a Block data type to the class definition.
- Inside the Block, add a field (e.g., Field1).
![image](https://github.com/user-attachments/assets/ce05e007-a873-4955-8fda-7ccd9c227fb6)

### 2. Create a new object of the TestClass type.
- Create an Object
- Fill in some values for Field1 in the Block and save the object.
![image](https://github.com/user-attachments/assets/b1a2ba7b-fc99-4c31-b94f-837e74486b39)

### 3. Update the class definition for TestClass.
- Add another field (e.g., Field2) to the Block.
![image](https://github.com/user-attachments/assets/9538622b-19de-4581-8165-5fff31ea14c8)

### 4. Open the previously created object.
- Add values to the newly added field (Field2).
- Save the object again.
![image](https://github.com/user-attachments/assets/51382024-e2f8-480e-8944-610b83f0c012)

### 5. Open the version history of the object.
- Try to preview a previous version.
![image](https://github.com/user-attachments/assets/9ea3b774-900a-4f25-a805-0acb6f1dd8b1)


**Result**: An error will be thrown (Warning: Undefined array key "Field2") due to the mismatch in Block structure between versions. This behavior highlights the issue in the getDiffVersionPreview function. 
