### PR TITLE
Update checkout action to v4

### DIFF
--- a/.github/workflows/codeception.yaml
+++ b/.github/workflows/codeception.yaml
@@ -76,7 +76,9 @@ jobs:
 
         steps:
             - name: "Checkout code"
-              uses: "actions/checkout@v2"
+              uses: "actions/checkout@v4"
+              with:
+                  ref: "${{ github.ref }}"
 
             - uses: "actions/setup-node@v3"
               with:


### PR DESCRIPTION
Updated the GitHub checkout action to version 4 and explicitly specified the branch reference for improved clarity and