### PR TITLE
[Improvement] Consistently use symfony/mime to get MIME type of assets

### DIFF
--- a/lib/Helper/MimeTypeHelper.php
+++ b/lib/Helper/MimeTypeHelper.php
@@ -22,8 +22,9 @@ use Symfony\Component\Mime\MimeTypes;
 
 final class MimeTypeHelper implements MimeTypeHelperInterface
 {
+
     /**
-     * @var $file resource|string
+     * @param string|resource $file
      */
     public function guessMimeType(mixed $file): ?string
     {

--- a/lib/Helper/MimeTypeHelper.php
+++ b/lib/Helper/MimeTypeHelper.php
@@ -27,9 +27,12 @@ final class MimeTypeHelper implements MimeTypeHelperInterface
         return MimeTypes::getDefault()->guessMimeType($filePath);
     }
 
+    /**
+     * @var resource $stream
+    */
     public static function guessMimeTypeFromStream(mixed $stream): ?string
     {
-        $fpPosition = 0;
+        $fpPosition = false;
 
         if (!is_resource($stream) || get_resource_type($stream) !== 'stream') {
             throw new InvalidArgumentException('The provided stream is not a valid stream resource.');
@@ -41,7 +44,7 @@ final class MimeTypeHelper implements MimeTypeHelperInterface
             fseek($stream, 0);
         }
 
-        $magicBytes = fread($stream, 1024);
+        $bytes = fread($stream, 1024);
 
         if($seekable &&
             $fpPosition !== false
@@ -50,7 +53,7 @@ final class MimeTypeHelper implements MimeTypeHelperInterface
         }
 
         $fileInfo = new finfo(FILEINFO_MIME_TYPE);
-        $mimeType = $fileInfo->buffer($magicBytes);
+        $mimeType = $fileInfo->buffer($bytes);
 
         return $mimeType === false ? null : $mimeType;
     }

--- a/lib/Helper/MimeTypeHelper.php
+++ b/lib/Helper/MimeTypeHelper.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Helper;
+
+use finfo;
+use InvalidArgumentException;
+use Symfony\Component\Mime\MimeTypes;
+
+final class MimeTypeHelper implements MimeTypeHelperInterface
+{
+    public static function guessMimeTypeFromFile(string $filePath): ?string
+    {
+        return MimeTypes::getDefault()->guessMimeType($filePath);
+    }
+
+    public static function guessMimeTypeFromStream(mixed $stream): ?string
+    {
+        $fpPosition = 0;
+
+        if (!is_resource($stream) || get_resource_type($stream) !== 'stream') {
+            throw new InvalidArgumentException('The provided stream is not a valid stream resource.');
+        }
+
+        $seekable = stream_get_meta_data($stream)['seekable'] ?? false;
+        if($seekable) {
+            $fpPosition = ftell($stream);
+            fseek($stream, 0);
+        }
+
+        $magicBytes = fread($stream, 1024);
+
+        if($seekable &&
+            $fpPosition !== false
+        ) {
+            fseek($stream, $fpPosition);
+        }
+
+        $fileInfo = new finfo(FILEINFO_MIME_TYPE);
+        $mimeType = $fileInfo->buffer($magicBytes);
+
+        return $mimeType === false ? null : $mimeType;
+    }
+}

--- a/lib/Helper/MimeTypeHelper.php
+++ b/lib/Helper/MimeTypeHelper.php
@@ -27,9 +27,6 @@ final class MimeTypeHelper implements MimeTypeHelperInterface
         return MimeTypes::getDefault()->guessMimeType($filePath);
     }
 
-    /**
-     * @var resource $stream
-    */
     public static function guessMimeTypeFromStream(mixed $stream): ?string
     {
         $fpPosition = false;
@@ -38,7 +35,7 @@ final class MimeTypeHelper implements MimeTypeHelperInterface
             throw new InvalidArgumentException('The provided stream is not a valid stream resource.');
         }
 
