### PR TITLE
[Docs] Removed obsolete Redis cache info

### DIFF
--- a/doc/19_Development_Tools_and_Details/09_Cache/README.md
+++ b/doc/19_Development_Tools_and_Details/09_Cache/README.md
@@ -57,9 +57,6 @@ save ""
 
 > With the default settings, the minimum supported Redis version is 3.0.
 
-> Please note that the Redis adapter currently doesn't properly support Redis Cluster setups.
-
-
 ## Element Cache Workflow (Asset, Document, Object)
 
 ![Element Cache Workflow](../../img/pimcore-cache.png)


### PR DESCRIPTION
The info that the Redis cache adapter doesn't support clustering was from the times where Pimcore had a custom Redis Cache implementation using LUA scripts - which is now obsolete by using Symfony default Redis caching implementation. 