### PR TITLE
[Bug]: Implement null check for className in Document.php

### DIFF
--- a/models/Document.php
+++ b/models/Document.php
@@ -73,7 +73,7 @@ class Document extends Element\AbstractElement
     protected ?int $userModification = null;
 
     /**
-     * @internal'newsletter'
+     * @internal
      *
      * @var array<string, Listing>
      */

--- a/models/Document.php
+++ b/models/Document.php
@@ -73,7 +73,7 @@ class Document extends Element\AbstractElement
     protected ?int $userModification = null;
 
     /**
-     * @internal
+     * @internal'newsletter'
      *
      * @var array<string, Listing>
      */
@@ -212,6 +212,9 @@ class Document extends Element\AbstractElement
             // Getting classname from document resolver
             $className = Pimcore::getContainer()->get('pimcore.class.resolver.document')->resolve($document->getType());
 
+            if (!$className){
+                return null;
+            }
             /** @var Document $newDocument */
             $newDocument = self::getModelFactory()->build($className);
 


### PR DESCRIPTION
Add null check for className in document resolver

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `12.3`
- Feature/Improvement: choose `2026.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`2026.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `12.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves `An exception has been thrown during the rendering of a template (&quot;Pimcore\Model\Factory::build(): Argument #1 ($name) must be of type string, null given, called in /var/www/html/vendor/pimcore/pimcore/models/Document.php on line 216`

## Additional info
Happens if you have a document with type `newsletter` and then deactivate the newsletter bundle

Casually encountered this issue when trying to work on demo 2026.1 and the dump still had some newsletter related documents