### PR TITLE
[Bug, EC] PEES-846: Copying with DataRange field fails due DatePeriod

### DIFF
--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -1127,6 +1127,16 @@ class Service extends Model\AbstractModel
                 ),
                 new PimcoreClassDefinitionMatcher(Data\CustomDataCopyInterface::class)
             );
+
+            $deepCopy->prependTypeFilter(
+                new class implements TypeFilter {
+                    public function apply($element): CarbonPeriod
+                    {
+                        return CarbonPeriod::instance($element);
+                    }
+                },
+                new TypeMatcher(CarbonPeriod::class),
+            );
         }
 
         $deepCopy->addFilter(new SetNullFilter(), new PropertyNameMatcher('dao'));


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/service-operations/issues/289, https://pimcore.atlassian.net/browse/PEES-846

## Additional info
Follow up of `cloneMe()` based on https://github.com/pimcore/pimcore/pull/18050/files#diff-f1c5d50aa07c3685f76a2947c0c3859e2582f8b683ebadf175679eb4aae78785R1388-R1397, see also [this](https://github.com/myclabs/DeepCopy/issues/201)
