### PR TITLE
Fix objectbrick container class written to wrong directory

### DIFF
--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -470,7 +470,7 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
      */
     public function getContainerClassFolder(string $classname): string
     {
-        return PIMCORE_CLASS_DEFINITION_DIRECTORY . '/DataObject/' . ucfirst($classname);
+        return PIMCORE_CLASS_DIRECTORY . '/DataObject/' . ucfirst($classname);
     }
 
     /**


### PR DESCRIPTION
## Changes in this pull request
Resolves #18934

`getContainerClassFolder()` uses `PIMCORE_CLASS_DEFINITION_DIRECTORY` instead of `PIMCORE_CLASS_DIRECTORY`, causing generated objectbrick container classes to be written to the definitions directory when `PIMCORE_CLASS_DEFINITION_DIRECTORY` is overridden.

Corrects the constant to `PIMCORE_CLASS_DIRECTORY`, which is the intended constant for generated class files.

## Additional info

### How to reproduce
1. Override `PIMCORE_CLASS_DEFINITION_DIRECTORY` in `config/pimcore/constants.php`:
   ```php
   const PIMCORE_CLASS_DEFINITION_DIRECTORY = PIMCORE_PROJECT_ROOT . '/config/pimcore/classes';
   ```
2. Create a data object class with an objectbrick field
3. Save the objectbrick definition
4. Container class files appear in `config/pimcore/classes/DataObject/` instead of `var/classes/DataObject/`

### Root cause
PR #18809 changed the constant from `PIMCORE_CLASS_DIRECTORY` to `PIMCORE_CUSTOM_CONFIGURATION_DIRECTORY`. PR #18815 attempted to fix it but used `PIMCORE_CLASS_DEFINITION_DIRECTORY` instead of the correct `PIMCORE_CLASS_DIRECTORY`.

Container classes are generated PHP files (like `getPhpClassFile()` which uses `PIMCORE_CLASS_DIRECTORY` via `locateFile()`), not definition files.
