### PR TITLE
Security/dependency dao param binding backport

### DIFF
--- a/models/Dependency/Dao.php
+++ b/models/Dependency/Dao.php
@@ -76,7 +76,7 @@ class Dao extends Model\Dao\AbstractDao
             throw new SuspiciousOperationException('Illegal source type ' . $this->model->getSourceType());
         }
 
-        if (!in_array($orderBy, ['id', 'type', 'path'])) {
+        if (!in_array($orderBy, ['id', 'type'])) {
             $orderBy = 'id';
         }
 
@@ -140,7 +140,7 @@ class Dao extends Model\Dao\AbstractDao
             throw new SuspiciousOperationException('Illegal source type ' . $this->model->getSourceType());
         }
 
-        if (!in_array($orderBy, ['id', 'type', 'path'])) {
+        if (!in_array($orderBy, ['id', 'type'])) {
             $orderBy = 'id';
         }
 
@@ -154,17 +154,17 @@ class Dao extends Model\Dao\AbstractDao
         FROM (
             SELECT d.sourceid AS id, d.sourcetype AS type
             FROM dependencies d
-            INNER JOIN objects o ON o.id = d.sourceid AND d.targettype = 'object'
+            INNER JOIN objects o ON o.id = d.sourceid AND d.sourcetype = 'object'
             WHERE d.targettype = :targetType AND d.targetid = :targetId AND LOWER(CONCAT(o.path, o.key)) RLIKE :value
             UNION
             SELECT d.sourceid AS id, d.sourcetype AS type
             FROM dependencies d
-            INNER JOIN documents doc ON doc.id = d.sourceid AND d.targettype = 'document'
+            INNER JOIN documents doc ON doc.id = d.sourceid AND d.sourcetype = 'document'
             WHERE d.targettype = :targetType AND d.targetid = :targetId AND LOWER(CONCAT(doc.path, doc.key)) RLIKE :value
             UNION
             SELECT d.sourceid AS id, d.sourcetype AS type
             FROM dependencies d
-            INNER JOIN assets a ON a.id = d.sourceid AND d.targettype = 'asset'
+            INNER JOIN assets a ON a.id = d.sourceid AND d.sourcetype = 'asset'
             WHERE d.targettype = :targetType AND d.targetid = :targetId AND LOWER(CONCAT(a.path, a.filename)) RLIKE :value
         ) dep
         ORDER BY " . $orderBy . ' ' . $orderDirection;
@@ -348,28 +348,38 @@ class Dao extends Model\Dao\AbstractDao
         $query = "
             SELECT id, type, path
             FROM (
-                SELECT d.sourceid as id, d.sourcetype as `type`, CONCAT(o.path, o.key) as `path`
+                SELECT d.sourceid AS id, d.sourcetype AS `type`, CONCAT(o.path, o.key) AS `path`
                 FROM dependencies d
                 JOIN objects o ON o.id = d.sourceid
-                WHERE d.targettype = '" . $targetType. "' AND d.targetid = " . $targetId . " AND d.sourceType = 'object'
+                WHERE d.targettype = :targetType AND d.targetid = :targetId AND d.sourceType = 'object'
                 UNION
-                SELECT d.sourceid as id, d.sourcetype as `type`, CONCAT(doc.path, doc.key) as `path`
+                SELECT d.sourceid AS id, d.sourcetype AS `type`, CONCAT(doc.path, doc.key) AS `path`
                 FROM dependencies d
                 JOIN documents doc ON doc.id = d.sourceid
-                WHERE d.targettype = '" . $targetType. "' AND d.targetid = " . $targetId . " AND d.sourceType = 'document'
+                WHERE d.targettype = :targetType AND d.targetid = :targetId AND d.sourceType = 'document'
                 UNION
-                SELECT d.sourceid as id, d.sourcetype as `type`, CONCAT(a.path, a.filename) as `path`
+                SELECT d.sourceid AS id, d.sourcetype AS `type`, CONCAT(a.path, a.filename) AS `path`
                 FROM dependencies d
                 JOIN assets a ON a.id = d.sourceid
-                WHERE d.targettype = '" . $targetType. "' AND d.targetid = " . $targetId . " AND d.sourceType = 'asset'
+                WHERE d.targettype = :targetType AND d.targetid = :targetId AND d.sourceType = 'asset'
             ) dep
             ORDER BY " . $orderBy . ' ' . $orderDirection;
+
+        $params = [
+            'targetType' => $targetType,
+            'targetId'   => $targetId,
+        ];
+
+        $types = [
+            'targetType' => ParameterType::STRING,
+            'targetId'   => ParameterType::INTEGER,
+        ];
 
         if (is_int($offset) && is_int($limit)) {
             $query .= ' LIMIT ' . $offset . ', ' . $limit;
         }
 
-        return $this->db->fetchAllAssociative($query);
+        return $this->db->fetchAllAssociative($query, $params, $types);
     }
 
     /**

--- a/models/Dependency/Dao.php
+++ b/models/Dependency/Dao.php
@@ -16,6 +16,7 @@
 namespace Pimcore\Model\Dependency;
 
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\DBAL\ParameterType;
 use Exception;
 use Pimcore;
 use Pimcore\Db\Helper;
@@ -87,34 +88,40 @@ class Dao extends Model\Dao\AbstractDao
         $query = "
         SELECT id, type
         FROM (
-            SELECT d.targetid as id, d.targettype as type
+            SELECT d.targetid AS id, d.targettype AS type
             FROM dependencies d
-            INNER JOIN objects o ON o.id = d.targetid AND d.targettype= 'object'
-            WHERE d.sourcetype = '" . $sourceType. "' AND d.sourceid = " . $sourceId . " AND LOWER(CONCAT(o.path, o.key)) RLIKE '".$value."'
+            INNER JOIN objects o ON o.id = d.targetid AND d.targettype = 'object'
+            WHERE d.sourcetype = :sourceType AND d.sourceid = :sourceId AND LOWER(CONCAT(o.path, o.key)) RLIKE :value
             UNION
-            SELECT d.targetid as id, d.targettype as type
+            SELECT d.targetid AS id, d.targettype AS type
             FROM dependencies d
-            INNER JOIN documents doc ON doc.id = d.targetid AND d.targettype= 'document'
-            WHERE d.sourcetype = '" . $sourceType. "' AND d.sourceid = " . $sourceId . " AND LOWER(CONCAT(doc.path, doc.key)) RLIKE '".$value."'
+            INNER JOIN documents doc ON doc.id = d.targetid AND d.targettype = 'document'
+            WHERE d.sourcetype = :sourceType AND d.sourceid = :sourceId AND LOWER(CONCAT(doc.path, doc.key)) RLIKE :value
             UNION
-            SELECT d.targetid as id, d.targettype as type
+            SELECT d.targetid AS id, d.targettype AS type
             FROM dependencies d
-            INNER JOIN assets a ON a.id = d.targetid AND d.targettype= 'asset'
-            WHERE d.sourcetype = '" . $sourceType. "' AND d.sourceid = " . $sourceId . " AND LOWER(CONCAT(a.path, a.filename)) RLIKE '".$value."'
+            INNER JOIN assets a ON a.id = d.targetid AND d.targettype = 'asset'
+            WHERE d.sourcetype = :sourceType AND d.sourceid = :sourceId AND LOWER(CONCAT(a.path, a.filename)) RLIKE :value
         ) dep
         ORDER BY " . $orderBy . ' ' . $orderDirection;
+
+        $params = [
+            'sourceType' => $sourceType,
+            'sourceId'   => $sourceId,
+            'value'      => preg_quote((string) $value),
+        ];
+
+        $types = [
+            'sourceType' => ParameterType::STRING,
+            'sourceId'   => ParameterType::INTEGER,
+            'value'      => ParameterType::STRING,
+        ];
 
         if ($offset !== null && $limit !== null) {
             $query = sprintf($query . ' LIMIT %d,%d', $offset, $limit);
         }
 
-        $requiresByPath = $this->db->fetchAllAssociative($query);
-
-        if (count($requiresByPath) > 0) {
-            return $requiresByPath;
-        } else {
-            return [];
-        }
+        return $this->db->fetchAllAssociative($query, $params, $types);
     }
 
     public function getFilterRequiredByPath(
@@ -145,34 +152,40 @@ class Dao extends Model\Dao\AbstractDao
         $query = "
         SELECT id, type
         FROM (
-            SELECT d.sourceid as id, d.sourcetype as type
+            SELECT d.sourceid AS id, d.sourcetype AS type
             FROM dependencies d
-            INNER JOIN objects o ON o.id = d.sourceid AND d.targettype= 'object'
-            WHERE d.targettype = '" . $targetType. "' AND d.targetid = " . $targetId . " AND LOWER(CONCAT(o.path, o.key)) RLIKE '".$value."'
+            INNER JOIN objects o ON o.id = d.sourceid AND d.targettype = 'object'
+            WHERE d.targettype = :targetType AND d.targetid = :targetId AND LOWER(CONCAT(o.path, o.key)) RLIKE :value
             UNION
-            SELECT d.sourceid as id, d.sourcetype as type
+            SELECT d.sourceid AS id, d.sourcetype AS type
             FROM dependencies d
-            INNER JOIN documents doc ON doc.id = d.sourceid AND d.targettype= 'document'
-            WHERE d.targettype = '" . $targetType. "' AND d.targetid = " . $targetId . " AND LOWER(CONCAT(doc.path, doc.key)) RLIKE '".$value."'
+            INNER JOIN documents doc ON doc.id = d.sourceid AND d.targettype = 'document'
+            WHERE d.targettype = :targetType AND d.targetid = :targetId AND LOWER(CONCAT(doc.path, doc.key)) RLIKE :value
             UNION
-            SELECT d.sourceid as id, d.sourcetype as type
+            SELECT d.sourceid AS id, d.sourcetype AS type
             FROM dependencies d
-            INNER JOIN assets a ON a.id = d.sourceid AND d.targettype= 'asset'
-            WHERE d.targettype = '" . $targetType. "' AND d.targetid = " . $targetId . " AND LOWER(CONCAT(a.path, a.filename)) RLIKE '".$value."'
+            INNER JOIN assets a ON a.id = d.sourceid AND d.targettype = 'asset'
+            WHERE d.targettype = :targetType AND d.targetid = :targetId AND LOWER(CONCAT(a.path, a.filename)) RLIKE :value
         ) dep
         ORDER BY " . $orderBy . ' ' . $orderDirection;
+
+        $params = [
+            'targetType' => $targetType,
+            'targetId'   => $targetId,
+            'value'      => preg_quote((string) $value),
+        ];
+
+        $types = [
+            'targetType' => ParameterType::STRING,
+            'targetId'   => ParameterType::INTEGER,
+            'value'      => ParameterType::STRING,
+        ];
 
         if ($offset !== null && $limit !== null) {
             $query = sprintf($query . ' LIMIT %d,%d', $offset, $limit);
         }
 
-        $requiredByPath = $this->db->fetchAllAssociative($query);
-
-        if (count($requiredByPath) > 0) {
-            return $requiredByPath;
-        } else {
-            return [];
-        }
+        return $this->db->fetchAllAssociative($query, $params, $types);
     }
 
     /**


### PR DESCRIPTION
## Description

This PR backports the security fix from #18991 (merged into `12.3`) to the `11.5` maintenance branch, and extends the same fix to cover a third method that was missed in the original PR.

### What was fixed

`models/Dependency/Dao.php` contained raw SQL string interpolation in three methods, making them potentially vulnerable to SQL injection via the `$value` (RLIKE filter) parameter:

| Method | Status before | Status after |
|---|---|---|
| `getFilterRequiresByPath` | 🔴 Raw string interpolation | ✅ Named parameter binding |
| `getFilterRequiredByPath` | 🔴 Raw string interpolation | ✅ Named parameter binding |
| `getRequiredByWithPath` | 🟡 Raw string interpolation | ✅ Named parameter binding |

### Commit 1 — Backport from #18991

Cherry-pick of commit `1c3925fbec4895abeb21e5c244a83679c4e4a6f4` from `12.3` to `11.5`.

Fixes `getFilterRequiresByPath` and `getFilterRequiredByPath` by replacing raw `$sourceType`, `$sourceId`, `$value` / `$targetType`, `$targetId`, `$value` string interpolation with named Doctrine DBAL parameter binding (`:sourceType`, `:sourceId`, `:value`). The `$value` parameter is also wrapped with `preg_quote()` since it is used inside a `RLIKE` regex clause.

### Commit 2 — Extend fix to `getRequiredByWithPath`

The original PR #18991 did not cover `getRequiredByWithPath`, which used the same raw string interpolation pattern for `$targetType` and `$targetId`. While these values are validated against whitelists before use (making direct exploitation harder), the inconsistency leaves the door open to future regressions.

This commit applies the same named parameter binding pattern to `getRequiredByWithPath` for consistency and defense-in-depth.

## Related

- Original fix: #18991
- Original commit: `1c3925fbec4895abeb21e5c244a83679c4e4a6f4`
