### PR TITLE
Pass the transition itself into notification service rather than the transition label.

### DIFF
--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -40,7 +40,7 @@
 
 #### [Workflow]
 - Method `getWorkflowByName()` now returns `?WorkflowInterface` instead of `?object`. This also affected the `lib/Workflow/Notification/NotificationEmailService.php` and `lib/Workflow/Notification/PimcoreNotificationService.php`.
-- Methods `sendPimcoreNotification` and `sendWorkflowEmailNotification` in `lib/Workflow/Notification/NotificationEmailService.php` and `lib/Workflow/Notification/PimcoreNotificationService.php` now accept the `Transition` object itself, rather than the `string` label.
+- Methods `sendPimcoreNotification` and `sendWorkflowEmailNotification` in `lib/Workflow/Notification/NotificationEmailService.php` and `lib/Workflow/Notification/PimcoreNotificationService.php` now accept the `Transition` itself, rather than the `string` label.
 
 ## Pimcore 11.6.0
 ### Elements

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -40,6 +40,7 @@
 
 #### [Workflow]
 - Method `getWorkflowByName()` now returns `?WorkflowInterface` instead of `?object`. This also affected the `lib/Workflow/Notification/NotificationEmailService.php` and `lib/Workflow/Notification/PimcoreNotificationService.php`.
+- Methods `sendPimcoreNotification` and `sendWorkflowEmailNotification` in `lib/Workflow/Notification/NotificationEmailService.php` and `lib/Workflow/Notification/PimcoreNotificationService.php` now accept the `Transition` object itself, rather than the `string` label.
 
 ## Pimcore 11.6.0
 ### Elements

--- a/lib/Workflow/EventSubscriber/NotificationSubscriber.php
+++ b/lib/Workflow/EventSubscriber/NotificationSubscriber.php
@@ -142,7 +142,7 @@ class NotificationSubscriber implements EventSubscriberInterface
             $workflow,
             $subjectType,
             $subject,
-            $transition->getLabel(),
+            $transition,
             $mailType,
             $mailPath
         );
@@ -162,7 +162,7 @@ class NotificationSubscriber implements EventSubscriberInterface
             $workflow,
             $subjectType,
             $subject,
-            $transition->getLabel()
+            $transition
         );
     }
 

--- a/lib/Workflow/Notification/NotificationEmailService.php
+++ b/lib/Workflow/Notification/NotificationEmailService.php
@@ -29,6 +29,7 @@ use Pimcore\Workflow\EventSubscriber\NotificationSubscriber;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Templating\EngineInterface;
 use Symfony\Component\Workflow\WorkflowInterface;
+use Pimcore\Workflow\Transition;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -59,7 +60,7 @@ class NotificationEmailService extends AbstractNotificationService
         WorkflowInterface $workflow,
         string $subjectType,
         ElementInterface $subject,
-        string $action,
+        Transition $transition,
         string $mailType,
         string $mailPath
     ): void {
@@ -98,7 +99,7 @@ class NotificationEmailService extends AbstractNotificationService
                             $subjectType,
                             $subject,
                             $workflow,
-                            $action,
+                            $transition->getLabel(),
                             $language,
                             $localizedMailPath,
                             $deeplink
@@ -113,7 +114,7 @@ class NotificationEmailService extends AbstractNotificationService
                             $subjectType,
                             $subject,
                             $workflow,
-                            $action,
+                            $transition->getLabel(),
                             $language,
                             $localizedMailPath,
                             $deeplink

--- a/lib/Workflow/Notification/PimcoreNotificationService.php
+++ b/lib/Workflow/Notification/PimcoreNotificationService.php
@@ -21,6 +21,7 @@ use Pimcore\Logger;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Notification\Service\NotificationService;
 use Symfony\Component\Workflow\WorkflowInterface;
+use Pimcore\Workflow\Transition;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class PimcoreNotificationService extends AbstractNotificationService
@@ -45,7 +46,7 @@ class PimcoreNotificationService extends AbstractNotificationService
         WorkflowInterface $workflow,
         string $subjectType,
         ElementInterface $subject,
-        string $action
+        Transition $transition
     ): void {
         try {
             $recipients = $this->getNotificationUsersByName($users, $roles, true);
@@ -65,7 +66,7 @@ class PimcoreNotificationService extends AbstractNotificationService
                     [
                         $subjectType . ' ' . $subject->getFullPath(),
                         $subject->getId(),
-                        $this->translator->trans($action, [], 'admin', $language),
+                        $this->translator->trans($transition->getLabel(), [], 'admin', $language),
                         $this->translator->trans($workflow->getName(), [], 'admin', $language),
                     ],
                     'admin',


### PR DESCRIPTION


<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  

This PR:
* Make parameter passing between workflow and transition consistent (pass object vs string)
* Allows filtering based on it rather than label (see #18089)

## Changes in this pull request  
Continuing conversation from https://github.com/pimcore/pimcore/pull/18067#discussion_r1945188903 and better for https://github.com/pimcore/pimcore/pull/18089


## Additional info
/CC @kingjia90 @MartaMarija
