### PR TITLE
[Bug] Empty custom settings can lead to a json exception

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1303,7 +1303,7 @@ class Asset extends Element\AbstractElement
     {
         if (
             is_string($customSettings) &&
-            !empty($customSettings)
+            $customSettings !== ''
         ){
             if (strlen($customSettings) > 10e6) {
                 $this->customSettingsCanBeCached = false;

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1301,11 +1301,13 @@ class Asset extends Element\AbstractElement
      */
     public function setCustomSettings(mixed $customSettings): static
     {
-        if (is_string($customSettings)) {
+        if (
+            is_string($customSettings) &&
+            !empty($customSettings)
+        ){
             if (strlen($customSettings) > 10e6) {
                 $this->customSettingsCanBeCached = false;
             }
-
             $customSettings = Serialize::fromJson($customSettings);
         }
 


### PR DESCRIPTION
Check for empty string before serializing data to json.