### PR TITLE
BugFix: Make FieldCollection Key/Name Check in Maintenance Command case insensitive (first char)

### DIFF
--- a/lib/Maintenance/Tasks/DataObject/CleanupFieldcollectionTablesTaskHelper.php
+++ b/lib/Maintenance/Tasks/DataObject/CleanupFieldcollectionTablesTaskHelper.php
@@ -87,7 +87,7 @@ class CleanupFieldcollectionTablesTaskHelper implements ConcreteTaskHelperInterf
         if (!$fcDef) {
             $fcDef = \Pimcore\Model\DataObject\Fieldcollection\Definition::getByKey(lcfirst($fcType));
         }
-        
+
         if (!$fcDef) {
             $this->logger->error("Fieldcollection '" . $fcType . "' not found. Please check table " . $tableName);
 

--- a/lib/Maintenance/Tasks/DataObject/CleanupFieldcollectionTablesTaskHelper.php
+++ b/lib/Maintenance/Tasks/DataObject/CleanupFieldcollectionTablesTaskHelper.php
@@ -83,7 +83,11 @@ class CleanupFieldcollectionTablesTaskHelper implements ConcreteTaskHelperInterf
 
     private function checkIfFcExists(string $fcType, string $tableName): bool
     {
-        $fcDef = \Pimcore\Model\DataObject\Fieldcollection\Definition::getByKey($fcType);
+        $fcDef = \Pimcore\Model\DataObject\Fieldcollection\Definition::getByKey(ucfirst($fcType));
+        if (!$fcDef) {
+            $fcDef = \Pimcore\Model\DataObject\Fieldcollection\Definition::getByKey(lcfirst($fcType));
+        }
+        
         if (!$fcDef) {
             $this->logger->error("Fieldcollection '" . $fcType . "' not found. Please check table " . $tableName);
 


### PR DESCRIPTION
In Pimcore Admin there is no restriction for adding a new field collection with lower case names/keys. It is allowed to use "testCollection" or "TestCollection", but for the maintenance job it is important, that the collection name/key is "TestCollection".

example:
field collection key/name: testCollection
error message: "Fieldcollection 'TestCollection' not found. Please check table object_collection_testcollection_testobject [] []"

## Changes in this pull request  

Changed the field collection check in maintenance command.