### PR TITLE
[Bug]: Migration "Version20250526125951" fails if SEO Bundle is not installed

### DIFF
--- a/bundles/CoreBundle/src/Migrations/Version20250526125951.php
+++ b/bundles/CoreBundle/src/Migrations/Version20250526125951.php
@@ -29,11 +29,19 @@ final class Version20250526125951 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        if(!$schema->hasTable('redirects')) {
+            return;
+        }
+
         $this->addSql('UPDATE redirects SET sourceSite=0 WHERE sourceSite IS NULL');
     }
 
     public function down(Schema $schema): void
     {
+        if(!$schema->hasTable('redirects')) {
+            return;
+        }
+
         $this->addSql('UPDATE redirects SET sourceSite=NULL WHERE sourceSite=0');
     }
 }


### PR DESCRIPTION
Resolves https://github.com/pimcore/pimcore/issues/18534