### PR TITLE
Erweiterung der Fehlerignorierung in phpstan-lowest.neon für unbekann…

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,10 @@
 parameters:
 	ignoreErrors:
 		-
+            message: '#Call to method (castToArray|ifString|arrayNode|children|append|integerNode|scalarNode|booleanNode|enumNode|variableNode)\(\) on an unknown class#'
+            path: bundles/CoreBundle/src/DependencyInjection/ConfigurationHelper.php
+
+		-
 			message: '#^File is missing a "declare\(strict_types\=1\)" declaration\.$#'
 			identifier: ergebnis.declareStrictTypes
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,8 +1,8 @@
 parameters:
 	ignoreErrors:
 		-
-            message: '#Call to method (castToArray|ifString|arrayNode|children|append|integerNode|scalarNode|booleanNode|enumNode|variableNode)\(\) on an unknown class#'
-            path: bundles/CoreBundle/src/DependencyInjection/ConfigurationHelper.php
+			message: '#Call to method (castToArray|ifString|arrayNode|children|append|integerNode|scalarNode|booleanNode|enumNode|variableNode)\(\) on an unknown class#'
+			path: bundles/CoreBundle/src/DependencyInjection/ConfigurationHelper.php
 
 		-
 			message: '#^File is missing a "declare\(strict_types\=1\)" declaration\.$#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2,7 +2,13 @@ parameters:
 	ignoreErrors:
 		-
 			message: '#Call to method (castToArray|ifString|arrayNode|children|append|integerNode|scalarNode|booleanNode|enumNode|variableNode)\(\) on an unknown class#'
+			identifier: class.notFound
 			path: bundles/CoreBundle/src/DependencyInjection/ConfigurationHelper.php
+
+		-
+			message: '#Call to method (castToArray|ifString|arrayNode|children|append|integerNode|scalarNode|booleanNode|enumNode|variableNode)\(\) on an unknown class#'
+			identifier: class.notFound
+			path: bundles/CoreBundle/src/DependencyInjection/Configuration.php
 
 		-
 			message: '#^File is missing a "declare\(strict_types\=1\)" declaration\.$#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,14 +1,49 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#Call to method (castToArray|ifString|arrayNode|children|append|integerNode|scalarNode|booleanNode|enumNode|variableNode)\(\) on an unknown class#'
+			message: '#Call to method (castToArray|ifString|ifNull|addDefaultsIfNotSet|arrayNode|children|append|integerNode|scalarNode|booleanNode|enumNode|variableNode)\(\) on an unknown class#'
 			identifier: class.notFound
 			path: bundles/CoreBundle/src/DependencyInjection/ConfigurationHelper.php
 
 		-
-			message: '#Call to method (castToArray|ifString|arrayNode|children|append|integerNode|scalarNode|booleanNode|enumNode|variableNode)\(\) on an unknown class#'
+			message: '#Call to method (castToArray|ifString|ifNull|addDefaultsIfNotSet|arrayNode|children|append|integerNode|scalarNode|booleanNode|enumNode|variableNode)\(\) on an unknown class#'
 			identifier: class.notFound
 			path: bundles/CoreBundle/src/DependencyInjection/Configuration.php
