### PR TITLE
Fix Listing Alias for CustomViews

### DIFF
--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -1450,9 +1450,9 @@ class Service extends Model\AbstractModel
     private static function getListingFrom(PaginateListingInterface $listing): ?string
     {
         return match(true) {
-            $listing instanceof Asset\Listing => 'asset',
-            $listing instanceof DataObject\Listing => 'object',
-            $listing instanceof Document\Listing => 'document',
+            $listing instanceof Asset\Listing => 'assets',
+            $listing instanceof DataObject\Listing => 'objects',
+            $listing instanceof Document\Listing => 'documents',
             default => null,
         };
     }


### PR DESCRIPTION
fix listing problem when using custom views

e.g. custom view: https://docs.pimcore.com/platform/Pimcore/Objects/Object_Classes/Class_Settings/Custom_Views/#additional-object-tree-including-condition-filter

results in following error: 
![image](https://github.com/user-attachments/assets/a3a67f0a-a381-4225-9a84-31a17fc12366)
