### PR TITLE
[Data Objects] Wrong date with different client / server timezone

### DIFF
--- a/bundles/CoreBundle/src/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Configuration.php
@@ -198,7 +198,7 @@ final class Configuration implements ConfigurationInterface
             ->addDefaultsIfNotSet()
             ->children()
                 ->scalarNode('timezone')
-                    ->defaultValue('')
+                    ->defaultValue(date_default_timezone_get())
                 ->end()
                 ->scalarNode('path_variable')
                     ->info('Additional $PATH variable (: separated) (/x/y:/foo/bar):')


### PR DESCRIPTION
Steps to reproduce bug:
1. Assure that Pimcore setting `pimcore.general.timezone` is empty (as it is by default) via `bin/console debug:config pimcore general.timezone`
2. Set PHP setting `date.timezone` via php.ini to anything east of `UTC`, e.g. `Europe/Berlin` or `Asia/Tokyo`
3. Create class with `Date` field and "Column Type" `DATE`
4. Create object and set the date field to `2025-06-18`
5. Reload object

Expected result: Date `2025-06-18` gets displayed
Actual result: Date `2025-06-17` gets displayed

The cause:
In https://github.com/pimcore/pimcore/blob/5e069f55b26607a32cd0237da8f76cc7eb1dae6e/models/DataObject/ClassDefinition/Data/Date.php#L77 the date from the database gets converted to a UNIX timestamp - but it assumes that the given date is in PHP's `date.timezone`.

In https://github.com/pimcore/admin-ui-classic-bundle/blob/6ad887e762b2c3b5b02527b0d61080394436d2b8/public/js/pimcore/object/tags/date.js#L94-L98 the value from the database gets converted for display. 

For `date` fields with "Column Type" `DATE` the function `this.isRespectTimezone()` returns `false` in https://github.com/pimcore/admin-ui-classic-bundle/blob/6ad887e762b2c3b5b02527b0d61080394436d2b8/public/js/pimcore/object/tags/date.js#L169

Thus the date gets converted via `dateToServerTimezone()`. This uses `pimcore.general.timezone` setting in https://github.com/pimcore/admin-ui-classic-bundle/blob/6ad887e762b2c3b5b02527b0d61080394436d2b8/public/js/pimcore/functions.js#L1801 which is by default empty: https://github.com/pimcore/pimcore/blob/4211cdb9a2d504ee12e4352a524ac13bb948d6f8/bundles/CoreBundle/src/DependencyInjection/Configuration.php#L198-L199
And when it is empty the JS assumes that the server timezone (= PHP timezone) is `UTC`.

This mismatch between `pimcore.general.timezone` and PHP's `date.timezone` causes the date shift.

This PR sets the PHP timezone as default value for `pimcore.general.timezone`, then it works.