### PR TITLE
[Data Objects] Support overriding object brick class

### DIFF
--- a/doc/20_Extending_Pimcore/03_Overriding_Models.md
+++ b/doc/20_Extending_Pimcore/03_Overriding_Models.md
@@ -9,7 +9,10 @@ Currently this works for all implementations of the following classes (but not f
 - `Pimcore\Model\AbstractObject`
 - `Pimcore\Model\DataObject\Listing`
 - `Pimcore\Model\Asset`
-- `Pimcore\Model\Asset\Listing` 
+- `Pimcore\Model\Asset\Listing`
+- `Pimcore\Model\AbstractObject`
+- `Pimcore\Model\DataObject\Objectbrick\Data\AbstractData`
+- `Pimcore\Model\DataObject\Fieldcollection\Data\AbstractData`
 
 So for example overriding a listing class of a custom class definition like `Pimcore\Model\DataObject\News\Listing` or 
 `Pimcore\Model\Asset\Image` is supported. 

--- a/lib/DataObject/ClassBuilder/ObjectBrickClassBuilder.php
+++ b/lib/DataObject/ClassBuilder/ObjectBrickClassBuilder.php
@@ -77,7 +77,7 @@ class ObjectBrickClassBuilder implements ObjectBrickClassBuilderInterface
         $cd .= '* @param DataObject\Concrete $object' . "\n";
         $cd .= '*/' . "\n";
 
-        $cd .= 'public function __construct(DataObject\Concrete $object)' . "\n";
+        $cd .= 'public function __construct(?DataObject\Concrete $object = null)' . "\n";
         $cd .= '{' . "\n";
         $cd .= "\t" . 'parent::__construct($object);' . "\n";
         $cd .= "\t" .'$this->markFieldDirty("_self");' . "\n";

--- a/lib/DataObject/ClassBuilder/ObjectBrickContainerClassBuilder.php
+++ b/lib/DataObject/ClassBuilder/ObjectBrickContainerClassBuilder.php
@@ -55,8 +55,10 @@ class ObjectBrickContainerClassBuilder implements ObjectBrickContainerClassBuild
                 $cd .= "\t\t\t\t" . '//check if parent object has brick, and if so, create an empty brick to enable inheritance' . "\n";
                 $cd .= "\t\t\t\t" . '$parentBrick = $this->getObject()->getValueFromParent("' . $fieldName . '")->get' . ucfirst($brickKey) . '($includeDeletedBricks);'. "\n";
                 $cd .= "\t\t\t\t" . 'if (!empty($parentBrick)) {' . "\n";
+                $cd .= "\t\t\t\t\t" . '$modelFactory = \Pimcore::getContainer()->get(\'pimcore.model.factory\');' . "\n";
                 $cd .= "\t\t\t\t\t" . '$brickType = "\\\Pimcore\\\Model\\\DataObject\\\Objectbrick\\\Data\\\" . ucfirst($parentBrick->getType());' . "\n";
-                $cd .= "\t\t\t\t\t" . '$brick = new $brickType($this->getObject());' . "\n";
+                $cd .= "\t\t\t\t\t" . '$brick = $modelFactory->build($brickType);' . "\n";
+                $cd .= "\t\t\t\t\t" . '$brick->setObject($this->getObject());' . "\n";
                 $cd .= "\t\t\t\t\t" . '$brick->setFieldname("' . $fieldName . '");' . "\n";
                 $cd .= "\t\t\t\t\t" . '$this->set'. ucfirst($brickKey) . '($brick);' . "\n";
                 $cd .= "\t\t\t\t\t" . 'return $brick;' . "\n";

--- a/models/DataObject/ClassDefinition/Data/Objectbricks.php
+++ b/models/DataObject/ClassDefinition/Data/Objectbricks.php
@@ -261,8 +261,10 @@ class Objectbricks extends Data implements CustomResourcePersistingInterface, Ty
                 $getter = 'get' . ucfirst($collectionRaw['type']);
                 $brick = $container->$getter();
                 if (empty($brick)) {
+                    $modelFactory = \Pimcore::getContainer()->get('pimcore.model.factory');
                     $brickClass = '\\Pimcore\\Model\\DataObject\\Objectbrick\\Data\\' . ucfirst($collectionRaw['type']);
-                    $brick = new $brickClass($object);
+                    $brick = $modelFactory->build($brickClass);
+                    $brick->setObject($object);
                 }
 
                 $brick->setFieldname($this->getName());
@@ -687,8 +689,10 @@ class Objectbricks extends Data implements CustomResourcePersistingInterface, Ty
             $brick = $brickdata->$getter();
             if (!$brick) {
                 // brick must be added to object
+                $modelFactory = \Pimcore::getContainer()->get('pimcore.model.factory');
                 $brickClass = '\\Pimcore\\Model\\DataObject\\Objectbrick\\Data\\' . ucfirst($brickname);
-                $brick = new $brickClass($object);
+                $brick = $modelFactory->build($brickClass);
+                $brick->setObject($object);
             }
 
             $fieldname = $subdata['name'];

--- a/models/DataObject/Objectbrick.php
+++ b/models/DataObject/Objectbrick.php
@@ -157,8 +157,10 @@ class Objectbrick extends Model\AbstractModel implements DirtyIndicatorInterface
                 });
 
                 if (!empty($parentBrick)) {
+                    $modelFactory = \Pimcore::getContainer()->get('pimcore.model.factory');
                     $brickType = '\\Pimcore\\Model\\DataObject\\Objectbrick\\Data\\' . ucfirst($parentBrick->getType());
-                    $brick = new $brickType($object);
+                    $brick = $modelFactory->build($brickType);
+                    $brick->setObject($object);
                     $brick->setFieldname($this->getFieldname());
                     $brick->save($object, $params);
                 }

