### PR TITLE
[Bug, EC] PEES-894: Video Editable getThumbnail throws Type Error when e.g. type is missing

### DIFF
--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -1067,11 +1067,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface, Edit
 
     public function getThumbnail(string|Asset\Video\Thumbnail\Config $config): array
     {
-        if ($this->getVideoAsset()) {
-            return $this->getVideoAsset()->getThumbnail($config);
-        }
-
-        return [];
+        return $this->getVideoAsset()?->getThumbnail($config) ?? [];
     }
 
     public function rewriteIds(array $idMapping): void


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/service-operations/issues/321

## Additional info
`getVideoAsset()->getThumbnail()` can return null https://github.com/pimcore/pimcore/blob/4a8aa8d99aad32dab605d3f80dc2610c092080eb/models/Asset/Video.php#L86, so null coalescing it, also small refactor to be a one liner