### PR TITLE
[Improvement] Rename PIMCORE_MESSENGER_TRANSPORT_DSN to PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX

### DIFF
--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -1,7 +1,7 @@
 parameters:
     locale: en
-    env(PIMCORE_MESSENGER_TRANSPORT_DSN): 'doctrine://default?queue_name='
-    pimcore.messenger.transport_dsn: '%env(resolve:PIMCORE_MESSENGER_TRANSPORT_DSN)%'
+    env(PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX): 'doctrine://default?queue_name='
+    pimcore.messenger.transport_dsn_prefix: '%env(resolve:PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX)%'
     env(PIMCORE_ENCRYPTION_SECRET): ''
     env(PIMCORE_INSTANCE_IDENTIFIER): ''
     env(PIMCORE_PRODUCT_KEY): ''
@@ -35,13 +35,13 @@ framework:
             main: native://default
     messenger:
         transports:
-            pimcore_core: "%pimcore.messenger.transport_dsn%pimcore_core"
-            pimcore_maintenance: "%pimcore.messenger.transport_dsn%pimcore_maintenance"
-            pimcore_scheduled_tasks: "%pimcore.messenger.transport_dsn%pimcore_scheduled_tasks"
-            pimcore_image_optimize: "%pimcore.messenger.transport_dsn%pimcore_image_optimize"
-            pimcore_asset_update: "%pimcore.messenger.transport_dsn%pimcore_asset_update"
+            pimcore_core: "%pimcore.messenger.transport_dsn_prefix%pimcore_core"
+            pimcore_maintenance: "%pimcore.messenger.transport_dsn_prefix%pimcore_maintenance"
+            pimcore_scheduled_tasks: "%pimcore.messenger.transport_dsn_prefix%pimcore_scheduled_tasks"
+            pimcore_image_optimize: "%pimcore.messenger.transport_dsn_prefix%pimcore_image_optimize"
+            pimcore_asset_update: "%pimcore.messenger.transport_dsn_prefix%pimcore_asset_update"
             #Dependency resolving is synchronous by default, use the following commented lines below (transports/routing) to make it async
-            #pimcore_dependencies: "%pimcore.messenger.transport_dsn%pimcore_dependencies"
+            #pimcore_dependencies: "%pimcore.messenger.transport_dsn_prefix%pimcore_dependencies"
         routing:
             'Pimcore\Messenger\VideoConvertMessage': pimcore_core
             'Pimcore\Messenger\CleanupThumbnailsMessage': pimcore_core

--- a/bundles/GenericExecutionEngineBundle/config/pimcore/config.yaml
+++ b/bundles/GenericExecutionEngineBundle/config/pimcore/config.yaml
@@ -16,6 +16,6 @@ framework:
         enabled: true
         transports:
             pimcore_generic_execution_engine:
-                dsn: '%pimcore.messenger.transport_dsn%pimcore_generic_execution_engine'
+                dsn: '%pimcore.messenger.transport_dsn_prefix%pimcore_generic_execution_engine'
                 retry_strategy:
                     max_retries: 0 # no retries to prevent data corruption

