### PR TITLE
[Bug] Add object as fallback if no version is available

### DIFF
--- a/bundles/CoreBundle/src/EventListener/Frontend/ElementListener.php
+++ b/bundles/CoreBundle/src/EventListener/Frontend/ElementListener.php
@@ -260,7 +260,6 @@ class ElementListener implements EventSubscriberInterface, LoggerAwareInterface
 
     private function getLatestVersion(int $id, UserInterface $user): ?Concrete
     {
-        /** @var Concrete|null $dataObject */
         $dataObject = Service::getElementById('object', $id);
 
         if (!$dataObject instanceof Concrete) {

--- a/bundles/CoreBundle/src/EventListener/Frontend/ElementListener.php
+++ b/bundles/CoreBundle/src/EventListener/Frontend/ElementListener.php
@@ -260,6 +260,7 @@ class ElementListener implements EventSubscriberInterface, LoggerAwareInterface
 
     private function getLatestVersion(int $id, UserInterface $user): ?Concrete
     {
+        /** @var Concrete|null $dataObject */
         $dataObject = Service::getElementById('object', $id);
 
         if ($dataObject === null) {
@@ -269,7 +270,7 @@ class ElementListener implements EventSubscriberInterface, LoggerAwareInterface
         $version = $dataObject->getLatestVersion($user->getId());
 
         if ($version === null || !$version->getData() instanceof Concrete) {
-            return null;
+            return $dataObject;
         }
 
         return $version->getData();

--- a/bundles/CoreBundle/src/EventListener/Frontend/ElementListener.php
+++ b/bundles/CoreBundle/src/EventListener/Frontend/ElementListener.php
@@ -263,7 +263,7 @@ class ElementListener implements EventSubscriberInterface, LoggerAwareInterface
         /** @var Concrete|null $dataObject */
         $dataObject = Service::getElementById('object', $id);
 
-        if ($dataObject === null) {
+        if (!$dataObject instanceof Concrete) {
             return null;
         }
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #18080 

## Additional info
Use dataobject as fallback if no version is available
