### PR TITLE
[Bug]: Fix Command pimcore:deployment:classes-rebuild flags -c and -o do not work together 

### DIFF
--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -343,10 +343,8 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
     /**
      * @throws Exception
      */
-    private function createContainerClasses(): void
+    private function createContainerClasses(bool $dumpPHPClasses = true): void
     {
-        $containerDefinition = [];
-
         if (!empty($this->classDefinitions)) {
             foreach ($this->classDefinitions as $cl) {
                 $class = DataObject\ClassDefinition::getByName($cl['classname']);
@@ -380,7 +378,9 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
             }
         }
 
-        Pimcore::getContainer()->get(PHPObjectBrickContainerClassDumperInterface::class)->dumpContainerClasses($this);
+        if ($dumpPHPClasses) {
+            Pimcore::getContainer()->get(PHPObjectBrickContainerClassDumperInterface::class)->dumpContainerClasses($this);
+        }
     }
 
     /**
@@ -561,7 +561,7 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
         // for localized fields getting a fresh copy
         RuntimeCache::set($cacheKey, $this);
 
-        $this->createContainerClasses();
+        $this->createContainerClasses($dumpPHPClasses);
         $this->updateDatabase();
 
         foreach ($fieldDefinitions as $fd) {


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/18928

## Additional info
Before PR
`inotifywait -m -r -e close_write var/classes/`
<img width="999" height="1155" alt="image" src="https://github.com/user-attachments/assets/261146c3-3d45-483b-b217-49a64e2fee34" />

It's empty after PR

