### PR TITLE
Fix race conditions in LogArchiveTask and FileSystemVersionStorageAdapter

### DIFF
--- a/bundles/ApplicationLoggerBundle/src/Maintenance/LogArchiveTask.php
+++ b/bundles/ApplicationLoggerBundle/src/Maintenance/LogArchiveTask.php
@@ -21,6 +21,8 @@ use Doctrine\DBAL\Connection;
 use Pimcore\Bundle\ApplicationLoggerBundle\Handler\ApplicationLoggerDb;
 use Pimcore\Config;
 use Pimcore\Maintenance\TaskInterface;
+use League\Flysystem\UnableToDeleteDirectory;
+use League\Flysystem\UnableToDeleteFile;
 use Pimcore\Tool\Storage;
 use Psr\Log\LoggerInterface;
 use function in_arrayi;
@@ -100,8 +102,10 @@ class LogArchiveTask implements TaskInterface
             foreach ($fileObjectPaths as $objectPath) {
                 $filePath = $objectPath['fileobject'];
                 if ($filePath !== null) {
-                    if ($storage->fileExists($filePath)) {
+                    try {
                         $storage->delete($filePath);
+                    } catch (UnableToDeleteFile) {
+                        // File may have already been deleted by another process
                     }
                 }
             }
@@ -127,8 +131,10 @@ class LogArchiveTask implements TaskInterface
 
                     $folderName = $deleteArchiveLogDate->format('Y/m');
 
-                    if ($storage->directoryExists($folderName)) {
+                    try {
                         $storage->deleteDirectory($folderName);
+                    } catch (UnableToDeleteDirectory) {
+                        // Directory may have already been deleted by another process
                     }
                 }
             }

--- a/bundles/ApplicationLoggerBundle/src/Maintenance/LogArchiveTask.php
+++ b/bundles/ApplicationLoggerBundle/src/Maintenance/LogArchiveTask.php
@@ -104,8 +104,13 @@ class LogArchiveTask implements TaskInterface
                 if ($filePath !== null) {
                     try {
                         $storage->delete($filePath);
-                    } catch (UnableToDeleteFile) {
-                        // File may have already been deleted by another process
+                    } catch (UnableToDeleteFile $e) {
+                        if ($storage->fileExists($filePath)) {
+                            $this->logger->warning('Unable to delete log file object: ' . $e->getMessage());
+
+                            throw $e;
+                        }
+                        // File was already deleted (race condition) — safe to ignore
                     }
                 }
             }
@@ -133,8 +138,13 @@ class LogArchiveTask implements TaskInterface
 
                     try {
                         $storage->deleteDirectory($folderName);
-                    } catch (UnableToDeleteDirectory) {
-                        // Directory may have already been deleted by another process
+                    } catch (UnableToDeleteDirectory $e) {
+                        if ($storage->directoryExists($folderName)) {
+                            $this->logger->warning('Unable to delete log archive directory: ' . $e->getMessage());
+
+                            throw $e;
+                        }
+                        // Directory was already deleted (race condition) — safe to ignore
                     }
                 }
             }

--- a/models/Version/Adapter/FileSystemVersionStorageAdapter.php
+++ b/models/Version/Adapter/FileSystemVersionStorageAdapter.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Model\Version\Adapter;
 
 use League\Flysystem\FilesystemOperator;
+use League\Flysystem\UnableToDeleteFile;
 use League\Flysystem\UnableToReadFile;
 use Pimcore\Config;
 use Pimcore\File;
@@ -114,13 +115,19 @@ class FileSystemVersionStorageAdapter implements VersionStorageAdapterInterface
         $storageFileName = $this->getStorageFilename($version->getId(), $version->getCid(), $version->getCtype());
 
         $storagePath = dirname($storageFileName);
-        if ($this->storage->fileExists($storageFileName)) {
+        try {
             $this->storage->delete($storageFileName);
             File::recursiveDeleteEmptyDirs($this->storage, $storagePath);
+        } catch (UnableToDeleteFile) {
+            // File may have already been deleted by another process
         }
 
-        if ($this->storage->fileExists($binaryStoragePath) && !$isBinaryHashInUse) {
-            $this->storage->delete($binaryStoragePath);
+        if (!$isBinaryHashInUse) {
+            try {
+                $this->storage->delete($binaryStoragePath);
+            } catch (UnableToDeleteFile) {
+                // File may have already been deleted by another process
+            }
         }
     }
 

--- a/models/Version/Adapter/FileSystemVersionStorageAdapter.php
+++ b/models/Version/Adapter/FileSystemVersionStorageAdapter.php
@@ -18,6 +18,7 @@ use League\Flysystem\UnableToDeleteFile;
 use League\Flysystem\UnableToReadFile;
 use Pimcore\Config;
 use Pimcore\File;
+use Pimcore\Logger;
 use Pimcore\Model\Version;
 use Pimcore\Tool\Storage;
 
@@ -118,15 +119,25 @@ class FileSystemVersionStorageAdapter implements VersionStorageAdapterInterface
         try {
             $this->storage->delete($storageFileName);
             File::recursiveDeleteEmptyDirs($this->storage, $storagePath);
-        } catch (UnableToDeleteFile) {
-            // File may have already been deleted by another process
+        } catch (UnableToDeleteFile $e) {
+            if ($this->storage->fileExists($storageFileName)) {
+                Logger::warning('Unable to delete version file: ' . $e->getMessage());
+
+                throw $e;
+            }
+            // File was already deleted (race condition) — safe to ignore
         }
 
         if (!$isBinaryHashInUse) {
             try {
                 $this->storage->delete($binaryStoragePath);
-            } catch (UnableToDeleteFile) {
-                // File may have already been deleted by another process
+            } catch (UnableToDeleteFile $e) {
+                if ($this->storage->fileExists($binaryStoragePath)) {
+                    Logger::warning('Unable to delete version binary file: ' . $e->getMessage());
+
+                    throw $e;
+                }
+                // File was already deleted (race condition) — safe to ignore
             }
         }
     }

