### PR TITLE
[Improvement] Better error message for symfony-config write target in production migrations

### DIFF
--- a/bundles/CoreBundle/src/Migrations/Version20240708083500.php
+++ b/bundles/CoreBundle/src/Migrations/Version20240708083500.php
@@ -66,9 +66,13 @@ final class Version20240708083500 extends AbstractMigration
             }
         } catch (DataObject\Exception\DefinitionWriteException $e) {
             $this->write(
-                'Could not write class definition file. Please set PIMCORE_CLASS_DEFINITION_WRITABLE env.' . "\n" .
+                'Could not write class definition file.' . "\n" .
+                'Possible causes:' . "\n" .
+                '- If using symfony-config write target: Configs are read-only in production mode (non-debug). ' .
+                'Temporarily enable debug mode or switch to an alternate config-storage to run this migration.' . "\n" .
+                '- Missing write permissions: Set PIMCORE_CLASS_DEFINITION_WRITABLE env variable.' . "\n" .
                 sprintf(
-                    'If you already have migrate the definitions you can skip this migration via "php bin/console doctrine:migrations:version --add %s"',
+                    'If definitions are already migrated, skip this migration: "php bin/console doctrine:migrations:version --add %s"',
                     __CLASS__
                 )
             );

--- a/bundles/CoreBundle/src/Migrations/Version20240708083500.php
+++ b/bundles/CoreBundle/src/Migrations/Version20240708083500.php
@@ -72,7 +72,8 @@ final class Version20240708083500 extends AbstractMigration
                 'Temporarily enable debug mode or switch to an alternate config-storage to run this migration.' . "\n" .
                 '- Missing write permissions: Set PIMCORE_CLASS_DEFINITION_WRITABLE env variable.' . "\n" .
                 sprintf(
-                    'If definitions are already migrated, skip this migration: "php bin/console doctrine:migrations:version --add %s"',
+                    'If definitions are already migrated, skip this migration: ' . "\n" .
+                    '  "php bin/console doctrine:migrations:version --add %s"',
                     __CLASS__
                 )
             );


### PR DESCRIPTION
Fixes #17388

### Changes
Improved the error output message in class definition migrations to better explain the symfony-config write target limitation when running in production mode.

### What was changed
- Enhanced error message to clearly indicate that symfony-config write target makes configs read-only in non-debug mode
- Added line breaks for better readability
- Provided actionable solutions (enable debug mode, switch to alternate config-storage, or set environment variable)

### Why
The previous error message didn't clearly explain why definitions couldn't be written when using symfony-config in production, leading to confusion for developers running migrations.