### PR TITLE
Add getFilterConditionExt for ReverseObjectRelation.

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Relations/ManyToManyRelationTrait.php
+++ b/models/DataObject/ClassDefinition/Data/Relations/ManyToManyRelationTrait.php
@@ -91,9 +91,9 @@ trait ManyToManyRelationTrait
     {
         $prefix = '';
         $name = $params['name'] ?: $this->name;
+        $prefix = $params['brickPrefix'] ?? null;
 
-        if ($params['brickPrefix']) {
-            $prefix = $params['brickPrefix'];
+        if ($prefix !== null) {
             // The brick prefix might be quoted and with a dot suffix, if so, removing the first
             // and second last character to unquote
             $quoteIdentifierSymbol  = substr(Db::get()->quoteIdentifier(''), 0, 1);

--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -211,4 +211,16 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
 
         return [];
     }
+
+    public function getFilterConditionExt(mixed $value, string $operator, array $params = []): string
+    {
+        $name = $params['name'] ?: $this->name;
+
+        // TODO: handle null
+        // TODO: check operator
+        // TODO: what is $name for
+
+        // we are looking for membership in the reverse relation
+        return "id IN (". 'SELECT dest_id FROM object_relations_'. $this->getOwnerClassId() . " WHERE src_id = '" . $value . "' AND fieldname = '". $this->getOwnerFieldName() . "' AND ownertype = 'object'" . ")";
+    }
 }

--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -231,7 +231,7 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
         } elseif ($operator === 'LIKE' || $operator === 'IN') {
             $values = explode(',', $value);
             // we treat LIKE and IN the same. UI sends LIKE
-            $fieldConditions = array_map(function ($value) use ($name) {
+            $fieldConditions = array_map(function ($value) {
                 return '`' . 'src_id' . '`' . " = '" . $value . "'";
             }, array_filter($values));
             if (!empty($fieldConditions)) {

--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -214,13 +214,32 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
 
     public function getFilterConditionExt(mixed $value, string $operator, array $params = []): string
     {
+        // TODO: what is $name for
         $name = $params['name'] ?: $this->name;
 
-        // TODO: handle null
-        // TODO: check operator
-        // TODO: what is $name for
+        if ($value === null || $value === 'null') {
+            return "1 = 0";
+        }
+
+        if ($operator === '=') {
+            $subFilter = '`' . "src_id" . '`' . " = '" . $value . "'";
+        } else if ($operator === 'like' || $operator === 'in') {
+            $values = explode(',', $value);
+            // not a real like for now
+            $fieldConditions = array_map(function ($value) use ($name) {
+                return '`' . "src_id" . '`' . " = '" . $value . "'";
+            }, array_filter($values));
+            if (!empty($fieldConditions)) {
+                // we use OR
+                $subFilter = '(' . implode(' OR ', $fieldConditions) . ')';
+            } else {
+                return "1 = 0";
+            }
+        } else {
+            return "1 = 0";
+        }
 
         // we are looking for membership in the reverse relation
-        return "id IN (". 'SELECT dest_id FROM object_relations_'. $this->getOwnerClassId() . " WHERE src_id = '" . $value . "' AND fieldname = '". $this->getOwnerFieldName() . "' AND ownertype = 'object'" . ")";
+        return "id IN (". 'SELECT dest_id FROM object_relations_'. $this->getOwnerClassId() . " WHERE ". $subFilter . " AND fieldname = '". $this->getOwnerFieldName() . "' AND ownertype = 'object'" . ")";
     }
 }

--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -247,8 +247,8 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
         return 'id IN ('
             . 'SELECT dest_id FROM object_relations_'. $this->getOwnerClassId()
             . ' WHERE '. $subFilter
-            . " AND fieldname = '". $this->getOwnerFieldName()
-            . "' AND ownertype = 'object'"
+            . " AND fieldname = '". $this->getOwnerFieldName() . "'"
+            . " AND ownertype = 'object'"
         . ')';
     }
 }

--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -245,6 +245,11 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
         }
 
         // we are looking for membership in the reverse relation
