### PR TITLE
Fix housekeeping race condition

### DIFF
--- a/lib/Maintenance/Tasks/HousekeepingTask.php
+++ b/lib/Maintenance/Tasks/HousekeepingTask.php
@@ -60,7 +60,7 @@ class HousekeepingTask implements TaskInterface
 
             if ($current->getATime() && $current->getATime() < (time() - $seconds)) {
                 return true;
-            };
+            }
 
             return false;
         });

--- a/lib/Maintenance/Tasks/HousekeepingTask.php
+++ b/lib/Maintenance/Tasks/HousekeepingTask.php
@@ -58,13 +58,9 @@ class HousekeepingTask implements TaskInterface
                 return false;
             }
 
-            if ($current->isFile()) {
-                if ($current->getATime() && $current->getATime() < (time() - $seconds)) {
-                    return true;
-                }
-            } else {
+            if ($current->getATime() && $current->getATime() < (time() - $seconds)) {
                 return true;
-            }
+            };
 
             return false;
         });


### PR DESCRIPTION
## Changes in this pull request  
Resolves #

Currently housekeeping task deletes the folder if it's empty. This creates race condition with data hub file importer. 

Given the conditions below
1. Pimcore maintenace run every 5 minute
2. Pimcore datahub file importer runs also every 5th minute or in the same minute that housekeeping is triggered
3. Datahub uses http request to import data objects
```
1.Data hub creates folder ---
2. Data hub starts http request ---
3. Pimciore starts housekeeping process ---
4. Pimcore housekeeping deletes the empty datahub directory ---
5. Data hub receives response from http request ---
6. File is tried to be saved but the folder was deleted in step 4 and import fails
```

## Additional info

This PR checks also the folder modified time and compares it if it's old enough to be deleted
