### PR TITLE
[Bug, EC] PEES-805: [Riedel] Error with invalid default workflow place

### DIFF
--- a/lib/Workflow/Manager.php
+++ b/lib/Workflow/Manager.php
@@ -385,10 +385,10 @@ class Manager
 
             try {
                 $marking = $workflow->getMarking($element);
-            } catch (LogicException $e){
+            } catch (LogicException $e) {
                 continue;
             }
-            
+
             if (!count($marking->getPlaces())) {
                 continue;
             }

--- a/lib/Workflow/Manager.php
+++ b/lib/Workflow/Manager.php
@@ -386,10 +386,9 @@ class Manager
             try {
                 $marking = $workflow->getMarking($element);
             } catch (LogicException $e){
-                //do nothing
                 continue;
             }
-
+            
             if (!count($marking->getPlaces())) {
                 continue;
             }

--- a/lib/Workflow/Manager.php
+++ b/lib/Workflow/Manager.php
@@ -383,7 +383,12 @@ class Manager
                 continue;
             }
 
-            $marking = $workflow->getMarking($element);
+            try {
+                $marking = $workflow->getMarking($element);
+            } catch (LogicException $e){
+                //do nothing
+                continue;
+            }
 
             if (!count($marking->getPlaces())) {
                 continue;


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/service-operations/issues/277

## Additional info
When  workflow places are stored in select fields and the default or value is invalid, it would end up on an exception "When a Place ‘' is not a valid place for workflow X"
By looking 
```
if (!count($marking->getPlaces())) {
                continue;
            }
```
we could just directly continue also when thrown from symfony getMarking checks