-        return $tablePrefix . 'id IN ('. 'SELECT dest_id FROM object_relations_'. $this->getOwnerClassId() . ' WHERE '. $subFilter . " AND fieldname = '". $this->getOwnerFieldName() . "' AND ownertype = 'object'" . ')';
+        return $tablePrefix . 'id IN ('
+            . 'SELECT dest_id FROM object_relations_'. $this->getOwnerClassId()
+            . ' WHERE '. $subFilter
+            . " AND fieldname = '" . $this->getOwnerFieldName() . "'"
+            . " AND ownertype = 'object'"
+        . ')';
     }
 }

--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -218,28 +218,28 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
         $name = $params['name'] ?: $this->name;
 
         if ($value === null || $value === 'null') {
-            return "1 = 0";
+            return '1 = 0';
         }
 
         if ($operator === '=') {
-            $subFilter = '`' . "src_id" . '`' . " = '" . $value . "'";
-        } else if ($operator === 'like' || $operator === 'in') {
+            $subFilter = '`' . 'src_id' . '`' . " = '" . $value . "'";
+        } elseif ($operator === 'like' || $operator === 'in') {
             $values = explode(',', $value);
             // not a real like for now
             $fieldConditions = array_map(function ($value) use ($name) {
-                return '`' . "src_id" . '`' . " = '" . $value . "'";
+                return '`' . 'src_id' . '`' . " = '" . $value . "'";
             }, array_filter($values));
             if (!empty($fieldConditions)) {
                 // we use OR
                 $subFilter = '(' . implode(' OR ', $fieldConditions) . ')';
             } else {
-                return "1 = 0";
+                return '1 = 0';
             }
         } else {
-            return "1 = 0";
+            return '1 = 0';
         }
 
         // we are looking for membership in the reverse relation
-        return "id IN (". 'SELECT dest_id FROM object_relations_'. $this->getOwnerClassId() . " WHERE ". $subFilter . " AND fieldname = '". $this->getOwnerFieldName() . "' AND ownertype = 'object'" . ")";
+        return 'id IN ('. 'SELECT dest_id FROM object_relations_'. $this->getOwnerClassId() . ' WHERE '. $subFilter . " AND fieldname = '". $this->getOwnerFieldName() . "' AND ownertype = 'object'" . ')';
     }
 }

--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -226,13 +226,15 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
             return $noResult;
         }
 
+        $db = \Pimcore\Db::get();
+
         if ($operator === '=') {
-            $subFilter = '`' . 'src_id' . '`' . " = '" . $value . "'";
+            $subFilter = '`' . 'src_id' . '`' . " = " . $db->quote($value);
         } elseif ($operator === 'LIKE' || $operator === 'IN') {
             $values = explode(',', $value);
             // we treat LIKE and IN the same. UI sends LIKE
-            $fieldConditions = array_map(function ($value) {
-                return '`' . 'src_id' . '`' . " = '" . $value . "'";
+            $fieldConditions = array_map(function ($value) use ($db) {
+                return '`' . 'src_id' . '`' . " = " . $db->quote($value);
             }, array_filter($values));
             if (!empty($fieldConditions)) {
                 // we use OR
@@ -248,7 +250,7 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
         return $tablePrefix . 'id IN ('
             . 'SELECT dest_id FROM object_relations_'. $this->getOwnerClassId()
             . ' WHERE '. $subFilter
-            . " AND fieldname = '" . $this->getOwnerFieldName() . "'"
+            . " AND fieldname = " . $db->quote($this->getOwnerFieldName())
             . " AND ownertype = 'object'"
         . ')';
     }

--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -217,8 +217,10 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
         // TODO: what is $name for
         $name = $params['name'] ?: $this->name;
 
+        $noResult = '1 = 0';
+
         if ($value === null || $value === 'null') {
-            return '1 = 0';
+            return $noResult;
         }
 
         $db = \Pimcore\Db::get();
@@ -235,13 +237,18 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
                 // we use OR
                 $subFilter = '(' . implode(' OR ', $fieldConditions) . ')';
             } else {
-                return '1 = 0';
+                return $noResult;
             }
         } else {
-            return '1 = 0';
+            return $noResult;
         }
 
         // we are looking for membership in the reverse relation
-        return 'id IN ('. 'SELECT dest_id FROM object_relations_'. $this->getOwnerClassId() . ' WHERE '. $subFilter . " AND fieldname = '". $this->getOwnerFieldName() . "' AND ownertype = 'object'" . ')';
+        return 'id IN ('
+            . 'SELECT dest_id FROM object_relations_'. $this->getOwnerClassId()
+            . ' WHERE '. $subFilter
+            . " AND fieldname = '". $this->getOwnerFieldName()
+            . "' AND ownertype = 'object'"
+        . ')';
     }
 }

