### PR TITLE
[Bug] Fixed query that fetches outdated versions

### DIFF
--- a/models/Version/Dao.php
+++ b/models/Version/Dao.php
@@ -121,11 +121,11 @@ class Dao extends Model\Dao\AbstractDao
                 $tmpVersionIds = $this->db->fetchFirstColumn(
                     'SELECT a.id as id FROM versions AS a
                     LEFT JOIN schedule_tasks ON a.id = schedule_tasks.version
-                    LEFT JOIN '. $elementType['elementType'] .'s AS element ON sub.cid = element.id
-                    WHERE ctype = ?
+                    LEFT JOIN '. $elementType['elementType'] .'s AS element ON a.cid = element.id
+                    WHERE a.ctype = ?
                     AND public = 0 AND autosave = 0
                     AND element.modificationDate >= a.`date`
-                    AND `date` < ? AND AND IFNULL(active,  0) = 0',
+                    AND a.`date` < ? AND IFNULL(active,  0) = 0',
                     [
                         $elementType['elementType'],
                         $deadline,

--- a/models/Version/Dao.php
+++ b/models/Version/Dao.php
@@ -125,7 +125,7 @@ class Dao extends Model\Dao\AbstractDao
                     WHERE a.ctype = ?
                     AND public = 0 AND autosave = 0
                     AND element.modificationDate >= a.`date`
-                    AND a.`date` < ? AND IFNULL(active,  0) = 0',
+                    AND a.`date` < ? AND IFNULL(active, 0) = 0',
                     [
                         $elementType['elementType'],
                         $deadline,
@@ -145,7 +145,7 @@ class Dao extends Model\Dao\AbstractDao
                     ) sub
                     LEFT JOIN schedule_tasks ON sub.id = schedule_tasks.version
                     LEFT JOIN '. $elementType['elementType'] .'s AS element ON sub.cid = element.id
-                    WHERE rownumber > ? AND IFNULL(active,  0) = 0 AND element.modificationDate >= sub.`date`
+                    WHERE rownumber > ? AND IFNULL(active, 0) = 0 AND element.modificationDate >= sub.`date`
                 ';
 
                 $iterator = $this->db->iterateAssociative(


### PR DESCRIPTION
Pimcore version: v12.3.2

Maintenance log contained this error:
```
Failed to execute job with ID versioncleanup: Doctrine\DBAL\Exception\SyntaxErrorException {#message: "An exception occurred while executing a query: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'AND IFNULL(active,  0) = 0' at line 7
```

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `12.3`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `12.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Fixed query that fetches outdated versions.

## Additional info
