### PR TITLE
bugfix: fixed type-specific exceptions

### DIFF
--- a/models/Document/Editable/Textarea.php
+++ b/models/Document/Editable/Textarea.php
@@ -48,11 +48,11 @@ class Textarea extends Model\Document\Editable implements EditmodeDataInterface
 
         $text = $this->text;
         if (!isset($config['htmlspecialchars']) || $config['htmlspecialchars'] !== false) {
-            $text = htmlspecialchars($this->text);
+            $text = htmlspecialchars((string)$this->text);
         }
 
         if (isset($config['nl2br']) && $config['nl2br']) {
-            $text = nl2br($text);
+            $text = nl2br((string)$text);
         }
 
         return $text;
@@ -72,8 +72,8 @@ class Textarea extends Model\Document\Editable implements EditmodeDataInterface
 
     public function setDataFromEditmode(mixed $data): static
     {
-        // this is because the input is now an div contenteditable -> therefore in entities
-        $data = html_entity_decode($data, ENT_HTML5 | ENT_QUOTES);
+        // this is because the input is now a div contenteditable -> therefore in entities
+        $data = html_entity_decode((string)$data, ENT_HTML5 | ENT_QUOTES);
         $this->text = $data;
 
         return $this;

--- a/tests/Unit/Document/Editable/TextareaTest.php
+++ b/tests/Unit/Document/Editable/TextareaTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Document\Editable;
+
+use Pimcore\Model\Document\Editable\Textarea;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * @covers Textarea
+ */
+class TextareaTest extends TestCase
+{
+    public function testEmptyTextareaFrontendWithDefaultConfig(): void
+    {
+        $textarea = new Textarea();
+
+        $this->assertSame('', $textarea->frontend());
+    }
+
+    public function testEmptyTextareaFrontendWithNl2br(): void
+    {
+        $textarea = new Textarea();
+        $textarea->setConfig(['nl2br' => true]);
+
+        $this->assertSame('', $textarea->frontend());
+    }
+}

--- a/tests/Unit/Document/Editable/TextareaTest.php
+++ b/tests/Unit/Document/Editable/TextareaTest.php
@@ -17,9 +17,6 @@ namespace Pimcore\Tests\Unit\Document\Editable;
 use Pimcore\Model\Document\Editable\Textarea;
 use Pimcore\Tests\Support\Test\TestCase;
 
-/**
- * @covers Textarea
- */
 class TextareaTest extends TestCase
 {
     public function testEmptyTextareaFrontendWithDefaultConfig(): void
@@ -32,8 +29,18 @@ class TextareaTest extends TestCase
     public function testEmptyTextareaFrontendWithNl2br(): void
     {
         $textarea = new Textarea();
-        $textarea->setConfig(['nl2br' => true]);
+        // htmlspecialchars must be disabled, otherwise it already converts the null text
+        // to a string before it reaches nl2br()
+        $textarea->setConfig(['htmlspecialchars' => false, 'nl2br' => true]);
 
         $this->assertSame('', $textarea->frontend());
+    }
+
+    public function testSetDataFromEditmodeWithNull(): void
+    {
+        $textarea = new Textarea();
+        $textarea->setDataFromEditmode(null);
+
+        $this->assertSame('', $textarea->getText());
     }
 }


### PR DESCRIPTION
## Changes in this pull request
Currently, rendering an empty `Editable\TextArea` will throw
```
htmlspecialchars(): Argument #1 ($string) must be of type string, null given File: /php/vendor/pimcore/pimcore/models/Document/Editable/Textarea.php Line: 51
#0 /php/vendor/pimcore/pimcore/models/Document/Editable/Textarea.php(51): htmlspecialchars(NULL)
#1 /php/vendor/pimcore/pimcore/models/Document/Editable.php(435): Pimcore\Model\Document\Editable\Textarea->frontend()
#2 /php/vendor/pimcore/pimcore/models/Document/Editable.php(446): Pimcore\Model\Document\Editable->render()
...
```

The same applies for nl2br.
This is caused by possible null-values in the `$text`-property.
