### PR TITLE
Save generated object brick container class in PIMCORE_CLASS_DIRECTORY, not PIMCORE_CLASS_DEFINITION_DIRECTORY

### DIFF
--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -404,7 +404,7 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
      */
     public function getContainerClassFolder(string $classname): string
     {
-        return PIMCORE_CLASS_DEFINITION_DIRECTORY . '/DataObject/' . ucfirst($classname);
+        return PIMCORE_CLASS_DIRECTORY . '/DataObject/' . ucfirst($classname);
     }
 
     /**


### PR DESCRIPTION
Steps to reproduce bug:

1. Override constant `PIMCORE_CLASS_DEFINITION_DIRECTORY` in `config/pimcore/constants.php`:
   ```php
   const PIMCORE_CLASS_DEFINITION_DIRECTORY = PIMCORE_PROJECT_ROOT . '/config/pimcore/classes';
   ```
2. Create data object class `Product` with object brick container field `bricks` -> definition file gets created in `<Pimcore root>/config/pimcore/classes` according to (`PIMCORE_CLASS_DEFINITION_DIRECTORY`), PHP class gets generated in `<pimcore root>/var/classes` (according to `PIMCORE_CLASS_DIRECTORY`)
3. Create object Brick `MyBrick` and assign allowed class `Product` and field `bricks`

Expected result:
- brick class gets saved in `<pimcore root>/var/classes/DataObject/Objectbrick/Data/MyBrick.php` ✅
- brick definition gets saved in `<pimcore root>/config/pimcore/classes/objectbricks/MyBrick.php` ✅
- brick container class gets saved in `<pimcore root>/var/classes/DataObject/Product/MyBrick.php`, similar to the generated data object classes ❌

Actual result:
- brick container class gets saved in `<pimcore root>/config/pimcore/classes/DataObject/Product/MyBrick.php` (which is actually the directory for class and brick definitions.

Background:
It works when not overriding `PIMCORE_CLASS_DEFINITION_DIRECTORY` as this points to `PIMCORE_CLASS_DIRECTORY` by default:
https://github.com/pimcore/pimcore/blob/0b14457ee4777a75d55e47569a9e3e8280ed588c/lib/Bootstrap.php#L224

This PR fixes this so that the object brick container class gets saved in the folder where Pimcore also creates to generated PHP classes for data objects and object bricks.