### PR TITLE
Remove ext-pdo_mysql from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,6 @@
     "ext-mbstring": "*",
     "ext-openssl": "*",
     "ext-pdo": "*",
-    "ext-pdo_mysql": "*",
     "ext-zip": "*",
     "ext-zlib": "*",
     "composer-runtime-api": "^2.0",


### PR DESCRIPTION
As Pimcore is DBAL managed either way, as mentioned 9 years ago in https://github.com/pimcore/pimcore/issues/1236#issuecomment-276081162 it is up for the Doctrine configuration to determine the database type. By default Doctrine does not need any other extension as just the PDO extension.

The code base does not have any hard dependency on this extension. As can be seen on the overview relates to other DBMSs like MariaDB and Percona as well: https://github.com/pimcore/pimcore#overview

The installation process and container compilation of Doctrine will direct end users if their configured DSN requires any additional dependencies. It is recommended connecting using a URL / DSN (ideally through env vars) https://www.doctrine-project.org/projects/doctrine-dbal/en/4.3/reference/configuration.html#connecting-using-a-url

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info
