### PR TITLE
[Security]: Install Third-Party bundles with security advisories fixed version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -130,18 +130,24 @@
   },
   "conflict": {
     "doctrine/doctrine-migrations-bundle": "3.4.0",
+    "nesbot/carbon": "<2.72.6",
     "pimcore/admin-ui-classic-bundle": "<1.5",
     "pimcore/output-data-config-toolkit-bundle": "<5.0",
     "pimcore/translations-provider-interfaces": "<3.0",
     "pimcore/web2print-tools-bundle": "<5.0",
     "phpstan/phpdoc-parser": ">=2.0",
     "sabre/dav": "4.2.2",
+    "spatie/image-optimizer": "<1.7.3",
+    "symfony/http-foundation": "<6.4.29",
+    "symfony/security-bundle": "<6.4.10",
+    "symfony/security-http": "<6.4.15",
     "symfony/symfony": "*",
+    "symfony/validator": "<6.4.11",
     "thecodingmachine/safe": "<2.0"
   },
   "require-dev": {
     "behat/gherkin": "4.12.0",
-    "chrome-php/chrome": "^1.4.0",
+    "chrome-php/chrome": "^1.14.0",
     "codeception/codeception": "5.2.2",
     "codeception/module-symfony": "^3.1.0",
     "composer/composer": "*",
@@ -151,7 +157,7 @@
     "phpstan/phpstan-symfony": "^1.3.5",
     "phpunit/phpunit": "^9.3",
     "symfony/dotenv": "^6.4",
-    "symfony/runtime": "^6.4",
+    "symfony/runtime": "^6.4.14",
     "webmozarts/console-parallelization": "^2.1"
   },
   "suggest": {


### PR DESCRIPTION
~It seems today got tagged many security bundles~
https://blog.packagist.com/composer-2-9/ composer changed the behavior and block insecure packages

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves 
<img width="1333" height="113" alt="image" src="https://github.com/user-attachments/assets/2bfee397-85f3-4c64-8d23-6fc679d0220f" />

<img width="413" height="718" alt="image" src="https://github.com/user-attachments/assets/4752682b-deb3-4e53-b402-b61cef8a084f" />
https://packagist.org/packages/spatie/image-optimizer


## Additional info