--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -244,7 +244,7 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
         }
 
         // we are looking for membership in the reverse relation
-        return "object_" . $this->getOwnerFieldName() . '.id IN ('
+        return 'object_' . $this->getOwnerFieldName() . '.id IN ('
             . 'SELECT dest_id FROM object_relations_'. $this->getOwnerClassId()
             . ' WHERE '. $subFilter
             . " AND fieldname = '". $this->getOwnerFieldName() . "'"

--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -223,9 +223,9 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
 
         if ($operator === '=') {
             $subFilter = '`' . 'src_id' . '`' . " = '" . $value . "'";
-        } elseif ($operator === 'like' || $operator === 'in') {
+        } elseif ($operator === 'LIKE' || $operator === 'IN') {
             $values = explode(',', $value);
-            // not a real like for now
+            // we treat LIKE and IN the same. UI sends LIKE
             $fieldConditions = array_map(function ($value) use ($name) {
                 return '`' . 'src_id' . '`' . " = '" . $value . "'";
             }, array_filter($values));

--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -221,13 +221,15 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
             return '1 = 0';
         }
 
+        $db = \Pimcore\Db::get();
+
         if ($operator === '=') {
-            $subFilter = '`' . 'src_id' . '`' . " = '" . $value . "'";
+            $subFilter = '`' . 'src_id' . '`' . " = '" . $db->quote($value) . "'";
         } elseif ($operator === 'LIKE' || $operator === 'IN') {
             $values = explode(',', $value);
             // we treat LIKE and IN the same. UI sends LIKE
-            $fieldConditions = array_map(function ($value) {
-                return '`' . 'src_id' . '`' . " = '" . $value . "'";
+            $fieldConditions = array_map(function ($value) use ($db) {
+                return '`' . 'src_id' . '`' . " = '" . $db->quote($value) . "'";
             }, array_filter($values));
             if (!empty($fieldConditions)) {
                 // we use OR

--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -227,12 +227,12 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
         }
 
         if ($operator === '=') {
-            $subFilter = '`' . "src_id" . '`' . " = '" . $value . "'";
-        } else if ($operator === 'LIKE' || $operator === 'IN') {
+            $subFilter = '`' . 'src_id' . '`' . " = '" . $value . "'";
+        } elseif ($operator === 'LIKE' || $operator === 'IN') {
             $values = explode(',', $value);
             // we treat LIKE and IN the same. UI sends LIKE
             $fieldConditions = array_map(function ($value) use ($name) {
-                return '`' . "src_id" . '`' . " = '" . $value . "'";
+                return '`' . 'src_id' . '`' . " = '" . $value . "'";
             }, array_filter($values));
             if (!empty($fieldConditions)) {
                 // we use OR
@@ -245,6 +245,6 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
         }
 
         // we are looking for membership in the reverse relation
-        return $tablePrefix . "id IN (". 'SELECT dest_id FROM object_relations_'. $this->getOwnerClassId() . " WHERE ". $subFilter . " AND fieldname = '". $this->getOwnerFieldName() . "' AND ownertype = 'object'" . ")";
+        return $tablePrefix . 'id IN ('. 'SELECT dest_id FROM object_relations_'. $this->getOwnerClassId() . ' WHERE '. $subFilter . " AND fieldname = '". $this->getOwnerFieldName() . "' AND ownertype = 'object'" . ')';
     }
 }

--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -244,7 +244,7 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
         }
 
         // we are looking for membership in the reverse relation
-        return 'id IN ('
+        return "object_" . $this->getOwnerFieldName() . '.id IN ('
             . 'SELECT dest_id FROM object_relations_'. $this->getOwnerClassId()
             . ' WHERE '. $subFilter
             . " AND fieldname = '". $this->getOwnerFieldName() . "'"

--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -214,24 +214,25 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
 
     public function getFilterConditionExt(mixed $value, string $operator, array $params = []): string
     {
-        // TODO: what is $name for
-        $name = $params['name'] ?: $this->name;
-
         $noResult = '1 = 0';
+
+        $tablePrefix = $params['tablePrefix'] ?? null;
+
+        if (null === $tablePrefix) {
+            throw new Exception('Function ReverseObjectRelation::getFilterConditionExt called without a table prefix.');
+        }
 
         if ($value === null || $value === 'null') {
             return $noResult;
         }
 
-        $db = \Pimcore\Db::get();
-
         if ($operator === '=') {
-            $subFilter = '`' . 'src_id' . '`' . " = '" . $db->quote($value) . "'";
-        } elseif ($operator === 'LIKE' || $operator === 'IN') {
+            $subFilter = '`' . "src_id" . '`' . " = '" . $value . "'";
+        } else if ($operator === 'LIKE' || $operator === 'IN') {
             $values = explode(',', $value);
             // we treat LIKE and IN the same. UI sends LIKE
-            $fieldConditions = array_map(function ($value) use ($db) {
-                return '`' . 'src_id' . '`' . " = '" . $db->quote($value) . "'";
+            $fieldConditions = array_map(function ($value) use ($name) {
+                return '`' . "src_id" . '`' . " = '" . $value . "'";
             }, array_filter($values));
             if (!empty($fieldConditions)) {
                 // we use OR
@@ -244,11 +245,6 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
         }
 
         // we are looking for membership in the reverse relation
-        return 'object_' . $this->getOwnerFieldName() . '.id IN ('
-            . 'SELECT dest_id FROM object_relations_'. $this->getOwnerClassId()
-            . ' WHERE '. $subFilter
-            . " AND fieldname = '". $this->getOwnerFieldName() . "'"
-            . " AND ownertype = 'object'"
-        . ')';
+        return $tablePrefix . "id IN (". 'SELECT dest_id FROM object_relations_'. $this->getOwnerClassId() . " WHERE ". $subFilter . " AND fieldname = '". $this->getOwnerFieldName() . "' AND ownertype = 'object'" . ")";
     }
 }

--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -226,7 +226,7 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
         } elseif ($operator === 'LIKE' || $operator === 'IN') {
             $values = explode(',', $value);
             // we treat LIKE and IN the same. UI sends LIKE
-            $fieldConditions = array_map(function ($value) use ($name) {
+            $fieldConditions = array_map(function ($value) {
                 return '`' . 'src_id' . '`' . " = '" . $value . "'";
             }, array_filter($values));
             if (!empty($fieldConditions)) {

--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -229,12 +229,12 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
         $db = \Pimcore\Db::get();
 
         if ($operator === '=') {
-            $subFilter = '`' . 'src_id' . '`' . " = " . $db->quote($value);
+            $subFilter = '`' . 'src_id' . '`' . ' = ' . $db->quote($value);
         } elseif ($operator === 'LIKE' || $operator === 'IN') {
             $values = explode(',', $value);
             // we treat LIKE and IN the same. UI sends LIKE
             $fieldConditions = array_map(function ($value) use ($db) {
-                return '`' . 'src_id' . '`' . " = " . $db->quote($value);
+                return '`' . 'src_id' . '`' . ' = ' . $db->quote($value);
             }, array_filter($values));
             if (!empty($fieldConditions)) {
                 // we use OR
@@ -250,7 +250,7 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
         return $tablePrefix . 'id IN ('
             . 'SELECT dest_id FROM object_relations_'. $this->getOwnerClassId()
             . ' WHERE '. $subFilter
-            . " AND fieldname = " . $db->quote($this->getOwnerFieldName())
+            . ' AND fieldname = ' . $db->quote($this->getOwnerFieldName())
             . " AND ownertype = 'object'"
         . ')';
     }


### PR DESCRIPTION
Looking for initial feedback on the approach here.

The idea is that with this logic we can enable filtering on reverse relationships from the admin-ui (ie revert: https://github.com/pimcore/admin-ui-classic-bundle/pull/375).

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Follow up to #16273
/CC @kingjia90 @wisconaut

## Additional info
