### PR TITLE
[Bugfix] Change installer sequence

### DIFF
--- a/bundles/InstallBundle/src/Installer.php
+++ b/bundles/InstallBundle/src/Installer.php
@@ -153,8 +153,8 @@ class Installer
         'setup_database' => 'Running database setup...',
         'install_assets' => 'Installing assets...',
         'install_classes' => 'Installing classes...',
-        'install_bundles' => 'Installing bundles...',
         'migrations' => 'Marking all migrations as done...',
+        'install_bundles' => 'Installing bundles...',
         'complete' => 'Install complete!',
     ];
 
@@ -163,8 +163,8 @@ class Installer
         'setup_database',
         'install_assets',
         'install_classes',
-        'install_bundles',
         'mark_migrations_as_done',
+        'install_bundles',
         'clear_cache',
     ];
 
@@ -470,11 +470,6 @@ class Installer
             $this->installAssets($kernel);
         }
 
-        if (!empty($this->bundlesToInstall) && in_array('install_bundles', $stepsToRun)) {
-            $this->dispatchStepEvent('install_bundles');
-            $this->installBundles();
-        }
-
         if (in_array('install_classes', $stepsToRun)) {
             $this->dispatchStepEvent('install_classes');
             $this->installClasses();
@@ -483,6 +478,11 @@ class Installer
         if (in_array('mark_migrations_as_done', $stepsToRun)) {
             $this->dispatchStepEvent('migrations');
             $this->markMigrationsAsDone();
+        }
+
+        if (!empty($this->bundlesToInstall) && in_array('install_bundles', $stepsToRun)) {
+            $this->dispatchStepEvent('install_bundles');
+            $this->installBundles();
         }
 
         if (in_array('clear_cache', $stepsToRun)) {


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/17995

## Additional info
Due to a sequence problem with marking migrations as done and installing bundles, there was a potential error of the metadata storage being not initialized or synced.

```bash
 [ERROR] The metadata storage is not initialized, please run the                
         sync-metadata-storage command to fix this issue.                       

 ! [NOTE] Installing Pimcore\Bundle\DataHubBundle\PimcoreDataHubBundle failed. Please run the following command         
 !        manually:         
 ```
