### PR TITLE
fix: Listing::getTotalCount() should use connected parameters

### DIFF
--- a/doc/20_Extending_Pimcore/17_Custom_Persistent_Models.md
+++ b/doc/20_Extending_Pimcore/17_Custom_Persistent_Models.md
@@ -455,7 +455,11 @@ class Dao extends Listing\Dao\AbstractDao
         $this->prepareQueryBuilderForTotalCount($queryBuilder, $this->getTableName() . '.id');
         
         if ($this->isQueryBuilderPartInUse($queryBuilder, 'groupBy') || $this->isQueryBuilderPartInUse($queryBuilder, 'having')) {
-            return (int)$this->db->fetchOne('SELECT COUNT(*)  FROM (' . $queryBuilder->getSQL() . ') as XYZ');
+            return (int)$this->db->fetchOne(
+                'SELECT COUNT(*) FROM (' . $queryBuilder->getSQL() . ') as XYZ',
+                $queryBuilder->getParameters(),
+                $queryBuilder->getParameterTypes()
+            );
         } else {
             return (int)$this->db->fetchOne($queryBuilder->getSql(), $queryBuilder->getParameters(), $queryBuilder->getParameterTypes());
         }

--- a/models/Asset/Listing/Dao.php
+++ b/models/Asset/Listing/Dao.php
@@ -100,7 +100,11 @@ class Dao extends Model\Listing\Dao\AbstractDao
                 $queryBuilder->select($identifierColumn);
             }
 
-            return (int)$this->db->fetchOne('SELECT COUNT(*)  FROM (' . $queryBuilder->getSQL() . ') as XYZ');
+            return (int)$this->db->fetchOne(
+                'SELECT COUNT(*) FROM (' . $queryBuilder->getSQL() . ') as XYZ',
+                $queryBuilder->getParameters(),
+                $queryBuilder->getParameterTypes()
+            );
         }
 
         return (int)$this->db->fetchOne(

--- a/models/DataObject/Listing/Dao.php
+++ b/models/DataObject/Listing/Dao.php
@@ -81,7 +81,11 @@ class Dao extends Model\Listing\Dao\AbstractDao
             $this->isQueryBuilderPartInUse($queryBuilder, 'groupBy') ||
             $this->isQueryBuilderPartInUse($queryBuilder, 'having')
         ) {
-            return (int)$this->db->fetchOne('SELECT COUNT(*)  FROM (' . $queryBuilder->getSQL() . ') as XYZ');
+            return (int)$this->db->fetchOne(
+                'SELECT COUNT(*) FROM (' . $queryBuilder->getSQL() . ') as XYZ',
+                $queryBuilder->getParameters(),
+                $queryBuilder->getParameterTypes()
+            );
         }
 
         return (int)$this->db->fetchOne(

--- a/models/Document/Listing/Dao.php
+++ b/models/Document/Listing/Dao.php
@@ -110,7 +110,11 @@ class Dao extends Model\Listing\Dao\AbstractDao
             $this->isQueryBuilderPartInUse($queryBuilder, 'groupBy') ||
             $this->isQueryBuilderPartInUse($queryBuilder, 'having')
         ) {
-            return (int)$this->db->fetchOne('SELECT COUNT(*)  FROM (' . $queryBuilder->getSQL() . ') as XYZ');
+            return (int)$this->db->fetchOne(
+                'SELECT COUNT(*) FROM (' . $queryBuilder->getSQL() . ') as XYZ',
+                $queryBuilder->getParameters(),
+                $queryBuilder->getParameterTypes()
+            );
         }
 
         return (int)$this->db->fetchOne(

--- a/tests/Model/Asset/ListingTest.php
+++ b/tests/Model/Asset/ListingTest.php
@@ -107,6 +107,19 @@ class ListingTest extends ModelTestCase
         $list->load();
         $count = $list->getCount();
         $this->assertEquals(3, $count, 'expected 3 assets on grouped limited query');
+
+        // Test: on a grouped query, the ->getTotalCount() should use connected parameters (filtering on asset type image in this case)
+        $list = new Asset\Listing();
+        $list->addConditionParam('assets.type = ?', 'image');
+        $list->getDao()->onCreateQueryBuilder(function (QueryBuilder $queryBuilder) use ($tagA, $tagB) {
+            $this->joinTags($queryBuilder, $tagA, $tagB);
+        });
+
+        $totalCount = $list->getTotalCount();
+        $this->assertEquals(2, $totalCount, 'expected 4 assets on totalCount of grouped query containing parameters');
+        $list->load();
+        $count = $list->getCount();
+        $this->assertEquals(2, $count, 'expected 4 assets on grouped query containing parameters');
     }
 
     private function joinTags(QueryBuilder $queryBuilder, Tag ...$tags): void

--- a/tests/Model/Asset/ListingTest.php
+++ b/tests/Model/Asset/ListingTest.php
@@ -119,7 +119,7 @@ class ListingTest extends ModelTestCase
         $this->assertEquals(2, $totalCount, 'expected 2 assets on totalCount of grouped query containing parameters');
         $list->load();
         $count = $list->getCount();
-        $this->assertEquals(2, $count, 'expected 4 assets on grouped query containing parameters');
+        $this->assertEquals(2, $count, 'expected 2 assets on grouped query containing parameters');
     }
 
     private function joinTags(QueryBuilder $queryBuilder, Tag ...$tags): void

--- a/tests/Model/Asset/ListingTest.php
+++ b/tests/Model/Asset/ListingTest.php
@@ -116,7 +116,7 @@ class ListingTest extends ModelTestCase
         });
 
         $totalCount = $list->getTotalCount();
-        $this->assertEquals(2, $totalCount, 'expected 4 assets on totalCount of grouped query containing parameters');
+        $this->assertEquals(2, $totalCount, 'expected 2 assets on totalCount of grouped query containing parameters');
         $list->load();
         $count = $list->getCount();
         $this->assertEquals(2, $count, 'expected 4 assets on grouped query containing parameters');


### PR DESCRIPTION
Error: When a listing was prepared containing a `addConditionParam('field = ?', 'value'`) and also containing a `addGroupBy()` then Listing::getTotalCount() resulted in SQL errors.

Caused by: Parameters added to the QueryBuilder were not passed to `db->fetchOne()` in that particular scenario.

Resolved with: Adding parameters, expanding integration test, updating documentation.


**Steps to reproduce**

Either see updated unit test, or

```
$listing = new Asset\Listing();

// Error was that the params weren't passed to the db->fetchOne() operation
$listing->addConditionParam('assets.type = ?', 'image');

// Which only was triggered when the query contained a GROUP BY or HAVING  (which in this case doesn't
//     make sense, but in JOIN scenarios it does, e.g. to filter assets with certain tags or Asset Metadata)
$list->getDao()->addQueryBuilderProcessor(function (QueryBuilder $queryBuilder) {
    $queryBuilder->addGroupBy('assets.id');
});

// And then this will error ...
$listing->getTotalCount();

// ... with [Doctrine\DBAL\Exception\SyntaxErrorException] An exception occurred while executing a query: 
//     SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the 
//     manual that corresponds to your MariaDB server version for the right syntax to use near
//     '?)  GROUP BY assets.id) as XYZ' at line 1 
```

P.s. not to blame anyone, just to indicate affected versions, bug is introduced in f670222f86702fedccf2755ec45ae2c83f239243 so affects Pimcore 12.0.0 till current 12.3.x