### PR TITLE
SetModificationDate() should make field dirty

### DIFF
--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -160,10 +160,8 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
 
     public function setModificationDate(int $modificationDate): static
     {
-        if ($this->modificationDate != $modificationDate) {
-            $this->markFieldDirty('modificationDate');
-            $this->modificationDate = $modificationDate;
-        }
+        $this->markFieldDirty('modificationDate');
+        $this->modificationDate = $modificationDate;
 
         return $this;
     }


### PR DESCRIPTION
On using method setModificationDate() the modification date "changed" even if it looks similar and it became dirty regardless of value.

## Changes in this pull request  

Resolves #

It was a BUG on saving an DataObject: 
- If custom modification date and value in DB are **equal** - **NOW()** date will be saved
- If custom modification date and value in DB are **NOT** equal - **custom** date will be saved

This code
```
$product = Product::getById(77);
$product->setModificationDate(1753768622);
$product->save();
```
could store unexpected value depends on which value already in DB.

Now, any usage of setModificationDate() makes this field dirty and stores new value to DB.
