### PR TITLE
[Bug]: Doctrine command prefix followup fix

### DIFF
--- a/bundles/CoreBundle/src/EventListener/ConsoleCommandListener.php
+++ b/bundles/CoreBundle/src/EventListener/ConsoleCommandListener.php
@@ -44,14 +44,5 @@ class ConsoleCommandListener implements EventSubscriberInterface
         if ($command) {
             $this->contextHolder->setCommandName($command->getName());
         }
-
-        if ($command instanceof DoctrineCommand) {
-            $command->addOption(
-                'prefix',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Optional prefix filter for version classes, e.g., Pimcore\Bundle\CoreBundle\Migrations'
-            );
-        }
     }
 }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Followup https://github.com/pimcore/pimcore/pull/18863

## Additional info
In the listener is at a later point, enough to not trigger errors on execution but it won't appear in `--help` and work properly

Actually fix is https://github.com/pimcore/pimcore/commit/9820a750f71e11de79ea67a429846b6e3c7fd6b1 because of all lazy initialization of commands in 7.4, a compiler pass might help