### PR TITLE
Add symfony/var-exporter dependency to composer.json

### DIFF
--- a/bundles/GlossaryBundle/src/Tool/Processor.php
+++ b/bundles/GlossaryBundle/src/Tool/Processor.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\GlossaryBundle\Tool;
 
-use Pimcore\Bundle\GlossaryBundle\Model\Glossary;
 use Pimcore\Cache;
+use Pimcore\Model\Site;
+use Pimcore\Model\Document;
+use Pimcore\Tool\DomCrawler;
+use Pimcore\Http\RequestHelper;
+use Pimcore\Bundle\GlossaryBundle\Model\Glossary;
 use Pimcore\Http\Request\Resolver\DocumentResolver;
 use Pimcore\Http\Request\Resolver\EditmodeResolver;
-use Pimcore\Http\RequestHelper;
-use Pimcore\Model\Document;
-use Pimcore\Model\Site;
-use Pimcore\Tool\DomCrawler;
 
 /**
  * @internal
@@ -115,7 +115,6 @@ class Processor
         $data['count'] = array_fill(0, count($data['search']), 0);
 
         $es->each(function ($parentNode, $i) use ($options, $data) {
-            /** @var DomCrawler|null $parentNode */
             $text = $parentNode->html();
             if (
                 $parentNode instanceof DomCrawler &&

--- a/composer.json
+++ b/composer.json
@@ -121,6 +121,7 @@
     "symfony/uid": "^6.4 || ^7.3",
     "symfony/validator": "^6.4 || ^7.3",
     "symfony/var-dumper": "^6.4 || ^7.3",
+    "symfony/var-exporter": "^6.4 || ^7.3",
     "symfony/web-profiler-bundle": "^6.4 || ^7.3",
     "symfony/webpack-encore-bundle": "^1.17 || ^2.0",
     "symfony/workflow": "^6.4 || ^7.3",


### PR DESCRIPTION
This pull request makes a minor update to the project's dependencies by adding the `symfony/var-exporter` package to `composer.json`. This package will be installed alongside the other Symfony components.