### PR TITLE
feat: locale workspace permissions default behaviour none

### DIFF
--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -564,7 +564,8 @@ class Dao extends Model\Element\Dao
                 $firstPermission = $allPermissions[0];
                 $firstPermissionCid = $firstPermission['cid'];
                 $mergedPermissions = [];
-                $allowAllForEmptyConfig = $_SERVER['PIMCORE_PERMISSION_WORKSPACE_LOCALES_EMPTY'] !== 'deny'|| !in_array($type, ['lView', 'lEdit']);
+                $allowAllForEmptyConfig = $_SERVER['PIMCORE_PERMISSION_WORKSPACE_LOCALES_EMPTY'] !== 'deny'
+                    || !in_array($type, ['lView', 'lEdit']);
 
                 foreach ($allPermissions as $permission) {
                     $cid = $permission['cid'];

--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -564,19 +564,16 @@ class Dao extends Model\Element\Dao
                 $firstPermission = $allPermissions[0];
                 $firstPermissionCid = $firstPermission['cid'];
                 $mergedPermissions = [];
+                $allowAllForEmptyConfig = $_SERVER['PIMCORE_PERMISSION_WORKSPACE_LOCALES_EMPTY'] !== 'deny'|| !in_array($type, ['lView', 'lEdit']);
 
                 foreach ($allPermissions as $permission) {
                     $cid = $permission['cid'];
-                    if ($cid != $firstPermissionCid) {
+                    if ($cid != $firstPermissionCid && $allowAllForEmptyConfig) {
                         break;
                     }
 
                     $permissionValues = $permission[$type];
-                    if (!$permissionValues
-                        && (
-                            $_SERVER['PIMCORE_PERMISSION_WORKSPACE_LOCALES_EMPTY'] !== 'deny'
-                            || !in_array($type, ['lView', 'lEdit']))
-                    ) {
+                    if (!$permissionValues && $allowAllForEmptyConfig) {
                         $firstPermission[$type] = null;
 
                         return $firstPermission;

--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -572,7 +572,11 @@ class Dao extends Model\Element\Dao
                     }
 
                     $permissionValues = $permission[$type];
-                    if (!$permissionValues) {
+                    if (!$permissionValues
+                        && (
+                            $_SERVER['PIMCORE_PERMISSION_WORKSPACE_LOCALES_EMPTY'] !== 'deny'
+                            || !in_array($type, ['lView', 'lEdit']))
+                    ) {
                         $firstPermission[$type] = null;
 
                         return $firstPermission;


### PR DESCRIPTION
With this PR we introduce an option to change the default behaviour for workspace permission on localized fields to not allow all languages but none.

**Use Case:**

* Have a role handling workspace access i.e. "pim-editor" with access to /PIM

<img width="3398" height="1378" alt="image" src="https://github.com/user-attachments/assets/8a346d2f-d4a8-4925-8fc2-fee3c862127d" />

* Have another role handling workspace permissions for languages i.e. "lang-en" just with configured access to all objects without permissions but configured language "en"
<img width="3399" height="1312" alt="image" src="https://github.com/user-attachments/assets/e3d777a2-734c-47a0-a3c3-4a8ae920d456" />

Currently pimcore would allow all languages if a user is granted the role "pim-editor" even if he only would be allowed specific languages in the language role "lang-en".

WDYT?