### PR TITLE
[GenericExecutionEngine] Support environment variable replacement for config values to handle nested arrays

### DIFF
--- a/bundles/GenericExecutionEngineBundle/src/Messenger/Handler/AbstractAutomationActionHandler.php
+++ b/bundles/GenericExecutionEngineBundle/src/Messenger/Handler/AbstractAutomationActionHandler.php
@@ -188,14 +188,31 @@ abstract class AbstractAutomationActionHandler
         }
 
         $value = $config[$key];
-        if (is_string($value)) {
-            $value = $this->replaceConfigValueWithEnvVariable(
-                $value,
+
+        return $this->recursivelyReplaceConfigValuesWithEnvVariables($message, $value);
+    }
+
+    protected function recursivelyReplaceConfigValuesWithEnvVariables(
+        GenericExecutionEngineMessageInterface $message,
+        mixed $configValue
+    ): mixed {
+
+        if (is_string($configValue)) {
+            return $this->replaceConfigValueWithEnvVariable(
+                $configValue,
                 $this->getEnvironmentVariables($message)
             );
         }
 
-        return $value;
+        if(is_array($configValue)) {
+            $replacedValue = [];
+            foreach($configValue as $key => $value) {
+                $replacedValue[$key] = $this->recursivelyReplaceConfigValuesWithEnvVariables($message, $value);
+            }
+            return $replacedValue;
+        }
+
+        return $configValue;
     }
 
     protected function updateJobRunContext(

--- a/bundles/GenericExecutionEngineBundle/src/Messenger/Handler/AbstractAutomationActionHandler.php
+++ b/bundles/GenericExecutionEngineBundle/src/Messenger/Handler/AbstractAutomationActionHandler.php
@@ -204,11 +204,12 @@ abstract class AbstractAutomationActionHandler
             );
         }
 
-        if(is_array($configValue)) {
+        if (is_array($configValue)) {
             $replacedValue = [];
-            foreach($configValue as $key => $value) {
+            foreach ($configValue as $key => $value) {
                 $replacedValue[$key] = $this->recursivelyReplaceConfigValuesWithEnvVariables($message, $value);
             }
+
             return $replacedValue;
         }
 


### PR DESCRIPTION
followup to https://github.com/pimcore/pimcore/pull/17460

to also allow configurations like: 

```
recipients:
    - job_env('recipient')
```