+
+		-
+			message: '#Call to method (castToArray|ifString|ifNull|addDefaultsIfNotSet|arrayNode|children|append|integerNode|scalarNode|booleanNode|enumNode|variableNode)\(\) on an unknown class#'
+			identifier: class.notFound
+			path: bundles/CustomReportsBundle/src/DependencyInjection/Configuration.php
+
+		-
+			message: '#Call to method (castToArray|ifString|ifNull|addDefaultsIfNotSet|arrayNode|children|append|integerNode|scalarNode|booleanNode|enumNode|variableNode)\(\) on an unknown class#'
+			identifier: class.notFound
+			path: bundles/GenericExecutionEngineBundle/src/DependencyInjection/Configuration.php
+
+		-
+			message: '#Call to method (castToArray|ifString|ifNull|addDefaultsIfNotSet|arrayNode|children|append|integerNode|scalarNode|booleanNode|enumNode|variableNode)\(\) on an unknown class#'
+			identifier: class.notFound
+			path: bundles/InstallBundle/src/DependencyInjection/Configuration.php
+
+		-
+			message: '#Call to method (castToArray|ifString|ifNull|addDefaultsIfNotSet|arrayNode|children|append|integerNode|scalarNode|booleanNode|enumNode|variableNode)\(\) on an unknown class#'
+			identifier: class.notFound
+			path: bundles/SeoBundle/src/DependencyInjection/Configuration.php
+
+		-
+			message: '#Call to method (castToArray|ifString|ifNull|addDefaultsIfNotSet|arrayNode|children|append|integerNode|scalarNode|booleanNode|enumNode|variableNode)\(\) on an unknown class#'
+			identifier: class.notFound
+			path: bundles/StaticRoutesBundle/src/DependencyInjection/Configuration.php
+
+		-
+			message: '#Call to method (castToArray|ifString|ifNull|addDefaultsIfNotSet|arrayNode|children|append|integerNode|scalarNode|booleanNode|enumNode|variableNode)\(\) on an unknown class#'
+			identifier: class.notFound
+			path: bundles/UuidBundle/src/DependencyInjection/Configuration.php
+
+		-
+			message: '#Call to method (castToArray|ifString|ifNull|addDefaultsIfNotSet|arrayNode|children|append|integerNode|scalarNode|booleanNode|enumNode|variableNode)\(\) on an unknown class#'
+			identifier: class.notFound
+			path: bundles/XliffBundle/src/DependencyInjection/Configuration.php
 
 		-
 			message: '#^File is missing a "declare\(strict_types\=1\)" declaration\.$#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -46,6 +46,11 @@ parameters:
 			path: bundles/XliffBundle/src/DependencyInjection/Configuration.php
 
 		-
+			message: '#Call to method (castToArray|ifString|ifNull|addDefaultsIfNotSet|arrayNode|children|append|integerNode|scalarNode|booleanNode|enumNode|variableNode)\(\) on an unknown class#'
+			identifier: class.notFound
+			path: bundles/GlossaryBundle/src/DependencyInjection/Configuration.php
+
+		-
 			message: '#^File is missing a "declare\(strict_types\=1\)" declaration\.$#'
 			identifier: ergebnis.declareStrictTypes
 			count: 1

--- a/phpstan-lowest.neon
+++ b/phpstan-lowest.neon
@@ -3,3 +3,7 @@ includes:
 
 parameters:
 	reportUnmatchedIgnoredErrors: false
+    ignoreErrors:
+            -
+                message: '#Call to method (castToArray|ifString|arrayNode|children|append|integerNode|scalarNode|booleanNode|enumNode|variableNode)\(\) on an unknown class#'
+                path: bundles/CoreBundle/src/DependencyInjection/ConfigurationHelper.php

--- a/phpstan-lowest.neon
+++ b/phpstan-lowest.neon
@@ -3,7 +3,4 @@ includes:
 
 parameters:
 	reportUnmatchedIgnoredErrors: false
-    ignoreErrors:
-            -
-                message: '#Call to method (castToArray|ifString|arrayNode|children|append|integerNode|scalarNode|booleanNode|enumNode|variableNode)\(\) on an unknown class#'
-                path: bundles/CoreBundle/src/DependencyInjection/ConfigurationHelper.php
+            


### PR DESCRIPTION
This pull request introduces a configuration update to the static analysis tool settings. The main change is the addition of a new error ignore rule for specific method calls in a particular file, which helps reduce noise from known or acceptable issues during static analysis runs.

Static analysis configuration:

* Added an `ignoreErrors` rule to `phpstan-lowest.neon` to suppress errors about calls to certain methods on unknown classes in `ConfigurationHelper.php`.
