### PR TITLE
Improve PHPDoc for `Asset|DataObject|Document::getById()` method

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -244,6 +244,9 @@ class Asset extends Element\AbstractElement
         return true;
     }
 
+    /**
+     * @param array{force?: bool, ...} $params
+     */
     public static function getById(int $id, array $params = []): ?static
     {
         if ($id < 1) {

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -190,6 +190,8 @@ abstract class AbstractObject extends Model\Element\AbstractElement
 
     /**
      * Static helper to get an object by the passed ID
+     *
+     * @param array{force?: bool, ...} $params
      */
     public static function getById(int $id, array $params = []): ?static
     {

--- a/models/Document.php
+++ b/models/Document.php
@@ -180,6 +180,9 @@ class Document extends Element\AbstractElement
         return true;
     }
 
+    /**
+     * @param array{force?: bool, ...} $params
+     */
     public static function getById(int $id, array $params = []): ?static
     {
         if ($id < 1) {

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -462,6 +462,8 @@ class Service extends Model\AbstractModel
 
     /**
      * @internal
+     * 
+     * @return array{force: bool, ...}
      */
     public static function prepareGetByIdParams(array $params): array
     {


### PR DESCRIPTION
## Changes in this pull request  

Add PHPDoc with type info for the second parameter (`$params`) of `Asset|DataObject|Document::getById()`.