### PR TITLE
[Bug, EC] PEES-781 Faulty if condition in \ManyToManyRelationTrait#getFilterConditionExt

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Relations/ManyToManyRelationTrait.php
+++ b/models/DataObject/ClassDefinition/Data/Relations/ManyToManyRelationTrait.php
@@ -97,11 +97,20 @@ trait ManyToManyRelationTrait
             // The brick prefix might be quoted and with a dot suffix, if so, removing the first
             // and second last character to unquote
             $quoteIdentifierSymbol  = substr(Db::get()->quoteIdentifier(''), 0, 1);
+
             if (
-                substr($prefix, 1, -2) === $quoteIdentifierSymbol &&
+                substr($prefix, 0, 1) === $quoteIdentifierSymbol &&
+                substr($prefix, -2, 1) === $quoteIdentifierSymbol &&
+                substr($prefix, -1) === '.'
+            ) {
+                // Case: `db`.
+                $prefix = substr($prefix, 1, -2) . '.';
+            } elseif (
+                substr($prefix, 0, 1) === $quoteIdentifierSymbol &&
                 substr($prefix, -1) === $quoteIdentifierSymbol
             ) {
-                $prefix = substr($prefix, 1, -2) . substr($prefix, -1);
+                // Case: `db`
+                $prefix = substr($prefix, 1, -1);
             }
         }
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/service-operations/issues/241

## Additional info
