### PR TITLE
Fix MaintenancePageListener docs

### DIFF
--- a/doc/20_Extending_Pimcore/15_Maintenance_Mode.md
+++ b/doc/20_Extending_Pimcore/15_Maintenance_Mode.md
@@ -23,7 +23,7 @@ Pimcore\Bundle\CoreBundle\EventListener\MaintenancePageListener:
     calls:
         - [loadTemplateFromResource, ['@@App/Resources/misc/maintenance.html']]
     tags:
-        - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 620 }
+        - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 127 }
 ```
 
 Use loadTemplateFromPath if the file is located outside a bundle.
@@ -33,5 +33,5 @@ Pimcore\Bundle\CoreBundle\EventListener\MaintenancePageListener:
     calls:
         - [loadTemplateFromPath, ['/templates/maintenance.html']]
     tags:
-        - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 620 }
+        - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 127 }
 ```

--- a/doc/20_Extending_Pimcore/15_Maintenance_Mode.md
+++ b/doc/20_Extending_Pimcore/15_Maintenance_Mode.md
@@ -22,8 +22,6 @@ Overwrite the service `Pimcore\Bundle\CoreBundle\EventListener\MaintenancePageLi
 Pimcore\Bundle\CoreBundle\EventListener\MaintenancePageListener:
     calls:
         - [loadTemplateFromResource, ['@@App/Resources/misc/maintenance.html']]
-    tags:
-        - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 127 }
 ```
 
 Use loadTemplateFromPath if the file is located outside a bundle.
@@ -32,6 +30,4 @@ Use loadTemplateFromPath if the file is located outside a bundle.
 Pimcore\Bundle\CoreBundle\EventListener\MaintenancePageListener:
     calls:
         - [loadTemplateFromPath, ['/templates/maintenance.html']]
-    tags:
-        - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 127 }
 ```


### PR DESCRIPTION
## Changes in this pull request  

See discussion: https://github.com/orgs/pimcore/discussions/16602

I assumed the correct priority would be just before the subscriber `pimcore/pimcore/bundles/CoreBundle/src/EventListener/MaintenancePageListener.php` which has a priority of 126, the old value 620 apparently does not work anymore.
