### PR TITLE
Fix: ManyToOneRelation with display mode "inline search" shows only data objects

### DIFF
--- a/bundles/SimpleBackendSearchBundle/src/Controller/DataObjectController.php
+++ b/bundles/SimpleBackendSearchBundle/src/Controller/DataObjectController.php
@@ -46,8 +46,32 @@ class DataObjectController extends UserAwareController
         }
 
         $searchRequest = $request;
-        $searchRequest->request->set('type', 'object');
-        $searchRequest->request->set('subtype', 'object,variant');
+        if ($fieldConfig['fieldtype'] === 'manyToOneRelation') {
+            $types = [];
+            $subtypes = [];
+            if ($fieldConfig['documentsAllowed']) {
+                $types[] = 'document';
+                foreach ($fieldConfig['documentTypes'] as $documentTypes) {
+                    $subtypes[] = $documentTypes['documentTypes'];
+                }
+            }
+            if ($fieldConfig['assetsAllowed']) {
+                $types[] = 'asset';
+                foreach ($fieldConfig['assetTypes'] as $assetTypes) {
+                    $subtypes[] = $assetTypes['assetTypes'];
+                }
+            }
+            if ($fieldConfig['objectsAllowed']) {
+                $types[] = 'object';
+                $subtypes[] = 'object';
+                $subtypes[] = 'variant';
+            }
+            $searchRequest->request->set('type', implode(',', $types));
+            $searchRequest->request->set('subtype', implode(',', $subtypes));
+        } else {
+            $searchRequest->request->set('type', 'object');
+            $searchRequest->request->set('subtype', 'object,variant');
+        }
         $searchRequest->request->set('class', implode(',', $classes));
         $searchRequest->request->set('fields', $visibleFields);
 


### PR DESCRIPTION
## Steps to reproduce

1. Create a manyToOneRelation field with:
1.1. display mode "Inline search"
1.2. document allowed
1.2. newsletter document type allowed
2. Create an object with this field
3. The fields only shows data objects from all classes