--- a/bundles/InstallBundle/src/EnvVarDefinition/Definitions/AmqpMessengerEnvVarDefinition.php
+++ b/bundles/InstallBundle/src/EnvVarDefinition/Definitions/AmqpMessengerEnvVarDefinition.php
@@ -22,7 +22,7 @@ use Pimcore\Bundle\InstallBundle\EnvVarDefinition\Validation\FormatValidator;
 /**
  * AMQP-based messenger transport definition.
  *
- * Writes PIMCORE_MESSENGER_TRANSPORT_DSN with an AMQP URL.
+ * Writes PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX with an AMQP URL.
  *
  * The DSN must end with a trailing "/" because Pimcore appends
  * queue names directly to this value in bundle YAML configs.
@@ -55,7 +55,7 @@ final readonly class AmqpMessengerEnvVarDefinition implements
     {
         return [
             new ConfigParameter(
-                'PIMCORE_MESSENGER_TRANSPORT_DSN',
+                'PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX',
                 'AMQP DSN',
                 ParameterType::Url,
                 defaultValue: 'amqp://guest:guest@127.0.0.1:5672/%2f/',
@@ -66,14 +66,14 @@ final readonly class AmqpMessengerEnvVarDefinition implements
     public function resolveEnvVars(array $collectedValues): array
     {
         return [
-            'PIMCORE_MESSENGER_TRANSPORT_DSN' => $collectedValues['PIMCORE_MESSENGER_TRANSPORT_DSN']
+            'PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX' => $collectedValues['PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX']
                 ?? 'amqp://guest:guest@127.0.0.1:5672/%2f/',
         ];
     }
 
     public function validate(array $collectedValues): array
     {
-        $url = $collectedValues['PIMCORE_MESSENGER_TRANSPORT_DSN'] ?? '';
+        $url = $collectedValues['PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX'] ?? '';
 
         $validator = new FormatValidator();
         $validator

--- a/bundles/InstallBundle/src/EnvVarDefinition/Definitions/DoctrineMessengerEnvVarDefinition.php
+++ b/bundles/InstallBundle/src/EnvVarDefinition/Definitions/DoctrineMessengerEnvVarDefinition.php
@@ -18,7 +18,7 @@ use Pimcore\Bundle\InstallBundle\EnvVarDefinition\MessengerTransportDefinitionIn
 /**
  * Doctrine-based messenger transport definition.
  *
- * Writes PIMCORE_MESSENGER_TRANSPORT_DSN=doctrine://default?queue_name=
+ * Writes PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX=doctrine://default?queue_name=
  * This is the default transport for all Pimcore messenger queues.
  * No user input is needed — the Doctrine connection is already
  * configured via DATABASE_URL.
@@ -57,7 +57,7 @@ final readonly class DoctrineMessengerEnvVarDefinition implements
     public function resolveEnvVars(array $collectedValues): array
     {
         return [
-            'PIMCORE_MESSENGER_TRANSPORT_DSN' => 'doctrine://default?queue_name=',
+            'PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX' => 'doctrine://default?queue_name=',
         ];
     }
 

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -47,7 +47,7 @@ The old configuration approach with separate `hosts` arrays in YAML is replaced 
 
 **This is a breaking change for existing installations.**
 
-The `PIMCORE_MESSENGER_TRANSPORT_DSN` env var format has changed. 
+The `PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX` env var (previously named `PIMCORE_MESSENGER_TRANSPORT_DSN`) format has changed. 
 It must now include a **trailing separator** for queue name concatenation, because Pimcore bundle configs append queue names directly to this value.
 
 **Before (old format):**
@@ -58,33 +58,33 @@ PIMCORE_MESSENGER_TRANSPORT_DSN=doctrine://default
 **After (new format):**
 ```
 # Doctrine
-PIMCORE_MESSENGER_TRANSPORT_DSN=doctrine://default?queue_name=
+PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX=doctrine://default?queue_name=
 
 # AMQP
-PIMCORE_MESSENGER_TRANSPORT_DSN=amqp://guest:guest@rabbit:5672/%2f/
+PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX=amqp://guest:guest@rabbit:5672/%2f/
 
 # Redis
-PIMCORE_MESSENGER_TRANSPORT_DSN=redis://localhost:6379/
+PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX=redis://localhost:6379/
 ```
 
-All Pimcore bundle transport configs now use the container parameter `%pimcore.messenger.transport_dsn%` with direct concatenation:
+All Pimcore bundle transport configs now use the container parameter `%pimcore.messenger.transport_dsn_prefix%` with direct concatenation:
 
 ```yaml
 framework:
     messenger:
         transports:
-            pimcore_core: '%pimcore.messenger.transport_dsn%pimcore_core'
-            pimcore_maintenance: '%pimcore.messenger.transport_dsn%pimcore_maintenance'
+            pimcore_core: '%pimcore.messenger.transport_dsn_prefix%pimcore_core'
+            pimcore_maintenance: '%pimcore.messenger.transport_dsn_prefix%pimcore_maintenance'
 ```
 
 A container-level default is provided in `bundles/CoreBundle/config/pimcore/default.yaml`:
 
 ```yaml
 parameters:
-    env(PIMCORE_MESSENGER_TRANSPORT_DSN): 'doctrine://default?queue_name='
+    env(PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX): 'doctrine://default?queue_name='
 ```
-If you have `PIMCORE_MESSENGER_TRANSPORT_DSN` explicitly set in your `.env` or environment, update its value to include the trailing separator. For Doctrine, change `doctrine://default` to `doctrine://default?queue_name=`. Failure to do this will result in invalid transport DSNs like `doctrine://defaultpimcore_core`.
-If you have custom transport definitions in your bundle or project YAML that hardcode `doctrine://default?queue_name=`, replace them with `'%pimcore.messenger.transport_dsn%'` concatenation to support backend-agnostic transport switching.
+If you have `PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX` (or the old `PIMCORE_MESSENGER_TRANSPORT_DSN`) explicitly set in your `.env` or environment, update its value to include the trailing separator and use the new name. For Doctrine, change `doctrine://default` to `doctrine://default?queue_name=`. Failure to do this will result in invalid transport DSNs like `doctrine://defaultpimcore_core`.
+If you have custom transport definitions in your bundle or project YAML that hardcode `doctrine://default?queue_name=`, replace them with `'%pimcore.messenger.transport_dsn_prefix%'` concatenation to support backend-agnostic transport switching.
 
 ## Pimcore 12.3.0
 

--- a/tests/Unit/InstallBundle/EnvVarDefinition/Definitions/AmqpMessengerEnvVarDefinitionTest.php
+++ b/tests/Unit/InstallBundle/EnvVarDefinition/Definitions/AmqpMessengerEnvVarDefinitionTest.php
@@ -52,18 +52,18 @@ final class AmqpMessengerEnvVarDefinitionTest extends TestCase
     public function testResolveEnvVars(): void
     {
         $envVars = $this->definition->resolveEnvVars([
-            'PIMCORE_MESSENGER_TRANSPORT_DSN' => 'amqp://guest:guest@127.0.0.1:5672/%2f/',
+            'PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX' => 'amqp://guest:guest@127.0.0.1:5672/%2f/',
         ]);
 
         $this->assertSame(
             'amqp://guest:guest@127.0.0.1:5672/%2f/',
-            $envVars['PIMCORE_MESSENGER_TRANSPORT_DSN'],
+            $envVars['PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX'],
         );
     }
 
     public function testValidateRejectsEmptyUrl(): void
     {
-        $errors = $this->definition->validate(['PIMCORE_MESSENGER_TRANSPORT_DSN' => '']);
+        $errors = $this->definition->validate(['PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX' => '']);
 
         $this->assertNotEmpty($errors);
         $this->assertStringContainsString('required', strtolower($errors[0]));
@@ -72,7 +72,7 @@ final class AmqpMessengerEnvVarDefinitionTest extends TestCase
     public function testValidateRejectsInvalidScheme(): void
     {
         $errors = $this->definition->validate([
-            'PIMCORE_MESSENGER_TRANSPORT_DSN' => 'http://guest:guest@localhost:5672/%2f/',
+            'PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX' => 'http://guest:guest@localhost:5672/%2f/',
         ]);
 
         $this->assertNotEmpty($errors);
@@ -82,7 +82,7 @@ final class AmqpMessengerEnvVarDefinitionTest extends TestCase
     public function testValidateRejectsMalformedUrl(): void
     {
         $errors = $this->definition->validate([
-            'PIMCORE_MESSENGER_TRANSPORT_DSN' => 'not-a-url',
+            'PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX' => 'not-a-url',
         ]);
 
         $this->assertNotEmpty($errors);
@@ -92,7 +92,7 @@ final class AmqpMessengerEnvVarDefinitionTest extends TestCase
     public function testValidateRejectsDsnWithoutTrailingSlash(): void
     {
         $errors = $this->definition->validate([
-            'PIMCORE_MESSENGER_TRANSPORT_DSN' => 'amqp://guest:guest@127.0.0.1:5672/%2f',
+            'PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX' => 'amqp://guest:guest@127.0.0.1:5672/%2f',
         ]);
 
         $this->assertNotEmpty($errors);
@@ -104,7 +104,7 @@ final class AmqpMessengerEnvVarDefinitionTest extends TestCase
         // Connection will fail in test env (no AMQP broker), but we verify
         // that no FORMAT errors are returned — only connection errors.
         $errors = $this->definition->validate([
-            'PIMCORE_MESSENGER_TRANSPORT_DSN' => 'amqp://guest:guest@127.0.0.1:5672/%2f/',
+            'PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX' => 'amqp://guest:guest@127.0.0.1:5672/%2f/',
         ]);
 
         // Either empty (broker reachable) or connection error (not a format error)
@@ -127,7 +127,7 @@ final class AmqpMessengerEnvVarDefinitionTest extends TestCase
 
     public function testParameterHintReturnsAmqpFormat(): void
     {
-        $hint = $this->definition->getParameterHint('PIMCORE_MESSENGER_TRANSPORT_DSN', []);
+        $hint = $this->definition->getParameterHint('PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX', []);
 
         $this->assertNotNull($hint);
         $this->assertStringContainsString('amqp://', $hint);
@@ -138,6 +138,6 @@ final class AmqpMessengerEnvVarDefinitionTest extends TestCase
     {
         $params = $this->definition->getParameters();
         $this->assertCount(1, $params);
-        $this->assertSame('PIMCORE_MESSENGER_TRANSPORT_DSN', $params[0]->getEnvVarName());
+        $this->assertSame('PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX', $params[0]->getEnvVarName());
     }
 }

--- a/tests/Unit/InstallBundle/EnvVarDefinition/Definitions/DoctrineMessengerEnvVarDefinitionTest.php
+++ b/tests/Unit/InstallBundle/EnvVarDefinition/Definitions/DoctrineMessengerEnvVarDefinitionTest.php
@@ -55,7 +55,7 @@ final class DoctrineMessengerEnvVarDefinitionTest extends TestCase
 
         $this->assertSame(
             'doctrine://default?queue_name=',
-            $envVars['PIMCORE_MESSENGER_TRANSPORT_DSN'],
+            $envVars['PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX'],
         );
     }
 

--- a/tests/Unit/InstallBundle/Integration/InstallerProfilesIntegrationTest.php
+++ b/tests/Unit/InstallBundle/Integration/InstallerProfilesIntegrationTest.php
@@ -76,7 +76,7 @@ final class InstallerProfilesIntegrationTest extends TestCase
         // Pre-set env vars for all definitions
         $envVarReader->set('DATABASE_URL', 'mysql://pimcore:secret@db:3306/pimcore');
         $envVarReader->set('PIMCORE_OPENSEARCH_DSN', 'opensearch://admin:admin@opensearch:9200?ssl_verify=false');
-        $envVarReader->set('PIMCORE_MESSENGER_TRANSPORT_DSN', 'doctrine://default');
+        $envVarReader->set('PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX', 'doctrine://default');
         $envVarReader->set('MERCURE_JWT_KEY', 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4');
         $envVarReader->set('MERCURE_URL', 'http://localhost/hub');
         $envVarReader->set('MERCURE_SERVER_URL', 'http://mercure/.well-known/mercure');
@@ -110,7 +110,7 @@ final class InstallerProfilesIntegrationTest extends TestCase
 
         // Verify env var values
         $this->assertStringContainsString('DATABASE_URL="mysql://pimcore:secret@db:3306/pimcore"', $envContent);
-        $this->assertStringContainsString('PIMCORE_MESSENGER_TRANSPORT_DSN="doctrine://default?queue_name="', $envContent);
+        $this->assertStringContainsString('PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX="doctrine://default?queue_name="', $envContent);
         $this->assertStringContainsString('PIMCORE_OPENSEARCH_DSN="opensearch://admin:admin@opensearch:9200?ssl_verify=false"', $envContent);
         $this->assertStringContainsString('MERCURE_JWT_KEY="a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"', $envContent);
         $this->assertStringContainsString('MERCURE_URL="http://localhost/hub"', $envContent);
@@ -161,7 +161,7 @@ final class InstallerProfilesIntegrationTest extends TestCase
         $envVarReader = new ArrayEnvVarReader();
         $envVarReader->set('DATABASE_URL', 'mysql://user:pass@localhost/db');
         $envVarReader->set('PIMCORE_OPENSEARCH_DSN', 'opensearch://localhost:9200?ssl_verify=false');
-        $envVarReader->set('PIMCORE_MESSENGER_TRANSPORT_DSN', 'doctrine://default');
+        $envVarReader->set('PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX', 'doctrine://default');
         $envVarReader->set('MERCURE_JWT_KEY', 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4');
         $envVarReader->set('MERCURE_URL', 'http://localhost/hub');
         $envVarReader->set('MERCURE_SERVER_URL', 'http://mercure/.well-known/mercure');
@@ -182,11 +182,11 @@ final class InstallerProfilesIntegrationTest extends TestCase
 
         $envContent = file_get_contents($this->tempDir . '/.env.local');
 
-        // DATABASE_URL and PIMCORE_MESSENGER_TRANSPORT_DSN should be
+        // DATABASE_URL and PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX should be
         // in the same pimcore/pimcore section
         $pimcoreSection = $this->extractSection($envContent, 'pimcore/pimcore');
         $this->assertStringContainsString('DATABASE_URL=', $pimcoreSection);
-        $this->assertStringContainsString('PIMCORE_MESSENGER_TRANSPORT_DSN=', $pimcoreSection);
+        $this->assertStringContainsString('PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX=', $pimcoreSection);
 
         // OpenSearch DSN should be in the opensearch-client section
         $opensearchSection = $this->extractSection($envContent, 'pimcore/opensearch-client');
@@ -204,7 +204,7 @@ final class InstallerProfilesIntegrationTest extends TestCase
         $envVarReader = new ArrayEnvVarReader();
         $envVarReader->set('DATABASE_URL', 'mysql://user:pass@localhost/db');
         $envVarReader->set('PIMCORE_OPENSEARCH_DSN', 'opensearch://localhost:9200?ssl_verify=false');
-        $envVarReader->set('PIMCORE_MESSENGER_TRANSPORT_DSN', 'doctrine://default');
+        $envVarReader->set('PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX', 'doctrine://default');
         $envVarReader->set('MERCURE_JWT_KEY', 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4');
         $envVarReader->set('MERCURE_URL', 'http://localhost/hub');
         $envVarReader->set('MERCURE_SERVER_URL', 'http://mercure/.well-known/mercure');
@@ -240,7 +240,7 @@ final class InstallerProfilesIntegrationTest extends TestCase
 
         // But required definitions should still be present
         $this->assertStringContainsString('DATABASE_URL=', $envContent);
-        $this->assertStringContainsString('PIMCORE_MESSENGER_TRANSPORT_DSN=', $envContent);
+        $this->assertStringContainsString('PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX=', $envContent);
     }
 
     public function testPhaseOneEventsAreDispatched(): void
@@ -260,7 +260,7 @@ final class InstallerProfilesIntegrationTest extends TestCase
         $envVarReader = new ArrayEnvVarReader();
         $envVarReader->set('DATABASE_URL', 'mysql://user:pass@localhost/db');
         $envVarReader->set('PIMCORE_OPENSEARCH_DSN', 'opensearch://localhost:9200?ssl_verify=false');
-        $envVarReader->set('PIMCORE_MESSENGER_TRANSPORT_DSN', 'doctrine://default');
+        $envVarReader->set('PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX', 'doctrine://default');
         $envVarReader->set('MERCURE_JWT_KEY', 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4');
         $envVarReader->set('MERCURE_URL', 'http://localhost/hub');
         $envVarReader->set('MERCURE_SERVER_URL', 'http://mercure/.well-known/mercure');


### PR DESCRIPTION
## Summary

- Renames env var `PIMCORE_MESSENGER_TRANSPORT_DSN` to `PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX` and container parameter `pimcore.messenger.transport_dsn` to `pimcore.messenger.transport_dsn_prefix` to better reflect that the value is a DSN prefix (not a complete DSN) that gets concatenated with queue/stream names
- Updates all 16 transport references in `default.yaml`, GEE config, installer definitions, tests, and upgrade notes

Ref: https://github.com/pimcore/product-management/issues/1148