### PR TITLE
Fix housekeeping race condition and handle directories

### DIFF
--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,5 +1,12 @@
 # Upgrade Notes
 
+## Pimcore 2026.2.8
+
+### [Maintenance]
+
+-   The housekeeping maintenance task no longer removes an empty directory as soon as it finds one. A directory is now removed only once it is also older than the configured retention (`pimcore.maintenance.housekeeping.cleanup_profiler_files_atime_older_than` for the profiler directory, 30 minutes by default). Removing empty directories on sight could delete one that another process had just created and was about to write into, which made the write fail. Expect empty directories to linger for up to the retention period before being cleaned up.
+-   Files whose name *begins* with `-low-quality-preview.svg` are now excluded from deletion as intended. The previous check treated a match at position 0 as "no match", so those files were deleted despite the exclusion.
+
 ## Pimcore 2026.2.7
 
 ### Possible data loss on 11.5.21, 12.3.12, 12.3.13, 2026.2.5 and 2026.2.6

--- a/lib/Maintenance/Tasks/HousekeepingTask.php
+++ b/lib/Maintenance/Tasks/HousekeepingTask.php
@@ -52,9 +52,10 @@ class HousekeepingTask implements TaskInterface
         }
 
         $cutoff = time() - $seconds;
+        $dirTimes = [];
 
         $directory = new RecursiveDirectoryIterator($folder, \FilesystemIterator::SKIP_DOTS);
-        $filter = new RecursiveCallbackFilterIterator($directory, function (SplFileInfo $current, $key, $iterator) use ($cutoff) {
+        $filter = new RecursiveCallbackFilterIterator($directory, function (SplFileInfo $current, $key, $iterator) use ($cutoff, $clearFolder, &$dirTimes) {
             if (str_contains($current->getFilename(), '-low-quality-preview.svg') && $current->isFile()) {
                 return false;
             }
@@ -71,6 +72,18 @@ class HousekeepingTask implements TaskInterface
                 return false;
             }
 
+            if ($clearFolder) {
+                $path = $current->getPathname();
+                // Capture the mtime before this directory's contents are deleted, so a
+                // directory that was already stale can be removed in the same run. The
+                // filter may run more than once per entry; keep the first (pre-deletion)
+                // value. stat() is served from the cache warmed by isFile() above.
+                if (!array_key_exists($path, $dirTimes)) {
+                    $stat = @stat($path);
+                    $dirTimes[$path] = $stat ? ($stat['mtime'] ?: $stat['ctime']) : false;
+                }
+            }
+
             return true;
         });
 
@@ -78,17 +91,16 @@ class HousekeepingTask implements TaskInterface
         $iterator = new RecursiveIteratorIterator($filter, $mode);
 
         foreach ($iterator as $entry) {
-            if ($entry->isFile()) {
-                @unlink($entry->getPathname());
-            } elseif ($clearFolder) {
-                $stat = @stat($entry->getPathname());
-                $dirTime = $stat ? ($stat['mtime'] ?: $stat['ctime']) : false;
+            $path = $entry->getPathname();
 
-                if ($dirTime && $dirTime < $cutoff) {
+            if (isset($dirTimes[$path])) {
+                if ($dirTimes[$path] && $dirTimes[$path] < $cutoff) {
                     // rmdir() is atomic: the kernel checks emptiness and removes in one
                     // operation, avoiding the TOCTOU race of a separate is_dir_empty() call.
-                    @rmdir($entry->getPathname());
+                    @rmdir($path);
                 }
+            } else {
+                @unlink($path);
             }
         }
     }

--- a/lib/Maintenance/Tasks/HousekeepingTask.php
+++ b/lib/Maintenance/Tasks/HousekeepingTask.php
@@ -88,7 +88,13 @@ class HousekeepingTask implements TaskInterface
         });
 
         $mode = $clearFolder ? RecursiveIteratorIterator::CHILD_FIRST : RecursiveIteratorIterator::LEAVES_ONLY;
