### PR TITLE
Fix SimpleBackendSearch Error 414 - Request-URI Too Large

### DIFF
--- a/bundles/SimpleBackendSearchBundle/public/js/pimcore/element/service.js
+++ b/bundles/SimpleBackendSearchBundle/public/js/pimcore/element/service.js
@@ -207,5 +207,9 @@ pimcore.bundle.search.element.service = Class.create({
 
     getObjectRelationInlineSearchRoute: function () {
         return Routing.generate('pimcore_bundle_search_dataobject_relation_objects_list');
+    },
+
+    getObjectRelationInlineSearchRouteMethod: function () {
+        return 'POST';
     }
 });

--- a/bundles/SimpleBackendSearchBundle/src/Controller/DataObjectController.php
+++ b/bundles/SimpleBackendSearchBundle/src/Controller/DataObjectController.php
@@ -21,10 +21,10 @@ use Symfony\Component\Routing\Attribute\Route;
 
 class DataObjectController extends UserAwareController
 {
-    #[Route('/relation-objects-list', name: 'pimcore_bundle_search_dataobject_relation_objects_list', methods: ['GET'])]
+    #[Route('/relation-objects-list', name: 'pimcore_bundle_search_dataobject_relation_objects_list', methods: ['GET', 'POST'])]
     public function optionsAction(Request $request): JsonResponse
     {
-        $fieldConfig = json_decode($request->query->getString('fieldConfig'), true);
+        $fieldConfig = json_decode($request->request->getString('fieldConfig', $request->query->getString('fieldConfig')), true);
 
         $options = [];
         $classes = [];
@@ -70,12 +70,12 @@ class DataObjectController extends UserAwareController
         $searchRequest->request->set('class', implode(',', $classes));
         $searchRequest->request->set('fields', $visibleFields);
 
-        $searchRequest->attributes->set('unsavedChanges', $request->query->getString('unsavedChanges'));
+        $searchRequest->attributes->set('unsavedChanges', $request->request->getString('unsavedChanges', $request->query->getString('unsavedChanges') ));
         $res = $this->forward(SearchController::class.'::findAction', ['request' => $searchRequest]);
         $objects = json_decode($res->getContent(), true)['data'];
 
-        if ($request->query->has('data')) {
-            $dataArray = json_decode($request->query->getString('data'), true);
+        if ($request->request->has('data') || $request->query->has('data')) {
+            $dataArray = json_decode($request->request->getString('data', $request->query->getString('data')), true);
             if (is_array($dataArray)) {
                 foreach ($dataArray as $preSelectedElement) {
                     if (isset($preSelectedElement['id'], $preSelectedElement['type'])) {

--- a/bundles/SimpleBackendSearchBundle/src/Controller/DataObjectController.php
+++ b/bundles/SimpleBackendSearchBundle/src/Controller/DataObjectController.php
@@ -24,7 +24,7 @@ class DataObjectController extends UserAwareController
     #[Route('/relation-objects-list', name: 'pimcore_bundle_search_dataobject_relation_objects_list', methods: ['GET', 'POST'])]
     public function optionsAction(Request $request): JsonResponse
     {
-        $fieldConfig = json_decode($request->request->getString('fieldConfig', $request->query->getString('fieldConfig')), true);
+        $fieldConfig = json_decode($this->getRequestParameter($request, 'fieldConfig'), true);
 
         $options = [];
         $classes = [];
@@ -70,12 +70,12 @@ class DataObjectController extends UserAwareController
         $searchRequest->request->set('class', implode(',', $classes));
         $searchRequest->request->set('fields', $visibleFields);
 
-        $searchRequest->attributes->set('unsavedChanges', $request->request->getString('unsavedChanges', $request->query->getString('unsavedChanges')));
+        $searchRequest->attributes->set('unsavedChanges', $this->getRequestParameter($request, 'unsavedChanges'));
         $res = $this->forward(SearchController::class.'::findAction', ['request' => $searchRequest]);
         $objects = json_decode($res->getContent(), true)['data'];
 
         if ($request->request->has('data') || $request->query->has('data')) {
-            $dataArray = json_decode($request->request->getString('data', $request->query->getString('data')), true);
+            $dataArray = json_decode($this->getRequestParameter($request, 'data'), true);
             if (is_array($dataArray)) {
                 foreach ($dataArray as $preSelectedElement) {
                     if (isset($preSelectedElement['id'], $preSelectedElement['type'])) {
@@ -128,5 +128,18 @@ class DataObjectController extends UserAwareController
         }
 
         return new JsonResponse($options);
+    }
+
+    /**
+     * Reads a request parameter preferring the POST body over the GET query string.
+     *
+     * The values sent to this action (fieldConfig, data, ...) can grow large enough
+     * to exceed the web server's URI length limit, resulting in an HTTP 414 error
+     * when transmitted via GET. Callers therefore send them via POST, while GET is
+     * kept as a fallback for backward compatibility.
+     */
+    protected function getRequestParameter(Request $request, string $key): string
+    {
+        return $request->request->getString($key, $request->query->getString($key));
     }
 }

--- a/bundles/SimpleBackendSearchBundle/src/Controller/DataObjectController.php
+++ b/bundles/SimpleBackendSearchBundle/src/Controller/DataObjectController.php
@@ -70,7 +70,7 @@ class DataObjectController extends UserAwareController
         $searchRequest->request->set('class', implode(',', $classes));
         $searchRequest->request->set('fields', $visibleFields);
 
-        $searchRequest->attributes->set('unsavedChanges', $request->request->getString('unsavedChanges', $request->query->getString('unsavedChanges') ));
+        $searchRequest->attributes->set('unsavedChanges', $request->request->getString('unsavedChanges', $request->query->getString('unsavedChanges')));
         $res = $this->forward(SearchController::class.'::findAction', ['request' => $searchRequest]);
         $objects = json_decode($res->getContent(), true)['data'];
 

--- a/tests/Unit/SimpleBackendSearchBundle/Controller/DataObjectControllerTest.php
+++ b/tests/Unit/SimpleBackendSearchBundle/Controller/DataObjectControllerTest.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\SimpleBackendSearchBundle\Controller;
+
+use Pimcore\Bundle\SimpleBackendSearchBundle\Controller\DataObjectController;
+use Pimcore\Tests\Support\Test\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class DataObjectControllerTest extends TestCase
+{
+    /**
+     * Exposes the protected getRequestParameter() helper without needing the
+     * full HTTP/DB stack the optionsAction() otherwise requires.
+     */
+    private function controller(): DataObjectController
+    {
+        return new class extends DataObjectController {
+            public function __construct()
+            {
+            }
+
+            public function readParameter(Request $request, string $key): string
+            {
+                return $this->getRequestParameter($request, $key);
+            }
+        };
+    }
+
+    public function testPrefersPostBodyOverQueryString(): void
+    {
+        $controller = $this->controller();
+
+        // Regression for Error 414: large parameters are now sent via the POST
+        // body, which must take precedence over the GET query string.
+        $request = new Request(query: ['fieldConfig' => 'fromGet'], request: ['fieldConfig' => 'fromPost']);
+
+        $this->assertSame('fromPost', $controller->readParameter($request, 'fieldConfig'));
+    }
+
+    public function testFallsBackToQueryStringWhenPostIsAbsent(): void
+    {
+        $controller = $this->controller();
+
+        // Backward compatibility: existing GET callers must keep working.
+        $request = new Request(query: ['data' => 'fromGet']);
+
+        $this->assertSame('fromGet', $controller->readParameter($request, 'data'));
+    }
+
+    public function testUsesPostBodyWhenQueryStringIsAbsent(): void
+    {
+        $controller = $this->controller();
+
+        $request = new Request(request: ['unsavedChanges' => 'fromPost']);
+
+        $this->assertSame('fromPost', $controller->readParameter($request, 'unsavedChanges'));
+    }
+
+    public function testReturnsEmptyStringWhenParameterIsMissingEverywhere(): void
+    {
+        $controller = $this->controller();
+
+        $this->assertSame('', $controller->readParameter(new Request(), 'fieldConfig'));
+    }
+}


### PR DESCRIPTION
## Changes in this pull request  
Adds POST support to Controller to replace GET (prefering POST params) , which may cause a 414 Error.

Change method from POST to GET via new method in service.js

## Additional info
This PR is loosely coupled to another [PR in _admin-ui-classic-bundle_](https://github.com/pimcore/admin-ui-classic-bundle/pull/1087), if the other PR is not available yet it should have no effect at all.
