### PR TITLE
Use Fieldcollection generics in generated code

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Fieldcollections.php
+++ b/models/DataObject/ClassDefinition/Data/Fieldcollections.php
@@ -721,9 +721,13 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
     public function getPhpdocInputType(): ?string
     {
         $types = array_map(
-            static fn ($type) => '\Pimcore\Model\DataObject\Fieldcollection\Data\\' . $type,
+            static fn ($type) => '\Pimcore\Model\DataObject\Fieldcollection\Data\\' . ucfirst($type),
             $this->getAllowedTypes(),
         );
+
+        if ([] === $types) {
+            return '\\' . DataObject\Fieldcollection::class . '|null';
+        }
 
         return '\\' . DataObject\Fieldcollection::class . '<' . implode('|', $types) . '>|null';
     }
@@ -731,9 +735,13 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
     public function getPhpdocReturnType(): ?string
     {
         $types = array_map(
-            static fn ($type) => '\Pimcore\Model\DataObject\Fieldcollection\Data\\' . $type,
+            static fn ($type) => '\Pimcore\Model\DataObject\Fieldcollection\Data\\' . ucfirst($type),
             $this->getAllowedTypes(),
         );
+
+        if ([] === $types) {
+            return '\\' . DataObject\Fieldcollection::class . '|null';
+        }
 
         return '\\' . DataObject\Fieldcollection::class . '<' . implode('|', $types) . '>|null';
     }

--- a/models/DataObject/ClassDefinition/Data/Fieldcollections.php
+++ b/models/DataObject/ClassDefinition/Data/Fieldcollections.php
@@ -720,12 +720,22 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
 
     public function getPhpdocInputType(): ?string
     {
-        return '\\' . DataObject\Fieldcollection::class . '|null';
+        $types = array_map(
+            static fn ($type) => '\Pimcore\Model\DataObject\Fieldcollection\Data\\' . $type,
+            $this->getAllowedTypes(),
+        );
+
+        return '\\' . DataObject\Fieldcollection::class . '<' . implode('|', $types) . '>|null';
     }
 
     public function getPhpdocReturnType(): ?string
     {
-        return '\\' . DataObject\Fieldcollection::class . '|null';
+        $types = array_map(
+            static fn ($type) => '\Pimcore\Model\DataObject\Fieldcollection\Data\\' . $type,
+            $this->getAllowedTypes(),
+        );
+
+        return '\\' . DataObject\Fieldcollection::class . '<' . implode('|', $types) . '>|null';
     }
 
     public function normalize(mixed $value, array $params = []): ?array

--- a/tests/Model/DataObject/ClassDefinitionTest.php
+++ b/tests/Model/DataObject/ClassDefinitionTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Tests\Model\DataObject;
 
 use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Fieldcollections;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Input;
 use Pimcore\Tests\Support\Test\ModelTestCase;
 
@@ -82,7 +83,7 @@ public function setInput(?string $input): static
         $expectedSetterCode =
             '/**
 * Set fieldcollection - fieldcollection
-* @param \Pimcore\Model\DataObject\Fieldcollection|null $fieldcollection
+* @param \Pimcore\Model\DataObject\Fieldcollection<\Pimcore\Model\DataObject\Fieldcollection\Data\Unittestfieldcollection>|null $fieldcollection
 * @return $this
 */
 public function setFieldcollection(?\Pimcore\Model\DataObject\Fieldcollection $fieldcollection): static
@@ -95,6 +96,20 @@ public function setFieldcollection(?\Pimcore\Model\DataObject\Fieldcollection $f
 
 ';
         $this->testSetterCode('fieldcollection', $expectedSetterCode);
+    }
+
+    public function testFieldCollectionPhpdocTypeWithoutAllowedTypes(): void
+    {
+        $fieldDefinition = new Fieldcollections();
+
+        $this->assertSame(
+            '\Pimcore\Model\DataObject\Fieldcollection|null',
+            $fieldDefinition->getPhpdocInputType()
+        );
+        $this->assertSame(
+            '\Pimcore\Model\DataObject\Fieldcollection|null',
+            $fieldDefinition->getPhpdocReturnType()
+        );
     }
 
     /**


### PR DESCRIPTION
## Changes in this pull request

`\Pimcore\Model\DataObject\Fieldcollection` is one of the few places which defines generics in this project. 

But sadly, it doesn't make use of it.

This PR adds the allowed types of a Fieldcollection as generic types for the getter/setter PHPDoc of the referencing field in, e.g., a DataObject.

The getter now looks like, e.g.:
```php
/**
* @return \Pimcore\Model\DataObject\Fieldcollection<\Pimcore\Model\DataObject\Fieldcollection\Data\PricingRule>|null
*/
public function getPricingRules(): ?\Pimcore\Model\DataObject\Fieldcollection
{
	// ...
}
```

or like this with multiple allowed types:

```php
/**
* @return \Pimcore\Model\DataObject\Fieldcollection<\Pimcore\Model\DataObject\Fieldcollection\Data\Something|\Pimcore\Model\DataObject\Fieldcollection\Data\SomethingElse>|null
*/
public function getSomethings ?\Pimcore\Model\DataObject\Fieldcollection
{
	// ...
}
```

This makes PHPStan a lot smarter about your code. 