### PR TITLE
[Bug, EC] PEES-824: Bug: Default Value When Using Field Collections

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Input.php
+++ b/models/DataObject/ClassDefinition/Data/Input.php
@@ -255,9 +255,7 @@ class Input extends Data implements
      */
     public function setDefaultValue(string $defaultValue): static
     {
-        if ($defaultValue !== '') {
-            $this->defaultValue = $defaultValue;
-        }
+        $this->defaultValue = $defaultValue;
 
         return $this;
     }

--- a/models/DataObject/Localizedfield.php
+++ b/models/DataObject/Localizedfield.php
@@ -95,6 +95,13 @@ final class Localizedfield extends Model\AbstractModel implements
     protected ?array $dirtyLanguages = null;
 
     /**
+     * whether this is entry is an update or not, useful for defining a default value
+     *
+     * @internal
+     */
+    protected bool $isUpdate = false;
+
+    /**
      * @internal
      */
     protected bool $_loadedAllLazyData = false;
@@ -781,9 +788,21 @@ final class Localizedfield extends Model\AbstractModel implements
         $dirtyLanguages = $this->getDirtyLanguages();
         $this->setObject($object);
         if (is_array($dirtyLanguages)) {
+            // it might be an empty array when adding emptyish localized data
+            $this->isUpdate = false;
             $this->markLanguagesAsDirty($dirtyLanguages);
         } else {
+            // there are no dirty languages detected, so it's loading from existing data
+            $this->isUpdate = true;
             $this->resetLanguageDirtyMap();
         }
