### PR TITLE
[Bug] Allow null for url slug setter

### DIFF
--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -66,6 +66,7 @@ ORDER BY TABLE_NAME;
 - Removed deprecated `getThumbnailConfig()` method from `Pimcore\Model\Asset\Image`.
 - Removed deprecated hashing algorithms from `Pimcore\Model\DataObject\Data\Password`. `password_hash` is the only supported hashing algorithm now.
 - Removed deprecated `getVersionDependentDatabaseColumnName` method. You can use the column name directly now.
+- UrlSlug fields can return null and array values now.
 
 #### [Events]
 - Removed `context` property of `ResolveUploadTargetEvent`.

--- a/models/DataObject/ClassDefinition/Data/UrlSlug.php
+++ b/models/DataObject/ClassDefinition/Data/UrlSlug.php
@@ -551,22 +551,22 @@ class UrlSlug extends Data implements CustomResourcePersistingInterface, LazyLoa
 
     public function getParameterTypeDeclaration(): ?string
     {
-        return 'array';
+        return '?array';
     }
 
     public function getReturnTypeDeclaration(): ?string
     {
-        return 'array';
+        return '?array';
     }
 
     public function getPhpdocInputType(): ?string
     {
-        return '\\' . Model\DataObject\Data\UrlSlug::class . '[]';
+        return '\\' . Model\DataObject\Data\UrlSlug::class . '[]|null';
     }
 
     public function getPhpdocReturnType(): ?string
     {
-        return '\\' . Model\DataObject\Data\UrlSlug::class . '[]';
+        return '\\' . Model\DataObject\Data\UrlSlug::class . '[]|null';
     }
 
     public function normalize(mixed $value, array $params = []): ?array


### PR DESCRIPTION
Copying a data object that includes a unique url slug field leads to a problem, see:
https://github.com/pimcore/pimcore/blob/d3fa96e999e0e390ee3159738e346eb17981065d/models/DataObject/Service.php#L228