### PR TITLE
[Bug, EC] PEES-655: Pimcore Copilot (Execution Engine) job runs table Log column breaks with newlines.

### DIFF
--- a/bundles/GenericExecutionEngineBundle/src/Utils/ValueObjects/LogLine.php
+++ b/bundles/GenericExecutionEngineBundle/src/Utils/ValueObjects/LogLine.php
@@ -39,6 +39,11 @@ final class LogLine
         return $this->logLine;
     }
 
+    public function appendLogLine(string $logLine): void
+    {
+        $this->logLine .= PHP_EOL . $logLine;
+    }
+
     public function getCreatedAt(): DateTimeImmutable
     {
         return $this->createdAt;


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/service-operations/issues/182

## Additional info
