### PR TITLE
Cache class definitions to prevent "Too many open files" error

### DIFF
--- a/doc/13_Upgrade_Notes/README.md
+++ b/doc/13_Upgrade_Notes/README.md
@@ -3,6 +3,7 @@
 ## Pimcore 2026.3.0
 
 ### [General]
+- [DataObject] Class definition files are now cached in-process by `Pimcore\Model\DataObject\ClassDefinition\DefinitionFileCache` (`@internal`), so clearing the runtime cache in long-running scripts no longer re-includes the definition file on every `ClassDefinition::getById()` call (previously very slow and eventually failing with "Too many open files"). The cache is validated against the definition file's modification time and is invalidated whenever Pimcore writes or deletes a definition file. Behavioral note: after `RuntimeCache::clear()` (or `Pimcore::collectGarbage()`), `getById()`/`getByName()` may now return the same `ClassDefinition` instance as before the clear (instead of a freshly included copy) as long as the definition file is unchanged — unsaved in-memory modifications of a class definition are therefore no longer discarded by a runtime cache clear. Use `ClassDefinition::getById($id, force: true)` to force a fresh include from disk.
 - [Composer] Bumped minimum requirements of `scheb/2fa-bundle` and `scheb/2fa-google-authenticator` to `8.6.1` and of `phpdocumentor/reflection-docblock` to `5.6.7` (5.x line) / `6.0.3` (6.x line). These are floor raises within the majors already required since 2026.1.0 and carry no BC impact of their own (see the 2026.1.0 notes below for the major-version upgrade guidance).
 
 ### [Console]

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -29,6 +29,7 @@ use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\ClassDefinition\Data\FieldDefinitionEnrichmentInterface;
 use Pimcore\Model\DataObject\ClassDefinition\Data\ManyToOneRelation;
+use Pimcore\Model\DataObject\ClassDefinition\DefinitionFileCache;
 
 /**
  * @method \Pimcore\Model\DataObject\ClassDefinition\Dao getDao()
@@ -223,7 +224,7 @@ final class ClassDefinition extends Model\AbstractModel implements ClassDefiniti
         }
 
         $class = (new ClassDefinition\Listing())
-            ->setForce(true)
+            ->setForce($force)
             ->setCondition('id = ?', [$id])
             ->current();
 
@@ -439,6 +440,7 @@ final class ClassDefinition extends Model\AbstractModel implements ClassDefiniti
         @unlink($this->getPhpListingClassFile());
         @rmdir(dirname($this->getPhpListingClassFile()));
         @unlink($this->getDefinitionFile());
+        DefinitionFileCache::clear($this->getDefinitionFile());
     }
 
     /**
@@ -1100,7 +1102,7 @@ final class ClassDefinition extends Model\AbstractModel implements ClassDefiniti
                 throw new Exception('Class definition with ID ' . $id . ' does not exist');
             }
             $definitionFile = $class->getDefinitionFile($name);
-            $class = @include $definitionFile;
+            $class = DefinitionFileCache::load($definitionFile);
 
             if (!$class instanceof self) {
                 throw new Exception('Class definition with name ' . $name . ' or ID ' . $id . ' does not exist');
@@ -1255,6 +1257,7 @@ final class ClassDefinition extends Model\AbstractModel implements ClassDefiniti
             $data .= 'return '.$exportedClass.";\n";
 
             \Pimcore\File::putPhpFile($definitionFile, $data);
+            DefinitionFileCache::clear($definitionFile);
         }
     }
 }

--- a/models/DataObject/ClassDefinition/DefinitionFileCache.php
+++ b/models/DataObject/ClassDefinition/DefinitionFileCache.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Model\DataObject\ClassDefinition;
+
+use Pimcore\Model\DataObject\ClassDefinition;
+
+/**
+ * In-process cache for included class definition files.
+ *
+ * Including a definition file on every runtime cache miss is expensive and exhausts
+ * file handles in long-running processes which clear the runtime cache periodically.
+ * Entries are validated against the definition file's modification time and are
+ * invalidated whenever Pimcore writes or deletes a definition file.
+ *
+ * @internal
+ */
+final class DefinitionFileCache
+{
+    /**
+     * @var array<string, array{mtime: int, definition: ClassDefinition}>
+     */
+    private static array $cache = [];
+
+    public static function load(string $definitionFile, bool $force = false): ?ClassDefinition
+    {
+        clearstatcache(false, $definitionFile);
+        $mtime = @filemtime($definitionFile);
+        if ($mtime === false) {
+            unset(self::$cache[$definitionFile]);
+
+            return null;
+        }
+
+        if (
+            !$force
+            && isset(self::$cache[$definitionFile])
+            && self::$cache[$definitionFile]['mtime'] === $mtime
+        ) {
+            return self::$cache[$definitionFile]['definition'];
+        }
+
+        $definition = @include $definitionFile;
+        if (!$definition instanceof ClassDefinition) {
+            unset(self::$cache[$definitionFile]);
+
+            return null;
+        }
+
+        self::$cache[$definitionFile] = ['mtime' => $mtime, 'definition' => $definition];
+
+        return $definition;
+    }
+
+    public static function clear(?string $definitionFile = null): void
+    {
+        if ($definitionFile !== null) {
+            unset(self::$cache[$definitionFile]);
+        } else {
+            self::$cache = [];
+        }
+    }
+}

