### PR TITLE
[Bug, EC] PEES-816: Fix Maintenance Mode does not work as intendend when activated via cli

### DIFF
--- a/.github/workflows/codeception.yaml
+++ b/.github/workflows/codeception.yaml
@@ -5,6 +5,7 @@ on:
     schedule:
         -   cron: '0 3 * * *'
     pull_request_target:
+        types: [opened, synchronize, reopened]
         branches:
             - "[0-9]+.[0-9]+"
             - "[0-9]+.x"
@@ -19,9 +20,7 @@ on:
         paths-ignore:
             - 'doc/**'
             - 'bundles/**/public/**'
-    pull_request:
-        types: [opened, synchronize, reopened]
-        
+            
 permissions:
   contents: read
  

--- a/lib/Tool/MaintenanceModeHelper.php
+++ b/lib/Tool/MaintenanceModeHelper.php
@@ -68,7 +68,7 @@ class MaintenanceModeHelper implements MaintenanceModeHelperInterface
 
     protected function addEntry(string $sessionId): void
     {
-        Cache::save($sessionId, self::ENTRY_ID, lifetime: null);
+        Cache::save($sessionId, self::ENTRY_ID, lifetime: null, force: true);
         TmpStore::add(self::ENTRY_ID, $sessionId);
     }
 
@@ -107,7 +107,7 @@ class MaintenanceModeHelper implements MaintenanceModeHelperInterface
     protected function removeEntry(): void
     {
         try {
-            Cache::save(self::OFF, self::ENTRY_ID, lifetime: null);
+            Cache::save(self::OFF, self::ENTRY_ID, lifetime: null, force: true);
             TmpStore::delete(self::ENTRY_ID);
         } catch (Exception $e) {
             //nothing to log as the tmp doesn't exist


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/service-operations/issues/275

## Additional info
likely caused by https://github.com/pimcore/pimcore/blob/df14e025d3db615fc75b190e3c9f3cc1d68d7304/lib/Cache/Core/CoreCacheHandler.php#L297-L305
