### PR TITLE
[Docs] 01_Image_Thumbnails: fix twig syntax highlighting

### DIFF
--- a/doc/04_Assets/03_Working_with_Thumbnails/01_Image_Thumbnails.md
+++ b/doc/04_Assets/03_Working_with_Thumbnails/01_Image_Thumbnails.md
@@ -102,7 +102,6 @@ The Auto Alt functionality will try to automatically fall back to any available 
 Ultimately, it would use the image `title` as `alt` value when nothing above is previously found.
 It is also possible to define an alternative metadata to be used as `alt`, `copyright`, `title` values (eg. by defining `pimcore.assets.metadata.alt` in the configuration) that would have used when the inline options are not passed.
 
-```yaml
 
 ## Usage Examples
 


### PR DESCRIPTION
There were a empty ` ```yaml` before the `Usage Examples` section which caused no syntax highlighting for the code block in the `Usage Examples` section

## Before:
<img width="767" alt="image" src="https://github.com/user-attachments/assets/d69a3639-2b25-4ac0-9c39-59096202ca64" />

## After:
<img width="827" alt="image" src="https://github.com/user-attachments/assets/2f5b1330-e8f4-4dc5-b4df-06bc705264f6" />
