### PR TITLE
Fix: Frontend::isDocumentInSite() returns false for site root document

### DIFF
--- a/lib/Tool/Frontend.php
+++ b/lib/Tool/Frontend.php
@@ -26,8 +26,10 @@ final class Frontend
 {
     public static function isDocumentInSite(?Site $site, Document $document): bool
     {
+        $siteRootDocument = $site?->getRootDocument();
+
         if (
-            ($siteRootDocument = $site?->getRootDocument()) &&
+            $siteRootDocument &&
             !str_starts_with($document->getRealFullPath() . '/', $siteRootDocument->getRealFullPath() . '/')
         ) {
             return false;

--- a/lib/Tool/Frontend.php
+++ b/lib/Tool/Frontend.php
@@ -26,15 +26,14 @@ final class Frontend
 {
     public static function isDocumentInSite(?Site $site, Document $document): bool
     {
-        $inSite = true;
-
-        if ($site && $site->getRootDocument() instanceof Document\Page) {
-            if (!str_starts_with($document->getRealFullPath() . '/', $site->getRootDocument()->getRealFullPath() . '/')) {
-                $inSite = false;
-            }
+        if (
+            ($siteRootDocument = $site?->getRootDocument()) &&
+            !str_starts_with($document->getRealFullPath() . '/', $siteRootDocument->getRealFullPath() . '/')
+        ) {
+            return false;
         }
 
-        return $inSite;
+        return true;
     }
 
     public static function isDocumentInCurrentSite(Document $document): bool

--- a/lib/Tool/Frontend.php
+++ b/lib/Tool/Frontend.php
@@ -29,7 +29,7 @@ final class Frontend
         $inSite = true;
 
         if ($site && $site->getRootDocument() instanceof Document\Page) {
-            if (!str_starts_with($document->getRealFullPath(), $site->getRootDocument()->getRealFullPath() . '/')) {
+            if (!str_starts_with($document->getRealFullPath() . '/', $site->getRootDocument()->getRealFullPath() . '/')) {
                 $inSite = false;
             }
         }

--- a/tests/Model/Tool/FrontendTest.php
+++ b/tests/Model/Tool/FrontendTest.php
@@ -24,7 +24,9 @@ use Pimcore\Tool\Frontend;
 class FrontendTest extends ModelTestCase
 {
     private Site $site1;
+
     private Site $site2;
+
     private Document\Page $testingDocument;
 
     protected function setUp(): void

--- a/tests/Model/Tool/FrontendTest.php
+++ b/tests/Model/Tool/FrontendTest.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Tests\Model\Tool;
+
+use Pimcore\Model\Document;
+use Pimcore\Model\Site;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+use Pimcore\Tool\Frontend;
+
+class FrontendTest extends ModelTestCase
+{
+    private Site $site1;
+    private Site $site2;
+    private Document\Page $testingDocument;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->site1 = $this->createSite('site', 'example.com');
+        $this->site2 = $this->createSite('site2', 'example2.com');
+        $this->testingDocument = $this->createDocument('testing', $this->site2->getRootDocument()->getId());
+    }
+
+    protected function needsDb(): bool
+    {
+        return true;
+    }
+
+    public function testIsDocumentInSite(): void
+    {
+        $this->assertFalse(
+            Frontend::isDocumentInSite($this->site1, $this->testingDocument),
+            'Test document should not be in site'
+        );
+        $this->assertTrue(
+            Frontend::isDocumentInSite($this->site2, $this->testingDocument),
+            'Test document should be in site'
+        );
+
+        $this->assertTrue(
+            Frontend::isDocumentInSite($this->site2, $this->site2->getRootDocument()),
+            'Root document should be in site'
+        );
+    }
+
+    private function createDocument(string $key, int $parentId): Document\Page
+    {
+        $document = new Document\Page();
+        $document->setKey($key);
+        $document->setPublished(true);
+        $document->setParentId($parentId);
+        $document->setUserOwner(1);
+        $document->setUserModification(1);
+        $document->setCreationDate(time());
+        $document->save();
+
+        return $document;
+    }
+
+    private function createSite(string $key, string $mainDomain): Site
+    {
+        $site = new Site();
+        $site->setRootDocument($this->createDocument($key, 1));
+        $site->setMainDomain($mainDomain);
+        $site->setRootPath('/');
+        $site->save();
+
+        return $site;
+    }
+}


### PR DESCRIPTION
## Changes in this pull request  
Frontend::isDocumentInSite() returns false for site root document. I think it should return true.