### PR TITLE
Add `string` return type to `Twig/TokenParser/BlockParser` and `Twig/TokenParser/ManualBlockParser`

### DIFF
--- a/lib/Twig/TokenParser/BlockParser.php
+++ b/lib/Twig/TokenParser/BlockParser.php
@@ -52,7 +52,7 @@ final class BlockParser extends AbstractTokenParser
         return $token->test('endpimcoreblock');
     }
 
-    public function getTag()
+    public function getTag(): string
     {
         return 'pimcoreblock';
     }

--- a/lib/Twig/TokenParser/ManualBlockParser.php
+++ b/lib/Twig/TokenParser/ManualBlockParser.php
@@ -78,7 +78,7 @@ final class ManualBlockParser extends AbstractTokenParser
         return $token->test('endpimcoremanualblock');
     }
 
-    public function getTag()
+    public function getTag(): string
     {
         return 'pimcoremanualblock';
     }


### PR DESCRIPTION
Fixes the following deprecations:

> User Deprecated: Method "Twig\TokenParser\TokenParserInterface::getTag()" might add "string" as a native return type declaration in the future. Do the same in implementation "Pimcore\Twig\TokenParser\BlockParser" now to avoid errors or add an explicit `@return` annotation to suppress this message. 

> User Deprecated: Method "Twig\TokenParser\TokenParserInterface::getTag()" might add "string" as a native return type declaration in the future. Do the same in implementation "Pimcore\Twig\TokenParser\ManualBlockParser" now to avoid errors or add an explicit `@return` annotation to suppress this message.