### PR TITLE
[Studio][Export]: Data object export for superuser does not work

### DIFF
--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -1270,7 +1270,7 @@ class Service extends Model\Element\Service
             return $result;
         }
 
-        $mergedFieldDefinition = self::getCustomGridFieldDefinitions($class->getId(), $objectId);
+        $mergedFieldDefinition = self::getCustomGridFieldDefinitions($class->getId(), $objectId, $user);
         if (is_array($mergedFieldDefinition)) {
             if (isset($mergedFieldDefinition['localizedfields'])) {
                 $children = $mergedFieldDefinition['localizedfields']->getFieldDefinitions();


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/studio-backend-bundle/issues/1550

## Additional info
User is currently not passed down to getCustomGridFieldDefinitions() method. This was probably missed when implementing https://github.com/pimcore/pimcore/pull/18237
