### PR TITLE
Only query users in configureOptions of user data type

### DIFF
--- a/models/DataObject/ClassDefinition/Data/User.php
+++ b/models/DataObject/ClassDefinition/Data/User.php
@@ -98,16 +98,18 @@ class User extends Model\DataObject\ClassDefinition\Data\Select
 
         $options = [];
         foreach ($users as $user) {
-            $value = $user->getName();
-            $first = $user->getFirstname();
-            $last = $user->getLastname();
-            if (!empty($first) || !empty($last)) {
-                $value .= ' (' . $first . ' ' . $last . ')';
+            if ($user instanceof Model\User) {
+                $value = $user->getName();
+                $first = $user->getFirstname();
+                $last = $user->getLastname();
+                if (!empty($first) || !empty($last)) {
+                    $value .= ' (' . $first . ' ' . $last . ')';
+                }
+                $options[] = [
+                    'value' => $user->getId(),
+                    'key' => $value,
+                ];
             }
-            $options[] = [
-                'value' => $user->getId(),
-                'key' => $value,
-            ];
         }
         $this->setOptions($options);
     }

--- a/models/DataObject/ClassDefinition/Data/User.php
+++ b/models/DataObject/ClassDefinition/Data/User.php
@@ -91,7 +91,6 @@ class User extends Model\DataObject\ClassDefinition\Data\Select
     public function configureOptions(): void
     {
         $list = new Model\User\Listing();
-        $list->setCondition('type = "user"');
         $list->setOrder('asc');
         $list->setOrderKey('name');
         $users = $list->load();

--- a/models/DataObject/ClassDefinition/Data/User.php
+++ b/models/DataObject/ClassDefinition/Data/User.php
@@ -91,6 +91,7 @@ class User extends Model\DataObject\ClassDefinition\Data\Select
     public function configureOptions(): void
     {
         $list = new Model\User\Listing();
+        $list->setCondition('type = "user"');
         $list->setOrder('asc');
         $list->setOrderKey('name');
         $users = $list->load();

--- a/models/User/Listing.php
+++ b/models/User/Listing.php
@@ -20,7 +20,7 @@ use Pimcore\Model\User;
 
 /**
  * @method \Pimcore\Model\User\Listing\Dao getDao()
- * @method User[] load()
+ * @method User[]|User\Folder[] load()
  */
 class Listing extends Listing\AbstractListing
 {


### PR DESCRIPTION
Don't know why this worked in the past but this query can also return user folders and then the loop produces an exception:

https://github.com/pimcore/pimcore/blob/96bd8551638479f305f1345ac954d1984746d84b/models/DataObject/ClassDefinition/Data/User.php#L102

Which leads to the result that the data object class will not be shown anymore in the pimcore backend.
