### PR TITLE
Fix CSP example in the docs

### DIFF
--- a/doc/26_Best_Practice/75_Security_Concept.md
+++ b/doc/26_Best_Practice/75_Security_Concept.md
@@ -38,7 +38,7 @@ pimcore_admin:
         additional_urls:
             script-src:
                 - 'https://oreo.cat/scripts/meow.js' 
-                - 'https://bagheera.cat/*'
+                - 'https://bagheera.cat'
             style-src:
                 - 'https://oreo.cat/scripts/meow.css'
 ```


### PR DESCRIPTION
## Additional info

Wildcards (`*`) can only be used for subdomains, host address, and port number, see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy#host-source