### PR TITLE
[Bug]: MultiSelectOptionsProviderInterface is deprecated and says to use SelectOptionsProviderInterface, which extends it

### DIFF
--- a/models/DataObject/ClassDefinition/DynamicOptionsProvider/MultiSelectOptionsProviderInterface.php
+++ b/models/DataObject/ClassDefinition/DynamicOptionsProvider/MultiSelectOptionsProviderInterface.php
@@ -15,8 +15,12 @@ namespace Pimcore\Model\DataObject\ClassDefinition\DynamicOptionsProvider;
 
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 
-trigger_deprecation('pimcore/pimcore', '11.2', '%s is deprecated. Use %s instead.', MultiSelectOptionsProviderInterface::class, SelectOptionsProviderInterface::class);
-
+if (
+    interface_exists(MultiSelectOptionsProviderInterface::class)
+    && !is_subclass_of(SelectOptionsProviderInterface::class, MultiSelectOptionsProviderInterface::class)
+) {
+    trigger_deprecation('pimcore/pimcore', '11.2', '%s is deprecated. Use %s instead.', MultiSelectOptionsProviderInterface::class, SelectOptionsProviderInterface::class);
+}
 /**
  * @deprecated use SelectOptionsProviderInterface instead
  */

--- a/models/DataObject/ClassDefinition/DynamicOptionsProvider/MultiSelectOptionsProviderInterface.php
+++ b/models/DataObject/ClassDefinition/DynamicOptionsProvider/MultiSelectOptionsProviderInterface.php
@@ -16,8 +16,7 @@ namespace Pimcore\Model\DataObject\ClassDefinition\DynamicOptionsProvider;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 
 if (
-    interface_exists(MultiSelectOptionsProviderInterface::class)
-    && !is_subclass_of(SelectOptionsProviderInterface::class, MultiSelectOptionsProviderInterface::class)
+   !is_subclass_of(SelectOptionsProviderInterface::class, MultiSelectOptionsProviderInterface::class)
 ) {
     trigger_deprecation('pimcore/pimcore', '11.2', '%s is deprecated. Use %s instead.', MultiSelectOptionsProviderInterface::class, SelectOptionsProviderInterface::class);
 }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/17266

## Additional info
Draft: nope, i guess i need reflectionClass or something like that