### PR TITLE
[Task][Tests]: Fix DomCrawler differences from PHP 8.4 HTML5 renderer

### DIFF
--- a/tests/Unit/Document/Glossary/GlossaryTest.php
+++ b/tests/Unit/Document/Glossary/GlossaryTest.php
@@ -41,7 +41,7 @@ class GlossaryTest extends TestCase
 
         $result = $this->processor->parse('<body><p>This is a Test for the Glossary</p></body>', [], 'en', null, null);
 
-        $expect = '<body><p>This is a Test for the <a class="pimcore_glossary" href="/test">Glossary</a></p></body>';
+        $expect = '<head></head><body><p>This is a Test for the <a class="pimcore_glossary" href="/test">Glossary</a></p></body>';
 
         $this->assertSame($expect, $result);
     }
@@ -62,7 +62,7 @@ class GlossaryTest extends TestCase
             null
         );
 
-        $expect = '<body><p>This is a Test for the&nbsp;<a class="pimcore_glossary" href="/test">Entity</a> &copy;</p></body>';
+        $expect = '<head></head><body><p>This is a Test for the&nbsp;<a class="pimcore_glossary" href="/test">Entity</a> &copy;</p></body>';
 
         $this->assertSame(html_entity_decode($expect), $result);
     }
@@ -77,7 +77,7 @@ class GlossaryTest extends TestCase
 
         $result = $this->processor->parse('<body><p>Test &nbsp; Eintrag ©</p></body>', [], 'en', null, null);
 
-        $expect = '<body><p>Test &nbsp; <a class="pimcore_glossary" href="/test">Eintrag</a> &copy;</p></body>';
+        $expect = '<head></head><body><p>Test &nbsp; <a class="pimcore_glossary" href="/test">Eintrag</a> &copy;</p></body>';
 
         $this->assertSame(html_entity_decode($expect), $result);
     }
@@ -123,7 +123,7 @@ class GlossaryTest extends TestCase
         </div>
     </section>';
 
-        $this->assertSame($expect, $result);
+        $this->assertSame(html_entity_decode($expect), $result);
     }
 
     public function testGlossaryWithAnotherHtml(): void

--- a/tests/Unit/Document/Glossary/GlossaryTest.php
+++ b/tests/Unit/Document/Glossary/GlossaryTest.php
@@ -123,7 +123,7 @@ class GlossaryTest extends TestCase
         </div>
     </section>';
 
-        $this->assertSame(html_entity_decode($expect), $result);
+        $this->assertSame(html_entity_decode($expect), html_entity_decode($result));
     }
 
     public function testGlossaryWithAnotherHtml(): void

--- a/tests/Unit/Document/Glossary/GlossaryTest.php
+++ b/tests/Unit/Document/Glossary/GlossaryTest.php
@@ -39,7 +39,7 @@ class GlossaryTest extends TestCase
         $entry->setLanguage('en');
         $entry->save();
 
-        $result = $this->processor->parse('<body><p>This is a Test for the Glossary</p></body>', [], 'en', null, null);
+        $result = $this->processor->parse('<head></head><body><p>This is a Test for the Glossary</p></body>', [], 'en', null, null);
 
         $expect = '<head></head><body><p>This is a Test for the <a class="pimcore_glossary" href="/test">Glossary</a></p></body>';
 
@@ -55,7 +55,7 @@ class GlossaryTest extends TestCase
         $entry->save();
 
         $result = $this->processor->parse(
-            '<body><p>This is a Test for the&nbsp;Entity &copy;</p></body>',
+            '<head></head><body><p>This is a Test for the&nbsp;Entity &copy;</p></body>',
             [],
             'en',
             null,
@@ -75,7 +75,7 @@ class GlossaryTest extends TestCase
         $entry->setLanguage('en');
         $entry->save();
 
-        $result = $this->processor->parse('<body><p>Test &nbsp; Eintrag ©</p></body>', [], 'en', null, null);
+        $result = $this->processor->parse('<head></head><body><p>Test &nbsp; Eintrag ©</p></body>', [], 'en', null, null);
 
         $expect = '<head></head><body><p>Test &nbsp; <a class="pimcore_glossary" href="/test">Eintrag</a> &copy;</p></body>';
 

--- a/tests/Unit/HttpKernel/Response/CodeInjectorTest.php
+++ b/tests/Unit/HttpKernel/Response/CodeInjectorTest.php
@@ -134,14 +134,12 @@ class CodeInjectorTest extends TestCase
         $data = [];
 
         $source = <<<EOF
-<html>
-<head>
+<html><head>
     <!-- ORIG HEAD -->
 </head>
-<body class="foo" bar>
+<body class="foo" bar="">
     <!-- ORIG BODY -->
-</body>
-</html>
+</body></html>
 EOF;
 
         $data[] = [
@@ -149,14 +147,12 @@ EOF;
             CodeInjector::POSITION_BEGINNING,
             $source,
             <<<EOF
-<html>
-<head><!-- INJECTED -->
+<html><head><!-- INJECTED -->
     <!-- ORIG HEAD -->
 </head>
-<body class="foo" bar>
+<body class="foo" bar="">
     <!-- ORIG BODY -->
-</body>
-</html>
+</body></html>
 EOF
         ];
 
@@ -165,14 +161,12 @@ EOF
             CodeInjector::POSITION_END,
             $source,
             <<<EOF
-<html>
-<head>
+<html><head>
     <!-- ORIG HEAD -->
 <!-- INJECTED --></head>
-<body class="foo" bar>
+<body class="foo" bar="">
     <!-- ORIG BODY -->
-</body>
-</html>
+</body></html>
 EOF
         ];
 
