### PR TITLE
fix: Skip http_error_log cleanup migration if table is missing

### DIFF
--- a/bundles/CoreBundle/src/Migrations/Version20251217000100.php
+++ b/bundles/CoreBundle/src/Migrations/Version20251217000100.php
@@ -29,6 +29,10 @@ final class Version20251217000100 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        if (!$schema->hasTable('http_error_log')) {
+            return;
+        }
+
         $this->addSql('
             ALTER TABLE `http_error_log`
                 DROP COLUMN `parametersPost`,


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [x] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  

When the `PimcoreSeoBundle` is not enabled the table `http_error_log` does not exist and the cleanup migration fails. To prevent this, the migration is skipped if the table does not exist.

## Additional info

Issue was introduced by PR #18918
