### PR TITLE
Improve PHPDoc in `PasswordHasherFactory`

### DIFF
--- a/lib/Security/Hasher/PasswordHasherFactory.php
+++ b/lib/Security/Hasher/PasswordHasherFactory.php
@@ -34,7 +34,7 @@ use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 class PasswordHasherFactory implements PasswordHasherFactoryInterface
 {
     /**
-     * @param PasswordHasherFactoryInterface[] $passwordHasherFactories
+     * @param array<class-string<PasswordHasherFactoryInterface>, PasswordHasherFactoryInterface> $passwordHasherFactories
      */
     public function __construct(protected PasswordHasherFactoryInterface $frameworkFactory, protected array $passwordHasherFactories = [])
     {
@@ -66,7 +66,6 @@ class PasswordHasherFactory implements PasswordHasherFactoryInterface
             $factoryKey = $factoryName;
         } else {
             foreach ($this->passwordHasherFactories as $class => $factory) {
-                /** @var class-string $class */
                 if (is_a($user, $class, true)) {
                     $factoryKey = $class;
 


### PR DESCRIPTION
## Changes in this pull request  
Correctly types the parameter instead of using an inline `@var` comment somewhere inside a method.

This is a follow-up of #18685