### PR TITLE
Use `buildUser` method to create user for better adaptability

### DIFF
--- a/lib/Security/User/UserProvider.php
+++ b/lib/Security/User/UserProvider.php
@@ -28,7 +28,7 @@ class UserProvider implements UserProviderInterface
         $pimcoreUser = PimcoreUser::getByName($identifier);
 
         if ($pimcoreUser) {
-            return new User($pimcoreUser);
+            return $this->buildUser($pimcoreUser);
         }
 
         throw new UserNotFoundException(sprintf('User %s was not found', $identifier));


### PR DESCRIPTION
## Changes in this pull request  
In the `UserProvider` there's a protected `buildUser` method. Instead of making a hard instantiation of the `User` object in `loadUserByIdentifier`, the method should call this `buildUser` method to make the whole `UserProvider` more extensible.