### PR TITLE
Fix: Create asset of correct class type (#16363)

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -380,9 +380,13 @@ class Asset extends Element\AbstractElement
             if (array_key_exists('type', $data)) {
                 unset($data['type']);
             }
+        } elseif (array_key_exists('type', $data)) {
+            $type = $data['type'];
+            unset($data['type']);
         }
 
-        $className = Pimcore::getContainer()->get('pimcore.class.resolver.asset')->resolve($type);
+        $className = Pimcore::getContainer()->get('pimcore.class.resolver.asset')->resolve($type)
+            ?? throw new InvalidArgumentException('Invalid asset type provided');
 
         /** @var Asset $asset */
         $asset = self::getModelFactory()->build($className);


### PR DESCRIPTION
## Changes in this pull request  
Resolves #16363

## Additional info
Error: `Asset::create(data: ['type' => 'folder'])` returned a `\Pimcore\Model\Asset\Unknown` instead of `\Pimcore\Model\Asset\Folder`
Caused by: The type was only used when detected by the binary file data
Resolved with: Adding a type check on the $data array

## Side effects of bug
The bug caused other effects such as the DataHub Simple Rest API Indexer not being able to process Asset Folders created via the Classic Admin (using `Asset::create`) as it checked on the asset `instanceof` within `getEntityTypeForElement` ( https://github.com/pimcore/data-hub-simple-rest/blob/3.x/src/Service/AbstractService.php#L258 )