### PR TITLE
[Bug]: Asset::updateChildPaths() can delete S3 source directory even when no files were moved (data loss risk on cloud storage)

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1701,93 +1701,50 @@ class Asset extends Element\AbstractElement
             $newPath = $this->getRealFullPath();
         }
 
-        // Fail-safe guard: never operate on root or empty paths
-        if ($oldPath === '/' || $oldPath === '') {
-            \Pimcore\Logger::warning('Refusing to delete or move root path.');
-
-            return;
-        }
-
         try {
-            // Step 1: get list of children
-            $children = iterator_to_array($storage->listContents($oldPath, true));
-            $totalFiles = count($children);
+            $movedFiles = [];
+            $children = $storage->listContents($oldPath, true);
+            $totalChildren = iterator_count($children);
 
-            $moved = [];
-            $failed = [];
-
-            // Step 2: try to move each file individually
-
-            /** @var \League\Flysystem\StorageAttributes $child */
-            foreach ($children as $child) {
-                if ($child->isFile()) {
-                    $src = $child->path();
-                    $dest = str_replace($oldPath, $newPath, $src);
-
-                    try {
+            if ($totalChildren > 0) {
+                /** @var \League\Flysystem\StorageAttributes $child */
+                foreach ($children as $child) {
+                    if ($child instanceof \League\Flysystem\FileAttributes) {
+                        $src  = $child['path'];
+                        $dest = str_replace($oldPath, $newPath, '/' . $src);
                         $storage->move($src, $dest);
-                        $moved[] = $src;
-                    } catch (Throwable $e) {
-                        $failed[] = $src;
-                        \Pimcore\Logger::error(sprintf(
-                            'Move failed for %s  %s: %s',
-                            $src,
-                            $dest,
-                            $e->getMessage()
-                        ));
+                        $movedFiles[$dest] = $src;
                     }
                 }
-            }
 
-            $movedCount = count($moved);
-            $failedCount = count($failed);
+                $movedCount = count($movedFiles);
 
-            // Step 3: decide what to do with the source path
-            if ($totalFiles === 0) {
-                // nothing listed  skip deletion
-                \Pimcore\Logger::warning(sprintf(
-                    'No files found in %s; skipping deleteDirectory().',
-                    $oldPath
-                ));
-
-                return;
-            }
-
-            if ($failedCount > 0) {
-                // partial success  keep source folder
-                \Pimcore\Logger::warning(sprintf(
-                    'Partial move for %s  %s: %d of %d files moved successfully. Source preserved.',
-                    $oldPath,
-                    $newPath,
-                    $movedCount,
-                    $totalFiles
-                ));
-
-                return;
-            }
-
-            // Step 4: all files moved successfully  safe to delete source
-            if ($movedCount === $totalFiles) {
-                $storage->deleteDirectory($oldPath);
-                \Pimcore\Logger::info(sprintf(
-                    'Moved %d files from %s  %s. Source directory deleted.',
-                    $movedCount,
-                    $oldPath,
-                    $newPath
-                ));
+                if ($movedCount === $totalChildren) {
+                    $storage->deleteDirectory($oldPath);
+                } else {
+                    \Pimcore\Logger::info(
+                        sprintf(
+                            'Moved %d/%d files from %s to %s. No exception was thrown for %d files,
+                            so the source directory was not deleted.',
+                            $movedCount, $totalChildren, $oldPath, $newPath, $totalChildren - $movedCount
+                        )
+                    );
+                }
             }
         } catch (Throwable $e) {
-            \Pimcore\Logger::error(sprintf(
-                'updateChildPaths() failed for %s  %s: %s',
-                $oldPath,
-                $newPath,
-                $e->getMessage()
-            ));
+            Logger::error(sprintf('Asset Move to %s failed: %s', $newPath, $e->getMessage()));
 
-            // Never delete source directory on any kind of error
-            if (!$skipError) {
-                throw $e;
+            if ($skipError) {
+                return;
             }
+
+            // rollback moved files
+            foreach ($movedFiles as $src => $dest) {
+                $storage->move($src, $dest);
+            }
+
+            // trigger database rollback
+            throw $e;
         }
     }
 

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -59,6 +59,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Mime\MimeTypes;
+use Throwable;
 
 /**
  * @method Dao getDao()
@@ -1703,6 +1704,7 @@ class Asset extends Element\AbstractElement
         // Fail-safe guard: never operate on root or empty paths
         if ($oldPath === '/' || $oldPath === '') {
             \Pimcore\Logger::warning('Refusing to delete or move root path.');
+
             return;
         }
 
@@ -1726,7 +1728,7 @@ class Asset extends Element\AbstractElement
                     try {
                         $storage->move($src, $dest);
                         $moved[] = $src;
-                    } catch (\Throwable $e) {
+                    } catch (Throwable $e) {
                         $failed[] = $src;
                         \Pimcore\Logger::error(sprintf(
                             'Move failed for %s  %s: %s',
@@ -1748,6 +1750,7 @@ class Asset extends Element\AbstractElement
                     'No files found in %s; skipping deleteDirectory().',
                     $oldPath
                 ));
+
                 return;
             }
 
@@ -1760,6 +1763,7 @@ class Asset extends Element\AbstractElement
                     $movedCount,
                     $totalFiles
                 ));
+
                 return;
             }
 
@@ -1773,7 +1777,7 @@ class Asset extends Element\AbstractElement
                     $newPath
                 ));
             }
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             \Pimcore\Logger::error(sprintf(
                 'updateChildPaths() failed for %s  %s: %s',
                 $oldPath,
@@ -1787,7 +1791,6 @@ class Asset extends Element\AbstractElement
             }
         }
     }
-
 
     /**
      * @throws FilesystemException

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1717,30 +1717,25 @@ class Asset extends Element\AbstractElement
             $failed = [];
 
             // Step 2: try to move each file individually
+
+            /** @var \League\Flysystem\StorageAttributes $child */
             foreach ($children as $child) {
-                $src = null;
-
-                if ($child instanceof \League\Flysystem\StorageAttributes && $child->isFile()) {
+                if ($child->isFile()) {
                     $src = $child->path();
-                } elseif (is_array($child) && ($child['type'] ?? null) === 'file') {
-                    $src = $child['path'];
-                }
+                    $dest = str_replace($oldPath, $newPath, $src);
 
-                if ($src === null) {
-                    continue;
-                }
-
-                try {
-                    $storage->move($src, $dest);
-                    $moved[] = $src;
-                } catch (Throwable $e) {
-                    $failed[] = $src;
-                    \Pimcore\Logger::error(sprintf(
-                        'Move failed for %s  %s: %s',
-                        $src,
-                        $dest,
-                        $e->getMessage()
-                    ));
+                    try {
+                        $storage->move($src, $dest);
+                        $moved[] = $src;
+                    } catch (Throwable $e) {
+                        $failed[] = $src;
+                        \Pimcore\Logger::error(sprintf(
+                            'Move failed for %s  %s: %s',
+                            $src,
+                            $dest,
+                            $e->getMessage()
+                        ));
+                    }
                 }
             }
 

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1700,32 +1700,94 @@ class Asset extends Element\AbstractElement
             $newPath = $this->getRealFullPath();
         }
 
+        // Fail-safe guard: never operate on root or empty paths
+        if ($oldPath === '/' || $oldPath === '') {
+            \Pimcore\Logger::warning('Refusing to delete or move root path.');
+            return;
+        }
+
         try {
-            $movedFiles = [];
-            $children = $storage->listContents($oldPath, true);
+            // Step 1: get list of children
+            $children = iterator_to_array($storage->listContents($oldPath, true));
+            $totalFiles = count($children);
+
+            $moved = [];
+            $failed = [];
+
+            // Step 2: try to move each file individually
             foreach ($children as $child) {
-                if ($child['type'] === 'file') {
-                    $src  = $child['path'];
-                    $dest = str_replace($oldPath, $newPath, '/' . $src);
-                    $storage->move($src, $dest);
-                    $movedFiles[$dest] = $src;
+                if (
+                    ($child instanceof \League\Flysystem\StorageAttributes && $child->isFile()) ||
+                    (is_array($child) && ($child['type'] ?? null) === 'file')
+                ) {
+                    $src = is_array($child) ? $child['path'] : $child->path();
+                    $dest = str_replace($oldPath, $newPath, $src);
+
+                    try {
+                        $storage->move($src, $dest);
+                        $moved[] = $src;
+                    } catch (\Throwable $e) {
+                        $failed[] = $src;
+                        \Pimcore\Logger::error(sprintf(
+                            'Move failed for %s  %s: %s',
+                            $src,
+                            $dest,
+                            $e->getMessage()
+                        ));
+                    }
                 }
             }
 
-            $storage->deleteDirectory($oldPath);
-        } catch (UnableToMoveFile $e) {
-            if ($skipError) {
+            $movedCount = count($moved);
+            $failedCount = count($failed);
+
+            // Step 3: decide what to do with the source path
+            if ($totalFiles === 0) {
+                // nothing listed  skip deletion
+                \Pimcore\Logger::warning(sprintf(
+                    'No files found in %s; skipping deleteDirectory().',
+                    $oldPath
+                ));
                 return;
             }
-            // rollback moved files
-            foreach ($movedFiles as $src => $dest) {
-                $storage->move($src, $dest);
+
+            if ($failedCount > 0) {
+                // partial success  keep source folder
+                \Pimcore\Logger::warning(sprintf(
+                    'Partial move for %s  %s: %d of %d files moved successfully. Source preserved.',
+                    $oldPath,
+                    $newPath,
+                    $movedCount,
+                    $totalFiles
+                ));
+                return;
             }
 
-            // trigger database rollback
-            throw $e;
+            // Step 4: all files moved successfully  safe to delete source
+            if ($movedCount === $totalFiles) {
+                $storage->deleteDirectory($oldPath);
+                \Pimcore\Logger::info(sprintf(
+                    'Moved %d files from %s  %s. Source directory deleted.',
+                    $movedCount,
+                    $oldPath,
+                    $newPath
+                ));
+            }
+        } catch (\Throwable $e) {
+            \Pimcore\Logger::error(sprintf(
+                'updateChildPaths() failed for %s  %s: %s',
+                $oldPath,
+                $newPath,
+                $e->getMessage()
+            ));
+
+            // Never delete source directory on any kind of error
+            if (!$skipError) {
+                throw $e;
+            }
         }
     }
+
 
     /**
      * @throws FilesystemException

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1718,25 +1718,29 @@ class Asset extends Element\AbstractElement
 
             // Step 2: try to move each file individually
             foreach ($children as $child) {
-                if (
-                    ($child instanceof \League\Flysystem\StorageAttributes && $child->isFile()) ||
-                    (is_array($child) && ($child['type'] ?? null) === 'file')
-                ) {
-                    $src = is_array($child) ? $child['path'] : $child->path();
-                    $dest = str_replace($oldPath, $newPath, $src);
+                $src = null;
 
-                    try {
-                        $storage->move($src, $dest);
-                        $moved[] = $src;
-                    } catch (Throwable $e) {
-                        $failed[] = $src;
-                        \Pimcore\Logger::error(sprintf(
-                            'Move failed for %s  %s: %s',
-                            $src,
-                            $dest,
-                            $e->getMessage()
-                        ));
-                    }
+                if ($child instanceof \League\Flysystem\StorageAttributes && $child->isFile()) {
+                    $src = $child->path();
+                } elseif (is_array($child) && ($child['type'] ?? null) === 'file') {
+                    $src = $child['path'];
+                }
+
+                if ($src === null) {
+                    continue;
+                }
+
+                try {
+                    $storage->move($src, $dest);
+                    $moved[] = $src;
+                } catch (Throwable $e) {
+                    $failed[] = $src;
+                    \Pimcore\Logger::error(sprintf(
+                        'Move failed for %s  %s: %s',
+                        $src,
+                        $dest,
+                        $e->getMessage()
+                    ));
                 }
             }
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/18794

## Additional info
Applying suggsted change in a draft