### PR TITLE
[Reports] Chart: sum-up y-axis values for same x-axis value

### DIFF
--- a/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
+++ b/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
@@ -375,7 +375,7 @@ class CustomReportController extends UserAwareController
         $groupedResult = [];
         foreach ($result['data'] as $record) {
             $xAxisValue = $record[$config->getXAxis()];
-            if (isset($resultEnhanced[$xAxisValue])) {
+            if (isset($groupedResult[$xAxisValue])) {
                 foreach ($config->getYAxis() as $yAxisField) {
                     $groupedResult[$xAxisValue][$yAxisField] += $record[$yAxisField];
                 }

--- a/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
+++ b/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
@@ -371,10 +371,23 @@ class CustomReportController extends UserAwareController
         $sortFilters = $this->getSortAndFilters($request, $configuration);
         $result = $adapter->getData($sortFilters['filters'], $sortFilters['sort'], $sortFilters['dir'], null, null, null, $sortFilters['drillDownFilters']);
 
+        // sum up values for same x-axis values
+        $groupedResult = [];
+        foreach ($result['data'] as $record) {
+            $xAxisValue = $record[$config->getXAxis()];
+            if (isset($resultEnhanced[$xAxisValue])) {
+                foreach ($config->getYAxis() as $yAxisField) {
+                    $groupedResult[$xAxisValue][$yAxisField] += $record[$yAxisField];
+                }
+            } else {
+                $groupedResult[$xAxisValue] = $record;
+            }
+        }
+
         return $this->jsonResponse([
             'success' => true,
-            'data' => $result['data'],
-            'total' => $result['total'],
+            'data' => array_values($groupedResult),
+            'total' => count($groupedResult),
         ]);
     }
 

--- a/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
+++ b/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
@@ -375,7 +375,7 @@ class CustomReportController extends UserAwareController
         $groupedResult = [];
         foreach ($result['data'] as $record) {
             $xAxisValue = $record[$config->getXAxis()];
-            if (isset($groupedResult[$xAxisValue])) {
+            if (isset($groupedResult[$xAxisValue]) && is_array($config->getYAxis())) {
                 foreach ($config->getYAxis() as $yAxisField) {
                     $groupedResult[$xAxisValue][$yAxisField] += $record[$yAxisField];
                 }

--- a/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
+++ b/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
@@ -373,10 +373,14 @@ class CustomReportController extends UserAwareController
 
         // sum up values for same x-axis values
         $groupedResult = [];
+        $xAxis = $config->getXAxis();
+        $yAxes = $config->getYAxis();
+        
         foreach ($result['data'] as $record) {
-            $xAxisValue = $record[$config->getXAxis()];
-            if (isset($groupedResult[$xAxisValue]) && is_array($config->getYAxis())) {
-                foreach ($config->getYAxis() as $yAxisField) {
+            $xAxisValue = $record[$xAxis];
+        
+            if (isset($groupedResult[$xAxisValue]) && is_array($yAxes)) {
+                foreach ($yAxes as $yAxisField) {
                     $groupedResult[$xAxisValue][$yAxisField] += $record[$yAxisField];
                 }
             } else {


### PR DESCRIPTION
Imagine you have some product orders as data objects:
| Date       | Total Net |
|------------|-------|
| 2025-01-01 | 10    |
| 2025-01-01 | 20    |
| 2025-01-02 | 5     |
| 2025-01-03 | 123   |

And you want to create a report including a bar chart with the summed-up totals of all orders from this day.

The SQL query is
`SELECT DATE_FORMAT(o_creationDate, '%Y-%m-%d') AS creationDate, total__value
FROM object_Order`

But the chart is a bit more complicated.
You can configure x-axis to `date` and y-axis to `total` but this will not give you the desired result:
<img width="1669" alt="Bildschirmfoto 2025-02-19 um 15 45 13" src="https://github.com/user-attachments/assets/09e8f180-9b28-4b0d-9d76-49b14072b5ea" />
The problem is that the totals for orders from the same day do not get summed up.
This PR changes this, now all the totals from the same day get summed up:
<img width="1684" alt="Bildschirmfoto 2025-02-19 um 16 24 09" src="https://github.com/user-attachments/assets/bcbec37c-db15-4747-ae99-51e587da9787" />
