### PR TITLE
docs: fix link to github security advisory mechanism

### DIFF
--- a/doc/26_Best_Practice/75_Security_Concept.md
+++ b/doc/26_Best_Practice/75_Security_Concept.md
@@ -65,7 +65,7 @@ This issue can be resolved either by using Pimcore [Headscript extension](../02_
 ### Handling Security Issues
 In the case of a security issue/vulnerability in the Pimcore core framework, we handle them with the following procedure: 
 - **Reporting Issue**: 
-Report issue via [Github security advisory mechanism]([https://pimcorehq.wufoo.com/forms/pimcore-security-report/](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) of the corresponding repository, e.g. for [here for core framework](https://github.com/pimcore/pimcore/security). Not via public 
+Report issue via [Github security advisory mechanism](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) of the corresponding repository, e.g. for [here for core framework](https://github.com/pimcore/pimcore/security). Not via public 
 issue tracker (according guidelines also available at public issue tracker)!
 
 - **Resolving Issue**: 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Fix link in docs.
