### PR TITLE
Add default value for PIMCORE_MESSENGER_TRANSPORT_DSN

### DIFF
--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -1,5 +1,6 @@
 parameters:
     locale: en
+    env(PIMCORE_MESSENGER_TRANSPORT_DSN): 'doctrine://default'
     pimcore.messenger.transport_dsn: '%env(resolve:PIMCORE_MESSENGER_TRANSPORT_DSN)%'
     env(PIMCORE_ENCRYPTION_SECRET): ''
     env(PIMCORE_INSTANCE_IDENTIFIER): ''


### PR DESCRIPTION
## Summary

Adds a Symfony `env()` parameter default for `PIMCORE_MESSENGER_TRANSPORT_DSN` set to `doctrine://default`, so the messenger transports work out of the box without the installer having explicitly written this env var.

This covers minimal testing scenarios and setups where the installer is not used directly. The Doctrine transport is a safe default since it only requires the database connection which is always available.

## Related

- Follow-up to #19033 (installer profiles redesign)

## Changes

- `bundles/CoreBundle/config/pimcore/default.yaml`: Add `env(PIMCORE_MESSENGER_TRANSPORT_DSN): 'doctrine://default'` parameter default, consistent with the existing pattern for `PIMCORE_ENCRYPTION_SECRET`, `PIMCORE_INSTANCE_IDENTIFIER`, and `PIMCORE_PRODUCT_KEY`.