--- a/models/DataObject/ClassDefinition/Listing/Dao.php
+++ b/models/DataObject/ClassDefinition/Listing/Dao.php
@@ -86,7 +86,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
                 }
 
                 $definitionFile = $class->getDefinitionFile($name);
-                $class = @include $definitionFile;
+                $class = ClassDefinition\DefinitionFileCache::load($definitionFile, $force);
 
                 if (!$class instanceof ClassDefinition) {
                     throw new Exception('Class definition with name ' . $name . ' or ID ' . $id . ' does not exist');

--- a/tests/Model/DataObject/ClassDefinitionTest.php
+++ b/tests/Model/DataObject/ClassDefinitionTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Model\DataObject;
 
+use Pimcore\Cache\RuntimeCache;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Fieldcollections;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Input;
@@ -293,6 +294,41 @@ public function getMybricks(): ?\Pimcore\Model\DataObject\Objectbrick
 
 ';
         $this->testGetterCode('mybricks', $expectedGetterCode);
+    }
+
+    /**
+     * Definition files are cached in-process (see DefinitionFileCache) so that long-running
+     * scripts clearing the runtime cache do not re-include them on every access. Saving a
+     * class definition must invalidate that cache, and a forced load must re-include the file.
+     */
+    public function testDefinitionChangeIsVisibleAfterRuntimeCacheClear(): void
+    {
+        $class = ClassDefinition::getByName('unittest');
+        $this->assertInstanceOf(ClassDefinition::class, $class);
+        $id = $class->getId();
+        $originalTitle = $class->getTitle();
+
+        // prime the runtime cache and the definition file cache
+        RuntimeCache::clear();
+        $this->assertInstanceOf(ClassDefinition::class, ClassDefinition::getById($id));
+
+        try {
+            $class->setTitle('definition file cache test');
+            $class->save();
+
+            RuntimeCache::clear();
+            $reloaded = ClassDefinition::getById($id);
+            $this->assertInstanceOf(ClassDefinition::class, $reloaded);
+            $this->assertSame('definition file cache test', $reloaded->getTitle());
+
+            $forced = ClassDefinition::getById($id, true);
+            $this->assertInstanceOf(ClassDefinition::class, $forced);
+            $this->assertNotSame($reloaded, $forced);
+            $this->assertSame('definition file cache test', $forced->getTitle());
+        } finally {
+            $class->setTitle($originalTitle);
+            $class->save();
+        }
     }
 
     public function testInputEmptyDefaultValueIsNormalizedToNullAfterImportAndReload(): void

--- a/tests/Model/DataObject/DefinitionModifierTest.php
+++ b/tests/Model/DataObject/DefinitionModifierTest.php
@@ -15,6 +15,7 @@ namespace Pimcore\Tests\Model\DataObject;
 
 use Pimcore;
 use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\ClassDefinition\DefinitionFileCache;
 use Pimcore\Model\DataObject\DefinitionModifier;
 use Pimcore\Tests\Support\Test\ModelTestCase;
 use ReflectionClass;
