### PR TITLE
[BUGFIX] Fixed dirty detection of classificationstore, which often returns the wrong result, when saving the first time.

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -1171,5 +1171,4 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
         // Compare items
         return serialize($oldValue->getItems()) === serialize($newValue->getItems());
     }
-
 }

--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -27,7 +27,7 @@ use Pimcore\Model\DataObject\Localizedfield;
 use Pimcore\Normalizer\NormalizerInterface;
 use Pimcore\Tool;
 
-class Classificationstore extends Data implements CustomResourcePersistingInterface, TypeDeclarationSupportInterface, NormalizerInterface, PreGetDataInterface, LayoutDefinitionEnrichmentInterface, VarExporterInterface, ClassSavedInterface
+class Classificationstore extends Data implements CustomResourcePersistingInterface, TypeDeclarationSupportInterface, NormalizerInterface, PreGetDataInterface, LayoutDefinitionEnrichmentInterface, VarExporterInterface, ClassSavedInterface, EqualComparisonInterface
 {
     use DataObject\Traits\DataHeightTrait;
     use DataObject\Traits\DataWidthTrait;
@@ -1150,4 +1150,26 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
     {
         return 'classificationstore';
     }
+
+    public function isEqual(mixed $oldValue, mixed $newValue): bool
+    {
+        // Check if they are the same reference
+        if ($oldValue === $newValue) {
+            return true;
+        }
+
+        // Check if related objects are the same
+        if ($oldValue->getObject()->getId() !== $newValue->getObject()->getId()) {
+            return false;
+        }
+
+        // Check if they are of the same type
+        if (get_class($oldValue) !== get_class($newValue)) {
+            return false;
+        }
+
+        // Compare items
+        return serialize($oldValue->getItems()) === serialize($newValue->getItems());
+    }
+
 }


### PR DESCRIPTION
Fixed dirty detection of classificationstore, which often returns the wrong result, when saving the first time.

Therefore implemented the EqualComparisonInterface and compare:
- The references
- the related objects
- the classes
- and the serialized items