--- a/models/DataObject/Objectbrick/Dao.php
+++ b/models/DataObject/Objectbrick/Dao.php
@@ -50,9 +50,10 @@ class Dao extends Model\DataObject\Fieldcollection\Dao
 
             $fieldDefinitions = $definition->getFieldDefinitions(['object' => $object, 'suppressEnrichment' => true]);
             $brickClass = '\\Pimcore\\Model\\DataObject\\Objectbrick\\Data\\' . ucfirst($type);
+            $modelFactory = \Pimcore::getContainer()->get('pimcore.model.factory');
 
             foreach ($results as $result) {
-                $brick = new $brickClass($object);
+                $brick = $modelFactory->build($brickClass);
                 $brick->setFieldname($result['fieldname']);
                 $brick->setObject($object);
 

--- a/models/DataObject/Objectbrick/Data/AbstractData.php
+++ b/models/DataObject/Objectbrick/Data/AbstractData.php
@@ -47,7 +47,7 @@ abstract class AbstractData extends Model\AbstractModel implements Model\DataObj
 
     protected ?int $objectId = null;
 
-    public function __construct(Concrete $object)
+    public function __construct(?Concrete $object = null)
     {
         $this->setObject($object);
     }


### PR DESCRIPTION
While it is possible to [override the generated classes](https://docs.pimcore.com/platform/Pimcore/Extending_Pimcore/Overriding_Models/) for data objects, documents, assets and field collections (was not documented yet), it is currently not possible to override object brick classes. With this PR overriding object brick classes gets supported.

Example:
1. Create data object class `Product` with object brick container field `bricks`
2. Create object brick class `MyBrick`, allow for `Product.bricks`
3. Create overriding class in `src/Model/DataObject/Objectbrick/MyBrick.php`:
```php
namespace App\Model\DataObject\Objectbrick;

use Pimcore\Model\DataObject\Objectbrick\Data\MyBrick as BaseClass;

class MyBrick extends BaseClass
{
}
```
4. Register overriding class in `config.yaml`:
```yaml
pimcore:
   models:
     class_overrides:
       'Pimcore\Model\DataObject\Objectbrick\Data\MyBrick': 'App\Model\DataObject\Objectbrick\MyBrick'
```
5. Run `bin/console cache:clear`
6. Create object of class `Product` and assign brick `MyBrick` -> Save & Publish
7. Run following script:
```php
$product = \Pimcore\Model\DataObject\Product::getById(123); // exchange id here
echo 'Class: '.get_class($product->getBricks()->getMyBrick()); // returns App\Model\DataObject\Objectbrick\MyBrick
```