### PR TITLE
Respect default value when using 'pimcore.workflow.place-options-provider'.

### DIFF
--- a/lib/Workflow/Place/OptionsProvider.php
+++ b/lib/Workflow/Place/OptionsProvider.php
@@ -98,6 +98,10 @@ class OptionsProvider implements SelectOptionsProviderInterface
 
     public function getDefaultValue(array $context, Data $fieldDefinition): ?string
     {
+        if ($fieldDefinition instanceof Data\Select) {
+            return $fieldDefinition->getDefaultValue();
+        }
+
         return null;
     }
 }


### PR DESCRIPTION


<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info
Without this, if you use `@pimcore.workflow.place-options-provider` for the Option Provider Service on a Select field, the specified default value is ignored. When using a `single_state` marking store, a null is then initially inserted in the DB for the state.