### PR TITLE
[Bug]: Pimcore\Model\Notification::setCreationDate(): Argument #1 ($creationDate) must be of type string, null given

### DIFF
--- a/models/Notification/Dao.php
+++ b/models/Notification/Dao.php
@@ -130,7 +130,7 @@ class Dao extends AbstractDao
         }
 
         $model->setId((int)$data['id']);
-        $model->setCreationDate($data['creationDate']);
+        $model->setCreationDate($data['creationDate'] ?? $data['modificationDate']);
         $model->setModificationDate($data['modificationDate']);
         $model->setSender($sender);
         $model->setRecipient($recipient);

--- a/models/Notification/Dao.php
+++ b/models/Notification/Dao.php
@@ -62,7 +62,7 @@ class Dao extends AbstractDao
         $model = $this->getModel();
         $model->setModificationDate(date('Y-m-d H:i:s'));
 
-        if ($model->getId() === null) {
+        if ($model->getId() === null || !$model->getCreationDate()) {
             $model->setCreationDate($model->getModificationDate());
         }
 


### PR DESCRIPTION

## Changes in this pull request  
Resolves https://github.com/pimcore/admin-ui-classic-bundle/issues/953

## Additional info
