### PR TITLE
Fix transactional handling in `NotificationService`

### DIFF
--- a/models/Notification/Service/NotificationService.php
+++ b/models/Notification/Service/NotificationService.php
@@ -158,12 +158,12 @@ class NotificationService
                 throw new AccessDeniedHttpException();
             }
 
-if ($recipientId && $recipientId === $notification->getRecipient()?->getId()) {
-    $notification->setRead(true);
-    $notification->save();
-    $this->commit();
-    $committed = true;
-}
+            if ($recipientId && $recipientId === $notification->getRecipient()?->getId()) {
+                $notification->setRead(true);
+                $notification->save();
+                $this->commit();
+                $committed = true;
+            }
 
             return $notification;
         } finally {
@@ -362,10 +362,10 @@ if ($recipientId && $recipientId === $notification->getRecipient()?->getId()) {
     /**
      * @throws Exception
      */
-private function commit(): void
-{
-    Db::getConnection()->commit();
-}
+    private function commit(): void
+    {
+        Db::getConnection()->commit();
+    }
 
     /**
      * @throws Exception

--- a/models/Notification/Service/NotificationService.php
+++ b/models/Notification/Service/NotificationService.php
@@ -158,7 +158,7 @@ class NotificationService
                 throw new AccessDeniedHttpException();
             }
 
-            if ($recipientId && $recipientId === $notification->getRecipient()?->getId()) {
+            if ($recipientId !== null && $recipientId === $notification->getRecipient()?->getId()) {
                 $notification->setRead(true);
                 $notification->save();
                 $this->commit();

--- a/models/Notification/Service/NotificationService.php
+++ b/models/Notification/Service/NotificationService.php
@@ -388,7 +388,7 @@ class NotificationService
 
         try {
             $connection->rollBack();
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             // PDO adapter throws exceptions if rollback fails
             \Pimcore\Logger::error((string) $e);
         }

--- a/models/Notification/Service/NotificationService.php
+++ b/models/Notification/Service/NotificationService.php
@@ -322,7 +322,7 @@ class NotificationService
         try {
             $notification = $this->find($id);
 
-            if ($recipientId && $recipientId === $notification->getRecipient()?->getId()) {
+            if ($recipientId !== null && $recipientId === $notification->getRecipient()?->getId()) {
                 $notification->delete();
             }
 

--- a/models/Notification/Service/NotificationService.php
+++ b/models/Notification/Service/NotificationService.php
@@ -367,11 +367,23 @@ class NotificationService
         Db::getConnection()->commit();
     }
 
-    /**
-     * @throws Exception
-     */
-    private function rollBack(): void
-    {
-        Db::getConnection()->rollBack();
+/**
+ * Attempts to roll back the current transaction (or savepoint).
+ *
+ * Rollback itself can fail/throw (depending on the driver / transaction state), so we guard against
+ * masking the original exception.
+ */
+private function rollBack(): void
+{
+    $connection = Db::getConnection();
+    if ($connection->isTransactionActive() === false) {
+        return;
+    }
+
+    try {
+        $connection->rollBack();
+    } catch (Exception $e) {
+        // PDO adapter throws exceptions if rollback fails
+        \Pimcore\Logger::error((string) $e);
     }
 }

--- a/models/Notification/Service/NotificationService.php
+++ b/models/Notification/Service/NotificationService.php
@@ -218,12 +218,18 @@ class NotificationService
 
         $this->beginTransaction();
 
-        $result = [
-            'total' => $listing->count(),
-            'data' => $listing->getItems($offset, $limit),
-        ];
+        try {
+            $result = [
+                'total' => $listing->count(),
+                'data' => $listing->getItems($offset, $limit),
+            ];
 
-        $this->commit();
+            $this->commit();
+        } catch (\Throwable $t) {
+            $this->rollBack();
+
+            throw $t;
+        }
 
         return $result;
     }

--- a/models/Notification/Service/NotificationService.php
+++ b/models/Notification/Service/NotificationService.php
@@ -367,23 +367,24 @@ class NotificationService
         Db::getConnection()->commit();
     }
 
-/**
- * Attempts to roll back the current transaction (or savepoint).
- *
- * Rollback itself can fail/throw (depending on the driver / transaction state), so we guard against
- * masking the original exception.
- */
-private function rollBack(): void
-{
-    $connection = Db::getConnection();
-    if ($connection->isTransactionActive() === false) {
-        return;
-    }
+    /**
+     * Attempts to roll back the current transaction (or savepoint).
+     *
+     * Rollback itself can fail/throw (depending on the driver / transaction state), so we guard against
+     * masking the original exception.
+     */
+    private function rollBack(): void
+    {
+        $connection = Db::getConnection();
+        if ($connection->isTransactionActive() === false) {
+            return;
+        }
 
-    try {
-        $connection->rollBack();
-    } catch (Exception $e) {
-        // PDO adapter throws exceptions if rollback fails
-        \Pimcore\Logger::error((string) $e);
+        try {
+            $connection->rollBack();
+        } catch (Exception $e) {
+            // PDO adapter throws exceptions if rollback fails
+            \Pimcore\Logger::error((string) $e);
+        }
     }
 }

--- a/models/Notification/Service/NotificationService.php
+++ b/models/Notification/Service/NotificationService.php
@@ -158,11 +158,12 @@ class NotificationService
                 throw new AccessDeniedHttpException();
             }
 
-            if ($recipientId && $recipientId === $notification->getRecipient()?->getId()) {
-                $notification->setRead(true);
-                $notification->save();
-                $committed = $this->commit();
-            }
+if ($recipientId && $recipientId === $notification->getRecipient()?->getId()) {
+    $notification->setRead(true);
+    $notification->save();
+    $this->commit();
+    $committed = true;
+}
 
             return $notification;
         } finally {
@@ -361,10 +362,10 @@ class NotificationService
     /**
      * @throws Exception
      */
-    private function commit(): bool
-    {
-        return Db::getConnection()->commit();
-    }
+private function commit(): void
+{
+    Db::getConnection()->commit();
+}
 
     /**
      * @throws Exception

--- a/models/Notification/Service/NotificationService.php
+++ b/models/Notification/Service/NotificationService.php
@@ -31,17 +31,12 @@ class NotificationService
 {
     private UserService $userService;
 
-    /**
-     * NotificationService constructor.
-     *
-     */
     public function __construct(UserService $userService)
     {
         $this->userService = $userService;
     }
 
     /**
-     *
      * @throws UnexpectedValueException
      * @throws Exception
      */
@@ -54,30 +49,36 @@ class NotificationService
     ): void {
         $this->beginTransaction();
 
-        $sender = User::getById($fromUser);
-        $recipient = User::getById($userId);
+        try {
+            $sender = User::getById($fromUser);
+            $recipient = User::getById($userId);
 
-        if (!$recipient instanceof User) {
-            throw new UnexpectedValueException(sprintf('No user found with the ID %d', $userId));
+            if (!$recipient instanceof User) {
+                throw new UnexpectedValueException(sprintf('No user found with the ID %d', $userId));
+            }
+
+            if (empty($title)) {
+                throw new UnexpectedValueException('Title of the Notification cannot be empty');
+            }
+
+            if (empty($message)) {
+                throw new UnexpectedValueException('Message text of the Notification cannot be empty');
+            }
+
+            $notification = new Notification();
+            $notification->setRecipient($recipient);
+            $notification->setSender($sender);
+            $notification->setTitle($title);
+            $notification->setMessage($message);
+            $notification->setLinkedElement($element);
+            $notification->save();
+
+            $this->commit();
+        } catch (\Throwable $t) {
+            $this->rollBack();
+
+            throw $t;
         }
-
-        if (empty($title)) {
-            throw new UnexpectedValueException('Title of the Notification cannot be empty');
-        }
-
-        if (empty($message)) {
-            throw new UnexpectedValueException('Message text of the Notification cannot be empty');
-        }
-
-        $notification = new Notification();
-        $notification->setRecipient($recipient);
-        $notification->setSender($sender);
-        $notification->setTitle($title);
-        $notification->setMessage($message);
-        $notification->setLinkedElement($element);
-        $notification->save();
-
-        $this->commit();
     }
 
     /**
@@ -142,27 +143,33 @@ class NotificationService
     }
 
     /**
-     *
-     *
      * @throws UnexpectedValueException
      * @throws Exception
      */
     public function findAndMarkAsRead(int $id, ?int $recipientId = null): Notification
     {
         $this->beginTransaction();
-        $notification = $this->find($id);
+        $committed = false;
 
-        if ($notification->getRecipient()?->getId() !== $recipientId) {
-            throw new AccessDeniedHttpException();
+        try {
+            $notification = $this->find($id);
+
+            if ($notification->getRecipient()?->getId() !== $recipientId) {
+                throw new AccessDeniedHttpException();
+            }
+
+            if ($recipientId && $recipientId === $notification->getRecipient()?->getId()) {
+                $notification->setRead(true);
+                $notification->save();
+                $committed = $this->commit();
+            }
+
+            return $notification;
+        } finally {
+            if (!$committed) {
+                $this->rollBack();
+            }
         }
-
-        if ($recipientId && $recipientId === $notification->getRecipient()?->getId()) {
-            $notification->setRead(true);
-            $notification->save();
-            $this->commit();
-        }
-
-        return $notification;
     }
 
     /**
@@ -239,12 +246,18 @@ class NotificationService
 
         $this->beginTransaction();
 
-        $result = [
-            'total' => $listing->count(),
-            'data' => $listing->getData(),
-        ];
+        try {
+            $result = [
+                'total' => $listing->count(),
+                'data' => $listing->getData(),
+            ];
 
-        $this->commit();
+            $this->commit();
+        } catch (\Throwable $t) {
+            $this->rollBack();
+
+            throw $t;
+        }
 
         return $result;
     }
@@ -299,13 +312,19 @@ class NotificationService
     {
         $this->beginTransaction();
 
-        $notification = $this->find($id);
+        try {
+            $notification = $this->find($id);
 
-        if ($recipientId && $recipientId === $notification->getRecipient()?->getId()) {
-            $notification->delete();
+            if ($recipientId && $recipientId === $notification->getRecipient()?->getId()) {
+                $notification->delete();
+            }
+
+            $this->commit();
+        } catch (\Throwable $t) {
+            $this->rollBack();
+
+            throw $t;
         }
-
-        $this->commit();
     }
 
     /**
@@ -318,11 +337,17 @@ class NotificationService
 
         $this->beginTransaction();
 
-        foreach ($listing->getData() as $notification) {
-            $notification->delete();
-        }
+        try {
+            foreach ($listing->getData() as $notification) {
+                $notification->delete();
+            }
 
-        $this->commit();
+            $this->commit();
+        } catch (\Throwable $t) {
+            $this->rollBack();
+
+            throw $t;
+        }
     }
 
     /**
@@ -336,8 +361,16 @@ class NotificationService
     /**
      * @throws Exception
      */
-    private function commit(): void
+    private function commit(): bool
     {
-        Db::getConnection()->commit();
+        return Db::getConnection()->commit();
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function rollBack(): void
+    {
+        Db::getConnection()->rollBack();
     }
 }

--- a/tests/Unit/Notification/Service/NotificationServiceTest.php
+++ b/tests/Unit/Notification/Service/NotificationServiceTest.php
@@ -64,6 +64,11 @@ class NotificationServiceTest extends TestCase
         );
     }
 
