### PR TITLE
Consistently call PreGetValueHook before actually getting the data

### DIFF
--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -864,11 +864,11 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         $code .= 'public function get' . ucfirst($key) . '(?string $language = null)' . $typeDeclaration . "\n";
         $code .= '{' . "\n";
 
-        $code .= "\t" . '$data = $this->getLocalizedfields()->getLocalizedValue("' . $key . '", $language);' . "\n";
-
         if (!$class instanceof DataObject\Fieldcollection\Definition) {
             $code .= $this->getPreGetValueHookCode($key);
         }
+
+        $code .= "\t" . '$data = $this->getLocalizedfields()->getLocalizedValue("' . $key . '", $language);' . "\n";
 
         $code .= "\t" . 'if ($data instanceof \\Pimcore\\Model\\DataObject\\Data\\EncryptedField) {' . "\n";
         $code .= "\t\t" . 'return $data->getPlain();' . "\n";

--- a/models/DataObject/ClassDefinition/Data/Objectbricks.php
+++ b/models/DataObject/ClassDefinition/Data/Objectbricks.php
@@ -479,11 +479,11 @@ class Objectbricks extends Data implements CustomResourcePersistingInterface, Ty
         $code .= "\t\t" . '}' . "\n";
         $code .= "\t" . '}' . "\n";
 
+        $code .= $this->getPreGetValueHookCode($key);
+
         if ($this instanceof PreGetDataInterface) {
             $code .= "\t" . '$data = $this->getClass()->getFieldDefinition("' . $key . '")->preGetData($this);' . "\n";
         }
-
-        $code .= $this->getPreGetValueHookCode($key);
 
         $code .= "\t" . 'return $data;' . "\n";
         $code .= "}\n\n";

--- a/models/DataObject/ClassDefinition/Data/Objectbricks.php
+++ b/models/DataObject/ClassDefinition/Data/Objectbricks.php
@@ -468,6 +468,8 @@ class Objectbricks extends Data implements CustomResourcePersistingInterface, Ty
         $code .= 'public function get' . ucfirst($key) . '()' . $typeDeclaration . "\n";
         $code .= '{' . "\n";
 
+        $code .= $this->getPreGetValueHookCode($key);
+
         $code .= "\t" . '$data = $this->' . $key . ";\n";
         $code .= "\t" . 'if (!$data) {' . "\n";
 
@@ -478,8 +480,6 @@ class Objectbricks extends Data implements CustomResourcePersistingInterface, Ty
         $code .= "\t\t\t" . 'return null;' . "\n";
         $code .= "\t\t" . '}' . "\n";
         $code .= "\t" . '}' . "\n";
-
-        $code .= $this->getPreGetValueHookCode($key);
 
         if ($this instanceof PreGetDataInterface) {
             $code .= "\t" . '$data = $this->getClass()->getFieldDefinition("' . $key . '")->preGetData($this);' . "\n";

--- a/models/DataObject/ClassDefinition/Data/Table.php
+++ b/models/DataObject/ClassDefinition/Data/Table.php
@@ -620,11 +620,11 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
         $code .= 'public function get' . ucfirst($key) . ' (?string $language = null)' . $typeDeclaration . "\n";
         $code .= '{' . "\n";
 
-        $code .= "\t" . '$data = $this->getLocalizedfields()->getLocalizedValue("' . $key . '", $language);' . "\n";
-
         if (!$class instanceof DataObject\Fieldcollection\Definition) {
             $code .= $this->getPreGetValueHookCode($key);
         }
+
+        $code .= "\t" . '$data = $this->getLocalizedfields()->getLocalizedValue("' . $key . '", $language);' . "\n";
 
         $code .= "\t" . 'if ($data instanceof \\Pimcore\\Model\\DataObject\\Data\\EncryptedField) {' . "\n";
         $code .= "\t\t" . 'return $data->getPlain() ?? [];' . "\n";

--- a/tests/Model/DataObject/ClassDefinitionTest.php
+++ b/tests/Model/DataObject/ClassDefinitionTest.php
@@ -38,6 +38,19 @@ class ClassDefinitionTest extends ModelTestCase
         $this->assertEquals($expectedSetterCode, $setterCode);
     }
 
