### PR TITLE
[SeoBundle: Redirects] Do not set expiry date for redirects which get automatically created due to path changes

### DIFF
--- a/bundles/SeoBundle/src/EventListener/DocumentListener.php
+++ b/bundles/SeoBundle/src/EventListener/DocumentListener.php
@@ -148,7 +148,6 @@ class DocumentListener implements EventSubscriberInterface
         $redirect->setTarget((string) $targetId);
         $redirect->setSource($source);
         $redirect->setStatusCode(301);
-        $redirect->setExpiry(time() + 86400 * 365); // this entry is removed automatically after 1 year
 
         if ($sourceSite) {
             $redirect->setSourceSite($sourceSite->getId());


### PR DESCRIPTION
When you move / rename a document, a redirect for the previous url can get created. This ensures that the old URLs still work. But it sets a hard-coded expiry date for this redirect for 1 year. Afterwards, this redirect will not get applied anymore and instead the users get a 404 error.

This is problematic for 3 reasons:
1. Links somewhere on the internet referring to the old URLs can often not be changed. So from user perspective, the content will not be accessible anymore and from SEO perspective, the document will not get any link juice.
2. If an agency context, clients will get angry that without any action, things which have worked in the past, now do not work anymore.
3. the comment when the expiry date gets set says "this entry is removed automatically after 1 year" -> this is luckily not true, so that one can remove / extend expiry date.

For those reasons, this PR drops setting expiry date for redirects which get created due to moving / renaming documents. It does not touch existing expiry dates.