### PR TITLE
[Security]: Brick key validity check during filtered search

### DIFF
--- a/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
+++ b/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
@@ -35,6 +35,7 @@ use Pimcore\Extension\Bundle\Exception\AdminClassicBundleNotFoundException;
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Localizedfields;
+use Pimcore\Model\DataObject\Objectbrick\Definition;
 use Pimcore\Model\Document;
 use Pimcore\Model\Element;
 use Pimcore\Model\Element\AdminStyle;
@@ -169,6 +170,11 @@ class SearchController extends UserAwareController
             $join = '';
             $localizedJoin = '';
             foreach ($bricks as $ob) {
+                $objectBrickDefinition = Definition::getByKey($ob);
+                if (!$objectBrickDefinition){
+                    throw new InvalidArgumentException('Check your object brick filter arguments.');
+                }
+
                 $join .= ' LEFT JOIN object_brick_query_' . $ob . '_' . $class->getId();
                 $join .= ' `' . $ob . '`';
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Adding an extra check on object brick validity, in case there some tampering attempt on it, the bricks should be Runtime cached and are not expensive to check at this point.
Giving more safety, considering that this brick filter parsing is done by simply exploding  `~` and `?` (for localized) and used as a string suffix for join

