### PR TITLE
[Bug, EC] PEES-881: Fix misleading Document Thumbnail Creation log message

### DIFF
--- a/models/Asset/Document.php
+++ b/models/Asset/Document.php
@@ -54,7 +54,7 @@ class Document extends Model\Asset
         if (!\Pimcore\Document::isAvailable()) {
             Logger::error(
                 sprintf(
-                    "Couldn't create image-thumbnail of document %s as no document adapter is available",
+                    "Couldn't process page count of document %s as no document adapter is available",
                     $this->getRealFullPath()
                 )
             );


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/service-operations/issues/308, https://pimcore.atlassian.net/browse/PEES-881

## Additional info
The log message is misleading, as there no image thumbnail generation