### PR TITLE
[BUG] Custom Reports throw an error when filtering by dates

### DIFF
--- a/bundles/CustomReportsBundle/src/Tool/Adapter/Sql.php
+++ b/bundles/CustomReportsBundle/src/Tool/Adapter/Sql.php
@@ -151,6 +151,8 @@ class Sql extends AbstractAdapter
                 $value = strtotime($value);
             }
 
+            $value = (string) $value;
+
             switch ($operator) {
                 case 'like':
                     $fields[] = $filter['property'];


### PR DESCRIPTION
## Changes in this pull request  

Cast the `$value` to a string before passing it to `\Doctrine\DBAL\Connection::quote(string $value)`, which requires a string argument.
This change prevents runtime exceptions that occurred when integer values were supplied.

## Additional info

See https://github.com/doctrine/dbal/blob/4.2.5/src/Connection.php#L568