### PR TITLE
[Data Objects] Do not return inherited properties if inheritance is disabled

### DIFF
--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -1082,17 +1082,4 @@ abstract class AbstractObject extends Model\Element\AbstractElement
 
         return $list;
     }
-
-    public function getProperties(): array
-    {
-        $properties = parent::getProperties();
-
-        if(!static::getGetInheritedValues()) {
-            $properties = array_filter($properties, static function (Model\Property $property) {
-                return !$property->isInherited();
-            });
-        }
-
-        return $properties;
-    }
 }

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -1087,7 +1087,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
     {
         $properties = parent::getProperties();
 
-        if(!self::getGetInheritedValues()) {
+        if(!static::getGetInheritedValues()) {
             $properties = array_filter($properties, static function (Model\Property $property) {
                 return !$property->isInherited();
             });

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -1082,4 +1082,17 @@ abstract class AbstractObject extends Model\Element\AbstractElement
 
         return $list;
     }
+
+    public function getProperties(): array
+    {
+        $properties = parent::getProperties();
+
+        if(!self::getGetInheritedValues()) {
+            $properties = array_filter($properties, static function (Model\Property $property) {
+                return !$property->isInherited();
+            });
+        }
+
+        return $properties;
+    }
 }

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -103,6 +103,8 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
      */
     protected ?int $parentId = null;
 
+    private static bool $getInheritedProperties = true;
+
     public function getPath(): ?string
     {
         return $this->path;
@@ -239,7 +241,14 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
             $this->properties = $properties;
         }
 
-        return $this->properties;
+        $properties = $this->properties;
+        if (!static::getGetInheritedProperties()) {
+            $properties = array_filter($properties, static function (Model\Property $property) {
+                return !$property->isInherited();
+            });
+        }
+
+        return $properties;
     }
 
     public function setProperties(?array $properties): static
@@ -277,6 +286,17 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
         $this->setProperties($properties);
 
         return $this;
+    }
+
+
+    public static function setGetInheritedProperties(bool $getInheritedProperties): void
+    {
+        self::$getInheritedProperties = $getInheritedProperties;
+    }
+
+    public static function getGetInheritedProperties(): bool
+    {
+        return self::$getInheritedProperties;
     }
 
     /**


### PR DESCRIPTION
With https://github.com/pimcore/pimcore/blob/abbc7aa1f9748cb6f51047141717d2447f750aba/models/DataObject/AbstractObject.php#L162 you can enable or disable inheritance. But for properties this is ignored: also inherited properties get returned, even if inheritance is disabled. This PR only returns non-inherited properties if inheritance is disabled.