### PR TITLE
[Documents] Do not save quotes HTML-encoded 

### DIFF
--- a/models/Document/Editable/Input.php
+++ b/models/Document/Editable/Input.php
@@ -69,7 +69,7 @@ class Input extends Model\Document\Editable implements EditmodeDataInterface
 
     public function setDataFromEditmode(mixed $data): static
     {
-        $data = html_entity_decode($data, ENT_HTML5); // this is because the input is now an div contenteditable -> therefore in entities
+        $data = html_entity_decode($data, ENT_HTML5 | ENT_QUOTES); // this is because the input is now an div contenteditable -> therefore in entities
         $this->text = $data;
 
         return $this;

--- a/models/Document/Editable/Input.php
+++ b/models/Document/Editable/Input.php
@@ -69,7 +69,8 @@ class Input extends Model\Document\Editable implements EditmodeDataInterface
 
     public function setDataFromEditmode(mixed $data): static
     {
-        $data = html_entity_decode($data, ENT_HTML5 | ENT_QUOTES); // this is because the input is now an div contenteditable -> therefore in entities
+        // this is because the input is now an div contenteditable -> therefore in entities
+        $data = html_entity_decode($data, ENT_HTML5 | ENT_QUOTES);
         $this->text = $data;
 
         return $this;

--- a/models/Document/Editable/Textarea.php
+++ b/models/Document/Editable/Textarea.php
@@ -72,7 +72,8 @@ class Textarea extends Model\Document\Editable implements EditmodeDataInterface
 
     public function setDataFromEditmode(mixed $data): static
     {
-        $data = html_entity_decode($data, ENT_HTML5 | ENT_QUOTES); // this is because the input is now an div contenteditable -> therefore in entities
+        // this is because the input is now an div contenteditable -> therefore in entities
+        $data = html_entity_decode($data, ENT_HTML5 | ENT_QUOTES);
         $this->text = $data;
 
         return $this;

--- a/models/Document/Editable/Textarea.php
+++ b/models/Document/Editable/Textarea.php
@@ -72,7 +72,7 @@ class Textarea extends Model\Document\Editable implements EditmodeDataInterface
 
     public function setDataFromEditmode(mixed $data): static
     {
-        $data = html_entity_decode($data, ENT_HTML5); // this is because the input is now an div contenteditable -> therefore in entities
+        $data = html_entity_decode($data, ENT_HTML5 | ENT_QUOTES); // this is because the input is now an div contenteditable -> therefore in entities
         $this->text = $data;
 
         return $this;


### PR DESCRIPTION
Steps to reproduce bug:
1. Create area brick with this configuration:
    ```php
    public function getEditableDialogBoxConfiguration(Document\Editable $area, ?Info $info): EditableDialogBoxConfiguration
    {
        $config = new EditableDialogBoxConfiguration();
        $config->setWidth(600);

        $config->setItems([
            [
                'type' => 'textarea',
                'name' => 'test',
                'label' => 'Enter a quote here'
            ],
        ]);

        $config->setReloadOnClose(true);

        return $config;
    }
   ```
2. Create document, add this area brick, click the area brick edit button and enter a `"` in the field. 
3. Because of `$config->setReloadOnClose(true);` the document gets saved to session and reloaded.
4. Reload again with the `Refresh` button on the left toolbar
5. Open area brick configuration

Expected behaviour: Field still contains `"`
Actual behaviour: Field contains `&quot;`

Cause:
The data arrives HTML-encoded at https://github.com/pimcore/pimcore/blob/769575dc84e888c095b608faa4c1b81ba0bf32d3/models/Document/Editable/Textarea.php#L75 but with `ENT_HTML5` the quotes stay encoded, see https://onlinephp.io?s=s7EvyCjg5VJJSSxJVLBVUFcrLM0vsVa35uXi5UpNzshXUHf1C4n3CPH1MbVSUNfLKMnNiU_NK8ksqYxPSU3OT0nVAGvVUYAr09RTislTssbQrlADVhMY6h_iGkykWSh6NK0B&v=8.1.20%2C7.4.30

Side note: This only occurs if `$config->setReloadOnClose(true);` gets used.