### PR TITLE
[Bug] Prevent database access in ReverseObjectRelation

### DIFF
--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -200,7 +200,7 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
 
     public function getClasses(): array
     {
-        if ($this->getOwnerClassId()) {
+        if ($this->ownerClassName) {
             return Model\Element\Service::fixAllowedTypes([$this->ownerClassName], 'classes');
         }
 


### PR DESCRIPTION
## Steps to reproduce

* Create a data object with a reverse relation
* Run `pimcore:build:classes` without a database connection
* You will get an error: "Reverse relation <myRelation> has no owner class assigned" and the type annotation in the generated PHP class will be invalid

## Reasoning

The `ReverseObjectRelation::getOwnerClassId()` method uses `\Pimcore\Model\DataObject\ClassDefinition::getByName()`. This fails if there is no database connection.

The method never uses the result of `getOwnerClassId()`, it uses the `ownerClassName` property. Therefore the if condition now checks that property instead of calling the method.