+    private function testGetterCode(string $fieldName, string $expectedGetterCode, bool $localizedField = false): void
+    {
+        $class = ClassDefinition::getByName('unittest');
+        if ($localizedField) {
+            $fd = $class->getFieldDefinition('localizedfields')->getFieldDefinition($fieldName);
+            $getterCode = $fd->getGetterCodeLocalizedfields($class);
+        } else {
+            $fd = $class->getFieldDefinition($fieldName);
+            $getterCode = $fd->getGetterCode($class);
+        }
+        $this->assertEquals($expectedGetterCode, $getterCode);
+    }
+
     /**
      * Verifies that the class definition gets renamed properly
      */
@@ -166,6 +179,105 @@ public function setLinput(?string $linput): static
 
 ';
         $this->testSetterCode('linput', $expectedSetterCode, true);
+    }
+
+    /**
+     * Verifies that the getter code gets created properly and that the
+     * PreGetValueHook is called before actually getting the data
+     */
+    public function testLocalizedFieldGetterCode(): void
+    {
+        $expectedGetterCode =
+            '/**
+* Get linput - linput
+* @return string|null
+*/
+public function getLinput(?string $language = null): ?string
+{
+	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
+		$preValue = $this->preGetValue("linput");
+		if ($preValue !== null) {
+			return $preValue;
+		}
+	}
+
+	$data = $this->getLocalizedfields()->getLocalizedValue("linput", $language);
+	if ($data instanceof \Pimcore\Model\DataObject\Data\EncryptedField) {
+		return $data->getPlain();
+	}
+
+	return $data;
+}
+
+';
+        $this->testGetterCode('linput', $expectedGetterCode, true);
+    }
+
+    /**
+     * Verifies that the getter code gets created properly and that the
+     * PreGetValueHook is called before actually getting the data
+     */
+    public function testLocalizedTableGetterCode(): void
+    {
+        $expectedGetterCode =
+            '/**
+* Get ltable - ltable
+* @return array
+*/
+public function getLtable (?string $language = null): array
+{
+	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
+		$preValue = $this->preGetValue("ltable");
+		if ($preValue !== null) {
+			return $preValue;
+		}
+	}
+
+	$data = $this->getLocalizedfields()->getLocalizedValue("ltable", $language);
+	if ($data instanceof \Pimcore\Model\DataObject\Data\EncryptedField) {
+		return $data->getPlain() ?? [];
+	}
+	return $data ?? [];
+}
+
+';
+        $this->testGetterCode('ltable', $expectedGetterCode, true);
+    }
+
+    /**
+     * Verifies that the getter code gets created properly and that the
+     * PreGetValueHook is called before actually getting the data
+     * (i.e. before the object brick container is lazily initialized)
+     */
+    public function testBricksGetterCode(): void
+    {
+        $expectedGetterCode =
+            '/**
+* @return \Pimcore\Model\DataObject\Unittest\Mybricks
+*/
+public function getMybricks(): ?\Pimcore\Model\DataObject\Objectbrick
+{
+	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
+		$preValue = $this->preGetValue("mybricks");
+		if ($preValue !== null) {
+			return $preValue;
+		}
+	}
+
+	$data = $this->mybricks;
+	if (!$data) {
+		if (\Pimcore\Tool::classExists("\\\\Pimcore\\\\Model\\\\DataObject\\\\Unittest\\\\Mybricks")) {
+			$data = new \Pimcore\Model\DataObject\Unittest\Mybricks($this, "mybricks");
+			$this->mybricks = $data;
+		} else {
+			return null;
+		}
+	}
+	return $data;
+}
+
+';
+        $this->testGetterCode('mybricks', $expectedGetterCode);
     }
 
     public function testInputEmptyDefaultValueIsNormalizedToNullAfterImportAndReload(): void


### PR DESCRIPTION
## Changes in this pull request  
There is no point in calling “PreGetValueHook” after the data has been loaded (which may be expensive), as it will be discarded anyway if the hook returns something.

Therefore, the hook should be called everywhere beforehand.