### PR TITLE
Bugfix: Calculated Value Saving Incorrect Value In Query Table When Inheriting

### DIFF
--- a/models/DataObject/ClassDefinition/Data/CalculatedValue.php
+++ b/models/DataObject/ClassDefinition/Data/CalculatedValue.php
@@ -389,4 +389,13 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
     {
         return true;
     }
+
+    public function isEmpty(mixed $data): bool
+    {
+        return match ($this->elementType) {
+            'boolean' => $data === null || $data === '',
+            'numeric' => !is_numeric($data),
+            default => parent::isEmpty($data)
+        };
+    }
 }


### PR DESCRIPTION
When inheritance is turned on, and using calculated fields it can cause values to be saved to the query table incorrectly depending on the value/type.

The calculated value class should implement the `isEmpty` function so it does not use the built in one which only does a `return empty($data);` check (https://github.com/pimcore/pimcore/blob/12.x/models/DataObject/ClassDefinition/Data.php#L1034-L1037). If the calculated field is either `false` for boolean or `0` for numeric, then it will try and use the parent's value which is not correct. 

The element types: `boolean` & `numeric` require additional checks to see if the value is actually empty before attempting to inherit from its parent.