### PR TITLE
[Data Objects] Set auto_id to BIGINT

### DIFF
--- a/bundles/CoreBundle/src/Migrations/Version20250821094211.php
+++ b/bundles/CoreBundle/src/Migrations/Version20250821094211.php
@@ -33,7 +33,9 @@ final class Version20250821094211 extends AbstractMigration
         $classes = new Listing();
         foreach($classes->getClasses() as $class) {
             if($schema->hasTable('object_metadata_' . $class->getId())) {
-                $this->addSql('ALTER TABLE object_metadata_' . $class->getId() . ' CHANGE auto_id auto_id BIGINT(20) NOT NULL');
+                $this->addSql(
+                    'ALTER TABLE object_metadata_' . $class->getId() . ' CHANGE auto_id auto_id BIGINT(20) NOT NULL'
+                );
             }
         }
     }
@@ -43,7 +45,9 @@ final class Version20250821094211 extends AbstractMigration
         $classes = new Listing();
         foreach ($classes->getClasses() as $class) {
             if ($schema->hasTable('object_metadata_'.$class->getId())) {
-                $this->addSql('ALTER TABLE object_metadata_'.$class->getId().' CHANGE auto_id auto_id INT(11) NOT NULL');
+                $this->addSql(
+                    'ALTER TABLE object_metadata_'.$class->getId().' CHANGE auto_id auto_id INT(11) NOT NULL'
+                );
             }
         }
     }

--- a/bundles/CoreBundle/src/Migrations/Version20250821094211.php
+++ b/bundles/CoreBundle/src/Migrations/Version20250821094211.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Pimcore\Model\DataObject\ClassDefinition\Listing;
+
+/**
+ * Sets sourceSite=0 (Main domain) for all redirects with sourceSite = NULL
+ * before NULL and 0 were both treated as main domain and in fact sourceSite was not optional (although UI told so)
+ */
+final class Version20250821094211 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Set column type of "auto_id" for object_metadata_* tables to BIGINT';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $classes = new Listing();
+        foreach($classes->getClasses() as $class) {
+            if($schema->hasTable('object_metadata_' . $class->getId())) {
+                $this->addSql('ALTER TABLE object_metadata_' . $class->getId() . ' CHANGE auto_id auto_id BIGINT(20) NOT NULL');
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $classes = new Listing();
+        foreach ($classes->getClasses() as $class) {
+            if ($schema->hasTable('object_metadata_'.$class->getId())) {
+                $this->addSql('ALTER TABLE object_metadata_'.$class->getId().' CHANGE auto_id auto_id INT(11) NOT NULL');
+            }
+        }
+    }
+}

--- a/bundles/CoreBundle/src/Migrations/Version20250821094211.php
+++ b/bundles/CoreBundle/src/Migrations/Version20250821094211.php
@@ -18,8 +18,9 @@ use Doctrine\Migrations\AbstractMigration;
 use Pimcore\Model\DataObject\ClassDefinition\Listing;
 
 /**
- * Sets sourceSite=0 (Main domain) for all redirects with sourceSite = NULL
- * before NULL and 0 were both treated as main domain and in fact sourceSite was not optional (although UI told so)
+ * Widens the "auto_id" column of the object_metadata_* tables from INT UNSIGNED to BIGINT UNSIGNED.
+ * Advanced many-to-many relations delete and re-insert their rows on every dirty save, which makes the
+ * AUTO_INCREMENT value grow quickly and can exhaust the INT UNSIGNED range (4294967295).
  */
 final class Version20250821094211 extends AbstractMigration
 {
@@ -34,7 +35,7 @@ final class Version20250821094211 extends AbstractMigration
         foreach($classes->getClasses() as $class) {
             if($schema->hasTable('object_metadata_' . $class->getId())) {
                 $this->addSql(
-                    'ALTER TABLE object_metadata_' . $class->getId() . ' CHANGE auto_id auto_id BIGINT(20) NOT NULL'
+                    'ALTER TABLE object_metadata_' . $class->getId() . ' CHANGE auto_id auto_id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT'
                 );
             }
         }
@@ -46,7 +47,7 @@ final class Version20250821094211 extends AbstractMigration
         foreach ($classes->getClasses() as $class) {
             if ($schema->hasTable('object_metadata_'.$class->getId())) {
                 $this->addSql(
-                    'ALTER TABLE object_metadata_'.$class->getId().' CHANGE auto_id auto_id INT(11) NOT NULL'
+                    'ALTER TABLE object_metadata_'.$class->getId().' CHANGE auto_id auto_id INT(11) UNSIGNED NOT NULL AUTO_INCREMENT'
                 );
             }
         }

--- a/lib/Db/Helper.php
+++ b/lib/Db/Helper.php
@@ -55,7 +55,9 @@ class Helper
                 $critera[$key] = $data[$key] ?? throw new LogicException(sprintf('Key "%s" passed for upsert not found in data', $key));
             }
 
