### PR TITLE
[Bug] Fix check for error while setting completion state in `GenericExecutionEngine`

### DIFF
--- a/bundles/GenericExecutionEngineBundle/src/Agent/JobExecutionAgent.php
+++ b/bundles/GenericExecutionEngineBundle/src/Agent/JobExecutionAgent.php
@@ -413,15 +413,18 @@ final class JobExecutionAgent implements JobExecutionAgentInterface
             $jobRun->getCurrentStep()
         );
 
-        if (count($logs) === $jobRun->getTotalElements()) {
+        $logsCount = count($logs);
+        $stepsCount = count($jobRun->getJob()?->getSteps() ?? []);
+
+        if ($logsCount === $stepsCount) {
             $jobRun->setState(JobRunStates::FAILED);
             $message = 'gee_job_failed';
-        } elseif (count($logs) > 0) {
+        } elseif ($logsCount) {
             $jobRun->setState(JobRunStates::FINISHED_WITH_ERRORS);
             $message = 'gee_job_finished_with_errors';
         }
 
-        if (empty($logs)) {
+        if ($logsCount === 0) {
             $jobRun->setCurrentMessage(null);
             $jobRun->setState(JobRunStates::FINISHED);
             $message = 'gee_job_finished';

--- a/bundles/GenericExecutionEngineBundle/src/Agent/JobExecutionAgent.php
+++ b/bundles/GenericExecutionEngineBundle/src/Agent/JobExecutionAgent.php
@@ -204,7 +204,7 @@ final class JobExecutionAgent implements JobExecutionAgentInterface
             return;
         }
 
-        $this->setJobStepState($jobRun, JobStepStates::FINISHED);
+        $this->setJobStepState($jobRun, JobStepStates::SUCCEEDED);
         $nextStep = $jobRun->getCurrentStep() + 1;
 
         if (count($job->getSteps()) <= $nextStep) {
@@ -421,7 +421,7 @@ final class JobExecutionAgent implements JobExecutionAgentInterface
         );
         $finishedStepsCount = count(
             array_filter($jobRunSteps,
-                static fn ($step) => $step->getState() === JobStepStates::FINISHED
+                static fn ($step) => $step->getState() === JobStepStates::SUCCEEDED
             )
         );
 
@@ -487,7 +487,7 @@ final class JobExecutionAgent implements JobExecutionAgentInterface
         }
 
         $currentJobStepState = $currentJobStep->getState();
-        if(in_array($currentJobStepState, [JobStepStates::FINISHED, JobStepStates::FAILED], true)) {
+        if($currentJobStepState === JobStepStates::FAILED) {
             return;
         }
 

--- a/bundles/GenericExecutionEngineBundle/src/Agent/JobExecutionAgent.php
+++ b/bundles/GenericExecutionEngineBundle/src/Agent/JobExecutionAgent.php
@@ -19,6 +19,8 @@ use Pimcore\Bundle\GenericExecutionEngineBundle\Entity\JobRun;
 use Pimcore\Bundle\GenericExecutionEngineBundle\Messenger\Messages\GenericExecutionEngineMessageInterface;
 use Pimcore\Bundle\GenericExecutionEngineBundle\Model\Job;
 use Pimcore\Bundle\GenericExecutionEngineBundle\Model\JobRunStates;
+use Pimcore\Bundle\GenericExecutionEngineBundle\Model\JobStep;
+use Pimcore\Bundle\GenericExecutionEngineBundle\Model\JobStepStates;
 use Pimcore\Bundle\GenericExecutionEngineBundle\Repository\JobRunErrorLogRepositoryInterface;
 use Pimcore\Bundle\GenericExecutionEngineBundle\Repository\JobRunRepositoryInterface;
 use Pimcore\Bundle\GenericExecutionEngineBundle\Utils\Enums\ErrorHandlingMode;
@@ -75,6 +77,7 @@ final class JobExecutionAgent implements JobExecutionAgentInterface
             'gee_job_started',
             $this->getLogParams($jobRun)
         );
+        $this->setJobStepState($jobRun, JobStepStates::RUNNING);
         $this->jobRunRepository->update($jobRun);
 
         $this->dispatchStepMessage($jobRun);
@@ -201,13 +204,13 @@ final class JobExecutionAgent implements JobExecutionAgentInterface
             return;
         }
 
+        $this->setJobStepState($jobRun, JobStepStates::FINISHED);
         $nextStep = $jobRun->getCurrentStep() + 1;
 
         if (count($job->getSteps()) <= $nextStep) {
             $jobRun->setCurrentStep(null);
             $this->setCompletionState($jobRun);
             $this->jobRunRepository->update($jobRun);
-
             $this->genericExecutionEngineLogger->info("[JobRun {$jobRun->getId()}]: Job '{$job->getName()}' finished.");
         } else {
             $jobRun->setProcessedElementsForStep(0);
@@ -291,6 +294,7 @@ final class JobExecutionAgent implements JobExecutionAgentInterface
             JobRunStates::RUNNING
         );
 
+        $this->setJobStepState($jobRun, JobStepStates::FAILED);
         $this->handleNextMessage($message);
     }
 
