### PR TITLE
[Task] Revert: Register SeoBundle installer for tests

### DIFF
--- a/.github/ci/files/config/services.yaml
+++ b/.github/ci/files/config/services.yaml
@@ -44,11 +44,6 @@ services:
     #     tags:
     #         - { name: kernel.event_listener, event: pimcore.dataobject.preUpdate, method: onObjectPreUpdate }
 
-    Pimcore\Bundle\SeoBundle\Installer:
-        public: true
-        arguments:
-            $bundle: "@=service('kernel').getBundle('PimcoreSeoBundle')"
-
     Pimcore\Model\Version\Adapter\VersionStorageAdapterInterface:
         public: true
         alias: Pimcore\Model\Version\Adapter\ProxyVersionStorageAdapter


### PR DESCRIPTION
Reverting https://github.com/pimcore/pimcore/pull/18445, SeoBundle needs to be enabled in each repo separately.