### PR TITLE
[Task]: Add admin storage configuration to flysystem.yaml and follow up pimcore_admin.translations.path

### DIFF
--- a/bundles/CoreBundle/config/pimcore/flysystem.yaml
+++ b/bundles/CoreBundle/config/pimcore/flysystem.yaml
@@ -1,5 +1,12 @@
 flysystem:
     storages:
+        pimcore.admin.storage:
+            # Storage for shared admin resources, such as the user avatar, custom logos, ...
+            adapter: 'local'
+            visibility: private
+            options:
+                directory: '%kernel.project_dir%/var/admin'
+            
         pimcore.document_static.storage:
             # Storage for generated static document pages, e.g. .html files generated out of Pimcore documents
             # which are then delivered directly by the web-server

--- a/lib/Tool/Admin.php
+++ b/lib/Tool/Admin.php
@@ -37,31 +37,15 @@ class Admin
     {
         $languageDirs = [];
         $translatedLanguages = [];
-        $languages = [];
 
         $container = Pimcore::getContainer();
 
-        if ($container->hasParameter('pimcore_admin.translations.path')) {
-            $baseResource = $container->getParameter('pimcore_admin.translations.path');
-            $languageDir = Pimcore::getKernel()->locateResource($baseResource);
+        $appDefaultPath = $container->getParameter('translator.default_path');
 
-            if (is_dir($languageDir)) {
-                $languageDirs[] = $languageDir;
-            }
+        if (is_dir($appDefaultPath)) {
+            $languageDirs[] = $appDefaultPath;
         }
-
-        if ($container->hasParameter('translator.default_path')) {
-            $appDefaultPath = $container->getParameter('translator.default_path');
-
-            if (is_dir($appDefaultPath)) {
-                $languageDirs[] = $appDefaultPath;
-            }
-        }
-
-        $adminLanguages = $container->hasParameter('pimcore_admin.admin_languages')
-            ? $container->getParameter('pimcore_admin.admin_languages')
-            : [];
-
+        
         $localeService = $container->get(LocaleServiceInterface::class);
 
         foreach ($languageDirs as $filesDir) {
@@ -99,22 +83,7 @@ class Admin
             }
         }
 
-        $translatedLanguages = array_unique($translatedLanguages);
-
-        foreach ($adminLanguages as $adminLanguage) {
-            if (
-                in_array($adminLanguage, $translatedLanguages, true) ||
-                in_array(Locale::getPrimaryLanguage($adminLanguage), $translatedLanguages, true)
-            ) {
-                $languages[] = $adminLanguage;
-            }
-        }
-
-        if (empty($languages)) {
-            $languages = $translatedLanguages;
-        }
-
-        return array_unique($languages);
+        return array_unique($translatedLanguages);
     }
 
     public static function getMinimizedScriptPath(string $scriptContent): array


### PR DESCRIPTION
Added configuration for admin storage in flysystem.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `12.3`
- Feature/Improvement: choose `2026.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`2026.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `12.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/studio-backend-bundle/issues/1655

## Additional info
Moved this storage bucket into Core for 2026.x only, in 2025.4 the Admin UI is still required to work with Studio.