--- a/tests/Unit/Models/Version/Adapter/FileSystemVersionStorageAdapterDeleteTest.php
+++ b/tests/Unit/Models/Version/Adapter/FileSystemVersionStorageAdapterDeleteTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Models\Version\Adapter;
+
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\UnableToDeleteFile;
+use Pimcore\Model\Version;
+use Pimcore\Model\Version\Adapter\FileSystemVersionStorageAdapter;
+use Pimcore\Tests\Support\Test\TestCase;
+
+class FileSystemVersionStorageAdapterDeleteTest extends TestCase
+{
+    private function createAdapter(FilesystemOperator $storage): FileSystemVersionStorageAdapter
+    {
+        $adapter = new \ReflectionClass(FileSystemVersionStorageAdapter::class);
+        $instance = $adapter->newInstanceWithoutConstructor();
+
+        $prop = $adapter->getProperty('storage');
+        $prop->setAccessible(true);
+        $prop->setValue($instance, $storage);
+
+        return $instance;
+    }
+
+    private function createVersion(int $id = 1, int $cid = 1, string $ctype = 'object'): Version
+    {
+        $version = new Version();
+        $version->setId($id);
+        $version->setCid($cid);
+        $version->setCtype($ctype);
+
+        return $version;
+    }
+
+    public function testDeleteIgnoresAlreadyDeletedFile(): void
+    {
+        $storage = $this->createMock(FilesystemOperator::class);
+
+        $storage->expects($this->once())
+            ->method('delete')
+            ->willThrowException(UnableToDeleteFile::atLocation('test/path'));
+
+        // File no longer exists — race condition, should be silently ignored
+        $storage->method('fileExists')
+            ->willReturn(false);
+
+        $adapter = $this->createAdapter($storage);
+        $version = $this->createVersion();
+
+        // Should not throw
+        $adapter->delete($version, true);
+    }
+
+    public function testDeleteRethrowsWhenFileStillExists(): void
+    {
+        $storage = $this->createMock(FilesystemOperator::class);
+
+        $storage->expects($this->once())
+            ->method('delete')
+            ->willThrowException(UnableToDeleteFile::atLocation('test/path', 'Permission denied'));
+
+        // File still exists — real error, should rethrow
+        $storage->method('fileExists')
+            ->willReturn(true);
+
+        $adapter = $this->createAdapter($storage);
+        $version = $this->createVersion();
+
+        $this->expectException(UnableToDeleteFile::class);
+        $adapter->delete($version, true);
+    }
+
+    public function testDeleteBinaryFileIgnoresAlreadyDeleted(): void
+    {
+        $storage = $this->createMock(FilesystemOperator::class);
+
+        $callCount = 0;
+        $storage->method('delete')
+            ->willReturnCallback(function () use (&$callCount) {
+                $callCount++;
+                if ($callCount === 2) {
+                    throw UnableToDeleteFile::atLocation('test/path.bin');
+                }
+            });
+
+        // First call (metadata file) succeeds, second call (binary) throws
+        $storage->method('fileExists')
+            ->willReturn(false);
+
+        $adapter = $this->createAdapter($storage);
+        $version = $this->createVersion();
+
+        // Should not throw — binary file already gone
+        $adapter->delete($version, false);
+    }
+
+    public function testDeleteBinaryFileRethrowsOnRealError(): void
+    {
+        $storage = $this->createMock(FilesystemOperator::class);
+
+        $callCount = 0;
+        $storage->method('delete')
+            ->willReturnCallback(function () use (&$callCount) {
+                $callCount++;
+                if ($callCount === 2) {
+                    throw UnableToDeleteFile::atLocation('test/path.bin', 'Permission denied');
+                }
+            });
+
+        $storage->method('fileExists')
+            ->willReturnCallback(function (string $path) {
+                // Binary file still exists — real error
+                return str_ends_with($path, '.bin');
+            });
+
+        $adapter = $this->createAdapter($storage);
+        $version = $this->createVersion();
+
+        $this->expectException(UnableToDeleteFile::class);
+        $adapter->delete($version, false);
+    }
+}


### PR DESCRIPTION
## Problem

Both `LogArchiveTask` and `FileSystemVersionStorageAdapter` have TOCTOU (time-of-check-time-of-use) race conditions where they check if a file/directory exists before deleting it. If another process deletes the file between the check and the delete call, an `UnableToDeleteFile` or `UnableToDeleteDirectory` exception is thrown.

**LogArchiveTask** (#18973): When multiple archive tasks run concurrently, one may delete a file object while another is about to delete the same file.

**FileSystemVersionStorageAdapter** (#18971): When a version file is deleted externally (or by another process) before the cleanup task runs, the delete call fails.

## Root Cause

The `fileExists()`/`directoryExists()` check followed by `delete()`/`deleteDirectory()` is not atomic — another process can delete the file between these two calls.

## Solution

Replace the check-then-delete pattern with a try-catch approach:
- Attempt the delete directly
- Catch `UnableToDeleteFile` / `UnableToDeleteDirectory` exceptions
- Silently continue since the desired state (file deleted) is already achieved

This makes the operations idempotent and race-condition-free.

Fixes pimcore/pimcore#18973
Fixes pimcore/platform-version#310