@@ -128,6 +129,9 @@ class DefinitionModifierTest extends ModelTestCase
     {
         if ($collectGarbage) {
             Pimcore::collectGarbage();
+            // discard unsaved in-memory modifications of the class definition, so the next
+            // fetch re-includes the pristine definition file (see DefinitionFileCache)
+            DefinitionFileCache::clear();
         }
 
         if ($type === self::_CLASS) {

--- a/tests/Unit/Models/DataObject/ClassDefinition/DefinitionFileCacheTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/DefinitionFileCacheTest.php
@@ -1,0 +1,104 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\DataObject\ClassDefinition;
+
+use PHPUnit\Framework\TestCase;
+use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\ClassDefinition\DefinitionFileCache;
+
+class DefinitionFileCacheTest extends TestCase
+{
+    private string $definitionFile;
+
+    protected function setUp(): void
+    {
+        $this->definitionFile = tempnam(sys_get_temp_dir(), 'definition_') . '.php';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->definitionFile);
+        DefinitionFileCache::clear();
+    }
+
+    private function writeDefinition(string $name): void
+    {
+        file_put_contents(
+            $this->definitionFile,
+            '<?php return \Pimcore\Model\DataObject\ClassDefinition::create([\'name\' => \'' . $name . '\']);'
+        );
+    }
+
+    public function testIncludedDefinitionIsCached(): void
+    {
+        $this->writeDefinition('CachedDefinition');
+
+        $first = DefinitionFileCache::load($this->definitionFile);
+        $second = DefinitionFileCache::load($this->definitionFile);
+
+        $this->assertInstanceOf(ClassDefinition::class, $first);
+        $this->assertSame('CachedDefinition', $first->getName());
+        $this->assertSame($first, $second);
+    }
+
+    public function testChangedFileIsReloaded(): void
+    {
+        $this->writeDefinition('OriginalDefinition');
+        $original = DefinitionFileCache::load($this->definitionFile);
+
+        $this->writeDefinition('ChangedDefinition');
+        touch($this->definitionFile, time() + 2);
+
+        $reloaded = DefinitionFileCache::load($this->definitionFile);
+
+        $this->assertNotSame($original, $reloaded);
+        $this->assertSame('ChangedDefinition', $reloaded->getName());
+    }
+
+    public function testForceBypassesCache(): void
+    {
+        $this->writeDefinition('ForcedDefinition');
+
+        $cached = DefinitionFileCache::load($this->definitionFile);
+        $forced = DefinitionFileCache::load($this->definitionFile, true);
+
+        $this->assertNotSame($cached, $forced);
+    }
+
+    public function testClearInvalidatesEntry(): void
+    {
+        $this->writeDefinition('ClearedDefinition');
+
+        $first = DefinitionFileCache::load($this->definitionFile);
+        DefinitionFileCache::clear($this->definitionFile);
+        $second = DefinitionFileCache::load($this->definitionFile);
+
+        $this->assertNotSame($first, $second);
+    }
+
+    public function testMissingFileReturnsNull(): void
+    {
+        $this->assertNull(DefinitionFileCache::load($this->definitionFile . '.missing'));
+    }
+
+    public function testDeletedFileIsEvicted(): void
+    {
+        $this->writeDefinition('DeletedDefinition');
+        $this->assertInstanceOf(ClassDefinition::class, DefinitionFileCache::load($this->definitionFile));
+
+        unlink($this->definitionFile);
+
+        $this->assertNull(DefinitionFileCache::load($this->definitionFile));
+    }
+}


### PR DESCRIPTION
When you have long-running scripts which load class definitions and also clear runtime cache, there are currently 2 problems:
1. It is horribly slow because it will load the class definitions again and again in https://github.com/pimcore/pimcore/blob/12.x/models/DataObject/ClassDefinition.php#L231
And we cannot use `include_once()` here because this would return `true` after first iteration, then the definition would not be available at all.
2. You will get "Too many open files" PHP error.

Script to reproduce the problem:
```php
<?php
for($i=1;$i<10000;$i++) {
  $classDefinition = \Pimcore\Model\DataObject\ClassDefinition::getById('Product');
  \Pimcore\Cache\RuntimeCache::clear();
}
```