### PR TITLE
[Bug]: Fix Dynamic Thumbnail Generation

### DIFF
--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Pimcore\Model\Asset;
 
 use Exception;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\UnableToReadFile;
 use Pimcore;
 use Pimcore\Config;
 use Pimcore\Event\AssetEvents;
@@ -568,26 +570,29 @@ class Service extends Model\Element\Service
         // thumbnail urls are at least 10 characters long
         if (strlen($uri) > 10) {
 
-            $asset = Asset::getById($config['asset_id']);
             $thumbnailConfig = ThumbnailConfig::getByName($config['thumbnail_name']);
+            $asset = Asset::getById($config['asset_id']);
 
             $hash = $thumbnailConfig->getHash([$asset->getChecksum()]);
             $hasHash = strpos($config['filename'], '.' . $hash .'.');
-            if ($hasHash === false) {
-                $storagePathWithHash = str_replace('.' . $config['file_extension'], '.'. $hash .'.'. $config['file_extension'], $storagePath);
-            }
 
-            if (isset($storagePathWithHash) && $storage->fileExists($storagePathWithHash)) {
-                if ($hasHash === false) {
-                    // if cache is expired we copy the file to the non-hashed version
+            //Only for Dynamic Thumbnails Generation on request without an Hash, make a copy without hash
+            //in filename for Maintanenace Mode purposes.
+            if ($hasHash === false) {
+                $storagePathWithHash = str_replace(
+                    '.' . $config['file_extension'],
+                    '.'. $hash .'.'. $config['file_extension'],
+                    $storagePath
+                );
+
+                if ($storage->fileExists($storagePathWithHash)){
                     $storage->copy($storagePathWithHash, $storagePath);
-                } else {
-                    $storagePath = $storagePathWithHash;
                 }
             }
-            $stream = $storage->readStream($storagePath);
 
-            if (isset($stream)) {
+            if ($storage->fileExists($storagePath)) {
+                $stream = $storage->readStream($storagePath);
+
                 $lifetime = 86400 * 7; // 1 week lifetime, same as direct delivery in .htaccess
 
                 return new StreamedResponse(function () use ($stream) {
@@ -599,6 +604,7 @@ class Service extends Model\Element\Service
                     'Content-Length' => $storage->fileSize($storagePath),
                 ]);
             }
+
         }
 
         $thumbnail = Asset\Service::getImageThumbnailByArrayConfig($config);

--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -566,24 +566,44 @@ class Service extends Model\Element\Service
         }
 
         // thumbnail urls are at least 10 characters long
-        if (strlen($uri) > 10 && $storage->fileExists($storagePath)) {
+        if (strlen($uri) > 10) {
+
+            $asset = Asset::getById($config['asset_id']);
+            $thumbnailConfig = ThumbnailConfig::getByName($config['thumbnail_name']);
+
+            $hash = $thumbnailConfig->getHash([$asset->getChecksum()]);
+            $hasHash = strpos($config['filename'], '.' . $hash .'.');
+            if ($hasHash === false) {
+                $storagePathWithHash = str_replace('.' . $config['file_extension'], '.'. $hash .'.'. $config['file_extension'], $storagePath);
+            }
+
+            if (isset($storagePathWithHash) && $storage->fileExists($storagePathWithHash)) {
+                if ($hasHash === false) {
+                    // if cache is expired we copy the file to the non-hashed version
+                    $storage->copy($storagePathWithHash, $storagePath);
+                } else {
+                    $storagePath = $storagePathWithHash;
+                }
+            }
             $stream = $storage->readStream($storagePath);
 
-            $lifetime = 86400 * 7; // 1 week lifetime, same as direct delivery in .htaccess
+            if (isset($stream)) {
+                $lifetime = 86400 * 7; // 1 week lifetime, same as direct delivery in .htaccess
 
-            return new StreamedResponse(function () use ($stream) {
-                fpassthru($stream);
-            }, 200, [
-                'Cache-Control' => 'public, max-age=' . $lifetime,
-                'Expires' => date('D, d M Y H:i:s T', time() + $lifetime),
-                'Content-Type' => $storage->mimeType($storagePath),
-                'Content-Length' => $storage->fileSize($storagePath),
-            ]);
-        } else {
-            $thumbnail = Asset\Service::getImageThumbnailByArrayConfig($config);
-            if ($thumbnail) {
-                return Asset\Service::getStreamedResponseFromImageThumbnail($thumbnail, $config);
+                return new StreamedResponse(function () use ($stream) {
+                    fpassthru($stream);
+                }, 200, [
+                    'Cache-Control' => 'public, max-age=' . $lifetime,
+                    'Expires' => date('D, d M Y H:i:s T', time() + $lifetime),
+                    'Content-Type' => $storage->mimeType($storagePath),
+                    'Content-Length' => $storage->fileSize($storagePath),
+                ]);
             }
+        }
+
+        $thumbnail = Asset\Service::getImageThumbnailByArrayConfig($config);
+        if ($thumbnail) {
+            return Asset\Service::getStreamedResponseFromImageThumbnail($thumbnail, $config);
         }
 
         return null;


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/18513

## Additional info 
Draft: not sure if copying is the only way to skip `index.php/` (PublicServicesController) from `try_files` is gonna be bad practice, also currently work if the hashed one is already generated (to copy from).

I am trying without copy, but need first to figure if is there a way StreamedResponse to be cached by browser.