### PR TITLE
Consider newline in migration of assets.customSettings

### DIFF
--- a/bundles/CoreBundle/src/Migrations/Version20250312132759.php
+++ b/bundles/CoreBundle/src/Migrations/Version20250312132759.php
@@ -120,7 +120,7 @@ final class Version20250312132759 extends AbstractMigration
 
     private function isTargetColumn(string $value, bool $up): bool
     {
-        return ($up === true && preg_match('/^a:\d+:\{.*\}$/', $value)) ||
+        return ($up === true && preg_match('/^a:\d+:\{.*\}$/s', $value)) ||
             ($up === false && preg_match('/^\{.*\}$/', $value));
     }
 


### PR DESCRIPTION
followup to #18193

I had the case that in the serialized string of `assets.customSettings` there was a new line character, which caused the migration to JSON to ignore that line ... and then fail to change the data type to `json`

this should fix it...