@@ -181,12 +175,10 @@ EOF
             CodeInjector::REPLACE,
             $source,
             <<<EOF
-<html>
-<head><!-- INJECTED --></head>
-<body class="foo" bar>
+<html><head><!-- INJECTED --></head>
+<body class="foo" bar="">
     <!-- ORIG BODY -->
-</body>
-</html>
+</body></html>
 EOF
         ];
 
@@ -195,14 +187,12 @@ EOF
             CodeInjector::POSITION_BEGINNING,
             $source,
             <<<EOF
-<html>
-<head>
+<html><head>
     <!-- ORIG HEAD -->
 </head>
-<body class="foo" bar><!-- INJECTED -->
+<body class="foo" bar=""><!-- INJECTED -->
     <!-- ORIG BODY -->
-</body>
-</html>
+</body></html>
 EOF
         ];
 
@@ -211,14 +201,12 @@ EOF
             CodeInjector::POSITION_END,
             $source,
             <<<EOF
-<html>
-<head>
+<html><head>
     <!-- ORIG HEAD -->
 </head>
-<body class="foo" bar>
+<body class="foo" bar="">
     <!-- ORIG BODY -->
-<!-- INJECTED --></body>
-</html>
+<!-- INJECTED --></body></html>
 EOF
         ];
 
@@ -227,12 +215,10 @@ EOF
             CodeInjector::REPLACE,
             $source,
             <<<EOF
-<html>
-<head>
+<html><head>
     <!-- ORIG HEAD -->
 </head>
-<body class="foo" bar><!-- INJECTED --></body>
-</html>
+<body class="foo" bar=""><!-- INJECTED --></body></html>
 EOF
         ];
 
@@ -244,15 +230,13 @@ EOF
         $data = [];
 
         $domSource = <<<EOF
-<html>
-<head>
+<html><head>
     <!-- ORIG HEAD -->
 </head>
-<body class="foo" bar>
+<body class="foo" bar="">
     <!-- ORIG BODY -->
     <div class="bar"><!-- ORIG DIV --></div>
-</body>
-</html>
+</body></html>
 EOF;
 
         $data[] = [
@@ -260,15 +244,13 @@ EOF;
             CodeInjector::REPLACE,
             $domSource,
             <<<EOF
-<html>
-<head>
+<html><head>
     <!-- ORIG HEAD -->
 </head>
-<body class="foo" bar>
+<body class="foo" bar="">
     <!-- ORIG BODY -->
     <div class="bar"><!-- INJECTED --></div>
-</body>
-</html>
+</body></html>
 EOF
         ];
 
@@ -277,15 +259,13 @@ EOF
             CodeInjector::POSITION_BEGINNING,
             $domSource,
             <<<EOF
-<html>
-<head>
+<html><head>
     <!-- ORIG HEAD -->
 </head>
-<body class="foo" bar>
+<body class="foo" bar="">
     <!-- ORIG BODY -->
     <div class="bar"><!-- INJECTED --><!-- ORIG DIV --></div>
-</body>
-</html>
+</body></html>
 EOF
         ];
 
@@ -294,15 +274,13 @@ EOF
             CodeInjector::POSITION_END,
             $domSource,
             <<<EOF
-<html>
-<head>
+<html><head>
     <!-- ORIG HEAD -->
 </head>
-<body class="foo" bar>
+<body class="foo" bar="">
     <!-- ORIG BODY -->
     <div class="bar"><!-- ORIG DIV --><!-- INJECTED --></div>
-</body>
-</html>
+</body></html>
 EOF
         ];
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info
so new DomCrawler has some magic that adds `head` tags when body is set, so adding it to the hardcoded html string to be used for assertion
