### PR TITLE
improve env variable based domain check

### DIFF
--- a/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php
+++ b/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php
@@ -89,7 +89,7 @@ final class PimcoreCoreExtension extends ConfigurableExtension implements Prepen
         if ($domain) {
             // when not an env variable, check if the domain is valid
             if (
-                !str_starts_with($domain, 'env_') &&
+                !str_contains($domain, 'env_') &&
                 !filter_var(idn_to_ascii($domain), FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)
             ) {
                 throw new InvalidArgumentException(sprintf('Invalid main domain name "%s"', $domain));


### PR DESCRIPTION
Instead of `str_starts_with($domain, 'env_')`, I'm proposing to use `str_contains($domain, 'env_')`.

Otherwise, it's not possible to use something like this:

```yaml
pimcore:
    general:
        domain: 'www.%env(PROJECT_DOMAIN)%'
```
