### PR TITLE
[Task]: Make Twig variable "_block" available outside of "blockiterate" when used with "pimcoremanualblock"

### DIFF
--- a/lib/Twig/Node/ManualBlockNode.php
+++ b/lib/Twig/Node/ManualBlockNode.php
@@ -74,6 +74,7 @@ final class ManualBlockNode extends Node
         return <<<PHP
         \$editableExtension = \$this->env->getExtension('Pimcore\Twig\Extension\DocumentEditableExtension');
         \$block = \$editableExtension->renderEditable(\$context, 'block', '{$this->blockName}', $optionsString);
+        \$context['_block'] = \$block;
 \$block->start();
 {$splitChars}
         foreach(\$block->getIterator() as \$index) {


### PR DESCRIPTION
Make Twig variable "_block" available outside of "blockiterate" when used with "pimcoremanualblock"

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  

## Additional info
