### PR TITLE
2FA: by default, use main domain as server_name

### DIFF
--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -348,3 +348,7 @@ pimcore:
 
     dependency:
         enabled: true
+
+scheb_two_factor:
+    google:
+        issuer: "%router.request_context.host%"

--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -351,4 +351,4 @@ pimcore:
 
 scheb_two_factor:
     google:
-        issuer: "%router.request_context.host%"
+        server_name: "%router.request_context.host%"


### PR DESCRIPTION
Problem:
By default, all Pimcore systems have the same 2FA issuer and server name, see https://github.com/pimcore/admin-ui-classic-bundle/blob/e6f26f187b0b31dee4ddb9d2615c4ebc76a22246/config/pimcore/two_factor_authentication.yaml#L1-L6

When working with multiple instances for 1 comapny or working for multiple clients as an agency, you will soon have lots of entries in Google Authenticator having  "Pimcore (user-name@Pimcore)". So you will need to manually rename them, otherwise you will not be able to distinguish them. With this PR the configured Pimcore main domain gets used as default `server_name`. 

This PR uses the parameter `router.request_context.host` which gets set in https://github.com/pimcore/pimcore/blob/0b14457ee4777a75d55e47569a9e3e8280ed588c/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php#L87-L97 to Pimcore's main domain. If `pimcore.general.domain` is not set, it falls back to either what has been set for `router.request_context.host` in Symfony config or if even this is not set, it uses `localhost`. 

As [pimcore/admin-ui-classic-bundle](https://github.com/pimcore/admin-ui-classic-bundle) is EOL, I have put the config to `pimcore/pimcore` because imho, it never made much sense to put default config for 2FA to https://github.com/pimcore/admin-ui-classic-bundle/blob/2.3/config/pimcore/two_factor_authentication.yaml because `scheb/2fa-bundle` has never been a dependency of `pimcore/admin-ui-classic-bundle` but of `pimcore/pimcore`.

Conclusion if this PR:
1. This way the 2FA `server_name` will point to the domain which the system uses.
2. As default `issuer` is still "Pimcore", people with lots of non-Pimcore applications in Google Authenticator will still find it.