### PR TITLE
[Bug, EC] PEES-636: Fix Empty Select Options Causes Errors

### DIFF
--- a/models/DataObject/SelectOptions/Config/Dao.php
+++ b/models/DataObject/SelectOptions/Config/Dao.php
@@ -77,8 +77,8 @@ class Dao extends Model\Dao\PimcoreLocationAwareConfigDao
     {
         $this->validateId();
 
-        $this->saveConfiguration();
         $this->model->generateEnumFiles();
+        $this->saveConfiguration();
     }
 
     protected function saveConfiguration(): void


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/service-operations/issues/168

## Additional info
When adding an invalid option, either empty or a name with just a number
<img width="1146" height="232" alt="image" src="https://github.com/user-attachments/assets/d08773c0-42b8-423e-b0aa-cc0313f570c7" /> it saves it regardlessy (see by Reload Definition). 
The generateEnumFiles() perfoms some checks and throws exceptions, so swapping the order is fixing it.
