### PR TITLE
Update branch alias in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -209,7 +209,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-12.x": "12.3.x-dev"
+      "dev-2026.x": "12.x-dev"
     }
   },
   "scripts": {


### PR DESCRIPTION
This pull request makes a minor update to the `composer.json` file, changing the branch alias from `dev-12.x` to `dev-2026.x` and updating the alias target to `12.x-dev`. This helps maintain correct branch versioning for Composer.

