### PR TITLE
[Bug, EC] PEES-619: SimpleBackendSearch issue with localized fields in bricks

### DIFF
--- a/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
+++ b/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
@@ -32,6 +32,7 @@ use Pimcore\Extension\Bundle\Exception\AdminClassicBundleNotFoundException;
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Localizedfields;
+use Pimcore\Model\DataObject\Objectbrick\Definition;
 use Pimcore\Model\Document;
 use Pimcore\Model\Element;
 use Pimcore\Model\Element\AdminStyle;
@@ -51,13 +52,14 @@ class SearchController extends UserAwareController
     use JsonHelperTrait;
 
     /**
-     * @todo: $conditionTypeParts could be undefined
-     *
+     * @throws \JsonException
      * @todo: $conditionSubtypeParts could be undefined
      *
      * @todo: $conditionClassnameParts could be undefined
      *
      * @todo: $data could be undefined
+     * @todo: $conditionTypeParts could be undefined
+     *
      */
     #[Route('/find', name: 'pimcore_bundle_search_search_find', methods: ['GET', 'POST'])]
     public function findAction(Request $request, EventDispatcherInterface $eventDispatcher, GridHelperService $gridHelperService): JsonResponse
@@ -117,17 +119,7 @@ class SearchController extends UserAwareController
             //remove sql comments
             $fields = str_replace('--', '', $fields);
 
-            foreach ($fields as $f) {
-                $parts = explode('~', $f);
-                if (str_starts_with($f, '~')) {
-                    //                    $type = $parts[1];
-                    //                    $field = $parts[2];
-                    //                    $keyid = $parts[3];
-                    // key value, ignore for now
-                } elseif (count($parts) > 1) {
-                    $bricks[$parts[0]] = $parts[0];
-                }
-            }
+            $bricks = $this->parseBricks($fields);
         }
 
         // filtering for objects
@@ -141,17 +133,23 @@ class SearchController extends UserAwareController
             $localizedFieldsFilters = [];
 
             foreach ($params as $paramConditionObject) {
+                $property = $paramConditionObject['property'] ?? null;
+                $isBrick = $this->isBrick($property);
+                $isLocalizedBrick = $this->isLocalizedFieldBrick($property);
+
                 //this loop divides filter parameters to localized and unlocalized groups
-                if (in_array($paramConditionObject['property'], DataObject\Service::getSystemFields())) {
+                if (in_array($property, DataObject\Service::getSystemFields())) {
                     $unlocalizedFieldsFilters[] = $paramConditionObject;
-                } elseif ($localizedFields instanceof Localizedfields && $localizedFields->getFieldDefinition($paramConditionObject['property'])) {
+                } elseif (($isBrick && $isLocalizedBrick) ||
+                    ($localizedFields instanceof Localizedfields && $localizedFields->getFieldDefinition($property))) {
                     $localizedFieldsFilters[] = $paramConditionObject;
-                } elseif ($class->getFieldDefinition($paramConditionObject['property'])) {
+                } elseif (
+                    $isBrick ||
+                    $class->getFieldDefinition($property)
+                ) {
                     $unlocalizedFieldsFilters[] = $paramConditionObject;
                 }
             }
-
-            //get filter condition only when filters array is not empty
 
             //string statements for divided filters
             $conditionFilters = count($unlocalizedFieldsFilters)
@@ -164,14 +162,22 @@ class SearchController extends UserAwareController
             $join = '';
             $localizedJoin = '';
             foreach ($bricks as $ob) {
-                $join .= ' LEFT JOIN object_brick_query_' . $ob . '_' . $class->getId();
-                $join .= ' `' . $ob . '`';
+                $brickAlias = ' `' . $ob .'`';
+                $objectTable = '`search_backend_data`';
+
+                $join .= ' LEFT JOIN object_brick_query_' . $ob . '_' . $class->getId() . $brickAlias;
+                $join .= ' ON ' . $brickAlias . '.id = ' . $objectTable . '.id';
 
                 if ($localizedConditionFilters) {
-                    $localizedJoin = $join . ' ON `' . $ob . '`.id = `object_localized_data_' . $class->getId() . '`.ooo_id';
+                    $localizedFieldAlias = ' `' . $ob .'_localized`';
+                    $localizedJoin = sprintf('%s LEFT JOIN %s as %s on %s.id = %s.ooo_id',
+                        empty($conditionFilters) ? $join : '',
+                        'object_brick_localized_' . $ob . '_' . $class->getId(),
+                        $localizedFieldAlias,
+                        $brickAlias,
+                        $localizedFieldAlias
+                    );
                 }
-
-                $join .= ' ON `' . $ob . '`.id = `object_' . $class->getId() . '`.id';
             }
 
             if (null !== $conditionFilters) {
@@ -644,5 +650,81 @@ class SearchController extends UserAwareController
             $data['cls'] .= $adminStyle->getElementCssClass() . ' ';
         }
         $data['qtipCfg'] = $adminStyle->getElementQtipConfig();
+    }
+
+    /**
+     * @throws \JsonException
+     */
+    private function parseBricks(array $fields): array
+    {
+        $bricks = [];
+
+        foreach ($fields as $f) {
+            $name = $this->getBrickData($f);
+            if ($name) {
+                $bricks[] = $name;
+            }
+        }
+
+        return array_unique($bricks);
+    }
+
+    /**
+     * @throws \JsonException
+     */
+    private function getBrickData(string $fieldName): ?string
+    {
+        $isLocalized = $this->isLocalizedFieldBrick($fieldName);
+        $parts = explode('~', $fieldName);
+
+        if (count($parts) <= 1) {
+            return null;
+        }
+
+        $brick = $parts[0];
+        if ($isLocalized) {
+            $encodedBrickData = json_decode(
+                substr($brick, 1),
+                true,
+                flags: JSON_THROW_ON_ERROR
+            );
+
+            return $encodedBrickData['containerKey'];
+        }
+
+        return $parts[0];
+    }
+
+    /**
+     * @throws \JsonException
+     */
+    private function isBrick(string $fieldName): bool
+    {
+        return $this->getBrickData($fieldName) !== null;
+    }
+
+    /**
+     * @throws \JsonException
+     */
+    private function isLocalizedFieldBrick(string $fieldName): bool
+    {
+        $parts = explode('~', $fieldName);
+        if (count($parts) <= 1) {
+            return false;
+        }
+
+        return str_starts_with(
+            $parts[0],
+            '?'
+            ) &&
+            isset(json_decode(
+                    substr(
+                        $parts[0],
+                        1
+                    ),
+                    true,
+                    512,
+                    JSON_THROW_ON_ERROR)
+                ['containerKey']);
     }
 }

--- a/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
+++ b/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
@@ -724,7 +724,8 @@ class SearchController extends UserAwareController
                     ),
                     true,
                     512,
-                    JSON_THROW_ON_ERROR)
+                    JSON_THROW_ON_ERROR
+                )
                 ['containerKey']);
     }
 }


### PR DESCRIPTION
Resolves https://github.com/pimcore/service-operations/issues/155

Fixes sql errors when adding object brick columns to the grid. Enables filtering for object brick values. 
There is still the possibility for sql related error messages, when filtering for more than one object brick column in the grid 