### PR TITLE
[Bug]: Translation setCondition() is getting cached 

### DIFF
--- a/lib/Model/Listing/AbstractListing.php
+++ b/lib/Model/Listing/AbstractListing.php
@@ -295,6 +295,8 @@ abstract class AbstractListing extends AbstractModel implements Iterator, Counta
         $this->condition = $condition;
 
         // statement variables
+        $this->setConditionVariablesFromSetCondition([]);
+
         if (is_array($conditionVariables)) {
             $this->setConditionVariablesFromSetCondition($conditionVariables);
         } elseif ($conditionVariables !== null) {

--- a/models/Translation/Listing/Dao.php
+++ b/models/Translation/Listing/Dao.php
@@ -112,7 +112,11 @@ class Dao extends Model\Listing\Dao\AbstractDao
         $queryBuilder = $this->getQueryBuilder($this->getDatabaseTableName() . '.key');
         $cacheKey = $this->getDatabaseTableName().'_data_' . md5((string)$queryBuilder);
 
-        if (!empty($this->model->getConditionParams()) || !$translations = Cache::load($cacheKey)) {
+        if (
+            !empty($this->model->getConditionParams()) ||
+            !empty($this->model->getConditionVariablesFromSetCondition()) ||
+            !$translations = Cache::load($cacheKey)
+        ) {
             $translations = [];
             $translationsData = $this->db->fetchAllAssociative($queryBuilder->getSql(), $queryBuilder->getParameters(), $queryBuilder->getParameterTypes());
             foreach ($translationsData as $t) {
@@ -123,7 +127,10 @@ class Dao extends Model\Listing\Dao\AbstractDao
                 }
             }
 
-            if (empty($this->model->getConditionParams())) {
+            if (
+                empty($this->model->getConditionParams()) &&
+                empty($this->model->getConditionVariablesFromSetCondition())
+            ) {
                 Cache::save($translations, $cacheKey, ['translator', 'translate'], null, 999);
             }
         }

--- a/models/Translation/Listing/Dao.php
+++ b/models/Translation/Listing/Dao.php
@@ -111,11 +111,12 @@ class Dao extends Model\Listing\Dao\AbstractDao
 
         $queryBuilder = $this->getQueryBuilder($this->getDatabaseTableName() . '.key');
         $cacheKey = $this->getDatabaseTableName().'_data_' . md5((string)$queryBuilder);
+        $translations = Cache::load($cacheKey);
 
         if (
+            !$translations ||
             !empty($this->model->getConditionParams()) ||
-            !empty($this->model->getConditionVariablesFromSetCondition()) ||
-            !$translations = Cache::load($cacheKey)
+            !empty($this->model->getConditionVariablesFromSetCondition())
         ) {
             $translations = [];
             $translationsData = $this->db->fetchAllAssociative($queryBuilder->getSql(), $queryBuilder->getParameters(), $queryBuilder->getParameterTypes());


### PR DESCRIPTION
Resolves https://github.com/pimcore/pimcore/issues/18260

### Additional Information
Reset `conditionVariablesFromSetCondition`, when `setCondition` gets called. Otherwise it would reapply the conditions again, when setting a condition that doesnt need a variable.
E.g. 

```
$list = new \Pimcore\Model\Translation\Listing();
$list->setCondition("text LIKE ?", ["%foo%"]);
$items = $list->load();

$list->setCondition("text LIKE ?", ["%bar%"]);
$items2 = $list->load();

//Without this pr, the last condition (text like %bar%) will be reapplied here
$list->setCondition("text is not null");
$items3 = $list->load();
```