### PR TITLE
[Improvement] Dispatching Event in Workflow NotificationEmailService

### DIFF
--- a/doc/07_Workflow_Management/09_Working_with_PHP_API.md
+++ b/doc/07_Workflow_Management/09_Working_with_PHP_API.md
@@ -61,9 +61,11 @@ Symfony workflow module comes with a bunch of events that can be used for custom
 default workflow functionality. See [Symfony docs](https://symfony.com/doc/current/workflow/usage.html#using-events)
 for details. 
 
-In addition to the Symfony events, Pimcore provides two additional events for global actions: 
+In addition to the Symfony events, Pimcore provides additional events for global actions: 
 - `pimcore.workflow.preGlobalAction`
 - `pimcore.workflow.postGlobalAction`
+- `pimcore.workflow.preNotificationSending`
+
 See [WorkflowEvents](https://github.com/pimcore/pimcore/blob/11.x/lib/Event/WorkflowEvents.php) for details. 
 
 ### Using Additional Data in Events

--- a/lib/Event/Workflow/NotificationEmailEvent.php
+++ b/lib/Event/Workflow/NotificationEmailEvent.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Event\Workflow;
+
+use Pimcore\Model\Element\ElementInterface;
+use Symfony\Component\Workflow\Workflow;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class NotificationEmailEvent extends Event
+{
+    public function __construct(
+        private readonly array $users,
+        private readonly array $roles,
+        private readonly Workflow $workflow,
+        private readonly string $subjectType,
+        private readonly ElementInterface $subject,
+        private readonly string $action,
+        private readonly string $mailType,
+        private readonly string $mailPath,
+        private array $recipients
+    ) {
+    }
+
+    public function getUsers(): array
+    {
+        return $this->users;
+    }
+
+    public function getRoles(): array
+    {
+        return $this->roles;
+    }
+
+    public function getWorkflow(): Workflow
+    {
+        return $this->workflow;
+    }
+
+    public function getSubjectType(): string
+    {
+        return $this->subjectType;
+    }
+
+    public function getSubject(): ElementInterface
+    {
+        return $this->subject;
+    }
+
+    public function getAction(): string
+    {
+        return $this->action;
+    }
+
+    public function getMailType(): string
+    {
+        return $this->mailType;
+    }
+
+    public function getMailPath(): string
+    {
+        return $this->mailPath;
+    }
+
+    public function setRecipients(array $recipients): void
+    {
+        $this->recipients = $recipients;
+    }
+
+    public function getRecipients(): array
+    {
+        return $this->recipients;
+    }
+}

--- a/lib/Event/WorkflowEvents.php
+++ b/lib/Event/WorkflowEvents.php
@@ -37,4 +37,14 @@ final class WorkflowEvents
      * @var string
      */
     const POST_GLOBAL_ACTION = 'pimcore.workflow.postGlobalAction';
+
+    /**
+     * Fired BEFORE emails are sent to users or roles that should be notified when a workflow transition occurs.
+     * Use this to modify the recipient list, i.e., include object's `userOwner` in the list.
+     *
+     * @Event("Pimcore\Event\Workflow\NotificationEmailEvent")
+     *
+     * @var string
+     */
+    const PRE_NOTIFICATION_SENDING = 'pimcore.workflow.preNotificationSending';
 }

--- a/lib/Workflow/Notification/NotificationEmailService.php
+++ b/lib/Workflow/Notification/NotificationEmailService.php
@@ -17,6 +17,8 @@ declare(strict_types=1);
 namespace Pimcore\Workflow\Notification;
 
 use Exception;
+use Pimcore\Event\Workflow\NotificationEmailEvent;
+use Pimcore\Event\WorkflowEvents;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\User;
@@ -25,6 +27,7 @@ use Pimcore\Workflow\EventSubscriber\NotificationSubscriber;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Templating\EngineInterface;
 use Symfony\Component\Workflow\Workflow;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -38,11 +41,18 @@ class NotificationEmailService extends AbstractNotificationService
 
     protected TranslatorInterface $translator;
 
-    public function __construct(EngineInterface $template, RouterInterface $router, TranslatorInterface $translator)
-    {
+    protected EventDispatcherInterface $eventDispatcher;
+
+    public function __construct(
+        EngineInterface $template,
+        RouterInterface $router,
+        TranslatorInterface $translator,
+        EventDispatcherInterface $eventDispatcher
+    ) {
         $this->template = $template;
         $this->translator = $translator;
         $this->router = $router;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     /**
@@ -53,6 +63,14 @@ class NotificationEmailService extends AbstractNotificationService
     {
         try {
             $recipients = $this->getNotificationUsersByName($users, $roles);
+
+            $event = new NotificationEmailEvent(
+                $users, $roles, $workflow, $subjectType, $subject, $action, $mailType, $mailPath, $recipients
+            );
+            $event = $this->eventDispatcher->dispatch($event, WorkflowEvents::PRE_NOTIFICATION_SENDING);
+
+            $recipients = $event->getRecipients();
+
             if (!count($recipients)) {
                 return;
             }

--- a/lib/Workflow/Notification/NotificationEmailService.php
+++ b/lib/Workflow/Notification/NotificationEmailService.php
@@ -65,7 +65,15 @@ class NotificationEmailService extends AbstractNotificationService
             $recipients = $this->getNotificationUsersByName($users, $roles);
 
             $event = new NotificationEmailEvent(
-                $users, $roles, $workflow, $subjectType, $subject, $action, $mailType, $mailPath, $recipients
+                $users,
+                $roles,
+                $workflow,
+                $subjectType,
+                $subject,
+                $action,
+                $mailType,
+                $mailPath,
+                $recipients
             );
             $event = $this->eventDispatcher->dispatch($event, WorkflowEvents::PRE_NOTIFICATION_SENDING);
 


### PR DESCRIPTION
Added event dispatching logic that allows developers to modify recipients list. Event is fired before emails are sent to users or roles that should be notified when a workflow transition occurs. It can be used to modify the recipient list, i.e., include object's `userOwner` in the list.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves # https://github.com/orgs/pimcore/discussions/17997

## Additional info
