### PR TITLE
[Bug]: Fix regression, `else` part is unreachable on validlanguages as null

### DIFF
--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -1643,7 +1643,8 @@ class Service extends Model\Element\Service
 
         foreach ($fields as $field) {
             $key = $field['key'];
-            if (static::isHelperGridColumnConfig($key) && $validLanguages = static::expandGridColumnForExport($helperDefinitions, $key)) {
+            $validLanguages = static::expandGridColumnForExport($helperDefinitions, $key);
+            if (static::isHelperGridColumnConfig($key) && $validLanguages) {
                 $mappedFieldnameBase = self::mapFieldname($field, $helperDefinitions, $header);
 
                 foreach ($validLanguages as $validLanguage) {

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -1643,8 +1643,7 @@ class Service extends Model\Element\Service
 
         foreach ($fields as $field) {
             $key = $field['key'];
-            if (static::isHelperGridColumnConfig($key)) {
-                $validLanguages = static::expandGridColumnForExport($helperDefinitions, $key) ?? [];
+            if (static::isHelperGridColumnConfig($key) && $validLanguages = static::expandGridColumnForExport($helperDefinitions, $key)) {
                 $mappedFieldnameBase = self::mapFieldname($field, $helperDefinitions, $header);
 
                 foreach ($validLanguages as $validLanguage) {


### PR DESCRIPTION

## Changes in this pull request  
Resolves https://pimcore.atlassian.net/browse/PEES-515
Regression from https://github.com/pimcore/pimcore/pull/18033

## Additional info
