### PR TITLE
fix: ambiguous bundle resolution in `BundleLocator`

### DIFF
--- a/lib/HttpKernel/BundleLocator/BundleLocator.php
+++ b/lib/HttpKernel/BundleLocator/BundleLocator.php
@@ -71,7 +71,7 @@ class BundleLocator implements BundleLocatorInterface
             $namespace = $reflectionClass->getNamespaceName();
 
             foreach ($bundles as $bundle) {
-                if (str_starts_with($namespace, $bundle->getNamespace())) {
+                if (str_starts_with($namespace, $bundle->getNamespace() . '\\')) {
                     return $bundle;
                 }
             }


### PR DESCRIPTION
### `BundleLocator` might resolve the wrong bundle name when names start identically.

E.g. if bundle `\App\Bundle\MyBundle` and `\App\Bundle\MyOtherBundle` coexist, `BundleLocator` currently matches both. This leads to the error that the first matching bundle will get resolved.

Adding a namespace delimiter at the end ensures uniqueness.
