### PR TITLE
[Image gallery] Write inherited hotspot data to query table when saving parent

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Hotspotimage.php
+++ b/models/DataObject/ClassDefinition/Data/Hotspotimage.php
@@ -95,7 +95,7 @@ class Hotspotimage extends Data implements ResourcePersistenceAwareInterface, Qu
                 'crop' => $data->getCrop(),
             ];
 
-            $metaData = $metaData ? Serialize::serialize($metaData) : null;
+            $metaData = Serialize::serialize($metaData);
 
             return [
                 $this->getName() . '__image' => $imageId,
@@ -128,7 +128,7 @@ class Hotspotimage extends Data implements ResourcePersistenceAwareInterface, Qu
             // check if the data is JSON (backward compatibility)
             $md = json_decode($metaData, true);
             if (!$md) {
-                $md = $metaData ? Serialize::unserialize($metaData) : [];
+                $md = Serialize::unserialize($metaData);
             } elseif (is_array($md)) {
                 $md['hotspots'] = $md;
             }

--- a/models/DataObject/ClassDefinition/Data/Hotspotimage.php
+++ b/models/DataObject/ClassDefinition/Data/Hotspotimage.php
@@ -95,7 +95,7 @@ class Hotspotimage extends Data implements ResourcePersistenceAwareInterface, Qu
                 'crop' => $data->getCrop(),
             ];
 
-            $metaData = Serialize::serialize($metaData);
+            $metaData = $metaData ? Serialize::serialize($metaData) : null;
 
             return [
                 $this->getName() . '__image' => $imageId,
@@ -128,7 +128,7 @@ class Hotspotimage extends Data implements ResourcePersistenceAwareInterface, Qu
             // check if the data is JSON (backward compatibility)
             $md = json_decode($metaData, true);
             if (!$md) {
-                $md = Serialize::unserialize($metaData);
+                $md = $metaData ? Serialize::unserialize($metaData) : [];
             } elseif (is_array($md)) {
                 $md['hotspots'] = $md;
             }

--- a/models/DataObject/ClassDefinition/Data/ImageGallery.php
+++ b/models/DataObject/ClassDefinition/Data/ImageGallery.php
@@ -115,7 +115,7 @@ class ImageGallery extends Data implements ResourcePersistenceAwareInterface, Qu
 
             return [
                 $this->getName() . '__images' => $ids,
-                $this->getName() . '__hotspots' => Serialize::serialize($hotspots),
+                $this->getName() . '__hotspots' => $hotspots ? Serialize::serialize($hotspots) : null,
             ];
         }
 
@@ -139,7 +139,7 @@ class ImageGallery extends Data implements ResourcePersistenceAwareInterface, Qu
 
         $images = $data[$this->getName() . '__images'];
         $hotspots = $data[$this->getName() . '__hotspots'];
-        $hotspots = Serialize::unserialize($hotspots);
+        $hotspots = $hotspots ? Serialize::unserialize($hotspots) : [];
 
         if (!$images) {
             return $this->createEmptyImageGallery($params);


### PR DESCRIPTION
Steps to reproduce bug:

1. Create data object class `Test`, enable inheritance, add an image gallery field named `images`
2. Create `Test` object `/parent` 
3. Create `Test` object `/parent/child` (so that it inherits data from `/parent`)
4. Assign an image to the image gallery field of `/parent`, add a hotspot, save

Expected behaviour:
Image gallery data gets inherited to the child object, thus in database table `object_query_Test` the column `images__hotspots` there is the same data for `/parent` and `/parent/child`

Actual behaviour:
Column `images__hotspots` only gets filled for `/parent` but not for `/parent/child`.
After saving the child, `images__hotspots` is the same for both objects.

Cause:
The place which is responsible for writing inherited data for the child objects to the query tables is 
https://github.com/pimcore/pimcore/blob/514e9ceaa22820280c6fc0e8a66fa9beef9d95e2/models/DataObject/Concrete/Dao/InheritanceHelper.php#L171-L183

Here `getIdsToUpdateForValuefields()` does not recognize the child column to be empty. There are multiple quirks here:
1. In https://github.com/pimcore/pimcore/blob/514e9ceaa22820280c6fc0e8a66fa9beef9d95e2/models/DataObject/Concrete/Dao/InheritanceHelper.php#L524-L525 
   `$fieldname` is `images__hotspots` and so `value` is only the content of this column, not all columns which belong to image gallery data. But `$this->fieldDefinitions[$fieldname]` is a `Pimcore\Model\DataObject\ClassDefinition\Data\ImageGallery` object. So the actual `$value` does not match what `ImageGallery::isEmpty()` usually expects to get (a `Pimcore\Model\DataObject\Data\ImageGallery` object or `null`).
2. `$value` is the string `"a:0:{}"` because when saving an image gallery without hotspots, an empty array gets serialized in https://github.com/pimcore/pimcore/blob/514e9ceaa22820280c6fc0e8a66fa9beef9d95e2/models/DataObject/ClassDefinition/Data/ImageGallery.php#L118 and stored in database.

So one way to solve the problem would be to add a check for `$data === "a:0:{}"` in https://github.com/pimcore/pimcore/blob/514e9ceaa22820280c6fc0e8a66fa9beef9d95e2/models/DataObject/ClassDefinition/Data/ImageGallery.php#L339-L343 but this only hides the quirks from above (nobody would immediately see how the string `a:0:{}` can get here).

For this reason I decided for a different approach: When saving an image gallery without hotspots, we store `null` in the database. This way the `ImageGallery::isEmpty()` will return `true` and thus the image gallery data in the query table gets updated when the parent gets saved.