### PR TITLE
[Bugfix]: mark editables anywhere in Twig as "safe"

### DIFF
--- a/bundles/CoreBundle/config/templating_twig.yaml
+++ b/bundles/CoreBundle/config/templating_twig.yaml
@@ -3,6 +3,10 @@ services:
         autowire: true
         autoconfigure: true
 
+    Pimcore\Twig\TwigEnvironmentConfigurator:
+        decorates: 'twig.configurator.environment'
+        arguments: ['@.inner']
+
     Pimcore\Twig\Extension\HelpersExtension: ~
 
     Pimcore\Twig\Extension\DocumentEditableExtension: ~

--- a/lib/Twig/TwigEnvironmentConfigurator.php
+++ b/lib/Twig/TwigEnvironmentConfigurator.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Twig;
+
+use Pimcore\Model\Document\Editable;
+use Symfony\Bundle\TwigBundle\DependencyInjection\Configurator\EnvironmentConfigurator;
+use Twig\Environment;
+use Twig\Runtime\EscaperRuntime;
+
+/**
+ * @internal
+ */
+final class TwigEnvironmentConfigurator
+{
+    public function __construct(
+        private readonly EnvironmentConfigurator $decorated,
+    ) {
+    }
+
+    public function configure(Environment $environment): void
+    {
+        $this->decorated->configure($environment);
+
+        $environment->getRuntime(EscaperRuntime::class)->addSafeClass(Editable::class, ['html']);
+    }
+}

--- a/models/Document/Editable.php
+++ b/models/Document/Editable.php
@@ -32,6 +32,7 @@ use Pimcore\Model\Document;
 use Pimcore\Tool\HtmlUtils;
 use Pimcore\Tool\Serialize;
 use RuntimeException;
+use Stringable;
 use Throwable;
 
 /**
@@ -39,7 +40,7 @@ use Throwable;
  * @method void save()
  * @method void delete()
  */
-abstract class Editable extends Model\AbstractModel implements Model\Document\Editable\EditableInterface
+abstract class Editable extends Model\AbstractModel implements Model\Document\Editable\EditableInterface, Stringable
 {
     /**
      * Contains some configurations for the editmode, or the thumbnail name, ...


### PR DESCRIPTION
## Changes in this pull request  
Editables are [already marked as `safe`](https://github.com/pimcore/pimcore/blob/11.5/lib/Twig/Extension/DocumentEditableExtension.php#L50) in the `pimocre_*` Twig function definition.

But that only seems to work inside the very template the function is used.

As soon as you start passing it around, like:

```twig
{# some/template.html.twig #}

{{ include('some/include.html.twig', {
    headline: pimcore_input('headline'),
}) }}
```

You suddenly have to apply the `raw` filter, otherwise you'll get double-escaped output:

```twig
{# some/include.html.twig #}

{{ headline|raw }}
```

This makes it difficult, because the `headline` may not *always* be an editable, but something else that you *want* to escape.

So you would have to do stuff like this:

```twig
{# some/include.html.twig #}

{{ headline is instanceof('Pimcore\\Model\\Document\\Editable\\EditableInterface') ? headline|raw : headline }}
```

All of this would not be necessary if Twig would know that instances of `Editable` handle escaping themselves ([like it already is for the editable functions](https://github.com/pimcore/pimcore/blob/11.5/lib/Twig/Extension/DocumentEditableExtension.php#L50)). 

Then you can just use it with auto-escaping and everything is fine:

```twig
{# some/include.html.twig #}

{{ headline }}
```

This is what this bug fix achieves.