-        $seekable = stream_get_meta_data($stream)['seekable'] ?? false;
+        $seekable = stream_get_meta_data($stream)['seekable'];
         if($seekable) {
             $fpPosition = ftell($stream);
             fseek($stream, 0);

--- a/lib/Helper/MimeTypeHelper.php
+++ b/lib/Helper/MimeTypeHelper.php
@@ -22,12 +22,28 @@ use Symfony\Component\Mime\MimeTypes;
 
 final class MimeTypeHelper implements MimeTypeHelperInterface
 {
-    public static function guessMimeTypeFromFile(string $filePath): ?string
+    /**
+     * @var $file resource|string
+     */
+    public function guessMimeType(mixed $file): ?string
+    {
+        if (is_string($file)) {
+            return $this->guessMimeTypeFromFile($file);
+        }
+
+        if (is_resource($file) && get_resource_type($file) === 'stream') {
+            return $this->guessMimeTypeFromStream($file);
+        }
+
+        throw new InvalidArgumentException('The provided file must be a string or a stream resource.');
+    }
+
+    private function guessMimeTypeFromFile(string $filePath): ?string
     {
         return MimeTypes::getDefault()->guessMimeType($filePath);
     }
 
-    public static function guessMimeTypeFromStream(mixed $stream): ?string
+    private function guessMimeTypeFromStream(mixed $stream): ?string
     {
         $fpPosition = false;
 

--- a/lib/Helper/MimeTypeHelperInterface.php
+++ b/lib/Helper/MimeTypeHelperInterface.php
@@ -17,16 +17,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Helper;
 
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Request;
-
-/** @internal  */
 interface MimeTypeHelperInterface
 {
-    public static function guessMimeTypeFromFile(string $filePath): ?string;
-
-    /**
-     * @param resource $stream
-     */
-    public static function guessMimeTypeFromStream(mixed $stream): ?string;
+    public function guessMimeType(mixed $file): ?string;
 }

--- a/lib/Helper/MimeTypeHelperInterface.php
+++ b/lib/Helper/MimeTypeHelperInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Helper;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/** @internal  */
+interface MimeTypeHelperInterface
+{
+    public static function guessMimeTypeFromFile(string $filePath): ?string;
+
+    /**
+     * @param resource $stream
+     */
+    public static function guessMimeTypeFromStream(mixed $stream): ?string;
+}

--- a/lib/Twig/Extension/HelpersExtension.php
+++ b/lib/Twig/Extension/HelpersExtension.php
@@ -108,7 +108,7 @@ class HelpersExtension extends AbstractExtension
     public function getAssetVersionPreview(string $file): string
     {
         $dataUri = 'data:'
-            .MimeTypeHelper::guessMimeTypeFromFile($file)
+            .(new MimeTypeHelper())->guessMimeType($file)
             .';base64,'
             .base64_encode(
                 file_get_contents($file)

--- a/lib/Twig/Extension/HelpersExtension.php
+++ b/lib/Twig/Extension/HelpersExtension.php
@@ -19,6 +19,7 @@ namespace Pimcore\Twig\Extension;
 
 use Exception;
 use Pimcore\Document;
+use Pimcore\Helper\MimeTypeHelper;
 use Pimcore\Twig\Extension\Templating\PimcoreUrl;
 use Pimcore\Video;
 use Symfony\Component\Mime\MimeTypes;
@@ -106,7 +107,7 @@ class HelpersExtension extends AbstractExtension
      */
     public function getAssetVersionPreview(string $file): string
     {
-        $dataUri = 'data:'.MimeTypes::getDefault()->guessMimeType($file).';base64,'.base64_encode(file_get_contents($file));
+        $dataUri = 'data:'.MimeTypeHelper::guessMimeTypeFromFile($file).';base64,'.base64_encode(file_get_contents($file));
         unlink($file);
 
         return $dataUri;

--- a/lib/Twig/Extension/HelpersExtension.php
+++ b/lib/Twig/Extension/HelpersExtension.php
@@ -107,7 +107,14 @@ class HelpersExtension extends AbstractExtension
      */
     public function getAssetVersionPreview(string $file): string
     {
-        $dataUri = 'data:'.MimeTypeHelper::guessMimeTypeFromFile($file).';base64,'.base64_encode(file_get_contents($file));
+        $dataUri = 'data:'
+            .MimeTypeHelper::guessMimeTypeFromFile($file)
+            .';base64,'
+            .base64_encode(
+                file_get_contents($file)
+            );
+
+
         unlink($file);
 
         return $dataUri;

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -31,6 +31,7 @@ use Pimcore\Event\AssetEvents;
 use Pimcore\Event\FrontendEvents;
 use Pimcore\Event\Model\AssetEvent;
 use Pimcore\File;
+use Pimcore\Helper\MimeTypeHelper;
 use Pimcore\Helper\TemporaryFileHelperTrait;
 use Pimcore\Loader\ImplementationLoader\Exception\UnsupportedException;
 use Pimcore\Localization\LocaleServiceInterface;
@@ -349,14 +350,15 @@ class Asset extends Element\AbstractElement
                         }
                     }
                 }
-                $mimeType = MimeTypes::getDefault()->guessMimeType($mimeTypeGuessData);
+                //TODO can probably improved by using the stream directly
+                $mimeType = MimeTypeHelper::guessMimeTypeFromFile($mimeTypeGuessData);
             } else {
                 if (!is_dir($data['sourcePath'])) {
                     $mimeTypeGuessData = $data['sourcePath'];
                     if (is_file($data['sourcePath'])) {
                         $data['stream'] = fopen($data['sourcePath'], 'rb', false, File::getContext());
                     }
-                    $mimeType = MimeTypes::getDefault()->guessMimeType($mimeTypeGuessData);
+                    $mimeType = MimeTypeHelper::guessMimeTypeFromFile($mimeTypeGuessData);
                 }
                 unset($data['sourcePath']);
             }
@@ -726,14 +728,12 @@ class Asset extends Element\AbstractElement
                     $storage->delete($dbPath);
                 }
 
-                $this->closeStream(); // set stream to null, so that the source stream isn't used anymore after saving
-
-                try {
-                    $mimeType = $storage->mimeType($path);
-                } catch (UnableToRetrieveMetadata $e) {
-                    $mimeType = 'application/octet-stream';
+                if (!is_resource($src)) {
+                    $src = $this->getStream();
                 }
+                $mimeType = MimeTypeHelper::guessMimeTypeFromStream($src);
                 $this->setMimeType($mimeType);
+                $this->closeStream(); // set stream to null, so that the source stream isn't used anymore after saving
 
                 // set type
                 $type = self::getTypeFromMimeMapping($mimeType, $this->getFilename());

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -317,6 +317,7 @@ class Asset extends Element\AbstractElement
                 array_key_exists('stream', $data)
             )
         ) {
+            $mimeTypeHelper = new MimeTypeHelper();
             $mimeType = 'directory';
             $mimeTypeGuessData = null;
             if (array_key_exists('data', $data) || array_key_exists('stream', $data)) {
@@ -333,7 +334,7 @@ class Asset extends Element\AbstractElement
                 } else {
                     // guess mime type from stream directly
                     $mimeTypeGuessData = $data['stream'];
-                    $mimeType = MimeTypeHelper::guessMimeTypeFromStream(
+                    $mimeType = $mimeTypeHelper->guessMimeType(
                         $mimeTypeGuessData
                     );
                 }
@@ -343,7 +344,7 @@ class Asset extends Element\AbstractElement
                     if (is_file($data['sourcePath'])) {
                         $data['stream'] = fopen($data['sourcePath'], 'rb', false, File::getContext());
                     }
-                    $mimeType = MimeTypeHelper::guessMimeTypeFromFile($mimeTypeGuessData);
+                    $mimeType = $mimeTypeHelper->guessMimeType($mimeTypeGuessData);
                 }
                 unset($data['sourcePath']);
             }
@@ -732,7 +733,7 @@ class Asset extends Element\AbstractElement
                 if (!is_resource($src)) {
                     $src = $this->getStream();
                 }
-                $mimeType = MimeTypeHelper::guessMimeTypeFromStream($src) ?? 'application/octet-stream';
+                $mimeType = (new MimeTypeHelper())->guessMimeType($src) ?? 'application/octet-stream';
                 $this->setMimeType($mimeType);
                 $this->closeStream(); // set stream to null, so that the source stream isn't used anymore after saving
 

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -331,27 +331,12 @@ class Asset extends Element\AbstractElement
                     $filesystem = new Filesystem();
                     $filesystem->dumpFile($tmpFile, $data['data']);
                 } else {
-                    $streamMeta = stream_get_meta_data($data['stream']);
-                    if (file_exists($streamMeta['uri'])) {
-                        // stream is a local file, so we don't have to write a tmp file
-                        $mimeTypeGuessData = $streamMeta['uri'];
-                    } else {
-                        // write a tmp file because the stream isn't a pointer to the local filesystem
-                        $isRewindable = @rewind($data['stream']);
-                        $dest = fopen($tmpFile, 'w+', false, File::getContext());
-                        stream_copy_to_stream($data['stream'], $dest);
-                        $mimeTypeGuessData = $tmpFile;
-
-                        if (!$isRewindable) {
-                            $data['stream'] = $dest;
-                        } else {
-                            fclose($dest);
-                            unlink($tmpFile);
-                        }
-                    }
+                    // guess mime type from stream directly
+                    $mimeTypeGuessData = $data['stream'];
+                    $mimeType = MimeTypeHelper::guessMimeTypeFromStream(
+                        $mimeTypeGuessData
+                    );
                 }