+    protected function needsDb(): bool
+    {
+        return true;
+    }
+
     public function testSendToNoExistUserLeavesNoActiveTransaction(): void
     {
         try {

--- a/tests/Unit/Notification/Service/NotificationServiceTest.php
+++ b/tests/Unit/Notification/Service/NotificationServiceTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Pimcore\Tests\Unit\Notification\Service;
 
 use Pimcore;
+use Pimcore\Db;
 use Pimcore\Model\Notification\Service\NotificationService;
 use Pimcore\Model\User;
 use Pimcore\Tests\Support\Test\TestCase;
@@ -60,6 +61,23 @@ class NotificationServiceTest extends TestCase
             'Test title',
             'Test message'
         );
+    }
+
+    public function testSendToNoExistUserLeavesNoActiveTransaction(): void
+    {
+        try {
+            $this->notificationService->sendToUser(
+                100,
+                100,
+                'Test title',
+                'Test message'
+            );
+            $this->fail('Expected UnexpectedValueException was not thrown');
+        } catch (UnexpectedValueException) {
+            // expected
+        }
+
+        $this->assertFalse(Db::getConnection()->isTransactionActive());
     }
 
     public function testSendToNoExistGroup(): void

--- a/tests/Unit/Notification/Service/NotificationServiceTest.php
+++ b/tests/Unit/Notification/Service/NotificationServiceTest.php
@@ -20,6 +20,7 @@ use Pimcore\Model\Notification\Service\NotificationService;
 use Pimcore\Model\User;
 use Pimcore\Tests\Support\Test\TestCase;
 use Pimcore\Tests\Support\Util\TestHelper;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use UnexpectedValueException;
 
 class NotificationServiceTest extends TestCase
