### PR TITLE
AbstractObject::getById() should log at debug level if record not found

### DIFF
--- a/doc/20_Extending_Pimcore/17_Custom_Persistent_Models.md
+++ b/doc/20_Extending_Pimcore/17_Custom_Persistent_Models.md
@@ -66,7 +66,7 @@ class Vote extends AbstractModel
             return $obj;
         }
         catch (NotFoundException $ex) {
-            \Pimcore\Logger::warn("Vote with id $id not found");
+            \Pimcore\Logger::debug("Vote with id $id not found");
         }
 
         return null;

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -249,7 +249,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
                     throw new Model\Exception\NotFoundException('No entry for object id ' . $id);
                 }
             } catch (Model\Exception\NotFoundException $e) {
-                Logger::error($e->getMessage());
+                Logger::debug($e->getMessage());
 
                 return null;
             }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #18214
