### PR TITLE
Translator: fallback catalogues should also contain database translation values

### DIFF
--- a/.github/ci/files/translations/messages.de.yml
+++ b/.github/ci/files/translations/messages.de.yml
@@ -1,0 +1,5 @@
+fallback_to_YML_AT: wrong fallback DE YML
+fallback_to_YML_DE: YML DE
+fallback_to_YML_EN:
+fallback_to_DE: wrong fallback DE YML
+fallback_to_EN:

--- a/.github/ci/files/translations/messages.de_AT.yml
+++ b/.github/ci/files/translations/messages.de_AT.yml
@@ -1,0 +1,5 @@
+fallback_to_YML_AT: YML AT
+fallback_to_YML_DE:
+fallback_to_YML_EN:
+fallback_to_DE: wrong fallback AT YML
+fallback_to_EN:

--- a/.github/ci/files/translations/messages.de_AT.yml
+++ b/.github/ci/files/translations/messages.de_AT.yml
@@ -1,5 +1,5 @@
 fallback_to_YML_AT: YML AT
 fallback_to_YML_DE:
 fallback_to_YML_EN:
-fallback_to_DE: wrong fallback AT YML
+fallback_to_DE:
 fallback_to_EN:

--- a/.github/ci/files/translations/messages.en.yml
+++ b/.github/ci/files/translations/messages.en.yml
@@ -1,0 +1,5 @@
+fallback_to_YML_AT: wrong fallback EN YML
+fallback_to_YML_DE: wrong fallback EN YML
+fallback_to_YML_EN: YML EN
+fallback_to_DE: wrong fallback EN YML
+fallback_to_EN: wrong fallback EN YML

--- a/.github/ci/scripts/setup-pimcore-environment.sh
+++ b/.github/ci/scripts/setup-pimcore-environment.sh
@@ -7,6 +7,7 @@ mkdir -p var/config
 cp -r .github/ci/files/config/. config
 mkdir -p config/local/
 cp -r .github/ci/files/templates/. templates
+cp -r .github/ci/files/translations/. translations
 cp -r .github/ci/files/bin/console bin/console
 cp -r .github/ci/files/src/. src
 cp -r .github/ci/files/public/. public

--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -195,7 +195,9 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
                     $this->lazyInitialize($domain, $fallbackCatalogue->getLocale());
 
                     try {
-                        $fallbackCatalogue->addCatalogue($this->getCatalogue($fallbackCatalogue->getLocale()));
+                        $this->getCatalogue($locale)->addFallbackCatalogue(
+                            $this->getCatalogue($fallbackCatalogue->getLocale())
+                        );
                     } catch (LogicException $e) {
                         // couldn't add fallback because of a circular reference
                     }

--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -191,12 +191,14 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
                 $c = $this->getCatalogue($locale);
                 $c->addCatalogue($catalogue);
                 $fallbackCatalogue = $c->getFallbackCatalogue();
-                $this->lazyInitialize($domain, $fallbackCatalogue->getLocale());
+                if($fallbackCatalogue) {
+                    $this->lazyInitialize($domain, $fallbackCatalogue->getLocale());
 
-                try {
-                    $fallbackCatalogue->addCatalogue($this->getCatalogue($fallbackCatalogue->getLocale()));
-                } catch (LogicException $e) {
-                    // couldn't add fallback because of a circular reference
+                    try {
+                        $fallbackCatalogue->addCatalogue($this->getCatalogue($fallbackCatalogue->getLocale()));
+                    } catch (LogicException $e) {
+                        // couldn't add fallback because of a circular reference
+                    }
                 }
             }
         }

--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -23,6 +23,7 @@ use Pimcore\Tool;
 use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Translation\Exception\InvalidArgumentException;
+use Symfony\Component\Translation\Exception\LogicException;
 use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\MessageCatalogueInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
