### PR TITLE
[Docs] bundles.php instead of bundle.php

### DIFF
--- a/doc/18_Tools_and_Features/29_Custom_Reports.md
+++ b/doc/18_Tools_and_Features/29_Custom_Reports.md
@@ -1,9 +1,17 @@
 # Custom Reports
 :::caution
 
-To use this feature, please enable the `PimcoreCustomReportsBundle` in your `bundle.php` file and install it accordingly with the following command:
+To use this feature, please enable the `PimcoreCustomReportsBundle` in your `bundles.php` file via: 
 
-`bin/console pimcore:bundle:install PimcoreCustomReportsBundle`
+```php
+Pimcore\Bundle\CustomReportsBundle\PimcoreCustomReportsBundle::class => ['all' => true]
+```
+
+and install it accordingly with the following command:
+
+```sh
+bin/console pimcore:bundle:install PimcoreCustomReportsBundle
+```
 
 :::
 


### PR DESCRIPTION
The docs currently refer to `bundle.php` instead of `bundles.php`.

Furthermore this PR adds some more details about installation.