### PR TITLE
[Simple Search] Cleanup temp files during reindexing

### DIFF
--- a/bundles/SimpleBackendSearchBundle/src/Command/SearchBackendReindexCommand.php
+++ b/bundles/SimpleBackendSearchBundle/src/Command/SearchBackendReindexCommand.php
@@ -102,6 +102,7 @@ class SearchBackendReindexCommand extends AbstractCommand
                     }
                 }
                 Pimcore::collectGarbage();
+                Pimcore::deleteTemporaryFiles();
             }
         }
 


### PR DESCRIPTION
When reindexing a huge amount of assets where the text or meta-data (EXIF) hasn't been extracted yet and is stored in the DB, for each an every asset there's a temporary file created. Those  files are cleaned up when the process terminates, but this is too late and this must be done at the end of every batch of assets that are getting processed within the command. 

