### PR TITLE
[Bugfix]: disallow matching pimcore context via route name

### DIFF
--- a/bundles/CoreBundle/src/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Configuration.php
@@ -1189,7 +1189,7 @@ final class Configuration implements ConfigurationInterface
         $prototype = $contextNode->prototype('array');
 
         // define routes child on each context entry
-        $this->addRoutesChild($prototype, 'routes');
+        $this->addRoutesChild($prototype, 'routes', supportsRoute: false);
     }
 
     private function addSecurityNode(ArrayNodeDefinition $rootNode): void
@@ -1291,32 +1291,33 @@ final class Configuration implements ConfigurationInterface
             ->arrayNode('toolbar')
                 ->addDefaultsIfNotSet();
 
-        $this->addRoutesChild($toolbarNode, 'excluded_routes');
+        $this->addRoutesChild($toolbarNode, 'excluded_routes', supportsRoute: true);
     }
 
     /**
      * Add a route prototype child
      */
-    private function addRoutesChild(ArrayNodeDefinition $parent, string $name): void
+    private function addRoutesChild(ArrayNodeDefinition $parent, string $name, bool $supportsRoute): void
     {
-        $node = $parent->children()->arrayNode($name);
-
-        /** @var ArrayNodeDefinition $prototype */
-        $prototype = $node->prototype('array');
-        $prototype
-            ->beforeNormalization()
-                ->ifNull()->then(function () {
-                    return [];
-                })
-            ->end()
+        $node = $parent
             ->children()
-                ->scalarNode('path')->defaultFalse()->end()
-                ->scalarNode('route')->defaultFalse()->end()
-                ->scalarNode('host')->defaultFalse()->end()
-                ->arrayNode('methods')
-                    ->prototype('scalar')->end()
-                ->end()
-            ->end();
+                ->arrayNode($name)
+                    ->prototype('array')
+                        ->beforeNormalization()
+                            ->ifNull()->then(function () {
+                                return [];
+                            })
+                        ->end()
+                        ->children()
+                            ->scalarNode('path')->defaultFalse()->end()
+                            ->scalarNode('host')->defaultFalse()->end()
+                            ->arrayNode('methods')
+                                ->prototype('scalar')->end()
+                            ->end();
+
+        if ($supportsRoute) {
+            $node->scalarNode('route')->defaultFalse();
+        }
     }
 
     /**


### PR DESCRIPTION
Pimcore context can be configured via request matchers, e.g. (which is the only way it is used by Pimcore itself)
```yaml
pimcore:
    context:
        api:
            routes:
                - { path: ^/my/api/$ }
```

It also allows matching via route name, like:
```yaml
pimcore:
    context:
        api:
            routes:
                - { route: my_api }
```

But the latter does not actually work! 
When the route with name `my_api` the context is resolved as `default` instead of `api`.

The reason is, that it is only resolved the first time it gets checked (which is good). But this first check happens _way_ before the route is matched by Symfony, which listens on `kernel.request` with priority `32`, and populates the necessary `_route` attribute in the request. In fact, Pimcore has listeners on this event with priority `560` (`CustomAdminEntryPointCheckListener`), `512` (`RoutingListener`) or `120` (`FullPageCacheListener`) which all check the context (and thus initialize it, which is bad).
This means those routes never match and will always be `default`.

Thus, I propose to disallow using the `route` matcher for the context.