### PR TITLE
Feature: Update custom report docs with keyword filtering info

### DIFF
--- a/doc/18_Tools_and_Features/29_Custom_Reports.md
+++ b/doc/18_Tools_and_Features/29_Custom_Reports.md
@@ -81,7 +81,7 @@ the default javascript class for the reports which is `pimcore.bundle.customrepo
 
 :::caution
 
-Be aware that several SQL keywords cannot be used in column names unless they're escaped, such as:
+Be aware that several SQL keywords cannot be used in column names unless they're quoted, such as:
 
 ```sql
 ALTER|CREATE|DROP|RENAME|TRUNCATE|UPDATE|DELETE

--- a/doc/18_Tools_and_Features/29_Custom_Reports.md
+++ b/doc/18_Tools_and_Features/29_Custom_Reports.md
@@ -78,3 +78,19 @@ pimcore_custom_reports:
 If you need to fully customize the appearance of the report, you can specify a custom javascript class that should 
 be used when opening the report in Pimcore Backend. This class can be specified in `Report Class` option and should extend
 the default javascript class for the reports which is `pimcore.bundle.customreports.custom.report`.
+
+:::caution
+
+Be aware that several SQL keywords cannot be used in column names unless they're escaped, such as:
+
+```sql
+ALTER|CREATE|DROP|RENAME|TRUNCATE|UPDATE|DELETE
+```
+
+For example, a column named `lastUpdate` would need to be wrapped with backticks (``) like so:
+
+```sql
+SELECT `lastUpdate`
+```
+
+:::


### PR DESCRIPTION
## Changes in this pull request  
Improves Custom Report documentation with clarification that certain SQL keywords cannot be used in column names even if concatenated together with non-keywords, unless properly escaped.