### PR TITLE
[Task] Remove the deprecated method Image::getThumbnailConfig()

### DIFF
--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -3,7 +3,9 @@
 ## Pimcore 12.0.0
 #### [Documents]
 - Date Editable: Removed deprecated outputFormat config. Use outputIsoFormat config instead.
-- 
+
+#### [DataObjects]
+- Removed deprecated `getThumbnailConfig()` method from `Pimcore\Model\Asset\Image`.
 
 ## Pimcore 11.6.0
 ### Elements

--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -162,28 +162,6 @@ EOT;
     }
 
     /**
-     * Legacy method for backwards compatibility. Use getThumbnail($config)->getConfig() instead.
-     *
-     * @internal
-     *
-     * @deprecated Will be removed in Pimcore 12
-     */
-    public function getThumbnailConfig(array|string|Image\Thumbnail\Config|null $config): ?Image\Thumbnail\Config
-    {
-        trigger_deprecation(
-            'pimcore/pimcore',
-            '11.1',
-            'Using "%s" is deprecated and will be removed in Pimcore 12, use "%s" instead.',
-            __METHOD__,
-            'getThumbnail($config)->getConfig()'
-        );
-
-        $thumbnail = $this->getThumbnail($config);
-
-        return $thumbnail->getConfig();
-    }
-
-    /**
      * Returns a path to a given thumbnail or a thumbnail configuration.
      */
     public function getThumbnail(array|string|Image\Thumbnail\Config|null $config = null, bool $deferred = true): Image\ThumbnailInterface


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #15995 

## Additional info
Removed deprecated internal method