### PR TITLE
fix: error translating quantity value unit without abbreviation

### DIFF
--- a/models/DataObject/Data/QuantityValue.php
+++ b/models/DataObject/Data/QuantityValue.php
@@ -58,9 +58,16 @@ class QuantityValue extends AbstractQuantityValue
             }
         }
 
-        if ($this->getUnit() instanceof Unit) {
-            $translator = Pimcore::getContainer()->get('translator');
-            $value .= ' ' . $translator->trans($this->getUnit()->getAbbreviation(), [], 'admin');
+        $unit = $this->getUnit();
+        if ($unit instanceof Unit) {
+            if ($unit->getAbbreviation() === null) {
+                $unitAbbreviation = $unit->getId();
+            } else {
+                $translator = Pimcore::getContainer()->get('translator');
+                $unitAbbreviation = $translator->trans($unit->getAbbreviation(), [], 'admin');
+            }
+
+            $value .= ' ' . $unitAbbreviation;
         }
 
         return $value ? (string)$value : '';


### PR DESCRIPTION
Pimcore\Translation\Translator::trans(): Argument #1 ($id) must be of type string, null given
Fixed by adding a condition to check whether abbreviation is null and using the untranslated ID instead.

To reproduce, set a quantity value with a unit without an abbreviation. This unit would be created via the PHP API.

Encountered this error in the messenger failed queue of an import because it creates units for use in the Pimcore, but it doesn't provide any additional details (like abbreviation).