### PR TITLE
[Docs] Describe how to set workflow permissions for Pimcore roles

### DIFF
--- a/doc/07_Workflow_Management/01_Configuration_Details/README.md
+++ b/doc/07_Workflow_Management/01_Configuration_Details/README.md
@@ -70,10 +70,14 @@ pimcore:
                         label:               close product
                         permissions:
                             -
-                                condition:           is_fully_authenticated() and 'ROLE_PIMCORE_ADMIN' in role_names
-                                modify:
+                                condition: is_fully_authenticated() and 'ROLE_PIMCORE_ADMIN' in role_names
+                                modify: true
+                            # for Pimcore roles use ROLE_<role name in uppercase>
+                            -   
+                                condition: is_fully_authenticated() and 'ROLE_PIMCORE_EDITOR' in role_names
+                                modify: true
                             -
-                                modify:
+                                modify: false
                                 objectLayout:        2
 
                 # Prototype

--- a/doc/07_Workflow_Management/04_Permissions.md
+++ b/doc/07_Workflow_Management/04_Permissions.md
@@ -38,3 +38,5 @@ will be hidden. `modify` is a short hand for save, publish, unpublish, delete an
 > If multiple places provide a valid permission configuration the one with the highest priority will be used. 
 > The priority is based on the workflow priority (the workflow with the higher priority setting will win). Within a 
 > single workflow the order within the places section of the configuration file will be used.
+
+For conditions to other roles than admin users, use `ROLE_<role name in uppercase>`, e.g. `ROLE_EDITOR` for a role named "Editor".


### PR DESCRIPTION
Describe that `ROLE_<role name in uppercase>` has to be used as guard / permission condition, see https://github.com/pimcore/pimcore/blob/a279c030daf6b261487a7167c97e465ea5f00afa/lib/Security/User/User.php#L57-L67