### PR TITLE
[Task]: Deprecate unused method and exception in BundleLocator namespace

### DIFF
--- a/lib/HttpKernel/BundleLocator/BundleLocator.php
+++ b/lib/HttpKernel/BundleLocator/BundleLocator.php
@@ -36,6 +36,13 @@ class BundleLocator implements BundleLocatorInterface
 
     public function getBundlePath(object|string $class): string
     {
+        trigger_deprecation(
+            'pimcore/pimcore',
+            '12.3',
+            'The "%s()" method is deprecated and will be removed in Pimcore 13. Use "getBundle()->getPath()" instead.',
+            __METHOD__,
+        );
+
         return $this->getBundleForClass($class)->getPath();
     }
 

--- a/lib/HttpKernel/BundleLocator/BundleLocatorInterface.php
+++ b/lib/HttpKernel/BundleLocator/BundleLocatorInterface.php
@@ -31,7 +31,7 @@ interface BundleLocatorInterface
      *
      * AppBundle\Controller\FooController returns src/AppBundle
      *
-     *
+     * @deprecated will be removed in 13.0. Use "getBundle()->getPath()" instead.
      *
      * @throws NotFoundException
      */

--- a/lib/HttpKernel/BundleLocator/InvalidArgumentException.php
+++ b/lib/HttpKernel/BundleLocator/InvalidArgumentException.php
@@ -13,6 +13,15 @@ declare(strict_types=1);
 
 namespace Pimcore\HttpKernel\BundleLocator;
 
+trigger_deprecation(
+    'pimcore/pimcore',
+    '12.3',
+    'The "%s" class is deprecated and will be removed in Pimcore 13.',
+);
+
+/**
+ * @deprecated
+ */
 class InvalidArgumentException extends \InvalidArgumentException
 {
 }


### PR DESCRIPTION
Because of #18858 I had a closer look at the `Pimcore\HttpKernel\BundleLocator`.

It seems like `\Pimcore\HttpKernel\BundleLocator\InvalidArgumentException` is not used anywhere, so I deprecated it.

Also `\Pimcore\HttpKernel\BundleLocator\BundleLocatorInterface::getBundlePath()` is not used anywhere, so I deprecated it too.

The only place where `Pimcore\HttpKernel\BundleLocator\BundleLocatorInterface` is actually used seems to be the `\Pimcore\Document\Editable\EditableHandler` and it already uses `BundleLocatorInterface::getBundle()->getPath()`.