### PR TITLE
[Bug] Geopoint/Gebounds access data array directly without check

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Geobounds.php
+++ b/models/DataObject/ClassDefinition/Data/Geobounds.php
@@ -78,7 +78,11 @@ class Geobounds extends AbstractGeo implements
      */
     public function getDataFromResource(mixed $data, DataObject\Concrete $object = null, array $params = []): ?DataObject\Data\Geobounds
     {
-        if ($data[$this->getName() . '__NElongitude'] && $data[$this->getName() . '__NElatitude'] && $data[$this->getName() . '__SWlongitude'] && $data[$this->getName() . '__SWlatitude']) {
+        if (is_array($data) &&
+            $data[$this->getName() . '__NElongitude'] &&
+            $data[$this->getName() . '__NElatitude'] &&
+            $data[$this->getName() . '__SWlongitude'] && $data[$this->getName() . '__SWlatitude']
+        ) {
             $ne = new DataObject\Data\GeoCoordinates($data[$this->getName() . '__NElatitude'], $data[$this->getName() . '__NElongitude']);
             $sw = new DataObject\Data\GeoCoordinates($data[$this->getName() . '__SWlatitude'], $data[$this->getName() . '__SWlongitude']);
 

--- a/models/DataObject/ClassDefinition/Data/Geopoint.php
+++ b/models/DataObject/ClassDefinition/Data/Geopoint.php
@@ -58,7 +58,10 @@ class Geopoint extends AbstractGeo implements
      */
     public function getDataFromResource(mixed $data, Concrete $object = null, array $params = []): ?DataObject\Data\GeoCoordinates
     {
-        if ($data[$this->getName() . '__longitude'] && $data[$this->getName() . '__latitude']) {
+        if (is_array($data) &&
+            $data[$this->getName() . '__longitude'] &&
+            $data[$this->getName() . '__latitude']
+        ) {
             $geopoint = new DataObject\Data\GeoCoordinates($data[$this->getName() . '__latitude'], $data[$this->getName() . '__longitude']);
 
             if (isset($params['owner'])) {


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Added a check to prevent an array offset error. 
Can happen in combination with Pimcore Copilot, when creating variants.


