### PR TITLE
[Docs]: Specify that attribute classes has to be `null` in Many-To-One relation

### DIFF
--- a/doc/03_Documents/01_Editables/12_Relation_Many-To-One.md
+++ b/doc/03_Documents/01_Editables/12_Relation_Many-To-One.md
@@ -11,7 +11,7 @@ In frontend-mode this editable returns the path of the linked element.
 |--------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------|
 | `types`      | array   | Allowed types (document, asset, object), if empty all types are allowed                                                                    |
 | `subtypes`   | array   | Allowed subtypes grouped by type (folder, page, snippet, image, video, object, ...), if empty all subtypes are allowed (see example below) |
-| `classes`    | array   | Allowed object class names, if `null` all classes are allowed (in case of empty array no object can be dropped)                                                                              |
+| `classes`    | array   | Allowed object class names, if `null` all classes are allowed (in case of empty array no object can be dropped)                            |
 | `reload`     | boolean | `true` triggers page reload on each change                                                                                                 |
 | `width`      | int     | Width of the field in pixel.                                                                                                               |
 | `uploadPath` | string  | Target path for (inline) uploaded assets                                                                                                   |

--- a/doc/03_Documents/01_Editables/12_Relation_Many-To-One.md
+++ b/doc/03_Documents/01_Editables/12_Relation_Many-To-One.md
@@ -11,7 +11,7 @@ In frontend-mode this editable returns the path of the linked element.
 |--------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------|
 | `types`      | array   | Allowed types (document, asset, object), if empty all types are allowed                                                                    |
 | `subtypes`   | array   | Allowed subtypes grouped by type (folder, page, snippet, image, video, object, ...), if empty all subtypes are allowed (see example below) |
-| `classes`    | array   | Allowed object class names, if empty all classes are allowed                                                                               |
+| `classes`    | array   | Allowed object class names, if `null` all classes are allowed (in case of empty array no object can be dropped)                                                                              |
 | `reload`     | boolean | `true` triggers page reload on each change                                                                                                 |
 | `width`      | int     | Width of the field in pixel.                                                                                                               |
 | `uploadPath` | string  | Target path for (inline) uploaded assets                                                                                                   |


### PR DESCRIPTION
An empty array for attribute `classes` is not helpful for Relation. It has to be `null`.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info
