### PR TITLE
BugFix: Allow language on localized key value to be nullable

### DIFF
--- a/models/DataObject/Classificationstore.php
+++ b/models/DataObject/Classificationstore.php
@@ -324,8 +324,13 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @throws Exception
      */
-    public function getLocalizedKeyValue(int $groupId, int $keyId, ?string $language = 'default', bool $ignoreFallbackLanguage = false, bool $ignoreDefaultLanguage = false): mixed
-    {
+    public function getLocalizedKeyValue(
+        int $groupId,
+        int $keyId,
+        ?string $language = 'default',
+        bool $ignoreFallbackLanguage = false,
+        bool $ignoreDefaultLanguage = false
+    ): mixed {
         $keyConfig = Model\DataObject\Classificationstore\DefinitionCache::get($keyId);
 
         if ($keyConfig->getType() == 'calculatedValue') {

--- a/models/DataObject/Classificationstore.php
+++ b/models/DataObject/Classificationstore.php
@@ -331,8 +331,9 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
         bool $ignoreFallbackLanguage = false,
         bool $ignoreDefaultLanguage = false
     ): mixed {
-        $keyConfig = Model\DataObject\Classificationstore\DefinitionCache::get($keyId);
+        $language = $this->getLanguage($language);
 
+        $keyConfig = Model\DataObject\Classificationstore\DefinitionCache::get($keyId);
         if ($keyConfig->getType() == 'calculatedValue') {
             $data = new Model\DataObject\Data\CalculatedValue($this->getFieldname());
             $childDef = Model\DataObject\Classificationstore\Service::getFieldDefinitionFromKeyConfig($keyConfig);
@@ -343,8 +344,6 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
         }
 
         $fieldDefinition = Model\DataObject\Classificationstore\Service::getFieldDefinitionFromKeyConfig($keyConfig);
-
-        $language = $this->getLanguage($language);
         $data = null;
 
         if (array_key_exists($groupId, $this->items) && array_key_exists($keyId, $this->items[$groupId])

--- a/models/DataObject/Classificationstore.php
+++ b/models/DataObject/Classificationstore.php
@@ -324,7 +324,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @throws Exception
      */
-    public function getLocalizedKeyValue(int $groupId, int $keyId, string $language = 'default', bool $ignoreFallbackLanguage = false, bool $ignoreDefaultLanguage = false): mixed
+    public function getLocalizedKeyValue(int $groupId, int $keyId, ?string $language = 'default', bool $ignoreFallbackLanguage = false, bool $ignoreDefaultLanguage = false): mixed
     {
         $keyConfig = Model\DataObject\Classificationstore\DefinitionCache::get($keyId);
 

--- a/models/DataObject/Classificationstore.php
+++ b/models/DataObject/Classificationstore.php
@@ -140,7 +140,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
         return $this->class;
     }
 
-    public function getLanguage(string $language = null): string
+    public function getLanguage(?string $language = null): string
     {
         if ($language) {
             return $language;


### PR DESCRIPTION
## Additional info
The function [`getValue`](https://github.com/pimcore/pimcore/blob/11.5/models/DataObject/Classificationstore/Key.php#L44-L58), allows passing in `null` values for language. This function then immediately calls the [`getLocalizedKeyValue`](https://github.com/pimcore/pimcore/blob/11.5/models/DataObject/Classificationstore.php#L327) function, which does not allow `null` to be passed in.

Options:
1. Don't allow null to be passed in when calling `getValue` on the key.
2. Allow null to be passed in, and if null pass in default to the `getLocalizedKeyValue` function.
3. Allow `null` to be passed in to both functions, and let the `getLocalizedKeyValue` function generate the [correct language which will returns default when null](https://github.com/pimcore/pimcore/blob/11.5/models/DataObject/Classificationstore.php#L342).