### PR TITLE
[Bug, EC] PEES-576: Fix `pimcore:deployment:classes-rebuild -c` skipping generation of missing class files

### DIFF
--- a/lib/Model/DataObject/ClassDefinition/ClassDefinitionManager.php
+++ b/lib/Model/DataObject/ClassDefinition/ClassDefinitionManager.php
@@ -85,7 +85,8 @@ class ClassDefinitionManager
                         $classSaved = $this->saveClass($existingClass, false, $force);
                         $changes[] = [$existingClass->getName(), $existingClass->getId(), $classSaved ? self::SAVED : self::SKIPPED];
                     } else {
-                        $classSaved = $this->saveClass($class, false, true); //when creating, it should always save like as forced
+                        //when creating, it should always save like as forced
+                        $classSaved = $this->saveClass($class, false, true);
                         $changes[] = [$class->getName(), $class->getId(), $classSaved ? self::CREATED : self::SKIPPED];
                     }
                 }

--- a/lib/Model/DataObject/ClassDefinition/ClassDefinitionManager.php
+++ b/lib/Model/DataObject/ClassDefinition/ClassDefinitionManager.php
@@ -85,7 +85,7 @@ class ClassDefinitionManager
                         $classSaved = $this->saveClass($existingClass, false, $force);
                         $changes[] = [$existingClass->getName(), $existingClass->getId(), $classSaved ? self::SAVED : self::SKIPPED];
                     } else {
-                        $classSaved = $this->saveClass($class, false, $force);
+                        $classSaved = $this->saveClass($class, false, true); //when creating, it should always save like as forced
                         $changes[] = [$class->getName(), $class->getId(), $classSaved ? self::CREATED : self::SKIPPED];
                     }
                 }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/service-operations/issues/131

## Additional info
Since the class is not existing when rebuilding with `create-classes`, there's no need to "force" anything (with checking if model definition changed and so on).

The change would make it behave just like a `shouldSave` set to `true` https://github.com/pimcore/pimcore/blob/7f1898e7a538edead0e5ddc3246d75b3656b7a92/lib/Model/DataObject/ClassDefinition/ClassDefinitionManager.php#L100