+    }
+
+    /**
+     * @internal
+     */
+    public function isUpdate(): bool
+    {
+        return $this->isUpdate;
     }
 }

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -201,7 +201,7 @@ class Dao extends Model\Dao\AbstractDao
                             $this->model->setLocalizedValue($fieldName, $fd->getDataFromResource($insertDataArray, $object, $fieldDefinitionParams), $language, false);
                         } else {
                             $isUpdate = $params['isUpdate'] ?? false;
-                            if ($context['containerType'] === 'fieldcollection'){
+                            if ($context['containerType'] === 'fieldcollection') {
                                 $isUpdate = true;
                             }
                             $fieldDefinitionParams = $this->getFieldDefinitionParams($fieldName, $language, ['isUpdate' => $isUpdate]);

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -200,7 +200,11 @@ class Dao extends Model\Dao\AbstractDao
                             $insertData = array_merge($insertData, $insertDataArray);
                             $this->model->setLocalizedValue($fieldName, $fd->getDataFromResource($insertDataArray, $object, $fieldDefinitionParams), $language, false);
                         } else {
-                            $fieldDefinitionParams = $this->getFieldDefinitionParams($fieldName, $language, ['isUpdate' => ($params['isUpdate'] ?? false)]);
+                            $isUpdate = $params['isUpdate'] ?? false;
+                            if ($context['containerType'] === 'fieldcollection'){
+                                $isUpdate = true;
+                            }
+                            $fieldDefinitionParams = $this->getFieldDefinitionParams($fieldName, $language, ['isUpdate' => $isUpdate]);
                             $insertData[$fd->getName()] = $fd->getDataForResource(
                                 $this->model->getLocalizedValue($fieldName, $language, true),
                                 $object,

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -202,7 +202,7 @@ class Dao extends Model\Dao\AbstractDao
                         } else {
                             $isUpdate = $params['isUpdate'] ?? false;
                             if ($context['containerType'] === 'fieldcollection') {
-                                $isUpdate = true;
+                                $isUpdate = $this->model->getDirtyLanguages() === null;
                             }
                             $fieldDefinitionParams = $this->getFieldDefinitionParams(
                                 $fieldName,

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -204,7 +204,11 @@ class Dao extends Model\Dao\AbstractDao
                             if ($context['containerType'] === 'fieldcollection') {
                                 $isUpdate = true;
                             }
-                            $fieldDefinitionParams = $this->getFieldDefinitionParams($fieldName, $language, ['isUpdate' => $isUpdate]);
+                            $fieldDefinitionParams = $this->getFieldDefinitionParams(
+                                $fieldName,
+                                $language,
+                                ['isUpdate' => $isUpdate]
+                            );
                             $insertData[$fd->getName()] = $fd->getDataForResource(
                                 $this->model->getLocalizedValue($fieldName, $language, true),
                                 $object,

--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -470,7 +470,7 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
      */
     public function getContainerClassFolder(string $classname): string
     {
-        return PIMCORE_CLASS_DIRECTORY . '/DataObject/' . ucfirst($classname);
+        return PIMCORE_CUSTOM_CONFIGURATION_CLASS_DEFINITION_DIRECTORY . '/DataObject/' . ucfirst($classname);
     }
 
     /**

--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -470,7 +470,7 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
      */
     public function getContainerClassFolder(string $classname): string
     {
-        return PIMCORE_CUSTOM_CONFIGURATION_CLASS_DEFINITION_DIRECTORY . '/DataObject/' . ucfirst($classname);
+        return PIMCORE_CUSTOM_CONFIGURATION_DIRECTORY . '/DataObject/' . ucfirst($classname);
     }
 
     /**

--- a/tests/Model/Relations/FieldcollectionTest.php
+++ b/tests/Model/Relations/FieldcollectionTest.php
@@ -20,6 +20,7 @@ use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\Data\ElementMetadata;
 use Pimcore\Model\DataObject\Fieldcollection;
+use Pimcore\Model\DataObject\Fieldcollection\Definition;
 use Pimcore\Model\DataObject\RelationTest;
 use Pimcore\Model\DataObject\Service;
 use Pimcore\Tests\Support\Test\ModelTestCase;
@@ -241,4 +242,83 @@ class FieldcollectionTest extends ModelTestCase
         $lrel = $loadedFieldcollectionItem->getLRelation('en');
         $this->assertEquals(null, $lrel);
     }
+
+
+    public function testInputFieldWithNullAndThenDefaultValue(): void
+    {
+        //empty string
+        $item1 = new FieldCollection\Data\Unittestfieldcollection();
+        $item1->setLinput('', 'en');
+
+        //null by default
+        $item2 = new FieldCollection\Data\Unittestfieldcollection();
+
+        //null set manually
+        $item3 = new FieldCollection\Data\Unittestfieldcollection();
+        $item1->setLinput(null, 'en');
+
+        //save empty data for language "en"
+        $items = new Fieldcollection();
+        $items->add($item1);
+        $items->add($item2);
+        $items->add($item3);
+
+        $object = TestHelper::createEmptyObject();
+        $object->setFieldcollection($items);
+        $object->save();
+
+        //Reload object from db
+        $object = DataObject::getById($object->getId(), ['force' => true]);
+
+        $loadedFieldcollectionItem = $object->getFieldcollection()->get(0);
+        $linput = $loadedFieldcollectionItem->getLinput('en');
+        $this->assertEquals('', $linput);
+
+        $loadedFieldcollectionItem = $object->getFieldcollection()->get(1);
+        $linput = $loadedFieldcollectionItem->getLinput('en');
+        $this->assertEquals(null, $linput);
+
+        $loadedFieldcollectionItem = $object->getFieldcollection()->get(2);
+        $linput = $loadedFieldcollectionItem->getLinput('en');
+        $this->assertEquals(null, $linput);
+
+        // Add default value afterwards
+        $definition = Definition::getByKey('unittestfieldcollection');
+        $children = $definition->getFieldDefinition('localizedfields')->getChildren();
+        foreach ($children as $index => $child) {
+            if ($child->getName() == 'linput') {
+                $children[$index]->setDefaultValue('1234');
+            }
+        }
+        $definition->save();
+
+        // reload, resave and check
+        $object = DataObject::getById($object->getId(), ['force' => true]);
+
+        // add a ex-novo item that should have default value
+        $item4 = new FieldCollection\Data\Unittestfieldcollection();
+        $items->add($item4);
+        $object->save();
+        $object = DataObject::getById($object->getId(), ['force' => true]);
+
+        //check all again
+        $loadedFieldcollectionItem = $object->getFieldcollection()->get(0);
+        $linput = $loadedFieldcollectionItem->getLinput('en');
+        $this->assertEquals('', $linput);
+
+        //stays null, the default value is not applied retroactively
+        $loadedFieldcollectionItem = $object->getFieldcollection()->get(1);
+        $linput = $loadedFieldcollectionItem->getLinput('en');
+        $this->assertEquals(null, $linput);
+
+        //stays null, the default value is not applied retroactively
+        $loadedFieldcollectionItem = $object->getFieldcollection()->get(2);
+        $linput = $loadedFieldcollectionItem->getLinput('en');
+        $this->assertEquals(null, $linput);
+
+        $loadedFieldcollectionItem = $object->getFieldcollection()->get(2);
+        $linput = $loadedFieldcollectionItem->getLinput('en');
+        $this->assertEquals('1234', $linput);
+    }
+
 }

--- a/tests/Model/Relations/FieldcollectionTest.php
+++ b/tests/Model/Relations/FieldcollectionTest.php
@@ -286,8 +286,8 @@ class FieldcollectionTest extends ModelTestCase
         $fieldDefinitions = $definition->getFieldDefinitions();
         $children = $fieldDefinitions['localizedfields']->getChildren();
         foreach ($children as $index => $child) {
-            if ($child->getName() == 'title') {
-                $children[$index]->setDefaultValue('');
+            if ($child->getName() == 'linput') {
+                $children[$index]->setDefaultValue('1234');
             }
         }
         $fieldDefinitions['localizedfields']->setChildren($children);

--- a/tests/Model/Relations/FieldcollectionTest.php
+++ b/tests/Model/Relations/FieldcollectionTest.php
@@ -297,9 +297,11 @@ class FieldcollectionTest extends ModelTestCase
         // reload, resave and check
         $object = DataObject::getById($object->getId(), ['force' => true]);
 
+        $items = $object->getFieldcollection();
         // add a ex-novo item that should have default value
         $item4 = new FieldCollection\Data\Unittestfieldcollection();
         $items->add($item4);
+        $object->setFieldcollection($items);
         $object->save();
         $object = DataObject::getById($object->getId(), ['force' => true]);
 

--- a/tests/Model/Relations/FieldcollectionTest.php
+++ b/tests/Model/Relations/FieldcollectionTest.php
@@ -243,7 +243,6 @@ class FieldcollectionTest extends ModelTestCase
         $this->assertEquals(null, $lrel);
     }
 
-
     public function testInputFieldWithNullAndThenDefaultValue(): void
     {
         //empty string
@@ -320,5 +319,4 @@ class FieldcollectionTest extends ModelTestCase
         $linput = $loadedFieldcollectionItem->getLinput('en');
         $this->assertEquals('1234', $linput);
     }
-
 }

--- a/tests/Model/Relations/FieldcollectionTest.php
+++ b/tests/Model/Relations/FieldcollectionTest.php
@@ -315,7 +315,8 @@ class FieldcollectionTest extends ModelTestCase
         $linput = $loadedFieldcollectionItem->getLinput('en');
         $this->assertEquals(null, $linput);
 
-        $loadedFieldcollectionItem = $object->getFieldcollection()->get(2);
+        //newly added with no values define taking default value
+        $loadedFieldcollectionItem = $object->getFieldcollection()->get(3);
         $linput = $loadedFieldcollectionItem->getLinput('en');
         $this->assertEquals('1234', $linput);
     }

--- a/tests/Model/Relations/FieldcollectionTest.php
+++ b/tests/Model/Relations/FieldcollectionTest.php
@@ -283,12 +283,15 @@ class FieldcollectionTest extends ModelTestCase
 
         // Add default value afterwards
         $definition = Definition::getByKey('unittestfieldcollection');
-        $children = $definition->getFieldDefinition('localizedfields')->getChildren();
+        $fieldDefinitions = $definition->getFieldDefinitions();
+        $children = $fieldDefinitions['localizedfields']->getChildren();
         foreach ($children as $index => $child) {
-            if ($child->getName() == 'linput') {
-                $children[$index]->setDefaultValue('1234');
+            if ($child->getName() == 'title') {
+                $children[$index]->setDefaultValue('');
             }
         }
+        $fieldDefinitions['localizedfields']->setChildren($children);
+        $definition->setFieldDefinitions($fieldDefinitions);
         $definition->save();
 
         // reload, resave and check
@@ -317,6 +320,20 @@ class FieldcollectionTest extends ModelTestCase
 
         //newly added with no values define taking default value
         $loadedFieldcollectionItem = $object->getFieldcollection()->get(3);
+        $linput = $loadedFieldcollectionItem->getLinput('en');
+        $this->assertEquals('1234', $linput);
+
+        
+        //retest for a new object with the new definition with a default value
+        $items = new Fieldcollection();
+        $item1 = new FieldCollection\Data\Unittestfieldcollection();
+        $items->add($item1);
+
+        $object = TestHelper::createEmptyObject();
+        $object->setFieldcollection($items);
+        $object->save();
+
+        $loadedFieldcollectionItem = $object->getFieldcollection()->get(0);
         $linput = $loadedFieldcollectionItem->getLinput('en');
         $this->assertEquals('1234', $linput);
     }

--- a/tests/Model/Relations/FieldcollectionTest.php
+++ b/tests/Model/Relations/FieldcollectionTest.php
@@ -254,7 +254,7 @@ class FieldcollectionTest extends ModelTestCase
 
         //null set manually
         $item3 = new FieldCollection\Data\Unittestfieldcollection();
-        $item1->setLinput(null, 'en');
+        $item3->setLinput(null, 'en');
 
         //save empty data for language "en"
         $items = new Fieldcollection();

--- a/tests/Model/Relations/FieldcollectionTest.php
+++ b/tests/Model/Relations/FieldcollectionTest.php
@@ -323,7 +323,6 @@ class FieldcollectionTest extends ModelTestCase
         $linput = $loadedFieldcollectionItem->getLinput('en');
         $this->assertEquals('1234', $linput);
 
-        
         //retest for a new object with the new definition with a default value
         $items = new Fieldcollection();
         $item1 = new FieldCollection\Data\Unittestfieldcollection();


### PR DESCRIPTION
Resolves https://pimcore.atlassian.net/browse/PEES-824, https://github.com/pimcore/service-operations/issues/285
Related https://github.com/pimcore/admin-ui-classic-bundle/pull/1053

## Additional info
Added a isUpdate property, relies on `resetLanguageDirtyMap()`, is null when loading existing data, when setting anything even with emptish values, is an [empty array](https://github.com/pimcore/pimcore/pull/18814/files#diff-bcff749d99aba6e16e7b74921e17069cdb2b38c5e11c77f28bb0d88cec7ef44aR790)

On frontend, https://github.com/pimcore/admin-ui-classic-bundle/pull/1053 seems working right