### PR TITLE
Fix null pathReference causing error in convertToWebPath

### DIFF
--- a/bundles/CoreBundle/src/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/src/Controller/PublicServicesController.php
@@ -21,6 +21,7 @@ use Pimcore\Bundle\SeoBundle\Config;
 use Pimcore\Controller\Controller;
 use Pimcore\Logger;
 use Pimcore\Model\Asset;
+use Pimcore\Model\Asset\Image\Thumbnail;
 use Pimcore\Model\Site;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -57,7 +58,7 @@ class PublicServicesController extends Controller
         } catch (Exception $e) {
             Logger::error($e->getMessage());
 
-            return new RedirectResponse('/bundles/pimcoreadmin/img/filetype-not-supported.svg');
+            return new RedirectResponse(Thumbnail::FILETYPE_NOT_SUPPORTED_ICON);
         }
     }
 

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -35,6 +35,11 @@ final class Thumbnail implements ThumbnailInterface
     use ImageThumbnailTrait;
 
     /**
+     * @var string
+     */
+    public const FILETYPE_NOT_SUPPORTED_ICON = '/bundles/pimcoreadmin/img/filetype-not-supported.svg';
+
+    /**
      * @internal
      *
      * @var bool[]
@@ -138,7 +143,7 @@ final class Thumbnail implements ThumbnailInterface
         if (empty($this->pathReference)) {
             $this->pathReference = [
                 'type' => 'error',
-                'src' => '/bundles/pimcoreadmin/img/filetype-not-supported.svg',
+                'src' => self::FILETYPE_NOT_SUPPORTED_ICON,
             ];
         }
 

--- a/models/Asset/Video/ImageThumbnail.php
+++ b/models/Asset/Video/ImageThumbnail.php
@@ -144,7 +144,7 @@ final class ImageThumbnail implements ImageThumbnailInterface
 
                             $this->pathReference = [
                                 'type' => 'error',
-                                'src' => '/bundles/pimcoreadmin/img/filetype-not-supported.svg',
+                                'src' => Image\Thumbnail::FILETYPE_NOT_SUPPORTED_ICON,
                             ];
 
                             return;
@@ -155,7 +155,7 @@ final class ImageThumbnail implements ImageThumbnailInterface
 
                             $this->pathReference = [
                                 'type' => 'error',
-                                'src' => '/bundles/pimcoreadmin/img/filetype-not-supported.svg',
+                                'src' => Image\Thumbnail::FILETYPE_NOT_SUPPORTED_ICON,
                             ];
 
                             return;
@@ -190,7 +190,7 @@ final class ImageThumbnail implements ImageThumbnailInterface
         if (empty($this->pathReference)) {
             $this->pathReference = [
                 'type' => 'error',
-                'src' => '/bundles/pimcoreadmin/img/filetype-not-supported.svg',
+                'src' => Image\Thumbnail::FILETYPE_NOT_SUPPORTED_ICON,
             ];
         }
 

--- a/models/Asset/Video/ImageThumbnail.php
+++ b/models/Asset/Video/ImageThumbnail.php
@@ -142,11 +142,21 @@ final class ImageThumbnail implements ImageThumbnailInterface
                         if (false === $converter->saveImage($tempFile, (int) $timeOffset)) {
                             Logger::info('Creation of cache file stream of document ' . $this->asset->getRealFullPath() . ' is failed.');
 
+                            $this->pathReference = [
+                                'type' => 'error',
+                                'src' => '/bundles/pimcoreadmin/img/filetype-not-supported.svg',
+                            ];
+
                             return;
                         }
                         $tempFileContent = file_get_contents($tempFile);
                         if (false === $tempFileContent) {
                             Logger::info('Creation of cache file stream of document ' . $this->asset->getRealFullPath() . ' is failed.');
+
+                            $this->pathReference = [
+                                'type' => 'error',
+                                'src' => '/bundles/pimcoreadmin/img/filetype-not-supported.svg',
+                            ];
 
                             return;
                         }

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -22,6 +22,7 @@ use Pimcore\Bundle\CoreBundle\EventListener\Frontend\FullPageCacheListener;
 use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\Asset;
+use Pimcore\Model\Asset\Image\Thumbnail;
 use Pimcore\Tool;
 
 /**
@@ -529,7 +530,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
 
         $code = '
         <div id="pimcore_video_' . $this->getName() . '" class="pimcore_editable_video">
-            <div class="pimcore_editable_video_error" style="text-align:center; width: ' . $width . '; height: ' . $height . '; border:1px solid #000; background: url(/bundles/pimcoreadmin/img/filetype-not-supported.svg) no-repeat center center #fff;">
+            <div class="pimcore_editable_video_error" style="text-align:center; width: ' . $width . '; height: ' . $height . '; border:1px solid #000; background: url(' . Thumbnail::FILETYPE_NOT_SUPPORTED_ICON . ') no-repeat center center #fff;">
                 ' . $message . '
             </div>
         </div>';


### PR DESCRIPTION
## Changes in this pull request  
Fixes a bug where `$this->pathReference` could remain `null` in `Pimcore\Model\Asset\Thumbnail\ImageThumbnailTrait` and `\Pimcore\Model\Asset\Video\ImageThumbnail`, causing an error when `convertToWebPath()` attempts to process a `null` `$path` at line `308` in `ImageThumbnailTrait.php` :
```php
$path = urlencode_ignore_slash($path);
```

## Additional info
- Initialize `$this->pathReference` with error fallback at lines `145` and `156`
- Uses existing "filetype-not-supported" icon as fallback