### PR TITLE
Revert "[Security]: Install Third-Party bundles with security advisories fixed version"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -130,24 +130,18 @@
   },
   "conflict": {
     "doctrine/doctrine-migrations-bundle": "3.4.0",
-    "nesbot/carbon": "<2.72.6",
     "pimcore/admin-ui-classic-bundle": "<1.5",
     "pimcore/output-data-config-toolkit-bundle": "<5.0",
     "pimcore/translations-provider-interfaces": "<3.0",
     "pimcore/web2print-tools-bundle": "<5.0",
     "phpstan/phpdoc-parser": ">=2.0",
     "sabre/dav": "4.2.2",
-    "spatie/image-optimizer": "<1.7.3",
-    "symfony/http-foundation": "<6.4.29",
-    "symfony/security-bundle": "<6.4.10",
-    "symfony/security-http": "<6.4.15",
     "symfony/symfony": "*",
-    "symfony/validator": "<6.4.11",
     "thecodingmachine/safe": "<2.0"
   },
   "require-dev": {
     "behat/gherkin": "4.12.0",
-    "chrome-php/chrome": "^1.14.0",
+    "chrome-php/chrome": "^1.4.0",
     "codeception/codeception": "5.2.2",
     "codeception/module-symfony": "^3.1.0",
     "composer/composer": "*",
@@ -157,7 +151,7 @@
     "phpstan/phpstan-symfony": "^1.3.5",
     "phpunit/phpunit": "^9.3",
     "symfony/dotenv": "^6.4",
-    "symfony/runtime": "^6.4.14",
+    "symfony/runtime": "^6.4",
     "webmozarts/console-parallelization": "^2.1"
   },
   "suggest": {


### PR DESCRIPTION
Reverts pimcore/pimcore#18821

We internally agreed to NOT block insecure on Lowest tests
https://getcomposer.org/doc/06-config.md#block-insecure