### PR TITLE
Fix incorrect handling of inherited editables in PageSnippet (#18996)

### DIFF
--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -464,8 +464,11 @@ abstract class PageSnippet extends Model\Document
 
             if (self::getGetInheritedValues() && $this->supportsContentMain() && $this->getContentMainDocument()) {
                 $contentMainEditables = $this->getContentMainDocument()->getEditables();
+                foreach ($contentMainEditables as $editable) {
+                    $editable->setInherited(true);
+                }
                 $documentEditables = array_merge($contentMainEditables, $documentEditables);
-                $this->inheritedEditables = $documentEditables;
+                $this->inheritedEditables = $contentMainEditables;
             }
 
             $this->setEditables($documentEditables);

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -464,8 +464,10 @@ abstract class PageSnippet extends Model\Document
 
             if (self::getGetInheritedValues() && $this->supportsContentMain() && $this->getContentMainDocument()) {
                 $contentMainEditables = $this->getContentMainDocument()->getEditables();
-                foreach ($contentMainEditables as $editable) {
-                    $editable->setInherited(true);
+                foreach ($contentMainEditables as $key => $inheritedEditable) {
+                    $inheritedEditable = clone $inheritedEditable;
+                    $inheritedEditable->setInherited(true);
+                    $contentMainEditables[$key] = $inheritedEditable;
                 }
                 $documentEditables = array_merge($contentMainEditables, $documentEditables);
                 $this->inheritedEditables = $contentMainEditables;


### PR DESCRIPTION
## Changes in this pull request  
Resolves #18996

## Additional info
This PR fixes incorrect handling of inherited editables in
`\Pimcore\Model\Document\PageSnippet`

It is a follow-up to #14085.

### Problem

#### 1. Inherited editables are not flagged correctly

PageSnippet::getEditables() loads editables from the main document, but they are **not marked as inherited.**

When `Document\Page::setGetInheritedValues(true)` is enabled (e.g. in editmode), this leads to incorrect behavior:
	•	All returned editables are treated as local (non-inherited) values
	•	Inherited values may therefore be unintentionally overwritten

#### 2. Incorrect population of `$this->inheritedEditables`

Currently, $this->inheritedEditables contains **all editables,** including local ones.

However, in `PageSnippet::getEditable()`, the `$this->inheritedEditables` array is only accessed if the editable is not found locally.

Therefore:
	•	Storing local editables in `$this->inheritedEditables` is unnecessary
	•	It makes the inheritance logic misleading and inconsistent

#### Solution
	•	Properly mark inherited editables when loading them from the main document
	•	Ensure that `$this->inheritedEditables` only contains truly inherited editables

This restores consistent inheritance behavior and prevents unintended overwriting in editmode.