### PR TITLE
Additional info for event in getPath() and improving addCacheBuster() method in Thumbnail.php

### DIFF
--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -163,17 +163,13 @@ final class Thumbnail implements ThumbnailInterface
 
     private function addCacheBuster(string $path, array $options, Asset $asset): string
     {
-        if (isset($options['cacheBuster']) && $options['cacheBuster']) {
-             if (
-            isset($options['cacheBuster']) && 
-            $options['cacheBuster'] && 
-            !str_starts_with($path, 'http') && 
+        if (
+            isset($options['cacheBuster']) &&
+            $options['cacheBuster'] &&
+            !str_starts_with($path, 'http') &&
             !str_starts_with($path, '/cache-buster-')
         ) {
             $path = '/cache-buster-' . $asset->getVersionCount() . $path;
-        }
-                $path = '/cache-buster-' . $asset->getVersionCount() . $path;
-            }
         }
 
         return $path;

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -164,7 +164,14 @@ final class Thumbnail implements ThumbnailInterface
     private function addCacheBuster(string $path, array $options, Asset $asset): string
     {
         if (isset($options['cacheBuster']) && $options['cacheBuster']) {
-            if (!str_starts_with($path, 'http') && !str_starts_with($path, '/cache-buster-')) {
+             if (
+            isset($options['cacheBuster']) && 
+            $options['cacheBuster'] && 
+            !str_starts_with($path, 'http') && 
+            !str_starts_with($path, '/cache-buster-')
+        ) {
+            $path = '/cache-buster-' . $asset->getVersionCount() . $path;
+        }
                 $path = '/cache-buster-' . $asset->getVersionCount() . $path;
             }
         }

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -83,6 +83,8 @@ final class Thumbnail implements ThumbnailInterface
             $event = new GenericEvent($this, [
                 'pathReference' => $pathReference,
                 'frontendPath' => $path,
+                'asset' => $this->getAsset(),
+                'config' => $this->getConfig(),
             ]);
             Pimcore::getEventDispatcher()->dispatch($event, FrontendEvents::ASSET_IMAGE_THUMBNAIL);
             $path = $event->getArgument('frontendPath');
@@ -162,7 +164,7 @@ final class Thumbnail implements ThumbnailInterface
     private function addCacheBuster(string $path, array $options, Asset $asset): string
     {
         if (isset($options['cacheBuster']) && $options['cacheBuster']) {
-            if (!str_starts_with($path, 'http')) {
+            if (!str_starts_with($path, 'http') && !str_starts_with($path, '/cache-buster-')) {
                 $path = '/cache-buster-' . $asset->getVersionCount() . $path;
             }
         }


### PR DESCRIPTION
## Changes in this pull request  
Adds relevant info to the event which is dispatched in the `getPath()` method.

Additionally only add cache bust path in `addCacheBuster()`, if its not already set.

## Additional info

Useful when dealing with CDNs and custom implementations.