### PR TITLE
[Bug,EC]: PEES-883 - Blurry images fix should be limited to vectorial types

### DIFF
--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -523,7 +523,7 @@ class Imagick extends Adapter
             $this->setHeight($height);
         }
 
-        if ($this->resource->getNumberImages() > 1) {
+        if ($this->isVectorGraphic() && $this->resource->getNumberImages() > 1) {
             $this->resource->removeImage();
         }
 


### PR DESCRIPTION
Followup https://github.com/pimcore/pimcore/pull/18489
Resolves https://pimcore.atlassian.net/browse/PEES-883