@@ -407,24 +411,31 @@ final class JobExecutionAgent implements JobExecutionAgentInterface
     private function setCompletionState(JobRun $jobRun): void
     {
         $message = '';
+        $jobRunSteps = $jobRun->getJob()?->getSteps();
 
-        $logs = $this->jobRunErrorLogRepository->getLogsByJobRunId(
-            $jobRun->getId(),
-            $jobRun->getCurrentStep()
+        $totalStepsCount = count($jobRunSteps);
+        $failedStepsCount = count(
+                array_filter($jobRunSteps,
+                static fn ($step) => $step->getState() === JobStepStates::FAILED
+            )
+        );
+        $finishedStepsCount = count(
+            array_filter($jobRunSteps,
+                static fn ($step) => $step->getState() === JobStepStates::FINISHED
+            )
         );
 
-        $logsCount = count($logs);
-        $stepsCount = count($jobRun->getJob()?->getSteps() ?? []);
-
-        if ($logsCount === $stepsCount) {
+        if ($totalStepsCount === $failedStepsCount) {
             $jobRun->setState(JobRunStates::FAILED);
             $message = 'gee_job_failed';
-        } elseif ($logsCount) {
+        }
+
+        if ($failedStepsCount > 0 && $totalStepsCount !== $failedStepsCount) {
             $jobRun->setState(JobRunStates::FINISHED_WITH_ERRORS);
             $message = 'gee_job_finished_with_errors';
         }
 
-        if ($logsCount === 0) {
+        if ($totalStepsCount === $finishedStepsCount) {
             $jobRun->setCurrentMessage(null);
             $jobRun->setState(JobRunStates::FINISHED);
             $message = 'gee_job_finished';
@@ -465,5 +476,21 @@ final class JobExecutionAgent implements JobExecutionAgentInterface
             )
             );
         }
+    }
+
+    private function setJobStepState(JobRun|JobStep $jobElement, JobStepStates $jobStepState): void {
+        $currentJobStep = $jobElement instanceof JobStep ?
+            $jobElement : $jobElement->getJob()?->getSteps()[$jobElement->getCurrentStep()] ?? null;
+
+        if (!$currentJobStep) {
+            return;
+        }
+
+        $currentJobStepState = $currentJobStep->getState();
+        if(in_array($currentJobStepState, [JobStepStates::FINISHED, JobStepStates::FAILED], true)) {
+            return;
+        }
+
+        $currentJobStep->setState($jobStepState);
     }
 }

--- a/bundles/GenericExecutionEngineBundle/src/Model/JobStep.php
+++ b/bundles/GenericExecutionEngineBundle/src/Model/JobStep.php
@@ -18,12 +18,12 @@ use Pimcore\Bundle\GenericExecutionEngineBundle\Utils\Enums\SelectionProcessingM
 final class JobStep implements JobStepInterface
 {
     public function __construct(
-        private readonly string                  $name,
-        private readonly string                  $messageFQCN,
-        private readonly string                  $condition,
-        private readonly array                   $config,
+        private readonly string $name,
+        private readonly string $messageFQCN,
+        private readonly string $condition,
+        private readonly array  $config,
         private readonly SelectionProcessingMode $selectionProcessingMode = SelectionProcessingMode::FOR_EACH,
-        private JobStepStates                    $jobStepState = JobStepStates::NOT_STARTED,
+        private JobStepStates $jobStepState = JobStepStates::NOT_STARTED,
     ) {
     }
 

--- a/bundles/GenericExecutionEngineBundle/src/Model/JobStep.php
+++ b/bundles/GenericExecutionEngineBundle/src/Model/JobStep.php
@@ -18,11 +18,12 @@ use Pimcore\Bundle\GenericExecutionEngineBundle\Utils\Enums\SelectionProcessingM
 final class JobStep implements JobStepInterface
 {
     public function __construct(
-        private readonly string $name,
-        private readonly string $messageFQCN,
-        private readonly string $condition,
-        private readonly array $config,
-        private readonly SelectionProcessingMode $selectionProcessingMode = SelectionProcessingMode::FOR_EACH
+        private readonly string                  $name,
+        private readonly string                  $messageFQCN,
+        private readonly string                  $condition,
+        private readonly array                   $config,
+        private readonly SelectionProcessingMode $selectionProcessingMode = SelectionProcessingMode::FOR_EACH,
+        private JobStepStates                    $jobStepState = JobStepStates::NOT_STARTED,
     ) {
     }
 
@@ -49,5 +50,14 @@ final class JobStep implements JobStepInterface
     public function getSelectionProcessingMode(): SelectionProcessingMode
     {
         return $this->selectionProcessingMode;
+    }
+
+    public function getState(): JobStepStates
+    {
+        return $this->jobStepState;
+    }
+
+    public function setState(JobStepStates $state): void {
+        $this->jobStepState = $state;
     }
 }

--- a/bundles/GenericExecutionEngineBundle/src/Model/JobStepStates.php
+++ b/bundles/GenericExecutionEngineBundle/src/Model/JobStepStates.php
@@ -14,10 +14,13 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GenericExecutionEngineBundle\Model;
 
+/**
+ * @internal
+ */
 enum JobStepStates: string
 {
     case RUNNING = 'running';
-    case FINISHED = 'finished';
+    case SUCCEEDED = 'succeeded';
     case FAILED = 'failed';
     case NOT_STARTED = 'not_started';
 }

--- a/bundles/GenericExecutionEngineBundle/src/Model/JobStepStates.php
+++ b/bundles/GenericExecutionEngineBundle/src/Model/JobStepStates.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\GenericExecutionEngineBundle\Model;
+
+enum JobStepStates: string
+{
+    case RUNNING = 'running';
+    case FINISHED = 'finished';
+    case FAILED = 'failed';
+    case NOT_STARTED = 'not_started';
+}


### PR DESCRIPTION
Part of https://github.com/pimcore/copilot-bundle/issues/656

### Additional Information
Added `JobStepStates` to better indicate if a step failed, no need to get logs for that anymore. With this information available we have more control over setting the completion state of the actual job run.