### PR TITLE
[Bug, EC] PEES-605: Fix Warning: touch(): Utime failed

### DIFF
--- a/lib/Config/LocationAwareConfigRepository.php
+++ b/lib/Config/LocationAwareConfigRepository.php
@@ -276,7 +276,7 @@ class LocationAwareConfigRepository
     {
         // invalidate container config cache if debug flag on kernel is set
         $servicesConfig = PIMCORE_PROJECT_ROOT . '/config/services.yaml';
-        if (is_file($servicesConfig)) {
+        if (is_writable($servicesConfig)) {
             touch($servicesConfig);
         }
     }

--- a/lib/Config/LocationAwareConfigRepository.php
+++ b/lib/Config/LocationAwareConfigRepository.php
@@ -277,7 +277,7 @@ class LocationAwareConfigRepository
     {
         // invalidate container config cache if debug flag on kernel is set
         $servicesConfig = PIMCORE_PROJECT_ROOT . '/config/services.yaml';
-        if (is_writable($servicesConfig)) {
+        if (is_writable($servicesConfig) || fileowner($servicesConfig) === getmyuid()) {
             touch($servicesConfig);
         } else {
             $kernel = Pimcore::getKernel();

--- a/lib/Config/LocationAwareConfigRepository.php
+++ b/lib/Config/LocationAwareConfigRepository.php
@@ -281,8 +281,8 @@ class LocationAwareConfigRepository
             touch($servicesConfig);
         } else {
             $kernel = Pimcore::getKernel();
-            $app = new Application($kernel);
             if ($kernel->isDebug()) {
+                $app = new Application($kernel);
                 $app->setAutoExit(false);
                 $input = new \Symfony\Component\Console\Input\ArrayInput([
                     'command' => 'cache:clear',

--- a/lib/Config/LocationAwareConfigRepository.php
+++ b/lib/Config/LocationAwareConfigRepository.php
@@ -277,20 +277,8 @@ class LocationAwareConfigRepository
     {
         // invalidate container config cache if debug flag on kernel is set
         $servicesConfig = PIMCORE_PROJECT_ROOT . '/config/services.yaml';
-        if (is_writable($servicesConfig) || fileowner($servicesConfig) === getmyuid()) {
+        if (is_writable($servicesConfig)) {
             touch($servicesConfig);
-        } else {
-            $kernel = Pimcore::getKernel();
-            if ($kernel->isDebug()) {
-                $app = new Application($kernel);
-                $app->setAutoExit(false);
-                $input = new \Symfony\Component\Console\Input\ArrayInput([
-                    'command' => 'cache:clear',
-                    '--env' => $kernel->getEnvironment(),
-                ]);
-                $output = new \Symfony\Component\Console\Output\NullOutput();
-                $app->run($input, $output);
-            }
         }
     }
 

--- a/lib/Config/LocationAwareConfigRepository.php
+++ b/lib/Config/LocationAwareConfigRepository.php
@@ -16,6 +16,7 @@ namespace Pimcore\Config;
 use Exception;
 use Pimcore;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\ConfigurationHelper;
+use Pimcore\Console\Application;
 use Pimcore\Helper\StopMessengerWorkersTrait;
 use Pimcore\Model\Tool\SettingsStore;
 use Symfony\Component\Config\FileLocator;
@@ -278,6 +279,18 @@ class LocationAwareConfigRepository
         $servicesConfig = PIMCORE_PROJECT_ROOT . '/config/services.yaml';
         if (is_writable($servicesConfig)) {
             touch($servicesConfig);
+        } else {
+            $kernel = Pimcore::getKernel();
+            $app = new Application($kernel);
+            if ($kernel->isDebug()) {
+                $app->setAutoExit(false);
+                $input = new \Symfony\Component\Console\Input\ArrayInput([
+                    'command' => 'cache:clear',
+                    '--env' => $kernel->getEnvironment(),
+                ]);
+                $output = new \Symfony\Component\Console\Output\NullOutput();
+                $app->run($input, $output);
+            }
         }
     }
 

--- a/lib/Config/LocationAwareConfigRepository.php
+++ b/lib/Config/LocationAwareConfigRepository.php
@@ -16,7 +16,6 @@ namespace Pimcore\Config;
 use Exception;
 use Pimcore;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\ConfigurationHelper;
-use Pimcore\Console\Application;
 use Pimcore\Helper\StopMessengerWorkersTrait;
 use Pimcore\Model\Tool\SettingsStore;
 use Symfony\Component\Config\FileLocator;


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/service-operations/issues/143

## Additional info
Can't touch this because of the hammer Utime, so checking if is writeable instead of is_file, ~when not, try to cache:clear if is in debug mode~

~Checking also if is the owner, thanks to https://stackoverflow.com/a/49158663, it would be touchable even without write permissions~