### PR TITLE
Do not execute Composer Checks on fork repositories

### DIFF
--- a/.github/workflows/composer-checks-outdated-monthly.yaml
+++ b/.github/workflows/composer-checks-outdated-monthly.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
     composer-checks:
         uses: pimcore/workflows-collection-public/.github/workflows/reusable-composer-checks.yaml@main
-        if: github.repository == 'pimcore/pimcore'
+        if: github.repository_owner == 'pimcore'
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/composer-checks-outdated-monthly.yaml
+++ b/.github/workflows/composer-checks-outdated-monthly.yaml
@@ -11,6 +11,7 @@ permissions:
 jobs:
     composer-checks:
         uses: pimcore/workflows-collection-public/.github/workflows/reusable-composer-checks.yaml@main
+        if: github.repository == 'pimcore/pimcore'
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/composer-checks-outdated.yaml
+++ b/.github/workflows/composer-checks-outdated.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
     composer-checks:
         uses: pimcore/workflows-collection-public/.github/workflows/reusable-composer-checks.yaml@main
-        if: github.repository == 'pimcore/pimcore'
+        if: github.repository_owner == 'pimcore'
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/composer-checks-outdated.yaml
+++ b/.github/workflows/composer-checks-outdated.yaml
@@ -11,6 +11,7 @@ permissions:
 jobs:
     composer-checks:
         uses: pimcore/workflows-collection-public/.github/workflows/reusable-composer-checks.yaml@main
+        if: github.repository == 'pimcore/pimcore'
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/composer-checks-vulnerabilities.yaml
+++ b/.github/workflows/composer-checks-vulnerabilities.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
     composer-checks:
         uses: pimcore/workflows-collection-public/.github/workflows/reusable-composer-vulnerabilities.yaml@main
-        if: github.repository == 'pimcore/pimcore'
+        if: github.repository_owner == 'pimcore'
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/composer-checks-vulnerabilities.yaml
+++ b/.github/workflows/composer-checks-vulnerabilities.yaml
@@ -11,6 +11,7 @@ permissions:
 jobs:
     composer-checks:
         uses: pimcore/workflows-collection-public/.github/workflows/reusable-composer-vulnerabilities.yaml@main
+        if: github.repository == 'pimcore/pimcore'
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
The checks doesn't work on fork repositories. See for example: https://github.com/blankse/pimcore/actions/runs/13195085655