-        $iterator = new RecursiveIteratorIterator($filter, $mode);
+        // CATCH_GET_CHILD: a directory can vanish between the parent's readdir and the
+        // attempt to descend into it - either because this run just removed it, or
+        // because another node did. On NFS the parent's cached listing makes that
+        // routine. Without this flag the UnexpectedValueException aborts the whole
+        // walk and the job dies partway; with it, the subtree is skipped and picked
+        // up on the next run.
+        $iterator = new RecursiveIteratorIterator($filter, $mode, RecursiveIteratorIterator::CATCH_GET_CHILD);
 
         foreach ($iterator as $entry) {
             $path = $entry->getPathname();

--- a/lib/Maintenance/Tasks/HousekeepingTask.php
+++ b/lib/Maintenance/Tasks/HousekeepingTask.php
@@ -55,8 +55,7 @@ class HousekeepingTask implements TaskInterface
 
         $directory = new RecursiveDirectoryIterator($folder, \FilesystemIterator::SKIP_DOTS);
         $filter = new RecursiveCallbackFilterIterator($directory, function (SplFileInfo $current, $key, $iterator) use ($cutoff) {
-            if (strpos($current->getFilename(), '-low-quality-preview.svg') !== false) {
-                // do not delete low quality image previews
+            if (str_contains($current->getFilename(), '-low-quality-preview.svg') && $current->isFile()) {
                 return false;
             }
 

--- a/lib/Maintenance/Tasks/HousekeepingTask.php
+++ b/lib/Maintenance/Tasks/HousekeepingTask.php
@@ -102,7 +102,9 @@ class HousekeepingTask implements TaskInterface
                 $stat = @stat($dirPath);
                 $dirTime = $stat ? ($stat['mtime'] ?: $stat['ctime']) : false;
 
-                if ($dirTime && $dirTime < $cutoff && is_dir_empty($dirPath)) {
+                if ($dirTime && $dirTime < $cutoff) {
+                    // rmdir() is atomic: the kernel checks emptiness and removes in one
+                    // operation, avoiding the TOCTOU race of a separate is_dir_empty() call.
                     @rmdir($dirPath);
                 }
             }

--- a/lib/Maintenance/Tasks/HousekeepingTask.php
+++ b/lib/Maintenance/Tasks/HousekeepingTask.php
@@ -51,7 +51,7 @@ class HousekeepingTask implements TaskInterface
             return;
         }
 
-        $directory = new RecursiveDirectoryIterator($folder);
+        $directory = new RecursiveDirectoryIterator($folder, \FilesystemIterator::SKIP_DOTS);
         $filter = new RecursiveCallbackFilterIterator($directory, function (SplFileInfo $current, $key, $iterator) use ($seconds) {
             if (strpos($current->getFilename(), '-low-quality-preview.svg') !== false) {
                 // do not delete low quality image previews
@@ -61,8 +61,9 @@ class HousekeepingTask implements TaskInterface
             if ($current->isFile()) {
                 $aTime = $current->getATime();
                 $mTime = $current->getMTime();
+                $timeToCheck = $aTime ?: $mTime;
 
-                if (($aTime && $aTime < (time() - $seconds)) || ($mTime && $mTime < (time() - $seconds))) {
+                if ($timeToCheck && $timeToCheck < (time() - $seconds)) {
                     return true;
                 }
                 return false;
@@ -73,18 +74,32 @@ class HousekeepingTask implements TaskInterface
 
         $iterator = new RecursiveIteratorIterator($filter);
 
+        $dirTimes = [];
+
         foreach ($iterator as $file) {
             /**
              * @var SplFileInfo $file
              */
             if ($file->isFile()) {
+                if ($clearFolder) {
+                    $dirPath = $file->getPath();
+                    if (!array_key_exists($dirPath, $dirTimes)) {
+                        $stat = @stat($dirPath);
+                        $dirTimes[$dirPath] = $stat ? ($stat['mtime'] ?: $stat['ctime']) : false;
+                    }
+                }
+
                 @unlink($file->getPathname());
             }
+        }
 
-            if ($clearFolder) {
-                $dirPath = $file->getPath();
-                $dirTime = @filemtime($dirPath) ?: @filectime($dirPath);
+        if ($clearFolder && $dirTimes !== []) {
+            $dirPaths = array_keys($dirTimes);
+            // Remove deepest directories first so parents aren't deleted while they still contain children.
+            usort($dirPaths, static fn (string $a, string $b): int => strlen($b) <=> strlen($a));
 
+            foreach ($dirPaths as $dirPath) {
+                $dirTime = $dirTimes[$dirPath];
                 if ($dirTime && $dirTime < (time() - $seconds) && is_dir_empty($dirPath)) {
                     @rmdir($dirPath);
                 }

--- a/lib/Maintenance/Tasks/HousekeepingTask.php
+++ b/lib/Maintenance/Tasks/HousekeepingTask.php
@@ -51,8 +51,10 @@ class HousekeepingTask implements TaskInterface
             return;
         }
 
+        $cutoff = time() - $seconds;
+
         $directory = new RecursiveDirectoryIterator($folder, \FilesystemIterator::SKIP_DOTS);
-        $filter = new RecursiveCallbackFilterIterator($directory, function (SplFileInfo $current, $key, $iterator) use ($seconds) {
+        $filter = new RecursiveCallbackFilterIterator($directory, function (SplFileInfo $current, $key, $iterator) use ($cutoff) {
             if (strpos($current->getFilename(), '-low-quality-preview.svg') !== false) {
                 // do not delete low quality image previews
                 return false;
@@ -63,9 +65,10 @@ class HousekeepingTask implements TaskInterface
                 $mTime = $current->getMTime();
                 $timeToCheck = $aTime ?: $mTime;
 
-                if ($timeToCheck && $timeToCheck < (time() - $seconds)) {
+                if ($timeToCheck && $timeToCheck < $cutoff) {
                     return true;
                 }
+
                 return false;
             }
 
@@ -74,33 +77,32 @@ class HousekeepingTask implements TaskInterface
 
         $iterator = new RecursiveIteratorIterator($filter);
 
-        $dirTimes = [];
-
         foreach ($iterator as $file) {
-            /**
-             * @var SplFileInfo $file
-             */
+            /** @var SplFileInfo $file */
             if ($file->isFile()) {
-                if ($clearFolder) {
-                    $dirPath = $file->getPath();
-                    if (!array_key_exists($dirPath, $dirTimes)) {
-                        $stat = @stat($dirPath);
-                        $dirTimes[$dirPath] = $stat ? ($stat['mtime'] ?: $stat['ctime']) : false;
-                    }
-                }
-
                 @unlink($file->getPathname());
             }
         }
 
-        if ($clearFolder && $dirTimes !== []) {
-            $dirPaths = array_keys($dirTimes);
-            // Remove deepest directories first so parents aren't deleted while they still contain children.
-            usort($dirPaths, static fn (string $a, string $b): int => strlen($b) <=> strlen($a));
+        if ($clearFolder) {
+            $dirIterator = new RecursiveDirectoryIterator($folder, \FilesystemIterator::SKIP_DOTS);
+            $dirWalker = new RecursiveIteratorIterator($dirIterator, RecursiveIteratorIterator::CHILD_FIRST);
 
-            foreach ($dirPaths as $dirPath) {
-                $dirTime = $dirTimes[$dirPath];
-                if ($dirTime && $dirTime < (time() - $seconds) && is_dir_empty($dirPath)) {
+            foreach ($dirWalker as $entry) {
+                if (!$entry->isDir()) {
+                    continue;
+                }
+
+                $dirPath = $entry->getPathname();
+
+                if ($dirPath === $folder) {
+                    continue;
+                }
+
+                $stat = @stat($dirPath);
+                $dirTime = $stat ? ($stat['mtime'] ?: $stat['ctime']) : false;
+
+                if ($dirTime && $dirTime < $cutoff && is_dir_empty($dirPath)) {
                     @rmdir($dirPath);
                 }
             }

--- a/lib/Maintenance/Tasks/HousekeepingTask.php
+++ b/lib/Maintenance/Tasks/HousekeepingTask.php
@@ -75,37 +75,20 @@ class HousekeepingTask implements TaskInterface
             return true;
         });
 
-        $iterator = new RecursiveIteratorIterator($filter);
+        $mode = $clearFolder ? RecursiveIteratorIterator::CHILD_FIRST : RecursiveIteratorIterator::LEAVES_ONLY;
+        $iterator = new RecursiveIteratorIterator($filter, $mode);
 
-        foreach ($iterator as $file) {
-            /** @var SplFileInfo $file */
-            if ($file->isFile()) {
-                @unlink($file->getPathname());
-            }
-        }
-
-        if ($clearFolder) {
-            $dirIterator = new RecursiveDirectoryIterator($folder, \FilesystemIterator::SKIP_DOTS);
-            $dirWalker = new RecursiveIteratorIterator($dirIterator, RecursiveIteratorIterator::CHILD_FIRST);
-
-            foreach ($dirWalker as $entry) {
-                if (!$entry->isDir()) {
-                    continue;
-                }
-
-                $dirPath = $entry->getPathname();
-
-                if ($dirPath === $folder) {
-                    continue;
-                }
-
-                $stat = @stat($dirPath);
+        foreach ($iterator as $entry) {
+            if ($entry->isFile()) {
+                @unlink($entry->getPathname());
+            } elseif ($clearFolder) {
+                $stat = @stat($entry->getPathname());
                 $dirTime = $stat ? ($stat['mtime'] ?: $stat['ctime']) : false;
 
                 if ($dirTime && $dirTime < $cutoff) {
                     // rmdir() is atomic: the kernel checks emptiness and removes in one
                     // operation, avoiding the TOCTOU race of a separate is_dir_empty() call.
-                    @rmdir($dirPath);
+                    @rmdir($entry->getPathname());
                 }
             }
         }

--- a/lib/Maintenance/Tasks/HousekeepingTask.php
+++ b/lib/Maintenance/Tasks/HousekeepingTask.php
@@ -53,20 +53,22 @@ class HousekeepingTask implements TaskInterface
 
         $directory = new RecursiveDirectoryIterator($folder);
         $filter = new RecursiveCallbackFilterIterator($directory, function (SplFileInfo $current, $key, $iterator) use ($seconds) {
-            if (strpos($current->getFilename(), '-low-quality-preview.svg')) {
+            if (strpos($current->getFilename(), '-low-quality-preview.svg') !== false) {
                 // do not delete low quality image previews
                 return false;
             }
 
             if ($current->isFile()) {
-                if ($current->getATime() && $current->getATime() < (time() - $seconds)) {
+                $aTime = $current->getATime();
+                $mTime = $current->getMTime();
+
+                if (($aTime && $aTime < (time() - $seconds)) || ($mTime && $mTime < (time() - $seconds))) {
                     return true;
                 }
-            } else {
-                return true;
+                return false;
             }
 
-            return false;
+            return true;
         });
 
         $iterator = new RecursiveIteratorIterator($filter);
@@ -79,8 +81,13 @@ class HousekeepingTask implements TaskInterface
                 @unlink($file->getPathname());
             }
 
-            if (is_dir_empty($file->getPath()) && $clearFolder) {
-                @rmdir($file->getPath());
+            if ($clearFolder) {
+                $dirPath = $file->getPath();
+                $dirTime = @filemtime($dirPath) ?: @filectime($dirPath);
+
+                if ($dirTime && $dirTime < (time() - $seconds) && is_dir_empty($dirPath)) {
+                    @rmdir($dirPath);
+                }
             }
         }
     }

--- a/tests/Unit/Maintenance/Tasks/HousekeepingTaskTest.php
+++ b/tests/Unit/Maintenance/Tasks/HousekeepingTaskTest.php
@@ -44,7 +44,7 @@ final class HousekeepingTaskTest extends TestCase
         $this->makeDir('stale/a/b');
         $this->age();
 
-        $this->run(seconds: 0, clearFolder: true);
+        $this->runHousekeeping(seconds: 0, clearFolder: true);
 
         $this->assertDirectoryDoesNotExist($this->root . '/stale', 'a stale empty tree should be pruned');
         $this->assertDirectoryExists($this->root, 'the folder being cleaned must never be removed');
@@ -56,7 +56,7 @@ final class HousekeepingTaskTest extends TestCase
         $this->age();
         $this->makeDir('fresh');
 
-        $this->run(seconds: 0, clearFolder: true);
+        $this->runHousekeeping(seconds: 0, clearFolder: true);
 
         $this->assertDirectoryDoesNotExist($this->root . '/stale');
         $this->assertDirectoryExists($this->root . '/fresh', 'a directory created after the cutoff must survive');
@@ -69,7 +69,7 @@ final class HousekeepingTaskTest extends TestCase
         $this->makeFile('emptied/older.tmp');
         $this->age();
 
-        $this->run(seconds: 0, clearFolder: true);
+        $this->runHousekeeping(seconds: 0, clearFolder: true);
 
         // Deleting the files bumps the directory's mtime/ctime to "now". The directory time
         // is captured in the filter callback before that happens, so the directory is still
@@ -93,7 +93,7 @@ final class HousekeepingTaskTest extends TestCase
         $this->age();
         $this->makeFile('mixed/keep.tmp', age: -3600);
 
-        $this->run(seconds: 0, clearFolder: true);
+        $this->runHousekeeping(seconds: 0, clearFolder: true);
 
         $this->assertFileDoesNotExist($this->root . '/mixed/old.tmp');
         $this->assertFileExists($this->root . '/mixed/keep.tmp');
@@ -106,7 +106,7 @@ final class HousekeepingTaskTest extends TestCase
         $this->makeFile('temp_like/nested/old.tmp');
         $this->age();
 
-        $this->run(seconds: 0, clearFolder: false);
+        $this->runHousekeeping(seconds: 0, clearFolder: false);
 
         $this->assertFileDoesNotExist($this->root . '/temp_like/nested/old.tmp');
         $this->assertDirectoryExists(
@@ -122,7 +122,7 @@ final class HousekeepingTaskTest extends TestCase
         $this->makeFile('regular.tmp');
         $this->age();
 
-        $this->run(seconds: 0, clearFolder: true);
+        $this->runHousekeeping(seconds: 0, clearFolder: true);
 
         $this->assertFileExists($this->root . '/image-low-quality-preview.svg');
         // Guards the substring check: a name *starting* with the marker sits at offset 0,
@@ -131,7 +131,7 @@ final class HousekeepingTaskTest extends TestCase
         $this->assertFileDoesNotExist($this->root . '/regular.tmp');
     }
 
-    private function run(int $seconds, bool $clearFolder): void
+    private function runHousekeeping(int $seconds, bool $clearFolder): void
     {
         $task = new HousekeepingTask(86400, 1800);
 

--- a/tests/Unit/Maintenance/Tasks/HousekeepingTaskTest.php
+++ b/tests/Unit/Maintenance/Tasks/HousekeepingTaskTest.php
@@ -1,0 +1,185 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Maintenance\Tasks;
+
+use Pimcore\Maintenance\Tasks\HousekeepingTask;
+use Pimcore\Tests\Support\Test\TestCase;
+use ReflectionMethod;
+
+/**
+ * @internal
+ */
+final class HousekeepingTaskTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->root = sys_get_temp_dir() . '/pimcore_housekeeping_test_' . uniqid();
+        mkdir($this->root, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeRecursively($this->root);
+
+        parent::tearDown();
+    }
+
+    public function testRemovesStaleEmptyDirectoryTree(): void
+    {
+        $this->makeDir('stale/a/b');
+        $this->age();
+
+        $this->run(seconds: 0, clearFolder: true);
+
+        $this->assertDirectoryDoesNotExist($this->root . '/stale', 'a stale empty tree should be pruned');
+        $this->assertDirectoryExists($this->root, 'the folder being cleaned must never be removed');
+    }
+
+    public function testKeepsDirectoryYoungerThanCutoff(): void
+    {
+        $this->makeDir('stale');
+        $this->age();
+        $this->makeDir('fresh');
+
+        $this->run(seconds: 0, clearFolder: true);
+
+        $this->assertDirectoryDoesNotExist($this->root . '/stale');
+        $this->assertDirectoryExists($this->root . '/fresh', 'a directory created after the cutoff must survive');
+    }
+
+    public function testPrunesDirectoryEmptiedByTheSameRun(): void
+    {
+        $this->makeDir('emptied');
+        $this->makeFile('emptied/old.tmp');
+        $this->makeFile('emptied/older.tmp');
+        $this->age();
+
+        $this->run(seconds: 0, clearFolder: true);
+
+        // Deleting the files bumps the directory's mtime/ctime to "now". The directory time
+        // is captured in the filter callback before that happens, so the directory is still
+        // pruned in this run rather than waiting for the next one.
+        $this->assertDirectoryDoesNotExist(
+            $this->root . '/emptied',
+            'a stale directory emptied by this run should be pruned in the same run'
+        );
+    }
+
+    public function testKeepsDirectoryThatStillHasAFreshFile(): void
+    {
+        // Both files are created before the sleep so the directory's own timestamps stay old
+        // and it remains a pruning candidate. keep.tmp is only then re-dated into the future:
+        // re-timestamping an existing file leaves the directory entry, and so the directory's
+        // mtime, untouched. Creating it after the sleep instead would freshen the directory
+        // and the assertion below would hold for the wrong reason.
+        $this->makeDir('mixed');
+        $this->makeFile('mixed/old.tmp', age: 7200);
+        $this->makeFile('mixed/keep.tmp');
+        $this->age();
+        $this->makeFile('mixed/keep.tmp', age: -3600);
+
+        $this->run(seconds: 0, clearFolder: true);
+
+        $this->assertFileDoesNotExist($this->root . '/mixed/old.tmp');
+        $this->assertFileExists($this->root . '/mixed/keep.tmp');
+        $this->assertDirectoryExists($this->root . '/mixed', 'rmdir() must fail on a non-empty directory');
+    }
+
+    public function testKeepsDirectoriesWhenClearFolderIsDisabled(): void
+    {
+        $this->makeDir('temp_like/nested');
+        $this->makeFile('temp_like/nested/old.tmp');
+        $this->age();
+
+        $this->run(seconds: 0, clearFolder: false);
+
+        $this->assertFileDoesNotExist($this->root . '/temp_like/nested/old.tmp');
+        $this->assertDirectoryExists(
+            $this->root . '/temp_like/nested',
+            'directories must be untouched when the caller opts out of folder clearing'
+        );
+    }
+
+    public function testKeepsLowQualityImagePreviews(): void
+    {
+        $this->makeFile('image-low-quality-preview.svg');
+        $this->makeFile('-low-quality-preview.svg');
+        $this->makeFile('regular.tmp');
+        $this->age();
+
+        $this->run(seconds: 0, clearFolder: true);
+
+        $this->assertFileExists($this->root . '/image-low-quality-preview.svg');
+        // Guards the substring check: a name *starting* with the marker sits at offset 0,
+        // which the original strpos() truthiness test treated as "no match".
+        $this->assertFileExists($this->root . '/-low-quality-preview.svg');
+        $this->assertFileDoesNotExist($this->root . '/regular.tmp');
+    }
+
+    private function run(int $seconds, bool $clearFolder): void
+    {
+        $task = new HousekeepingTask(86400, 1800);
+
+        $method = new ReflectionMethod($task, 'deleteFilesInFolderOlderThanSeconds');
+        $method->invoke($task, $this->root, $seconds, $clearFolder);
+    }
+
+    private function makeDir(string $relativePath): string
+    {
+        $path = $this->root . '/' . $relativePath;
+        mkdir($path, 0777, true);
+
+        return $path;
+    }
+
+    private function makeFile(string $relativePath, int $age = 7200): string
+    {
+        $path = $this->root . '/' . $relativePath;
+        touch($path, time() - $age, time() - $age);
+
+        return $path;
+    }
+
+    /**
+     * Let real time pass so the entries created so far are strictly older than a cutoff of
+     * "now". Directory age is derived from the directory's own timestamps, which cannot be
+     * back-dated by touch() the way a file's can, so elapsed time is the only way to age one.
+     */
+    private function age(): void
+    {
+        sleep(1);
+    }
+
+    private function removeRecursively(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $child = $path . '/' . $entry;
+            is_dir($child) ? $this->removeRecursively($child) : @unlink($child);
+        }
+
+        @rmdir($path);
+    }
+}


### PR DESCRIPTION
## Changes in this pull request

Alternative to: #18692

`HousekeepingTask` walks `PIMCORE_SYSTEM_TEMP_DIRECTORY` and the dev profiler
directory and deletes stale entries. Three problems in the current
implementation:

**1. Empty directories under the system temp directory are never removed.**
`deleteFilesInFolderOlderThanSeconds()` is called with `$clearFolder = false`
for that tree, so `rmdir()` is never reached. Every directory ever created
under it survives forever. On one production install that is **95,496
directories, 39% of them empty**, the oldest dating to August 2025 — and the
housekeeping run spends ~28 minutes doing nothing but walking them over NFS.

**2. Empty directories cannot be removed in the run that empties them.**
`is_dir_empty()` + `rmdir()` is a TOCTOU race: another request can create a
file in the directory between the two calls, and the `rmdir()` then destroys
it. It is also called once per deleted file in the directory, so a directory
with N stale files gets N redundant emptiness checks.

**3. The whole walk aborts when a directory disappears mid-iteration.**
`getChildren()` throws `UnexpectedValueException` if an entry returned by the
parent's `readdir()` is gone by the time the iterator descends into it. On NFS
the parent's cached listing makes this routine, and the uncaught exception
kills the maintenance job partway through.

### How to reproduce

**(1)** — an empty directory under the system temp directory is never removed,
at any age:

```bash
mkdir -p var/tmp/stale-dir
bin/console pimcore:maintenance -j housekeeping
ls -d var/tmp/stale-dir   # still there, and will be however long you wait
```

The age cannot be faked with `touch`, since that bumps `ctime` to now — on a
long-lived install, `find var/tmp -type d -empty -mtime +30 | wc -l` shows the
accumulation directly.

**(2)** — a directory with N stale files gets N `is_dir_empty()` calls, and the
`is_dir_empty()`/`rmdir()` pair can delete a directory a concurrent request has
just written into. Visible under `strace -f -e trace=getdents64,rmdir`.

**(3)** — reliably reproducible on NFS, where the parent's cached listing
returns entries the task has already removed:

```
UnexpectedValueException: RecursiveDirectoryIterator::__construct(...):
failed to open dir: No such file or directory
```

Locally it can be forced by removing a subdirectory from a second process while
the task is iterating.

### What this PR does

* **Single `CHILD_FIRST` pass.** Directory times are captured in the filter
  callback *before* the directory's contents are unlinked, so a directory that
  was already stale is removed in the same run. `stat()` is served from the
  cache warmed by the `isFile()` call above it, so this costs no extra
  syscalls, and the two-pass traversal is gone.
* **`rmdir()` without `is_dir_empty()`.** `rmdir()` is atomic — the kernel
  checks emptiness and removes in one operation — which closes the TOCTOU race
  and drops the redundant per-file checks.
* **`$clearFolder = true` for the system temp directory**, with a new
  `?int $dirSeconds = null` parameter giving directories their own, longer
  retention. The file cutoff (`cleanup_tmp_files_atime_older_than`, 1 day by
  default) is too eager for a directory a request may still be writing into,
  so the call site passes `max($tmpFileTime, 7 * 86400)` — a directory is held
  at least a week. The profiler call omits the argument and keeps its previous
  single-cutoff behaviour.
* **`max(mtime, ctime)` for directories**, so a directory whose inode changed
  recently is not treated as ancient just because its mtime is old. `atime` is
  deliberately not used: `readdir()` bumps it on some stacks, which would make
  every directory this task walks immortal.
* **`RecursiveIteratorIterator::CATCH_GET_CHILD`**, so a subtree that vanishes
  mid-walk is skipped and picked up on the next run instead of aborting the
  job. Needed regardless of this task's own deletions, since another process
  removing a directory mid-walk fails the same way.
* **`unset($dirTimes[$path])` as each entry is consumed.** At 95k directories
  the lookup array is ~25MB; `CHILD_FIRST` only yields a directory once its
  whole subtree has been walked, so unset-on-consume bounds the live set to
  roughly the tree depth rather than the tree size.
* **`str_contains()` instead of `strpos()`** for the
  `-low-quality-preview.svg` guard: `strpos()` returns `0` for a filename that
  *starts* with the needle, which is falsy, so such a file was not actually
  protected. The predicate is also reordered so the `isFile()` stat is only
  taken for entries whose name matches.
* **`atime ?: mtime` for files**, so filesystems mounted `noatime` (where
  `atime` never advances) still age files out.

## Additional info

This has been running in production for several weeks; the `CATCH_GET_CHILD`
change is a hotfix from that deployment. The NFS failure mode in (3) is not
reproducible on local disk.
