### PR TITLE
#18100 Add password check to `isEqualTo` method of User class

### DIFF
--- a/lib/Security/User/User.php
+++ b/lib/Security/User/User.php
@@ -82,19 +82,9 @@ class User implements UserInterface, EquatableInterface, GoogleTwoFactorInterfac
 
     public function isEqualTo(UserInterface $user): bool
     {
-        if (!$user instanceof self) {
-            return false;
-        }
-
-        if ($this->getId() !== $user->getId()) {
-            return false;
-        }
-
-        if ($this->getPassword() !== $user->getPassword()) {
-            return false;
-        }
-
-        return true;
+        return $user instanceof self
+            && $user->getId() === $this->getId()
+            && $user->getPassword() === $this->getPassword();
     }
 
     /**

--- a/lib/Security/User/User.php
+++ b/lib/Security/User/User.php
@@ -82,7 +82,19 @@ class User implements UserInterface, EquatableInterface, GoogleTwoFactorInterfac
 
     public function isEqualTo(UserInterface $user): bool
     {
-        return $user instanceof self && $user->getId() === $this->getId() && $user->getPassword() === $this->getPassword();
+        if (!$user instanceof self) {
+            return false;
+        }
+
+        if ($this->getId() !== $user->getId()) {
+            return false;
+        }
+
+        if ($this->getPassword() !== $user->getPassword()) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/lib/Security/User/User.php
+++ b/lib/Security/User/User.php
@@ -82,7 +82,7 @@ class User implements UserInterface, EquatableInterface, GoogleTwoFactorInterfac
 
     public function isEqualTo(UserInterface $user): bool
     {
-        return $user instanceof self && $user->getId() === $this->getId();
+        return $user instanceof self && $user->getId() === $this->getId() && $user->getPassword() === $this->getPassword();
     }
 
     /**


### PR DESCRIPTION
## Changes in this pull request  
Resolves #18100 

## Additional info
This PR adds an additional password check to make sure that other sessions get terminated, when the user is being loaded from the session and meanwhile the password has been changed from another session.