@@ -72,6 +73,55 @@ class NotificationServiceTest extends TestCase
                 'Test title',
                 'Test message'
             );
+            $this->fail('Expected UnexpectedValueException was not thrown');
+        } catch (UnexpectedValueException) {
+            // expected
+        }
+
+        $this->assertFalse(Db::getConnection()->isTransactionActive());
+    }
+
+    public function testFindAndMarkAsReadWithInvalidIdLeavesNoActiveTransaction(): void
+    {
+        try {
+            $this->notificationService->findAndMarkAsRead(999999);
+            $this->fail('Expected UnexpectedValueException was not thrown');
+        } catch (UnexpectedValueException) {
+            // expected
+        }
+
+        $this->assertFalse(Db::getConnection()->isTransactionActive());
+    }
+
+    public function testFindAndMarkAsReadWithWrongRecipientLeavesNoActiveTransaction(): void
+    {
+        $user = new User();
+        $user->setName('notification-user')->save();
+
+        $this->notificationService->sendToUser(
+            $user->getId(),
+            0,
+            'Test title',
+            'Test message'
+        );
+
+        $notifications = $this->notificationService->findAll(['recipient' => $user->getId()]);
+        $notificationId = $notifications['data'][0]->getId();
+
+        try {
+            $this->notificationService->findAndMarkAsRead($notificationId, 999999);
+            $this->fail('Expected AccessDeniedHttpException was not thrown');
+        } catch (AccessDeniedHttpException) {
+            // expected
+        }
+
+        $this->assertFalse(Db::getConnection()->isTransactionActive());
+    }
+
+    public function testDeleteWithInvalidIdLeavesNoActiveTransaction(): void
+    {
+        try {
+            $this->notificationService->delete(999999);
             $this->fail('Expected UnexpectedValueException was not thrown');
         } catch (UnexpectedValueException) {
             // expected


### PR DESCRIPTION
## Changes in this pull request  

Transactions were not properly aborted when an error occurs. 
This adds the necessary `rollBack()` calls in case of an error.

> [!NOTE]
> This PR is best viewed *without* whitespace changes: https://github.com/pimcore/pimcore/pull/18923/files?w=1

## Additional info

I wanted to send a notification to a list of users. But if one of the users in the list does not exist, an exception gets thrown *after* the transaction gets started. As the transaction doesn't get committed in this case, the transaction is still open. Now the next user starts a new transaction *inside* the one that's still open, but even if this one gets committed, it'll never be persisted, because the outer one is still open.

Actually this means that *any* change to the DB after this call in the same request won't get persisted anymore.