### PR TITLE
Draft: Fixed usage of value in classificationstore as defined in field-type

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -332,7 +332,7 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
                             $keyConfig
                         );
 
-                        $dataFromEditMode = $dataDefinition->getDataFromEditmode($value);
+                        $dataFromEditMode = $dataDefinition->getDataFromEditmode($value, $object);
                         $activeGroups[$groupId] = true;
 
                         $classificationStore->setLocalizedKeyValue($groupId, $keyId, $dataFromEditMode, $language);

--- a/models/DataObject/Classificationstore.php
+++ b/models/DataObject/Classificationstore.php
@@ -189,11 +189,8 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
                 }
 
                 $newData = $dataDefinition->getDataForResource($value, $this->object, ['owner' => $this]);
-                if ($dataDefinition instanceof Model\DataObject\ClassDefinition\Data\Password) {
-                    $value = $newData;
-                } else {
-                    $newData = serialize($newData);
-                }
+                $value = $newData;
+                $newData = serialize($newData);
 
                 if ($newData != $oldData) {
                     $this->markFieldDirty('_self');


### PR DESCRIPTION
## Changes in this pull request  

When saving a property in the classificationstore, the data is received with the Data definition's function `getDataForResource`. 

This data is then being used for a comparison with the previously saved data to see if something has changed. Nonetheless, the data is not used to be stored in the database, the only exception is the Password field.

Why is this the case?

This is a problem in our case, where we have implemented our own data-type where `$value` is in fact an object, which only returns the data that should be stored, when calling its `getDataForResource` function