@@ -187,7 +188,16 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
             }
 
             if ($catalogue) {
-                $this->getCatalogue($locale)->addCatalogue($catalogue);
+                $c = $this->getCatalogue($locale);
+                $c->addCatalogue($catalogue);
+                $fallbackCatalogue = $c->getFallbackCatalogue();
+                $this->lazyInitialize($domain, $fallbackCatalogue->getLocale());
+
+                try {
+                    $fallbackCatalogue->addCatalogue($this->getCatalogue($fallbackCatalogue->getLocale()));
+                } catch (LogicException $e) {
+                    // couldn't add fallback because of a circular reference
+                }
             }
         }
     }

--- a/tests/Support/Resources/system_settings.json
+++ b/tests/Support/Resources/system_settings.json
@@ -5,11 +5,13 @@
     "valid_languages": [
       "en",
       "de",
+      "de_AT",
       "fr"
     ],
     "fallback_languages": {
       "en": "",
-      "de": "en"
+      "de": "en",
+      "de_AT": "de"
     },
     "default_language": "",
     "debug_admin_translations": false

--- a/tests/Unit/Translation/TranslatorTest.php
+++ b/tests/Unit/Translation/TranslatorTest.php
@@ -36,6 +36,7 @@ class TranslatorTest extends TestCase
     protected array $locales = [
         'en' => '',
         'de' => 'en',
+        'de_AT' => 'de',
         'fr' => '',
     ];
 
@@ -51,10 +52,32 @@ class TranslatorTest extends TestCase
             'count_plural_n' => '%count% Items',
             'case_key' => 'Lower Case Key',
             'CASE_KEY' => 'Upper Case Key',
+            'fallback_to_EN' => 'EN',
+            'fallback_to_DE' => 'wrong: EN DB',
+            'fallback_to_YML_EN' => '',
+            'fallback_to_YML_DE' => 'wrong: EN DB',
+            'fallback_to_YML_AT' => ''
         ],
         'de' => [
             'simple_key' => 'DE Text',
             'fallback_key' => '',
+            'fallback_to_EN' => '',
+            'fallback_to_DE' => 'DE',
+            'fallback_to_YML_EN' => '',
+            'fallback_to_YML_DE' => '',
+            'fallback_to_YML_AT' => '',
+            'Text As Key' => '',
+            'text_params' => '',
+            'count_key' => '',
+        ],
+        'de_AT' => [
+            'simple_key' => 'AT Text',
+            'fallback_key' => '',
+            'fallback_to_EN' => '',
+            'fallback_to_DE' => '',
+            'fallback_to_YML_EN' => '',
+            'fallback_to_YML_DE' => '',
+            'fallback_to_YML_AT' => '',
             'Text As Key' => '',
             'text_params' => '',
             'count_key' => '',
@@ -270,4 +293,20 @@ class TranslatorTest extends TestCase
         );
         $this->assertEquals('!@#$%^abc\'" 测试< edf > "', html_entity_decode($dbValue), 'Asserting translation is persisted as sanitized');
     }
+
+    public function testFallbackBetweenYMLandDB(): void
+    {
+        $this->translator->setLocale('de_AT');
+        $this->assertEquals('YML AT', $this->translator->trans('fallback_to_YML_AT'));
+
+        //fallback to german translation when no de_AT is set
+        $this->assertEquals('DE', $this->translator->trans('fallback_to_DE'));
+        $this->assertEquals('YML DE', $this->translator->trans('fallback_to_YML_DE'));
+
+        //fallback to english translation when no de_AT nor german is set
+        $this->translator->setLocale('de_AT');
+        $this->assertEquals('EN', $this->translator->trans('fallback_to_EN'));
+        $this->assertEquals('YML EN', $this->translator->trans('fallback_to_YML_EN'));
+    }
+
 }


### PR DESCRIPTION
fixes #15424
fixes #15790 (alternative approach to that) 

This should now result in this behavior: 

![image](https://github.com/user-attachments/assets/0189949f-c2d2-46bb-8856-79c41c7bb7a4)

