### PR TITLE
[Symfony Translator] Use configured default language as Symfony translator default language instead of "en"

### DIFF
--- a/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php
+++ b/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php
@@ -281,6 +281,7 @@ final class PimcoreCoreExtension extends ConfigurableExtension implements Prepen
      */
     public function prepend(ContainerBuilder $container): void
     {
+        $container->setParameter('locale', substr(Pimcore\Tool::getDefaultLanguage(), 0, 2));
         /*$securityConfigs = $container->getExtensionConfig('security');
 
         if (count($securityConfigs) > 1) {


### PR DESCRIPTION
Steps to reproduce problem:

1. Have system languages `de` (default language) and `en`, no fallbacks
2. Set your user's language to `de`
3. Create data object class with field `Beschreibung` and title `Beschreibung`
4. Create object of this class, open it -> label for the field is `Beschreibung`
5. Go to Tools > Translations > Translations
6. Select `admin` domain on the top left dropdown
7. Search for `Beschreibung`, you will find the automatically created entry from your data object field's title
8. Set translation for **English**, to `Description`, keep German empty
9. Reload Pimcore
10. Open Data Object

Expected behaviour:
As the translation for user's language `de` is not set, fall back to translation key = field title = `Beschreibung`

Actual behaviour:
1. The label of the data object field is `Description`. This is wrong because the user has langauge `de` and we have not set any fallbacks.
2. If you do the above steps but setting **French** translation instead in **English**, user's with German language do see `Beschreibung`.

This is caused by
https://github.com/pimcore/pimcore/blob/156e82b5314bddd6e35b04dbfbe77f3361af0136/bundles/CoreBundle/config/pimcore/default.yaml#L1-L6

Symfony Translator is hard-coded to fallback language `en`.

This PR removes this hard-coded language setting and instead uses the configured default language.