-            $connection->update($table, $data, $critera);
+            if(empty($connection->update($table, $data, $critera))) {
+                throw new \RuntimeException('Could not find entry to update in "' . $table . '" for the given criteria: ' . json_encode($critera).': '. $exception->getMessage());
+            }
 
             return null;
         }

--- a/lib/Db/Helper.php
+++ b/lib/Db/Helper.php
@@ -55,10 +55,6 @@ class Helper
                 $critera[$key] = $data[$key] ?? throw new LogicException(sprintf('Key "%s" passed for upsert not found in data', $key));
             }
 
-            if(empty($connection->update($table, $data, $critera))) {
-                throw new \RuntimeException('Could not find entry to update in "' . $table . '" for the given criteria: ' . json_encode($critera).': '. $exception->getMessage());
-            }
-
             return null;
         }
     }

--- a/lib/Db/Helper.php
+++ b/lib/Db/Helper.php
@@ -55,6 +55,8 @@ class Helper
                 $critera[$key] = $data[$key] ?? throw new LogicException(sprintf('Key "%s" passed for upsert not found in data', $key));
             }
 
+            $connection->update($table, $data, $critera);
+
             return null;
         }
     }

--- a/models/DataObject/Data/AbstractMetadata/Dao.php
+++ b/models/DataObject/Data/AbstractMetadata/Dao.php
@@ -49,7 +49,7 @@ class Dao extends Model\Dao\AbstractDao
         $table = 'object_metadata_' . $classId;
 
         $this->db->executeQuery('CREATE TABLE IF NOT EXISTS `' . $table . "` (
-              `auto_id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+              `auto_id` bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
               `id` int(11) UNSIGNED NOT NULL default '0',
               `dest_id` int(11) NOT NULL default '0',
 	          `type` VARCHAR(50) NOT NULL DEFAULT '',


### PR DESCRIPTION
In our case the `auto_id` in `object_metadata_<object id>` table reached the value 4294967295 (maximum value for an unsigned int column in MySQL). When saving an advanced many-to-many relation, the existing data first gets deleted in https://github.com/pimcore/pimcore/blob/c1e3114e95e635c1bf1bdf06a19dec18ce40e636/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php#L580 
And afterwards it new records get created in https://github.com/pimcore/pimcore/blob/c1e3114e95e635c1bf1bdf06a19dec18ce40e636/models/DataObject/Data/ElementMetadata/Dao.php#L43

Thus the `auto_id` increases with every save operation (when the advanced many-to-many relation field is dirty).

For this reason this PR sets the column type to `BIGINT`.

Alternatively / Additionally, it would make sense to do a diff calculation to only delete the records which are not present anymore, so that the `auto_id` does not increment that much.

And alternative 2: Is `auto_id` really necessary or can we make the unique key to the new primary key, see https://github.com/pimcore/pimcore/blob/c1e3114e95e635c1bf1bdf06a19dec18ce40e636/models/DataObject/Data/AbstractMetadata/Dao.php#L64-L66 ?