### PR TITLE
Removed unnecessary return type EncryptedField

### DIFF
--- a/models/DataObject/ClassDefinition/Service.php
+++ b/models/DataObject/ClassDefinition/Service.php
@@ -284,13 +284,11 @@ class Service
     }
 
     /**
-     *
-     *
      * @throws Exception
      *
      * @internal
      */
-    public static function generateLayoutTreeFromArray(array $array, bool $throwException = false, bool $insideLocalizedField = false): Data\EncryptedField|bool|Data|Layout
+    public static function generateLayoutTreeFromArray(array $array, bool $throwException = false, bool $insideLocalizedField = false): bool|Data|Layout
     {
         if ($array) {
             if ($title = $array['title'] ?? false) {

--- a/models/DataObject/Classificationstore/Service.php
+++ b/models/DataObject/Classificationstore/Service.php
@@ -40,20 +40,12 @@ class Service
         self::$definitionsCache = [];
     }
 
-    /**
-     *
-     * @return EncryptedField|Data|null
-     *
-     * @throws Exception
-     */
-    public static function getFieldDefinitionFromKeyConfig(KeyConfig|KeyGroupRelation $keyConfig): DataObject\ClassDefinition\Data\EncryptedField|DataObject\ClassDefinition\Data|null
+    public static function getFieldDefinitionFromKeyConfig(KeyConfig|KeyGroupRelation $keyConfig): ?DataObject\ClassDefinition\Data
     {
         if ($keyConfig instanceof KeyConfig) {
             $cacheId = $keyConfig->getId();
-        } elseif ($keyConfig instanceof KeyGroupRelation) {
-            $cacheId = $keyConfig->getKeyId();
         } else {
-            throw new Exception('$keyConfig should be KeyConfig or KeyGroupRelation');
+            $cacheId = $keyConfig->getKeyId();
         }
 
         if (array_key_exists($cacheId, self::$definitionsCache)) {
@@ -69,7 +61,7 @@ class Service
         return $fd;
     }
 
-    public static function getFieldDefinitionFromJson(array $definition, string $type): DataObject\ClassDefinition\Data\EncryptedField|DataObject\ClassDefinition\Data|null
+    public static function getFieldDefinitionFromJson(array $definition, string $type): ?DataObject\ClassDefinition\Data
     {
         if (!$definition) {
             return null;


### PR DESCRIPTION
`EncryptedField` is also part of `Data`.  `Data` type is enough.

See also: https://github.com/pimcore/static-resolver-bundle/pull/104