### PR TITLE
[Bug, EC]: Follow-up to #17814, add more brickprefixes to avoid ambiguity

### DIFF
--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -728,9 +728,15 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
      */
     public function getFilterConditionExt(mixed $value, string $operator, array $params = []): string
     {
+        $prefix = '';
         $name = $params['name'] ?: $this->name;
 
-        return $this->getRelationFilterCondition($value, $operator, $name);
+        if ($params['brickPrefix']){
+            // The brick prefix is always quoted and with a dot suffix, so removing the first
+            // and second last character to unquote
+            $prefix = substr($params['brickPrefix'], 1, -2) . substr($params['brickPrefix'], -1);
+        }
+        return $this->getRelationFilterCondition($value, $operator, $prefix . $name);
     }
 
     public function getQueryColumnType(): string

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -731,11 +731,12 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
         $prefix = '';
         $name = $params['name'] ?: $this->name;
 
-        if ($params['brickPrefix']){
+        if ($params['brickPrefix']) {
             // The brick prefix is always quoted and with a dot suffix, so removing the first
             // and second last character to unquote
             $prefix = substr($params['brickPrefix'], 1, -2) . substr($params['brickPrefix'], -1);
         }
+
         return $this->getRelationFilterCondition($value, $operator, $prefix . $name);
     }
 

--- a/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
@@ -18,7 +18,6 @@ namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
 use Exception;
 use InvalidArgumentException;
-use Pimcore\Db;
 use Pimcore\Model;
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
@@ -794,11 +793,12 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
         $prefix = '';
         $name = $params['name'] ?: $this->name;
 
-        if ($params['brickPrefix']){
+        if ($params['brickPrefix']) {
             // The brick prefix is always quoted and with a dot suffix, so removing the first
             // and second last character to unquote
             $prefix = substr($params['brickPrefix'], 1, -2) . substr($params['brickPrefix'], -1);
         }
+
         return $this->getRelationFilterCondition($value, $operator, $prefix . $name);
     }
 

--- a/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
@@ -18,6 +18,7 @@ namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
 use Exception;
 use InvalidArgumentException;
+use Pimcore\Db;
 use Pimcore\Model;
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
@@ -790,9 +791,15 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
      */
     public function getFilterConditionExt(mixed $value, string $operator, array $params = []): string
     {
+        $prefix = '';
         $name = $params['name'] ?: $this->name;
 
-        return $this->getRelationFilterCondition($value, $operator, $name);
+        if ($params['brickPrefix']){
+            // The brick prefix is always quoted and with a dot suffix, so removing the first
+            // and second last character to unquote
+            $prefix = substr($params['brickPrefix'], 1, -2) . substr($params['brickPrefix'], -1);
+        }
+        return $this->getRelationFilterCondition($value, $operator, $prefix . $name);
     }
 
     public function getQueryColumnType(): string


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/17830

## Additional info
workaround-ish, to avoid to couple tying this fix with an exact version of admin ui classic (from there it could be passed an unquoted table name/alias)
https://github.com/pimcore/admin-ui-classic-bundle/blob/2a129aa07f2f20c365f88c205d60d244468ff711/src/Helper/GridHelperService.php#L325-L327
also the method is called `getFilterConditionExt` which suffix suggest it used just for `ExtJS`