### PR TITLE
Fix: AbstractElement::__setDataVersionTimestamp(): Argument #1 ($_dat…

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -286,7 +286,9 @@ class Asset extends Element\AbstractElement
                 }
 
                 RuntimeCache::set($cacheKey, $asset);
-                $asset->__setDataVersionTimestamp($asset->getModificationDate());
+                if ($asset->getModificationDate() !== null) {
+                    $asset->__setDataVersionTimestamp($asset->getModificationDate());
+                }
 
                 $asset->resetDirtyMap();
 

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -233,7 +233,9 @@ abstract class AbstractObject extends Model\Element\AbstractElement
                     $object = self::getModelFactory()->build($className);
                     RuntimeCache::set($cacheKey, $object);
                     $object->getDao()->getById($id);
-                    $object->__setDataVersionTimestamp($object->getModificationDate() ?? 0);
+                    if ($object->getModificationDate() !== null) {
+                        $object->__setDataVersionTimestamp($object->getModificationDate());
+                    }
 
                     Service::recursiveResetDirtyMap($object);
 


### PR DESCRIPTION
…aVersionTimestamp) must be of type int, null given

## Changes in this pull request  
Resolves error in admin interface:
```

Timestamp: Tue Feb 04 2025 13:22:25 GMT+0100 (Mitteleuropäische Normalzeit)
Status: 500 | 
URL: /admin/asset/tree-get-root
Message: Pimcore\Model\Element\AbstractElement::__setDataVersionTimestamp(): Argument #1 ($_dataVersionTimestamp) must be of type int, null given, called in /var/www/html/vendor/pimcore/pimcore/models/Asset.php on line 289
Trace: 
in /var/www/html/vendor/pimcore/pimcore/models/Element/AbstractElement.php:554
#0 /var/www/html/vendor/pimcore/pimcore/models/Asset.php(289): Pimcore\Model\Element\AbstractElement->__setDataVersionTimestamp(NULL)
#1 /var/www/html/vendor/pimcore/pimcore/models/Element/Service.php(450): Pimcore\Model\Asset::getById(1, Array)
#2 /var/www/html/vendor/pimcore/admin-ui-classic-bundle/src/Controller/Admin/ElementControllerBase.php(71): Pimcore\Model\Element\Service::getElementById('asset', 1)
#3 /var/www/html/vendor/pimcore/admin-ui-classic-bundle/src/Controller/Admin/Asset/AssetController.php(89): Pimcore\Bundle\AdminBundle\Controller\Admin\ElementControllerBase->treeGetRootAction(Object(Symfony\Component\HttpFoundation\Request))
#4 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(181): Pimcore\Bundle\AdminBundle\Controller\Admin\Asset\AssetController->treeGetRootAction(Object(Symfony\Component\HttpFoundation\Request))
#5 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(76): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#6 /var/www/html/vendor/symfony/http-kernel/Kernel.php(197): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#7 /var/www/html/vendor/symfony/runtime/Runner/Symfony/HttpKernelRunner.php(35): Symfony\Component\HttpKernel\Kernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#8 /var/www/html/vendor/autoload_runtime.php(29): Symfony\Component\Runtime\Runner\Symfony\HttpKernelRunner->run()
#9 /var/www/html/public/index.php(20): require_once('/var/www/html/v...')
#10 {main}
```

## Additional info
Is fixed for Document/DataObject, but not for assets.
