### PR TITLE
[Improvement]: Reduce N+1 Queries in Version, Store, Collection, and ClassDefinition listing

### DIFF
--- a/models/DataObject/ClassDefinition/Listing/Dao.php
+++ b/models/DataObject/ClassDefinition/Listing/Dao.php
@@ -13,8 +13,11 @@
 namespace Pimcore\Model\DataObject\ClassDefinition\Listing;
 
 use Exception;
+use Pimcore\Cache\RuntimeCache;
+use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\DataObject;
+use Pimcore\Model\DataObject\ClassDefinition;
 
 /**
  * @internal
@@ -31,17 +34,61 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         $classes = [];
 
-        $classesRaw = $this->db->fetchFirstColumn('SELECT id FROM classes' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
+        $classesData = $this->db->fetchAllAssociative(
+            'SELECT * FROM classes' . 
+            $this->getCondition() . 
+            $this->getOrder() . 
+            $this->getOffsetLimit(), 
+            $this->model->getConditionVariables(), 
+            $this->model->getConditionVariableTypes()
+        );
 
-        foreach ($classesRaw as $classRaw) {
-            if ($class = DataObject\ClassDefinition::getById($classRaw)) {
-                $classes[] = $class;
-            }
+        foreach ($classesData as $classData) {
+            $classes[] = $this->buildModel($classData['id'], $classData['name']);
         }
 
         $this->model->setClasses($classes);
 
         return $classes;
+    }
+
+    public function buildModel(int $id, string $name, bool $force = false): ?ClassDefinition
+    {
+        $cacheKey = 'class_' . $id;
+
+        try {
+            if ($force) {
+                throw new Exception('Forced load');
+            }
+            $class = RuntimeCache::get($cacheKey);
+            if (!$class) {
+                throw new Exception('Class in registry is null');
+            }
+        } catch (Exception $e) {
+            try {
+                $class = new ClassDefinition();
+                if (!$name) {
+                    throw new Exception('Class definition with name ' . $name . ' or ID ' . $id . ' does not exist');
+                }
+
+                $definitionFile = $class->getDefinitionFile($name);
+                $class = @include $definitionFile;
+
+                if (!$class instanceof ClassDefinition) {
+                    throw new Exception('Class definition with name ' . $name . ' or ID ' . $id . ' does not exist');
+                }
+
+                $class->setId($id);
+
+                RuntimeCache::set($cacheKey, $class);
+            } catch (Exception $e) {
+                Logger::info($e->getMessage());
+
+                return null;
+            }
+        }
+
+        return $class;
     }
 
     public function getTotalCount(): int

--- a/models/DataObject/ClassDefinition/Listing/Dao.php
+++ b/models/DataObject/ClassDefinition/Listing/Dao.php
@@ -35,11 +35,11 @@ class Dao extends Model\Listing\Dao\AbstractDao
         $classes = [];
 
         $classesData = $this->db->fetchAllAssociative(
-            'SELECT * FROM classes' . 
-            $this->getCondition() . 
-            $this->getOrder() . 
-            $this->getOffsetLimit(), 
-            $this->model->getConditionVariables(), 
+            'SELECT * FROM classes' .
+            $this->getCondition() .
+            $this->getOrder() .
+            $this->getOffsetLimit(),
+            $this->model->getConditionVariables(),
             $this->model->getConditionVariableTypes()
         );
 
@@ -52,7 +52,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
         return $classes;
     }
 
-    public function buildModel(int $id, string $name, bool $force = false): ?ClassDefinition
+    public function buildModel(string $id, string $name, bool $force = false): ?ClassDefinition
     {
         $cacheKey = 'class_' . $id;
 

--- a/models/DataObject/Classificationstore/CollectionConfig/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/CollectionConfig/Listing/Dao.php
@@ -31,7 +31,10 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function load(): array
     {
         $collectionsData = $this->db->fetchAllAssociative(
-            'SELECT * FROM ' . DataObject\Classificationstore\CollectionConfig\Dao::TABLE_NAME_COLLECTIONS . ' ' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
+            'SELECT * FROM ' . DataObject\Classificationstore\CollectionConfig\Dao::TABLE_NAME_COLLECTIONS .
+            $this->getCondition() .
+            $this->getOrder() .
+            $this->getOffsetLimit(),
             $this->model->getConditionVariables(),
             $this->model->getConditionVariableTypes()
         );

--- a/models/DataObject/Classificationstore/CollectionConfig/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/CollectionConfig/Listing/Dao.php
@@ -39,11 +39,11 @@ class Dao extends Model\Listing\Dao\AbstractDao
         $modelFactory = Pimcore::getContainer()->get('pimcore.model.factory');
 
         foreach ($collectionsData as $collectionData) {
-            /** @var DataObject\Classificationstore\CollectionConfig $note */
-            $note = $modelFactory->build(DataObject\Classificationstore\CollectionConfig::class);
-            $note->getDao()->assignVariablesToModel($collectionData);
+            /** @var DataObject\Classificationstore\CollectionConfig $collection */
+            $collection = $modelFactory->build(DataObject\Classificationstore\CollectionConfig::class);
+            $collection->getDao()->assignVariablesToModel($collectionData);
 
