### PR TITLE
[Bug] Error message "Cannot traverse an already closed generator" pops up when moving folder with assets

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1658,20 +1658,21 @@ class Asset extends Element\AbstractElement
         try {
             $movedFiles = [];
             $children = $storage->listContents($oldPath, true);
-            $totalChildren = iterator_count($children);
+            $totalChildren = 0;
+
+            /** @var \League\Flysystem\StorageAttributes $child */
+            foreach ($children as $child) {
+                if ($child instanceof \League\Flysystem\FileAttributes) {
+                    ++$totalChildren;
+                    $src  = $child['path'];
+                    $dest = str_replace($oldPath, $newPath, '/' . $src);
+
+                    $storage->move($src, $dest);
+                    $movedFiles[$dest] = $src;
+                }
+            }
 
             if ($totalChildren > 0) {
-                /** @var \League\Flysystem\StorageAttributes $child */
-                foreach ($children as $child) {
-                    if ($child instanceof \League\Flysystem\FileAttributes) {
-                        $src  = $child['path'];
-                        $dest = str_replace($oldPath, $newPath, '/' . $src);
-
-                        $storage->move($src, $dest);
-                        $movedFiles[$dest] = $src;
-                    }
-                }
-
                 $movedCount = count($movedFiles);
 
                 if ($movedCount === $totalChildren) {


### PR DESCRIPTION
How to reproduce the issue:

- Pimcore version v12.2.4
- Project is storing assets on Azure. 
- When users try to move folder with assets to another folder, they get error "Cannot traverse an already closed generator".                                                                                                                          
                                                                                                                                                                  
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
The code calls `iterator_count($children)` which closes the generator returned by `$storage->listContents()`. When the loop starts to iterate variable `$children`, it fails because the generator is already closed.         

This PR replaces `iterator_count` with variable `$totalChildren` that increments during iteration

## Additional info

According to CONTRIBUTING.md I had to create this branch from branch `12.2`. If needed I will also create PR for `11.4`.
