### PR TITLE
[Bugfix]: Ensure `getConditionVariableTypes()` is used in all DAOs

### DIFF
--- a/bundles/GlossaryBundle/src/Model/Glossary/Listing/Dao.php
+++ b/bundles/GlossaryBundle/src/Model/Glossary/Listing/Dao.php
@@ -34,7 +34,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function load(): array
     {
-        $glossarysData = $this->db->fetchFirstColumn('SELECT id FROM glossary' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        $glossarysData = $this->db->fetchFirstColumn('SELECT id FROM glossary' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         $glossary = [];
         foreach ($glossarysData as $glossaryData) {
@@ -51,9 +51,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getDataArray(): array
     {
-        $glossarysData = $this->db->fetchAllAssociative('SELECT * FROM glossary' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
-
-        return $glossarysData;
+        return $this->db->fetchAllAssociative('SELECT * FROM glossary' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
     }
 
     /**
@@ -63,7 +61,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM glossary ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM glossary ' . $this->getCondition(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         } catch (Exception $e) {
             return 0;
         }

--- a/bundles/SeoBundle/src/Model/Redirect/Listing/Dao.php
+++ b/bundles/SeoBundle/src/Model/Redirect/Listing/Dao.php
@@ -33,7 +33,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function load(): array
     {
-        $redirectsData = $this->db->fetchFirstColumn('SELECT id FROM redirects' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        $redirectsData = $this->db->fetchFirstColumn('SELECT id FROM redirects' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         $redirects = [];
         foreach ($redirectsData as $redirectData) {
@@ -48,7 +48,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM redirects ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM redirects ' . $this->getCondition(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         } catch (Exception $e) {
             return 0;
         }

--- a/bundles/SimpleBackendSearchBundle/src/Model/Search/Backend/Data/Listing/Dao.php
+++ b/bundles/SimpleBackendSearchBundle/src/Model/Search/Backend/Data/Listing/Dao.php
@@ -36,7 +36,7 @@ class Dao extends AbstractDao
     public function load(): array
     {
         $entries = [];
-        $data = $this->db->fetchAllAssociative('SELECT * FROM search_backend_data' .  $this->getCondition() . $this->getGroupBy() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        $data = $this->db->fetchAllAssociative('SELECT * FROM search_backend_data' .  $this->getCondition() . $this->getGroupBy() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         foreach ($data as $entryData) {
             if (!in_array($entryData['maintype'], ['document', 'asset', 'object'], true)) {
@@ -68,7 +68,7 @@ class Dao extends AbstractDao
 
     public function getTotalCount(): int
     {
-        return (int)$this->db->fetchOne('SELECT COUNT(*) FROM search_backend_data' . $this->getCondition() . $this->getGroupBy(), $this->model->getConditionVariables());
+        return (int)$this->db->fetchOne('SELECT COUNT(*) FROM search_backend_data' . $this->getCondition() . $this->getGroupBy(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
     }
 
     public function getCount(): int|string
@@ -77,9 +77,7 @@ class Dao extends AbstractDao
             return count($this->model->getEntries());
         }
 
-        $amount = $this->db->fetchOne('SELECT COUNT(*) as amount FROM search_backend_data '  . $this->getCondition() . $this->getGroupBy() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
-
-        return $amount;
+        return $this->db->fetchOne('SELECT COUNT(*) as amount FROM search_backend_data '  . $this->getCondition() . $this->getGroupBy() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
     }
 
     protected function getCondition(): string

--- a/bundles/UuidBundle/src/Model/Tool/UUID/Listing/Dao.php
+++ b/bundles/UuidBundle/src/Model/Tool/UUID/Listing/Dao.php
@@ -33,7 +33,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function load(): array
     {
-        $items = $this->db->fetchFirstColumn('SELECT uuid FROM ' . UUID\Dao::TABLE_NAME .' '. $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        $items = $this->db->fetchFirstColumn('SELECT uuid FROM ' . UUID\Dao::TABLE_NAME .' '. $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         $result = [];
         foreach ($items as $uuid) {
             $result[] = UUID::getByUuid($uuid);
@@ -49,7 +49,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . UUID\Dao::TABLE_NAME .' ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . UUID\Dao::TABLE_NAME .' ' . $this->getCondition(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         } catch (Exception $e) {
             return 0;
         }

--- a/models/DataObject/ClassDefinition/Listing/Dao.php
+++ b/models/DataObject/ClassDefinition/Listing/Dao.php
@@ -50,7 +50,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM classes ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM classes ' . $this->getCondition(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         } catch (Exception $e) {
             return 0;
         }

--- a/models/DataObject/Classificationstore/CollectionConfig/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/CollectionConfig/Listing/Dao.php
@@ -33,7 +33,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function load(): array
     {
         $sql = 'SELECT id FROM ' . DataObject\Classificationstore\CollectionConfig\Dao::TABLE_NAME_COLLECTIONS . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit();
-        $configsData = $this->db->fetchFirstColumn($sql, $this->model->getConditionVariables());
+        $configsData = $this->db->fetchFirstColumn($sql, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         $configData = [];
         foreach ($configsData as $config) {
@@ -47,15 +47,13 @@ class Dao extends Model\Listing\Dao\AbstractDao
 
     public function getDataArray(): array
     {
-        $configsData = $this->db->fetchAllAssociative('SELECT * FROM ' . DataObject\Classificationstore\CollectionConfig\Dao::TABLE_NAME_COLLECTIONS . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
-
-        return $configsData;
+        return $this->db->fetchAllAssociative('SELECT * FROM ' . DataObject\Classificationstore\CollectionConfig\Dao::TABLE_NAME_COLLECTIONS . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
     }
 
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . DataObject\Classificationstore\CollectionConfig\Dao::TABLE_NAME_COLLECTIONS . ' '. $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . DataObject\Classificationstore\CollectionConfig\Dao::TABLE_NAME_COLLECTIONS . ' '. $this->getCondition(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         } catch (Exception $e) {
             return 0;
         }

--- a/models/DataObject/Classificationstore/CollectionGroupRelation/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/CollectionGroupRelation/Listing/Dao.php
@@ -45,7 +45,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
             . ',' . DataObject\Classificationstore\GroupConfig\Dao::TABLE_NAME_GROUPS
             . $condition . $this->getOrder() . $this->getOffsetLimit();
 
-        $data = $this->db->fetchAllAssociative($sql, $this->model->getConditionVariables());
+        $data = $this->db->fetchAllAssociative($sql, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         $configData = [];
         foreach ($data as $dataItem) {
@@ -63,15 +63,13 @@ class Dao extends Model\Listing\Dao\AbstractDao
 
     public function getDataArray(): array
     {
-        $configsData = $this->db->fetchAllAssociative('SELECT * FROM ' . DataObject\Classificationstore\CollectionGroupRelation\Dao::TABLE_NAME_RELATIONS . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
-
-        return $configsData;
+        return $this->db->fetchAllAssociative('SELECT * FROM ' . DataObject\Classificationstore\CollectionGroupRelation\Dao::TABLE_NAME_RELATIONS . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
     }
 
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . DataObject\Classificationstore\CollectionGroupRelation\Dao::TABLE_NAME_RELATIONS . ' '. $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . DataObject\Classificationstore\CollectionGroupRelation\Dao::TABLE_NAME_RELATIONS . ' '. $this->getCondition(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         } catch (Exception $e) {
             return 0;
         }

--- a/models/DataObject/Classificationstore/GroupConfig/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/GroupConfig/Listing/Dao.php
@@ -33,7 +33,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function load(): array
     {
         $sql = 'SELECT * FROM ' . DataObject\Classificationstore\GroupConfig\Dao::TABLE_NAME_GROUPS . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit();
-        $configsData = $this->db->fetchAllAssociative($sql, $this->model->getConditionVariables());
+        $configsData = $this->db->fetchAllAssociative($sql, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         $configList = [];
         foreach ($configsData as $configData) {
@@ -49,15 +49,13 @@ class Dao extends Model\Listing\Dao\AbstractDao
 
     public function getDataArray(): array
     {
-        $configsData = $this->db->fetchAllAssociative('SELECT * FROM ' . DataObject\Classificationstore\GroupConfig\Dao::TABLE_NAME_GROUPS . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
-
-        return $configsData;
+        return $this->db->fetchAllAssociative('SELECT * FROM ' . DataObject\Classificationstore\GroupConfig\Dao::TABLE_NAME_GROUPS . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
     }
 
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . DataObject\Classificationstore\GroupConfig\Dao::TABLE_NAME_GROUPS . ' '. $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . DataObject\Classificationstore\GroupConfig\Dao::TABLE_NAME_GROUPS . ' '. $this->getCondition(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         } catch (Exception $e) {
             return 0;
         }

--- a/models/DataObject/Classificationstore/KeyConfig/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/KeyConfig/Listing/Dao.php
@@ -33,7 +33,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function load(): array
     {
         $sql = 'SELECT * FROM ' . DataObject\Classificationstore\KeyConfig\Dao::TABLE_NAME_KEYS . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit();
-        $configsData = $this->db->fetchAllAssociative($sql, $this->model->getConditionVariables());
+        $configsData = $this->db->fetchAllAssociative($sql, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         $configList = [];
         foreach ($configsData as $keyConfigData) {
@@ -50,15 +50,13 @@ class Dao extends Model\Listing\Dao\AbstractDao
 
     public function getDataArray(): array
     {
-        $configsData = $this->db->fetchAllAssociative('SELECT * FROM ' . DataObject\Classificationstore\KeyConfig\Dao::TABLE_NAME_KEYS . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
-
-        return $configsData;
+        return $this->db->fetchAllAssociative('SELECT * FROM ' . DataObject\Classificationstore\KeyConfig\Dao::TABLE_NAME_KEYS . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
     }
 
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . DataObject\Classificationstore\KeyConfig\Dao::TABLE_NAME_KEYS . ' '. $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . DataObject\Classificationstore\KeyConfig\Dao::TABLE_NAME_KEYS . ' '. $this->getCondition(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         } catch (Exception $e) {
             return 0;
         }

--- a/models/DataObject/Classificationstore/KeyGroupRelation/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/KeyGroupRelation/Listing/Dao.php
@@ -41,7 +41,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
         }
 
         $sql .= $this->getFrom() . $this->getWhere() . $this->getOrder() . $this->getOffsetLimit();
-        $data = $this->db->fetchAllAssociative($sql, $this->model->getConditionVariables());
+        $data = $this->db->fetchAllAssociative($sql, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         $configData = [];
         foreach ($data as $dataItem) {
@@ -66,12 +66,12 @@ class Dao extends Model\Listing\Dao\AbstractDao
 
     public function getDataArray(): array
     {
-        return $this->db->fetchAllAssociative('SELECT *' . $this->getFrom() . $this->getWhere() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        return $this->db->fetchAllAssociative('SELECT *' . $this->getFrom() . $this->getWhere() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
     }
 
     public function getTotalCount(): int
     {
-        return (int) $this->db->fetchOne('SELECT COUNT(*)' . $this->getFrom() . $this->getWhere(), $this->model->getConditionVariables());
+        return (int) $this->db->fetchOne('SELECT COUNT(*)' . $this->getFrom() . $this->getWhere(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
     }
 
     private function getWhere(): string

--- a/models/DataObject/Classificationstore/StoreConfig/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/StoreConfig/Listing/Dao.php
@@ -33,7 +33,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function load(): array
     {
         $sql = 'SELECT id FROM ' . DataObject\Classificationstore\StoreConfig\Dao::TABLE_NAME_STORES . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit();
-        $configsData = $this->db->fetchFirstColumn($sql, $this->model->getConditionVariables());
+        $configsData = $this->db->fetchFirstColumn($sql, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         $configData = [];
         foreach ($configsData as $config) {
@@ -47,15 +47,13 @@ class Dao extends Model\Listing\Dao\AbstractDao
 
     public function getDataArray(): array
     {
-        $configsData = $this->db->fetchAllAssociative('SELECT * FROM ' . DataObject\Classificationstore\StoreConfig\Dao::TABLE_NAME_STORES . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
-
-        return $configsData;
+        return $this->db->fetchAllAssociative('SELECT * FROM ' . DataObject\Classificationstore\StoreConfig\Dao::TABLE_NAME_STORES . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
     }
 
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . DataObject\Classificationstore\StoreConfig\Dao::TABLE_NAME_STORES . ' '. $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . DataObject\Classificationstore\StoreConfig\Dao::TABLE_NAME_STORES . ' '. $this->getCondition(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         } catch (Exception $e) {
             return 0;
         }

--- a/models/DataObject/QuantityValue/Unit/Listing/Dao.php
+++ b/models/DataObject/QuantityValue/Unit/Listing/Dao.php
@@ -31,7 +31,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
         $units = [];
 
         $unitConfigs = $this->db->fetchAllAssociative('SELECT * FROM ' . DataObject\QuantityValue\Unit\Dao::TABLE_NAME .
-            $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+            $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         foreach ($unitConfigs as $unitConfig) {
             $unit = new DataObject\QuantityValue\Unit();
@@ -47,7 +47,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM '.DataObject\QuantityValue\Unit\Dao::TABLE_NAME.' ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM '.DataObject\QuantityValue\Unit\Dao::TABLE_NAME.' ' . $this->getCondition(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         } catch (Exception $e) {
             return 0;
         }

--- a/models/Element/Recyclebin/Item/Listing/Dao.php
+++ b/models/Element/Recyclebin/Item/Listing/Dao.php
@@ -31,7 +31,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function load(): array
     {
-        $itemsData = $this->db->fetchFirstColumn('SELECT id FROM recyclebin' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        $itemsData = $this->db->fetchFirstColumn('SELECT id FROM recyclebin' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         $items = [];
         foreach ($itemsData as $itemData) {
@@ -50,7 +50,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM recyclebin ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM recyclebin ' . $this->getCondition(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         } catch (Exception $e) {
             return 0;
         }

--- a/models/Element/Tag/Listing/Dao.php
+++ b/models/Element/Tag/Listing/Dao.php
@@ -31,7 +31,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function load(): array
     {
-        $tagsData = $this->db->fetchFirstColumn('SELECT id FROM tags' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        $tagsData = $this->db->fetchFirstColumn('SELECT id FROM tags' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         $tags = [];
         foreach ($tagsData as $tagData) {
@@ -50,7 +50,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function loadIdList(): array
     {
-        $tagsIds = $this->db->fetchFirstColumn('SELECT id FROM tags' . $this->getCondition() . $this->getGroupBy() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        $tagsIds = $this->db->fetchFirstColumn('SELECT id FROM tags' . $this->getCondition() . $this->getGroupBy() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         return array_map('intval', $tagsIds);
     }
@@ -58,7 +58,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM tags ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM tags ' . $this->getCondition(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         } catch (Exception $e) {
             return 0;
         }

--- a/models/Element/WorkflowState/Listing/Dao.php
+++ b/models/Element/WorkflowState/Listing/Dao.php
@@ -31,7 +31,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function load(): array
     {
-        $workflowStateData = $this->db->fetchAllAssociative('SELECT cid, ctype, workflow FROM element_workflow_state' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        $workflowStateData = $this->db->fetchAllAssociative('SELECT cid, ctype, workflow FROM element_workflow_state' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         $workflowStates = [];
         foreach ($workflowStateData as $entry) {
@@ -48,7 +48,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM element_workflow_state ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM element_workflow_state ' . $this->getCondition(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         } catch (Exception $e) {
             return 0;
         }

--- a/models/Notification/Dao.php
+++ b/models/Notification/Dao.php
@@ -59,22 +59,21 @@ class Dao extends AbstractDao
      */
     public function save(): void
     {
-        $model = $this->getModel();
-        $model->setModificationDate(date('Y-m-d H:i:s'));
+        $this->model->setModificationDate(date('Y-m-d H:i:s'));
 
-        if ($model->getId() === null || !$model->getCreationDate()) {
-            $model->setCreationDate($model->getModificationDate());
+        if ($this->model->getId() === null || !$this->model->getCreationDate()) {
+            $this->model->setCreationDate($this->model->getModificationDate());
         }
 
         Helper::upsert(
             $this->db,
             self::DB_TABLE_NAME,
-            $this->getData($model),
+            $this->getData($this->model),
             $this->getPrimaryKey(self::DB_TABLE_NAME)
         );
 
-        if ($model->getId() === null) {
-            $model->setId((int) $this->db->lastInsertId());
+        if ($this->model->getId() === null) {
+            $this->model->setId((int) $this->db->lastInsertId());
         }
     }
 
@@ -86,13 +85,12 @@ class Dao extends AbstractDao
     public function delete(): void
     {
         $this->db->delete(self::DB_TABLE_NAME, [
-            'id' => $this->getModel()->getId(),
+            'id' => $this->model->getId(),
         ]);
     }
 
     protected function assignVariablesToModel(array $data): void
     {
-        $model = $this->getModel();
         $sender = null;
 
         if ($data['sender']) {
@@ -129,18 +127,18 @@ class Dao extends AbstractDao
             $linkedElement = Service::getElementById($data['linkedElementType'], $data['linkedElement']);
         }
 
-        $model->setId((int)$data['id']);
-        $model->setCreationDate($data['creationDate'] ?? $data['modificationDate']);
-        $model->setModificationDate($data['modificationDate']);
-        $model->setSender($sender);
-        $model->setRecipient($recipient);
-        $model->setTitle($data['title']);
-        $model->setType($data['type'] ?? 'info');
-        $model->setMessage($data['message']);
-        $model->setLinkedElement($linkedElement);
-        $model->setRead($data['read'] === 1);
-        $model->setPayload($data['payload']);
-        $model->setIsStudio($data['isStudio'] === 1); // TODO: Remove with end of Classic-UI
+        $this->model->setId((int)$data['id']);
+        $this->model->setCreationDate($data['creationDate'] ?? $data['modificationDate']);
+        $this->model->setModificationDate($data['modificationDate']);
+        $this->model->setSender($sender);
+        $this->model->setRecipient($recipient);
+        $this->model->setTitle($data['title']);
+        $this->model->setType($data['type'] ?? 'info');
+        $this->model->setMessage($data['message']);
+        $this->model->setLinkedElement($linkedElement);
+        $this->model->setRead($data['read'] === 1);
+        $this->model->setPayload($data['payload']);
+        $this->model->setIsStudio($data['isStudio'] === 1); // TODO: Remove with end of Classic-UI
     }
 
     protected function getData(Notification $model): array
@@ -160,10 +158,5 @@ class Dao extends AbstractDao
             'payload' => $model->getPayload(),
             'isStudio' => (int) $model->isStudio(), // TODO: Remove with end of Classic-UI
         ];
-    }
-
-    protected function getModel(): Notification
-    {
-        return $this->model;
     }
 }

--- a/models/Notification/Listing/Dao.php
+++ b/models/Notification/Listing/Dao.php
@@ -33,7 +33,7 @@ class Dao extends AbstractDao
         $sql = sprintf('SELECT COUNT(*) AS num FROM `%s`%s', static::DB_TABLE_NAME, $this->getCondition());
 
         try {
-            $count = (int) $this->db->fetchOne($sql, $this->getModel()->getConditionVariables());
+            $count = (int) $this->db->fetchOne($sql, $this->getModel()->getConditionVariables(), $this->getModel()->getConditionVariableTypes());
         } catch (\Exception $ex) {
             $count = 0;
         }
@@ -61,8 +61,7 @@ class Dao extends AbstractDao
             $this->getOffsetLimit()
         );
 
-        $ids = $this->db->fetchFirstColumn($sql, $this->getModel()->getConditionVariables());
-
+        $ids = $this->db->fetchFirstColumn($sql, $this->getModel()->getConditionVariables(), $this->getModel()->getConditionVariableTypes());
         foreach ($ids as $id) {
             $notification = Notification::getById((int) $id);
 

--- a/models/Notification/Listing/Dao.php
+++ b/models/Notification/Listing/Dao.php
@@ -33,7 +33,7 @@ class Dao extends AbstractDao
         $sql = sprintf('SELECT COUNT(*) AS num FROM `%s`%s', static::DB_TABLE_NAME, $this->getCondition());
 
         try {
-            $count = (int) $this->db->fetchOne($sql, $this->getModel()->getConditionVariables(), $this->getModel()->getConditionVariableTypes());
+            $count = (int) $this->db->fetchOne($sql, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         } catch (\Exception $ex) {
             $count = 0;
         }
@@ -61,7 +61,7 @@ class Dao extends AbstractDao
             $this->getOffsetLimit()
         );
 
-        $ids = $this->db->fetchFirstColumn($sql, $this->getModel()->getConditionVariables(), $this->getModel()->getConditionVariableTypes());
+        $ids = $this->db->fetchFirstColumn($sql, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         foreach ($ids as $id) {
             $notification = Notification::getById((int) $id);
 
@@ -70,13 +70,8 @@ class Dao extends AbstractDao
             }
         }
 
-        $this->getModel()->setNotifications($notifications);
+        $this->model->setNotifications($notifications);
 
         return $notifications;
-    }
-
-    protected function getModel(): Notification\Listing
-    {
-        return $this->model;
     }
 }

--- a/models/Schedule/Task/Listing/Dao.php
+++ b/models/Schedule/Task/Listing/Dao.php
@@ -32,7 +32,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function load(): array
     {
         $tasks = [];
-        $tasksData = $this->db->fetchFirstColumn('SELECT id FROM schedule_tasks' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        $tasksData = $this->db->fetchFirstColumn('SELECT id FROM schedule_tasks' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         foreach ($tasksData as $taskData) {
             $tasks[] = Model\Schedule\Task::getById($taskData);
@@ -46,7 +46,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM schedule_tasks ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM schedule_tasks ' . $this->getCondition(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         } catch (Exception $e) {
             return 0;
         }

--- a/models/Site/Listing/Dao.php
+++ b/models/Site/Listing/Dao.php
@@ -32,7 +32,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function load(): array
     {
         $sites = [];
-        $sitesData = $this->db->fetchFirstColumn('SELECT id FROM sites' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        $sitesData = $this->db->fetchFirstColumn('SELECT id FROM sites' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         foreach ($sitesData as $siteData) {
             $sites[] = Model\Site::getById($siteData);
@@ -46,7 +46,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM sites ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM sites ' . $this->getCondition(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         } catch (Exception $e) {
             return 0;
         }

--- a/models/Tool/Email/Blocklist/Listing/Dao.php
+++ b/models/Tool/Email/Blocklist/Listing/Dao.php
@@ -31,7 +31,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function load(): array
     {
-        $addressData = $this->db->fetchFirstColumn('SELECT address FROM email_blocklist' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        $addressData = $this->db->fetchFirstColumn('SELECT address FROM email_blocklist' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         $addresses = [];
         foreach ($addressData as $data) {
@@ -48,7 +48,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM email_blocklist ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM email_blocklist ' . $this->getCondition(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         } catch (Exception $e) {
             return 0;
         }

--- a/models/Tool/Email/Log/Listing/Dao.php
+++ b/models/Tool/Email/Log/Listing/Dao.php
@@ -31,7 +31,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function load(): array
     {
-        $emailLogs = $this->db->fetchFirstColumn('SELECT id FROM email_log' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        $emailLogs = $this->db->fetchFirstColumn('SELECT id FROM email_log' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         $emailLogsArray = [];
         foreach ($emailLogs as $log) {
@@ -48,9 +48,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getDataArray(): array
     {
-        $emailLogData = $this->db->fetchAllAssociative('SELECT * FROM email_log ' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
-
-        return $emailLogData;
+        return $this->db->fetchAllAssociative('SELECT * FROM email_log ' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
     }
 
     /**
@@ -60,7 +58,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM email_log ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM email_log ' . $this->getCondition(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         } catch (Exception $e) {
             return 0;
         }

--- a/models/Translation/Listing/Dao.php
+++ b/models/Translation/Listing/Dao.php
@@ -42,7 +42,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
         $queryBuilder->setFirstResult(0);
 
         $query = sprintf('SELECT COUNT(*) as amount FROM (%s) AS a', (string) $queryBuilder);
-        $amount = (int) $this->db->fetchOne($query, $this->model->getConditionVariables());
+        $amount = (int) $this->db->fetchOne($query, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         return $amount;
     }
@@ -56,9 +56,8 @@ class Dao extends Model\Listing\Dao\AbstractDao
         $queryBuilder = $this->getQueryBuilder($this->getDatabaseTableName() . '.key');
 
         $query = sprintf('SELECT COUNT(*) as amount FROM (%s) AS a', (string) $queryBuilder);
-        $amount = (int) $this->db->fetchOne($query, $this->model->getConditionVariables());
 
-        return $amount;
+        return (int) $this->db->fetchOne($query, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
     }
 
     public function getAllTranslations(): array

--- a/models/User/Listing/AbstractListing/Dao.php
+++ b/models/User/Listing/AbstractListing/Dao.php
@@ -32,7 +32,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function load(): array
     {
         $items = [];
-        $usersData = $this->db->fetchAllAssociative('SELECT id,type FROM users' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        $usersData = $this->db->fetchAllAssociative('SELECT id,type FROM users' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         foreach ($usersData as $userData) {
             $className = Model\User\Service::getClassNameForType($userData['type']);
@@ -65,7 +65,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM users ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM users ' . $this->getCondition(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         } catch (Exception $e) {
             return 0;
         }

--- a/models/User/Permission/Definition/Listing/Dao.php
+++ b/models/User/Permission/Definition/Listing/Dao.php
@@ -32,7 +32,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function load(): array
     {
         $definitions = [];
-        $definitionsData = $this->db->fetchAllAssociative('SELECT * FROM users_permission_definitions' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        $definitionsData = $this->db->fetchAllAssociative('SELECT * FROM users_permission_definitions' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         foreach ($definitionsData as $definitionData) {
             $definition = new Model\User\Permission\Definition($definitionData);
@@ -47,7 +47,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM users_permission_definitions ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM users_permission_definitions ' . $this->getCondition(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         } catch (Exception $e) {
             return 0;
         }

--- a/models/Version/Listing/Dao.php
+++ b/models/Version/Listing/Dao.php
@@ -63,7 +63,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function loadIdList(): array
     {
-        $versionIds = $this->db->fetchFirstColumn('SELECT id FROM versions' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        $versionIds = $this->db->fetchFirstColumn('SELECT id FROM versions' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         return array_map('intval', $versionIds);
     }
@@ -71,7 +71,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM versions ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM versions ' . $this->getCondition(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         } catch (Exception $e) {
             return 0;
         }

--- a/models/WebsiteSetting/Listing/Dao.php
+++ b/models/WebsiteSetting/Listing/Dao.php
@@ -30,7 +30,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function load(): array
     {
         $sql = 'SELECT id FROM website_settings' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit();
-        $settingsData = $this->db->fetchFirstColumn($sql, $this->model->getConditionVariables());
+        $settingsData = $this->db->fetchFirstColumn($sql, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         $settings = [];
         foreach ($settingsData as $settingData) {
@@ -44,6 +44,6 @@ class Dao extends Model\Listing\Dao\AbstractDao
 
     public function getTotalCount(): int
     {
-        return (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM website_settings ' . $this->getCondition(), $this->model->getConditionVariables());
+        return (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM website_settings ' . $this->getCondition(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
     }
 }


### PR DESCRIPTION
## Changes in this pull request  
Passes the types to all queries in all DAOs. 
This is necessary for advanced queries, e.g., with `IN(?)`. 
Doctrine **needs** the types in this case.

## Additional info
This was already done for Notes in #9935.

There is a similar PR in pimcore/ecommerce-framework-bundle#277