-            $configData[] = $note;
+            $configData[] = $collection;
         }
 
         $this->model->setList($configData);

--- a/models/DataObject/Classificationstore/CollectionConfig/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/CollectionConfig/Listing/Dao.php
@@ -13,6 +13,7 @@
 namespace Pimcore\Model\DataObject\Classificationstore\CollectionConfig\Listing;
 
 use Exception;
+use Pimcore;
 use Pimcore\Model;
 use Pimcore\Model\DataObject;
 
@@ -29,12 +30,20 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function load(): array
     {
-        $sql = 'SELECT id FROM ' . DataObject\Classificationstore\CollectionConfig\Dao::TABLE_NAME_COLLECTIONS . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit();
-        $configsData = $this->db->fetchFirstColumn($sql, $this->model->getConditionVariables());
-
+        $collectionsData = $this->db->fetchAllAssociative(
+            'SELECT * FROM ' . DataObject\Classificationstore\CollectionConfig\Dao::TABLE_NAME_COLLECTIONS . ' ' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
+            $this->model->getConditionVariables(),
+            $this->model->getConditionVariableTypes()
+        );
         $configData = [];
-        foreach ($configsData as $config) {
-            $configData[] = DataObject\Classificationstore\CollectionConfig::getById($config);
+        $modelFactory = Pimcore::getContainer()->get('pimcore.model.factory');
+
+        foreach ($collectionsData as $collectionData) {
+            /** @var DataObject\Classificationstore\CollectionConfig $note */
+            $note = $modelFactory->build(DataObject\Classificationstore\CollectionConfig::class);
+            $note->getDao()->assignVariablesToModel($collectionData);
+
+            $configData[] = $note;
         }
 
         $this->model->setList($configData);

--- a/models/DataObject/Classificationstore/StoreConfig/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/StoreConfig/Listing/Dao.php
@@ -32,8 +32,8 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         $storesData = $this->db->fetchAllAssociative(
             'SELECT * FROM ' . DataObject\Classificationstore\StoreConfig\Dao::TABLE_NAME_STORES .
-            $this->getCondition() . 
-            $this->getOrder() . 
+            $this->getCondition() .
+            $this->getOrder() .
             $this->getOffsetLimit(),
             $this->model->getConditionVariables(),
             $this->model->getConditionVariableTypes()

--- a/models/DataObject/Classificationstore/StoreConfig/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/StoreConfig/Listing/Dao.php
@@ -13,6 +13,7 @@
 namespace Pimcore\Model\DataObject\Classificationstore\StoreConfig\Listing;
 
 use Exception;
+use Pimcore;
 use Pimcore\Model;
 use Pimcore\Model\DataObject;
 
@@ -29,12 +30,24 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function load(): array
     {
-        $sql = 'SELECT id FROM ' . DataObject\Classificationstore\StoreConfig\Dao::TABLE_NAME_STORES . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit();
-        $configsData = $this->db->fetchFirstColumn($sql, $this->model->getConditionVariables());
+        $storesData = $this->db->fetchAllAssociative(
+            'SELECT * FROM ' . DataObject\Classificationstore\StoreConfig\Dao::TABLE_NAME_STORES .
+            $this->getCondition() . 
+            $this->getOrder() . 
+            $this->getOffsetLimit(),
+            $this->model->getConditionVariables(),
+            $this->model->getConditionVariableTypes()
+        );
 
         $configData = [];
-        foreach ($configsData as $config) {
-            $configData[] = DataObject\Classificationstore\StoreConfig::getById($config);
+        $modelFactory = Pimcore::getContainer()->get('pimcore.model.factory');
+
+        foreach ($storesData as $storeData) {
+            /** @var DataObject\Classificationstore\StoreConfig $store */
+            $store = $modelFactory->build(DataObject\Classificationstore\StoreConfig::class);
+            $store->getDao()->assignVariablesToModel($storeData);
+
+            $configData[] = $store;
         }
 
         $this->model->setList($configData);

--- a/models/Version/Listing/Dao.php
+++ b/models/Version/Listing/Dao.php
@@ -13,6 +13,7 @@
 namespace Pimcore\Model\Version\Listing;
 
 use Exception;
+use Pimcore;
 use Pimcore\Model;
 
 /**
@@ -43,11 +44,24 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function load(): array
     {
+        $versionsData = $this->db->fetchAllAssociative(
+            'SELECT * FROM versions' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
+            $this->model->getConditionVariables(),
+            $this->model->getConditionVariableTypes()
+        );
         $versions = [];
-        $data = $this->loadIdList();
+        $modelFactory = Pimcore::getContainer()->get('pimcore.model.factory');
 
-        foreach ($data as $id) {
-            $versions[] = Model\Version::getById($id);
+        foreach ($versionsData as $versionData) {
+            $versionData['public'] = (bool)$versionData['public'];
+            $versionData['serialized'] = (bool)$versionData['serialized'];
+            $versionData['autoSave'] = (bool)$versionData['autoSave'];
+            
+            /** @var Model\Version $note */
+            $note = $modelFactory->build(Model\Version::class);
+            $note->getDao()->assignVariablesToModel($versionData);
+
+            $versions[] = $note;
         }
 
         $this->model->setVersions($versions);

--- a/models/Version/Listing/Dao.php
+++ b/models/Version/Listing/Dao.php
@@ -57,11 +57,11 @@ class Dao extends Model\Listing\Dao\AbstractDao
             $versionData['serialized'] = (bool)$versionData['serialized'];
             $versionData['autoSave'] = (bool)$versionData['autoSave'];
             
-            /** @var Model\Version $note */
-            $note = $modelFactory->build(Model\Version::class);
-            $note->getDao()->assignVariablesToModel($versionData);
+            /** @var Model\Version $version */
+            $version = $modelFactory->build(Model\Version::class);
+            $version->getDao()->assignVariablesToModel($versionData);
 
-            $versions[] = $note;
+            $versions[] = $version;
         }
 
         $this->model->setVersions($versions);


### PR DESCRIPTION
This PR continues the effort to improve performance by addressing N+1 query patterns in the following Pimcore model listings:

- Version
- StoreConfig
- CollectionConfig
- ClassDefinition

Previously, these listings were subject to inefficient query patterns where a list of IDs was fetched and then individual getById() calls were made within loops, resulting in excessive database queries.
For example, loading 100 entries would result in 1 + 100 queries. This has now been optimized to perform eager-loading or batched fetching where possible, reducing the number of queries to just 1.

**Context**:
This is a follow-up to the previous PR: #18548 which addressed similar performance issues in Note and Tag listings.