### PR TITLE
 Fix Acknowledger LogicException in batch handlers that have no batching benefit

### DIFF
--- a/lib/Messenger/Handler/AssetPreviewImageHandler.php
+++ b/lib/Messenger/Handler/AssetPreviewImageHandler.php
@@ -67,6 +67,12 @@ class AssetPreviewImageHandler implements BatchHandlerInterface
     // @phpstan-ignore-next-line
     private function shouldFlush(): bool
     {
-        return 5 <= count($this->jobs);
+        // Each job is processed independently with no cross-job aggregation, so there
+        // is no benefit to accumulating a batch. Flushing immediately prevents
+        // Acknowledgers from sitting unresolved in memory, which causes a
+        // LogicException in their destructor if the worker exits before the batch
+        // threshold is reached (regression introduced by symfony/messenger v6.4.32,
+        // see https://github.com/symfony/symfony/pull/62872).
+        return (bool) $this->jobs;
     }
 }

--- a/lib/Messenger/Handler/OptimizeImageHandler.php
+++ b/lib/Messenger/Handler/OptimizeImageHandler.php
@@ -69,6 +69,12 @@ class OptimizeImageHandler implements BatchHandlerInterface
     // @phpstan-ignore-next-line
     private function shouldFlush(): bool
     {
-        return 100 <= count($this->jobs);
+        // Each job is processed independently with no cross-job aggregation, so there
+        // is no benefit to accumulating a batch. Flushing immediately prevents
+        // Acknowledgers from sitting unresolved in memory, which causes a
+        // LogicException in their destructor if the worker exits before the batch
+        // threshold is reached (regression introduced by symfony/messenger v6.4.32,
+        // see https://github.com/symfony/symfony/pull/62872).
+        return (bool) $this->jobs;
     }
 }

--- a/lib/Messenger/Handler/VersionDeleteHandler.php
+++ b/lib/Messenger/Handler/VersionDeleteHandler.php
@@ -62,4 +62,16 @@ class VersionDeleteHandler implements BatchHandlerInterface
             }
         }
     }
+
+    // @phpstan-ignore-next-line
+    private function shouldFlush(): bool
+    {
+        // Each job is processed independently with no cross-job aggregation, so there
+        // is no benefit to accumulating a batch. Flushing immediately prevents
+        // Acknowledgers from sitting unresolved in memory, which causes a
+        // LogicException in their destructor if the worker exits before the batch
+        // threshold is reached (regression introduced by symfony/messenger v6.4.32,
+        // see https://github.com/symfony/symfony/pull/62872).
+        return (bool) $this->jobs;
+    }
 }


### PR DESCRIPTION
 ## Problem

  `symfony/messenger` v6.4.32 changed `BatchHandlerTrait::flush()` via [symfony/symfony#62872](https://github.com/symfony/symfony/pull/62872): idle-time calls to `flush(false)` no longer  process partial batches - they now return early if `shouldFlush()` is false. Before that change, partial batches were always drained on idle, so Acknowledgers had a very short lifetime. After it, they accumulate in the handler service until the configured threshold is reached or the worker shuts down cleanly via `flush(true)`.

If the worker process exits before either condition is met (OOM, SIGKILL, unhandled fatal, etc.), every pending Acknowledger is garbage-collected without being called and its destructor throws:

Symfony\Component\Messenger\Exception\LogicException:
"The acknowledger was not called by the … batch handler."

This affects `VersionDeleteHandler`, `AssetPreviewImageHandler` and `OptimizeImageHandler` — all three process each job independently with no cross-job aggregation, so the batch threshold (10 / 5 / 100 respectively) served no purpose other than creating an unnecessary exposure window.

Related issues: #18960, #18965

## Fix

Override `shouldFlush()` to return `true` whenever any jobs are pending. This causes `BatchHandlerTrait::handle()` to call `flush(true)` after each message, eliminating the accumulation window entirely while keeping the `BatchHandlerInterface` contract intact.

## Not fixed; requires discussion

`SearchBackendHandler`, `SanityCheckHandler` and `CleanupThumbnailsHandler` are intentionally not changed here - they use `filterUnique()` for cross-job deduplication, which is only effective when multiple messages are held in the same  batch. The right fix for those involves a trade-off that deserves a separate discussion.

## Symfony Fix?

[symfony/symfony#63277](https://github.com/symfony/symfony/pull/63277) adds `getIdleTimeout()` to `BatchHandlerTrait`,  which would be the correct general solution. However it was merged into the `8.1` branch only and is labelled as a *Feature*, not a bug fix. Symfony 6.4 is in LTS maintenance mode and only receives security and critical bug fixes, making a backport very unlikely. The provided PR tackles at least those jobs not presently involving a trade off (`filterUnique`)

## Testing

Verified on Pimcore 11.5.14.1 with `symfony/messenger` v6.4.32. The fix applies identically to 12.3 - the affected handler files are unchanged between branches.