### PR TITLE
[Improvement]: Eventlistener for customizing tags on full page cache entries

### DIFF
--- a/bundles/CoreBundle/src/EventListener/Frontend/FullPageCacheListener.php
+++ b/bundles/CoreBundle/src/EventListener/Frontend/FullPageCacheListener.php
@@ -28,6 +28,7 @@ use Pimcore\Cache\FullPage\SessionStatus;
 use Pimcore\Config;
 use Pimcore\Event\Cache\FullPage\CacheResponseEvent;
 use Pimcore\Event\Cache\FullPage\PrepareResponseEvent;
+use Pimcore\Event\Cache\FullPage\PrepareTagsEvent;
 use Pimcore\Event\FullPageCacheEvents;
 use Pimcore\Http\Request\Resolver\PimcoreContextResolver;
 use Pimcore\Logger;
@@ -342,13 +343,13 @@ class FullPageCacheListener
 
                 $event = new PrepareResponseEvent($request, $response);
                 $this->eventDispatcher->dispatch($event, FullPageCacheEvents::PREPARE_RESPONSE);
-
                 $cacheItem = $event->getResponse();
 
-                $tags = ['output'];
-                if ($this->lifetime) {
-                    $tags = ['output_lifetime'];
-                }
+                $event = new PrepareTagsEvent($request, $response);
+                $this->eventDispatcher->dispatch($event, FullPageCacheEvents::PREPARE_TAGS);
+                $tags = $event->getTags();
+
+                $tags[] = $this->lifetime ? 'output_lifetime': 'output';
 
                 Cache::save($cacheItem, $cacheKey, $tags, $this->lifetime, 1000, true);
             } catch (Exception $e) {

--- a/lib/Event/Cache/FullPage/PrepareTagsEvent.php
+++ b/lib/Event/Cache/FullPage/PrepareTagsEvent.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Event\Cache\FullPage;
+
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class PrepareTagsEvent extends Event
+{
+    /**
+     * Tags associated with the cache entry
+     *
+     * @var string[]
+     */
+    private array $tags = [];
+
+    public function __construct(
+        private readonly Request $request,
+        private readonly Response $response
+    )  {
+    }
+
+    public function addTag(string $tag): void
+    {
+        $this->tags[] = $tag;
+    }
+    /**
+     * @return string[]
+     */
+    public function getTags(): array
+    {
+        return $this->tags;
+    }
+
+    /**
+     * @param string[] $tags
+     */
+    public function setTags(array $tags): void
+    {
+        $this->tags = $tags;
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+
+    public function getResponse(): Response
+    {
+        return $this->response;
+    }
+
+}

--- a/lib/Event/FullPageCacheEvents.php
+++ b/lib/Event/FullPageCacheEvents.php
@@ -48,4 +48,14 @@ final class FullPageCacheEvents
      * @var string
      */
     const PREPARE_RESPONSE = 'pimcore.cache.full_page.prepare_response';
+
+    /**
+     * Fired before the response is written to cache. Can be used to add tags
+     * to the cached response.
+     *
+     * @Event("Pimcore\Event\Cache\FullPage\PrepareTagsEvent")
+     *
+     * @var string
+     */
+    const PREPARE_TAGS = 'pimcore.cache.full_page.prepare_tags';
 }


### PR DESCRIPTION
In our project we had the problem that an updated document wasn't show in the frontend. We use the full page cage and it turned out that this cache isn't invalidate if you update a document. We could change this by adding an other caching tag to the cache entry.

* Document tag added to force cache invalidation if document has been saved
