### PR TITLE
Set 100% as default table width

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Table.php
+++ b/models/DataObject/ClassDefinition/Data/Table.php
@@ -80,7 +80,7 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
      */
     public function setWidth(int|string|null $width): static
     {
-        return $this->setWidthTrait($width ?: 320);
+        return $this->setWidthTrait($width ?: '100%');
     }
 
     public function getCols(): ?int


### PR DESCRIPTION
## Changes in this pull request  
Currently, a fallback width of 320px is defined, which is quite specific and rather small.
When migrating from Pimcore versions prior to this fallback definition, it results in unexpectedly small tables.

I assume that the previous default was 100%, as I never explicitly set a width, and tables always spanned the full available width.

Therefore, I suggest using 100% as the fallback, as it is more intuitive.