### PR TITLE
[Bug, EC] PEES-842: followup PIMCORE_CLASS_DEFINITON_DIRECTORY setting not applied for brick container classes"

### DIFF
--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -470,7 +470,7 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
      */
     public function getContainerClassFolder(string $classname): string
     {
-        return PIMCORE_CLASS_DIRECTORY . '/DataObject/' . ucfirst($classname);
+        return PIMCORE_CLASS_DEFINITION_DIRECTORY . '/DataObject/' . ucfirst($classname);
     }
 
     /**

--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -470,7 +470,7 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
      */
     public function getContainerClassFolder(string $classname): string
     {
-        return PIMCORE_CUSTOM_CONFIGURATION_DIRECTORY . '/DataObject/' . ucfirst($classname);
+        return PIMCORE_CLASS_DIRECTORY . '/DataObject/' . ucfirst($classname);
     }
 
     /**


### PR DESCRIPTION
It was wrong ENV in https://github.com/pimcore/pimcore/pull/18809 (probably committed some temporary test change instead of the right fix)

No idea why the tests on the branch were green
https://github.com/pimcore/pimcore/actions/runs/19164917685