### PR TITLE
Fix Gotenberg document conversion failing for assets stored on S3

### DIFF
--- a/lib/Document/Adapter/Gotenberg.php
+++ b/lib/Document/Adapter/Gotenberg.php
@@ -116,10 +116,10 @@ class Gotenberg extends Ghostscript
             $psrStream = null;
 
             try {
-                $psrStream = new LazyOpenStream($localAssetTmpPath, 'r');
+                $psrStream = new LazyOpenStream($localAssetTmpPath, 'rb');
 
                 $request = GotenbergAPI::libreOffice(Config::getSystemConfiguration('gotenberg')['base_url'])
-                    ->convert(new \Gotenberg\Stream($asset->getFilename(), $psrStream));
+                    ->convert(new Stream($asset->getFilename(), $psrStream));
 
                 $response = GotenbergAPI::send($request);
                 $fileContent = $response->getBody()->getContents();

--- a/lib/Document/Adapter/Gotenberg.php
+++ b/lib/Document/Adapter/Gotenberg.php
@@ -21,6 +21,7 @@ use Pimcore\Helper\GotenbergHelper;
 use Pimcore\Logger;
 use Pimcore\Model\Asset;
 use Pimcore\Tool\Storage;
+use GuzzleHttp\Psr7\LazyOpenStream;
 
 /**
  * @internal
@@ -112,11 +113,13 @@ class Gotenberg extends Ghostscript
         if (!$storage->fileExists($storagePath)) {
             $localAssetTmpPath = $asset->getLocalFile();
 
+            $psrStream = null;
+
             try {
+                $psrStream = new LazyOpenStream($localAssetTmpPath, 'r');
+
                 $request = GotenbergAPI::libreOffice(Config::getSystemConfiguration('gotenberg')['base_url'])
-                    ->convert(
-                        Stream::path($localAssetTmpPath)
-                    );
+                    ->convert(new \Gotenberg\Stream($asset->getFilename(), $psrStream));
 
                 $response = GotenbergAPI::send($request);
                 $fileContent = $response->getBody()->getContents();
@@ -127,6 +130,10 @@ class Gotenberg extends Ghostscript
                 Logger::error($message. $e->getMessage());
 
                 throw $e;
+            } finally {
+                if ($psrStream instanceof \Psr\Http\Message\StreamInterface) {
+                    $psrStream->close();
+                }
             }
         }
 


### PR DESCRIPTION
## Context / Problem
When assets are stored on S3, Pimcore downloads them to a local temporary file without preserving the original file extension (e.g. *.tmp).
Gotenberg’s LibreOffice endpoint validates uploaded documents based on the uploaded filename extension, so sending a multipart file named *.tmp causes the conversion to fail with:

`Invalid form data: no form file found for extensions [...]`

This affected PDF preview generation and page count processing for non-PDF document assets.

## Solution
We updated the Gotenberg document adapter to explicitly set the multipart upload filename to the asset’s original filename (including its extension), instead of relying on the local temporary file path.

Concretely:
	•	keep using `getLocalFile()` to download the asset locally (unchanged)
	•	wrap the local file in a PSR-7 stream (`LazyOpenStream`)
	•	pass the asset’s real filename to `Gotenberg\Stream`, ensuring Gotenberg receives a supported extension (.docx, .pptx, etc.)

## Result
	•	Gotenberg correctly accepts and converts documents stored on S3
	•	no changes required to Flysystem, S3 configuration, or temporary file handling
	•	fix is isolated to the Gotenberg adapter and safe for async Messenger workers

Resolves https://github.com/pimcore/pimcore/issues/18898

## Additional info
