### PR TITLE
SimpleBackendSearch temporary files cleanup

### DIFF
--- a/bundles/SimpleBackendSearchBundle/src/MessageHandler/SearchBackendHandler.php
+++ b/bundles/SimpleBackendSearchBundle/src/MessageHandler/SearchBackendHandler.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\SimpleBackendSearchBundle\MessageHandler;
 
+use Pimcore\Helper\LongRunningHelper;
 use Pimcore\Bundle\SimpleBackendSearchBundle\Message\SearchBackendMessage;
 use Pimcore\Bundle\SimpleBackendSearchBundle\Model\Search\Backend\Data;
 use Pimcore\Messenger\Handler\HandlerHelperTrait;
@@ -29,6 +30,10 @@ class SearchBackendHandler implements BatchHandlerInterface
 {
     use BatchHandlerTrait;
     use HandlerHelperTrait;
+
+    public function __construct(protected LongRunningHelper $longRunningHelper)
+    {
+    }
 
     public function __invoke(SearchBackendMessage $message, ?Acknowledger $ack = null): mixed
     {
@@ -62,6 +67,8 @@ class SearchBackendHandler implements BatchHandlerInterface
             } catch (Throwable $e) {
                 $ack->nack($e);
             }
+
+            $this->longRunningHelper->deleteTemporaryFiles();
         }
     }
 

--- a/bundles/SimpleBackendSearchBundle/src/Model/Search/Backend/Data.php
+++ b/bundles/SimpleBackendSearchBundle/src/Model/Search/Backend/Data.php
@@ -416,7 +416,8 @@ class Data extends AbstractModel
                 }
             } elseif ($element instanceof Asset\Image) {
                 try {
-                    $metaData = array_merge($element->getEXIFData(), $element->getIPTCData());
+                    $assetFile = $element->getLocalFile();
+                    $metaData = array_merge($element->getEXIFData($assetFile), $element->getIPTCData($assetFile));
                     foreach ($metaData as $key => $value) {
                         if (is_array($value)) {
                             $this->data .= ' ' . $key . ' : ' . implode(' - ', $value);


### PR DESCRIPTION
## Changes in this pull request  

Make sure tmp-files are deleted after each message has been processed to prevent the local temp storage to fill up quickly. Additionally, only 1 instead of 2 tmp-files will be created when metadata is extracted via EXIF and IPTC for images.

## Additional info

- Assets are stored on a remote file-system 
- Retrieving image metadata will create 2 tmp-files / copies per image
- Local temporary files will not bet deleted when processed via messenger _pimcore_search_backend_message_ till the consumer terminates

This PR relates to [Messenger handlers: clean up temporary files after each iteration / jobs](https://github.com/pimcore/pimcore/pull/18785)