### PR TITLE
Fix/link-get-html-fallback

### DIFF
--- a/models/DataObject/Data/Link.php
+++ b/models/DataObject/Data/Link.php
@@ -412,7 +412,11 @@ class Link implements OwnerAwareFieldInterface
         $text = $this->getText();
 
         if (empty($text)) {
-            return '';
+            $text = $this->getHref();
+
+            if (empty($text)) {
+                return '';
+            }
         }
 
         return '<a href="' . $this->getHref() . '" ' . implode(' ', $attribs) . '>' . htmlspecialchars($text) . '</a>';

--- a/models/DataObject/Data/Link.php
+++ b/models/DataObject/Data/Link.php
@@ -409,12 +409,15 @@ class Link implements OwnerAwareFieldInterface
             $attribs[] = $this->getAttributes();
         }
 
+        $href = $this->getHref();
         $text = $this->getText();
 
-        if (empty($text)) {
-            $text = $this->getHref();
+        // Fall back to the URL as visible text when no text is set.
+        // Use a strict check so a legitimate "0" text is not treated as empty.
+        if ($text === '') {
+            $text = $href;
 
-            if (empty($text)) {
+            if ($text === '') {
                 return '';
             }
         }

--- a/tests/Model/DataType/LinkTest.php
+++ b/tests/Model/DataType/LinkTest.php
@@ -154,4 +154,28 @@ class LinkTest extends ModelTestCase
             $this->assertInstanceOf(TypeError::class, $e);
         }
     }
+
+    public function testGetHtmlWithText(): void
+    {
+        $link = new Link();
+        $link->setDirect('https://pimcore.com');
+        $link->setText('Pimcore');
+
+        $this->assertEquals('<a href="https://pimcore.com" >Pimcore</a>', $link->getHtml());
+    }
+
+    public function testGetHtmlFallsBackToHrefWhenTextIsEmpty(): void
+    {
+        $link = new Link();
+        $link->setDirect('https://pimcore.com');
+
+        $this->assertEquals('<a href="https://pimcore.com" >https://pimcore.com</a>', $link->getHtml());
+    }
+
+    public function testGetHtmlReturnsEmptyStringWhenNoTextAndNoHref(): void
+    {
+        $link = new Link();
+
+        $this->assertEmpty($link->getHtml());
+    }
 }

--- a/tests/Model/DataType/LinkTest.php
+++ b/tests/Model/DataType/LinkTest.php
@@ -178,4 +178,16 @@ class LinkTest extends ModelTestCase
 
         $this->assertEmpty($link->getHtml());
     }
+
+
+    
+    public function testGetHtmlKeepsZeroAsText(): void
+    {
+        $link = new Link();
+        $link->setDirect('https://pimcore.com');
+        $link->setText('0');
+
+        // "0" is valid link text and must not be treated as empty / fall back to the href.
+        $this->assertEquals('<a href="https://pimcore.com" >0</a>', $link->getHtml());
+    }
 }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `12.3`
- Feature/Improvement: choose `2026.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`2026.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `12.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Fixed the Link getHtml() method returning no content at all if no LinkText is specified. Now it will use the URL as the link text if no link text is specified, and only return nothing if there is no valid URL either.

## Additional info
