### PR TITLE
[Bug][ApplicationLogger] Ensure log timestamp are converted to UTC

### DIFF
--- a/bundles/ApplicationLoggerBundle/src/Controller/LogController.php
+++ b/bundles/ApplicationLoggerBundle/src/Controller/LogController.php
@@ -182,6 +182,10 @@ class LogController extends UserAwareController implements KernelControllerEvent
             }
         }
 
+        if ($dateTime instanceof DateTime) {
+            $dateTime->setTimezone(new \DateTimeZone('UTC'));
+        }
+
         return $dateTime;
     }
 


### PR DESCRIPTION
 ## Changes in this pull request  
Ensures log filtering correctly matches UTC-stored timestamps by converting local user input to UTC.

## Steps to reproduce
1. Set the PHP server timezone to a non-UTC value (e.g., Europe/Vienna at UTC+1).
2. Generate a log entry at 10:32 local time (which is stored in the DB as 09:32 UTC), see https://github.com/pimcore/pimcore/blob/11.5/bundles/ApplicationLoggerBundle/src/Handler/ApplicationLoggerDb.php#L46
3. In the Application Logger UI, filter for logs "after 10:30".
4. The log entry is not returned, because the application queries the DB for timestamp > '10:30', which fails to match the stored 09:32 UTC value.

## Additional info
The ApplicationLoggerBundle stores all log timestamps in UTC, but the admin interface filters were using the server's local timezone. This caused log entries to be "missed" during filtering when the server's offset (e.g., UTC+1) didn't match the database. This fix bridges the gap by letting PHP first interpret the input as local time and then mathematically shifting it to UTC for the database query.