### PR TITLE
Fix video editable editmode data

### DIFF
--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -25,7 +25,7 @@ use Pimcore\Tool;
 /**
  * @method \Pimcore\Model\Document\Editable\Dao getDao()
  */
-^class Video extends Model\Document\Editable implements IdRewriterInterface, EditmodeDataInterface
+class Video extends Model\Document\Editable implements IdRewriterInterface, EditmodeDataInterface
 {
     public const TYPE_ASSET = 'asset';
 

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -25,7 +25,7 @@ use Pimcore\Tool;
 /**
  * @method \Pimcore\Model\Document\Editable\Dao getDao()
  */
-class Video extends Model\Document\Editable implements IdRewriterInterface
+^class Video extends Model\Document\Editable implements IdRewriterInterface, EditmodeDataInterface
 {
     public const TYPE_ASSET = 'asset';
 
@@ -207,7 +207,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
         ];
     }
 
-    protected function getDataEditmode(): mixed
+    public function getDataEditmode(): mixed
     {
         $data = $this->getData();
 


### PR DESCRIPTION
It seems that it was forgotten to add the `EditmodeDataInterface` when this interface was introduced. This leads to the result that in the classic bundle the paths are encoded the wrong way (e.g. when the asset paths contain spaces):

<img width="508" height="368" alt="image" src="https://github.com/user-attachments/assets/ac85b478-7da1-4118-bae8-fc0703e7f6ca" />

This fix will also be relevant for studio.