### PR TITLE
[Bug, EC] PEES-888: Loss of all relation data in FC after moving DataObjects 

### DIFF
--- a/.github/workflows/codeception.yaml
+++ b/.github/workflows/codeception.yaml
@@ -23,7 +23,7 @@ on:
         
 permissions:
   contents: read
-  
+
 jobs:
     codeception-tests:
         uses: pimcore/workflows-collection-public/.github/workflows/reusable-codeception-public.yaml@main

--- a/.github/workflows/codeception.yaml
+++ b/.github/workflows/codeception.yaml
@@ -24,6 +24,7 @@ on:
 permissions:
   contents: read
 
+
 jobs:
     codeception-tests:
         uses: pimcore/workflows-collection-public/.github/workflows/reusable-codeception-public.yaml@main

--- a/.github/workflows/codeception.yaml
+++ b/.github/workflows/codeception.yaml
@@ -23,7 +23,7 @@ on:
         
 permissions:
   contents: read
- 
+  
 jobs:
     codeception-tests:
         uses: pimcore/workflows-collection-public/.github/workflows/reusable-codeception-public.yaml@main

--- a/.github/workflows/codeception.yaml
+++ b/.github/workflows/codeception.yaml
@@ -24,7 +24,6 @@ on:
 permissions:
   contents: read
  
-
 jobs:
     codeception-tests:
         uses: pimcore/workflows-collection-public/.github/workflows/reusable-codeception-public.yaml@main

--- a/lib/Messenger/Handler/ElementDependenciesHandler.php
+++ b/lib/Messenger/Handler/ElementDependenciesHandler.php
@@ -37,7 +37,7 @@ class ElementDependenciesHandler
 
     public function __invoke(ElementDependenciesMessage $message): void
     {
-        $element = Service::getElementById($message->getType(), $message->getId(), ['force' => true]);
+        $element = Service::getElementById($message->getType(), $message->getId());
         if ($element instanceof AbstractElement) {
             $this->saveDependencies($element);
         }

--- a/lib/Messenger/Handler/ElementDependenciesHandler.php
+++ b/lib/Messenger/Handler/ElementDependenciesHandler.php
@@ -37,7 +37,7 @@ class ElementDependenciesHandler
 
     public function __invoke(ElementDependenciesMessage $message): void
     {
-        $element = Service::getElementById($message->getType(), $message->getId());
+        $element = Service::getElementById($message->getType(), $message->getId(), ['force' => true]);
         if ($element instanceof AbstractElement) {
             $this->saveDependencies($element);
         }

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -716,7 +716,10 @@ abstract class AbstractObject extends Model\Element\AbstractElement
             }
         }
 
-        $this->__getRawRelationData();
+        // force loading of relation data
+        if ($this instanceof Concrete) {
+            $this->__getRawRelationData();
+        }
 
         // set object to registry
         RuntimeCache::set(self::getCacheKey($this->getId()), $this);

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -716,6 +716,8 @@ abstract class AbstractObject extends Model\Element\AbstractElement
             }
         }
 
+        $this->__getRawRelationData();
+
         // set object to registry
         RuntimeCache::set(self::getCacheKey($this->getId()), $this);
     }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://pimcore.atlassian.net/browse/PEES-888, https://github.com/pimcore/service-operations/issues/306

Field collection relations might be not fully initialized without forcing it, along with the "problem" that for the relations in a FC are not getting Delta calculated, but they get deleted and reinserted in the DB during update process.

## Additional info
Better and even more safer alternative to https://github.com/pimcore/admin-ui-classic-bundle/pull/1070