### PR TITLE
Allow installer for empty MySQL password

### DIFF
--- a/bundles/InstallBundle/src/Command/InstallCommand.php
+++ b/bundles/InstallBundle/src/Command/InstallCommand.php
@@ -378,6 +378,11 @@ class InstallCommand extends Command
                 );
             } else {
                 $validator = function ($answer) use ($name) {
+                    // MySQL password can be null
+                    if ($name === 'mysql-password') {
+                        return $answer;
+                    }
+                    
                     if (empty($answer)) {
                         throw new RuntimeException(sprintf('%s cannot be empty', $name));
                     }


### PR DESCRIPTION
## Changes in this pull request  

Allow using an empty MySQL password during Pimcore installation via `./vendor/bin/pimcore-install`.

## Additional info

While creating a Pimcore instance in my local environment, I was unable to run `./vendor/bin/pimcore-install` because of the error:
```
mysql-password cannot be empty
```
An empty password is a valid configuration in local setups, so the installer should allow it instead of failing validation.