### PR TITLE
[Bug, EC][PEES-579]: Fix select options translation

### DIFF
--- a/bundles/CoreBundle/src/OptionsProvider/SelectOptionsOptionsProvider.php
+++ b/bundles/CoreBundle/src/OptionsProvider/SelectOptionsOptionsProvider.php
@@ -14,10 +14,12 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\CoreBundle\OptionsProvider;
 
 use Exception;
+use Pimcore;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\ClassDefinition\DynamicOptionsProvider\SelectOptionsProviderInterface;
 use Pimcore\Model\DataObject\SelectOptions\Config;
 use Pimcore\Model\DataObject\SelectOptions\Data\SelectOption;
+use Pimcore\Tool\Admin;
 
 class SelectOptionsOptionsProvider implements SelectOptionsProviderInterface
 {
@@ -33,10 +35,14 @@ class SelectOptionsOptionsProvider implements SelectOptionsProviderInterface
             throw new Exception('Missing select options configuration ' . $configurationId, 1677137682677);
         }
 
+        $translator = Pimcore::getContainer()->get('translator');
+        $currentUserLocale = Admin::getCurrentUser()->getLanguage();
+        $translator->setLocale($currentUserLocale);
+
         return array_map(
             fn (SelectOption $selectOption) => [
                 'value' => $selectOption->getValue(),
-                'key' => $selectOption->getLabel(),
+                'key' => $translator->trans($selectOption->getLabel(), [], 'admin'),
             ],
             $selectOptionsConfiguration->getSelectOptions(),
         );


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://pimcore.atlassian.net/browse/PEES-579

## Additional info
### How to reproduce

#### Select Option Store
Add an English translation for "Scheduled" (display name from the select option store "EventStatus")
Open the GridView of the data object folder "Events" (ID: 1119)
Add the select field "Status" to the GridView
The GridView still displays "Scheduled", even though a translation has been provided

#### Static Select Option
Add an English translation for "Committed"
Open the GridView of the data object folder "/Shop/Orders/2022/01/27" (ID: 1160) of type "OnlineShopOrder"
In the "OrderState" field, the translation is displayed correctly

