### PR TITLE
Update checkout action to v4 and specify PR merge ref

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -48,7 +48,9 @@ jobs:
 
         steps:
             - name: "Checkout code"
-              uses: "actions/checkout@v2"
+              uses: "actions/checkout@v4"
+              with:
+                ref: "refs/pull/${{ github.event.pull_request.number }}/merge"
 
             - name: "Install PHP"
               uses: "shivammathur/setup-php@v2"


### PR DESCRIPTION
This pull request updates the GitHub Actions checkout to version 4 and includes specifying the pull request merge reference. This improvement ensures compatibility with the latest features of the checkout action and streamlines the workflow process