-                //TODO can probably improved by using the stream directly
-                $mimeType = MimeTypeHelper::guessMimeTypeFromFile($mimeTypeGuessData);
             } else {
                 if (!is_dir($data['sourcePath'])) {
                     $mimeTypeGuessData = $data['sourcePath'];
@@ -393,24 +378,40 @@ class Asset extends Element\AbstractElement
         return $asset;
     }
 
-    private static function checkMaxPixels(string $localPath, array $data): void
+    private static function getImageSizeFromStream(mixed $stream): array
+    {
+        if(!is_resource($stream)) {
+            return [];
+        }
+        $size = getimagesizefromstring(
+            @stream_get_contents($stream)
+        );
+
+        return $size === false ? [] : $size;
+    }
+
+    private static function checkMaxPixels(mixed $localPathOrStream, array $data): void
     {
         // this check is intentionally done in Asset::create() because in Asset::update() it would result
         // in an additional download from remote storage if configured, so in terms of performance
         // this is the more efficient way
         $maxPixels = (int)Config::getSystemConfiguration('assets')['image']['max_pixels'];
-        if ($maxPixels && $size = @getimagesize($localPath)) {
-            $imagePixels = (int)($size[0] * $size[1]);
+        if(is_string($localPathOrStream)) {
+            $size = @getimagesize($localPathOrStream);
+        }
+        else {
+            $size = self::getImageSizeFromStream($localPathOrStream);
+        }
+        if ($maxPixels && $size) {
+            $imagePixels = ($size[0] * $size[1]);
             if ($imagePixels > $maxPixels) {
-                Logger::error("Image to be created {$localPath} (temp. path) exceeds max pixel size of {$maxPixels}, you can change the value in config pimcore.assets.image.max_pixels");
+                Logger::error("Image to be created {$localPathOrStream} (temp. path) exceeds max pixel size of {$maxPixels}, you can change the value in config pimcore.assets.image.max_pixels");
 
                 $diff = sqrt(1 + $imagePixels / $maxPixels);
                 $suggestion_0 = (int)round($size[0] / $diff, -2, PHP_ROUND_HALF_DOWN);
                 $suggestion_1 = (int)round($size[1] / $diff, -2, PHP_ROUND_HALF_DOWN);
 
                 $mp = $maxPixels / 1_000_000;
-                // unlink file before throwing exception
-                unlink($localPath);
 
                 throw new ValidationException("<p>Image dimensions of <em>{$data['filename']}</em> are too large.</p>
 <p>Max size: <code>{$mp}</code> <abbr title='Million pixels'>Megapixels</abbr></p>

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -731,7 +731,7 @@ class Asset extends Element\AbstractElement
                 if (!is_resource($src)) {
                     $src = $this->getStream();
                 }
-                $mimeType = MimeTypeHelper::guessMimeTypeFromStream($src);
+                $mimeType = MimeTypeHelper::guessMimeTypeFromStream($src) ?? 'application/octet-stream';
                 $this->setMimeType($mimeType);
                 $this->closeStream(); // set stream to null, so that the source stream isn't used anymore after saving
 


### PR DESCRIPTION
Resolves #17257 

## Additional Information
In some cases it might be necessary to guess the mime type from the stream directly, to avoid downloading files again.
Right now, there is no symfony helper function to achieve this, therefore, we use `finfo` directly instead.

- [x] Check TODO
- [x] Check additional bundles