### PR TITLE
Remove phpstan/phpdoc-parser conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -138,7 +138,6 @@
     "pimcore/output-data-config-toolkit-bundle": "<6.0",
     "pimcore/translations-provider-interfaces": "<3.0",
     "pimcore/web2print-tools-bundle": "<6.0",
-    "phpstan/phpdoc-parser": ">=2.0",
     "sabre/dav": "4.2.2",
     "symfony/symfony": "*",
     "symfony/web-link": "<6.0",


### PR DESCRIPTION
Why was `"phpstan/phpdoc-parser": ">=2.0",` introduced as confict through this commit? Can that conflict be dropped? It was released November 2024 and blocks all applications from working with this repo https://github.com/phpstan/phpdoc-parser/releases/tag/2.0.0

Seems to relate to https://github.com/pimcore/pimcore/issues/17828 and specifically commit https://github.com/pimcore/pimcore/commit/c3beefe92e4ac592d09b2e103ad509de97b10e69

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info
