### PR TITLE
[Bug]: Fix data is null when forced in Core Cache Handler

### DIFF
--- a/lib/Cache/Core/CoreCacheHandler.php
+++ b/lib/Cache/Core/CoreCacheHandler.php
@@ -460,28 +460,27 @@ class CoreCacheHandler implements LoggerAwareInterface
         if ($data instanceof ElementInterface) {
             // fetch a fresh copy
             $type = Service::getElementType($data);
-            $latestData = Service::getElementById($type, $data->getId(), ['force' => true]);
-
-            if ($latestData === null || !$latestData->__isBasedOnLatestData()) {
-                $reason = $latestData === null
+            $id = $data->getId();
+            
+            $data = Service::getElementById($type, $id, ['force' => true]);
+            
+            if ($data === null || !$data->__isBasedOnLatestData()) {
+                $reason = $data === null
                     ? 'data is null'
                     : 'element is not based on latest data';
-
+                
                 $this->logger->warning(
                     'Not saving {key} to cache as {reason} (id: {id})',
                     [
                         'key'    => $key,
-                        'id'     => $data->getId(),
+                        'id'     => $id,
                         'reason' => $reason,
                     ]
                 );
-
+                
                 $this->writeInProgress = false;
-
                 return false;
             }
-
-            $data = $latestData;
 
             // dump state is used to trigger a full serialized dump in __sleep eg. in Document, AbstractObject
             $data->setInDumpState(false);

--- a/lib/Cache/Core/CoreCacheHandler.php
+++ b/lib/Cache/Core/CoreCacheHandler.php
@@ -462,7 +462,7 @@ class CoreCacheHandler implements LoggerAwareInterface
             $type = Service::getElementType($data);
             $data = Service::getElementById($type, $data->getId(), ['force' => true]);
 
-            if (!$data->__isBasedOnLatestData()) {
+            if (!$data?->__isBasedOnLatestData()) {
                 $this->logger->warning('Not saving {key} to cache as element is not based on latest data', [
                     'key' => $key,
                 ]);

--- a/lib/Cache/Core/CoreCacheHandler.php
+++ b/lib/Cache/Core/CoreCacheHandler.php
@@ -461,14 +461,14 @@ class CoreCacheHandler implements LoggerAwareInterface
             // fetch a fresh copy
             $type = Service::getElementType($data);
             $id = $data->getId();
-            
+
             $data = Service::getElementById($type, $id, ['force' => true]);
-            
+
             if ($data === null || !$data->__isBasedOnLatestData()) {
                 $reason = $data === null
                     ? 'data is null'
                     : 'element is not based on latest data';
-                
+
                 $this->logger->warning(
                     'Not saving {key} to cache as {reason} (id: {id})',
                     [
@@ -477,8 +477,9 @@ class CoreCacheHandler implements LoggerAwareInterface
                         'reason' => $reason,
                     ]
                 );
-                
+
                 $this->writeInProgress = false;
+
                 return false;
             }
 

--- a/lib/Cache/Core/CoreCacheHandler.php
+++ b/lib/Cache/Core/CoreCacheHandler.php
@@ -477,9 +477,10 @@ class CoreCacheHandler implements LoggerAwareInterface
                 );
 
                 $this->writeInProgress = false;
+
                 return false;
             }
-            
+
             $data = $latestData;
 
             // dump state is used to trigger a full serialized dump in __sleep eg. in Document, AbstractObject

--- a/lib/Cache/Core/CoreCacheHandler.php
+++ b/lib/Cache/Core/CoreCacheHandler.php
@@ -460,17 +460,27 @@ class CoreCacheHandler implements LoggerAwareInterface
         if ($data instanceof ElementInterface) {
             // fetch a fresh copy
             $type = Service::getElementType($data);
-            $data = Service::getElementById($type, $data->getId(), ['force' => true]);
+            $latestData = Service::getElementById($type, $data->getId(), ['force' => true]);
 
-            if (!$data?->__isBasedOnLatestData()) {
-                $this->logger->warning('Not saving {key} to cache as element is not based on latest data', [
-                    'key' => $key,
-                ]);
+            if ($latestData === null || !$latestData->__isBasedOnLatestData()) {
+                $reason = $latestData === null
+                    ? 'data is null'
+                    : 'element is not based on latest data';
+
+                $this->logger->warning(
+                    'Not saving {key} to cache as {reason} (id: {id})',
+                    [
+                        'key'    => $key,
+                        'id'     => $data->getId(),
+                        'reason' => $reason,
+                    ]
+                );
 
                 $this->writeInProgress = false;
-
                 return false;
             }
+            
+            $data = $latestData;
 
             // dump state is used to trigger a full serialized dump in __sleep eg. in Document, AbstractObject
             $data->setInDumpState(false);


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/18782

## Additional info
`$data` could be `null`, if it was effectively deleted before
https://github.com/pimcore/pimcore/blob/7e01c0eda077a5347bab8e65e7de125a5613bae5/models/Element/Service.php#L456 causing `Uncaught PHP Exception Error: "Call to a member function __isBasedOnLatestData() on null" at CoreCacheHandler.php line 464.`
