### PR TITLE
Fix select options translation regression caused by #18471

### DIFF
--- a/bundles/CoreBundle/src/OptionsProvider/SelectOptionsOptionsProvider.php
+++ b/bundles/CoreBundle/src/OptionsProvider/SelectOptionsOptionsProvider.php
@@ -36,8 +36,10 @@ class SelectOptionsOptionsProvider implements SelectOptionsProviderInterface
         }
 
         $translator = Pimcore::getContainer()->get('translator');
-        $currentUserLocale = Admin::getCurrentUser()->getLanguage();
-        $translator->setLocale($currentUserLocale);
+        $currentUserLocale = Admin::getCurrentUser()?->getLanguage();
+        if($currentUserLocale) {
+            $translator->setLocale($currentUserLocale);
+        }
 
         return array_map(
             fn (SelectOption $selectOption) => [

--- a/bundles/CoreBundle/src/OptionsProvider/SelectOptionsOptionsProvider.php
+++ b/bundles/CoreBundle/src/OptionsProvider/SelectOptionsOptionsProvider.php
@@ -37,7 +37,7 @@ class SelectOptionsOptionsProvider implements SelectOptionsProviderInterface
 
         $translator = Pimcore::getContainer()->get('translator');
         $currentUserLocale = Admin::getCurrentUser()?->getLanguage();
-        if($currentUserLocale) {
+        if ($currentUserLocale) {
             $translator->setLocale($currentUserLocale);
         }
 


### PR DESCRIPTION
Admin user shouldn't be required, and Admin::getCurrentUser() can return null

See #18471