### PR TITLE
[Bug] Fix missing Doctrine mapping_types config in new installer

### DIFF
--- a/bundles/InstallBundle/src/Installer.php
+++ b/bundles/InstallBundle/src/Installer.php
@@ -152,6 +152,10 @@ final class Installer
 
         $io->text('  <info>✓</info> .env.local written');
 
+        $this->dispatchStep('write_doctrine_config', 'Writing Doctrine mapping types config...');
+        $this->writeDoctrineConfig($projectRoot);
+        $io->text('  <info>✓</info> Doctrine mapping types config written');
+
         return [];
     }
 
@@ -387,6 +391,41 @@ final class Installer
         }
 
         return [];
+    }
+
+    /**
+     * Write static Doctrine mapping types config.
+     *
+     * Registers database type mappings (e.g. BIT -> boolean, ENUM -> string)
+     * that Doctrine DBAL does not support natively. Without this config,
+     * introspecting a schema containing these column types throws
+     * "Unknown database type" errors.
+     *
+     * This config was historically part of Pimcore's default.yaml but was
+     * moved to installer-generated config in PR #7848 to avoid container
+     * build failures when no database connection is configured yet.
+     */
+    private function writeDoctrineConfig(string $projectRoot): void
+    {
+        $configDir = $projectRoot . '/config/packages';
+        $filesystem = new Filesystem();
+
+        if (!$filesystem->exists($configDir)) {
+            $filesystem->mkdir($configDir);
+        }
+
+        $content = <<<'YAML'
+doctrine:
+    dbal:
+        connections:
+            default:
+                mapping_types:
+                    enum: string
+                    bit: boolean
+
+YAML;
+
+        $filesystem->dumpFile($configDir . '/doctrine_mapping_types.yaml', $content);
     }
 
     /**

--- a/tests/Unit/InstallBundle/InstallerTest.php
+++ b/tests/Unit/InstallBundle/InstallerTest.php
@@ -922,6 +922,122 @@ final class InstallerTest extends TestCase
         $this->assertStringContainsString('DB_HOST="localhost"', $envContent);
     }
 
+    public function testPhaseOneWritesDoctrineConfigFile(): void
+    {
+        $def = $this->createMockDefinition(
+            'database',
+            true,
+            [new ConfigParameter('DB_HOST', 'Host', ParameterType::String, defaultValue: 'localhost')],
+            ['DB_HOST'],
+        );
+
+        $profile = $this->createMockProfile([$def]);
+        $envVarReader = new ArrayEnvVarReader();
+        $collector = new ParameterCollector($envVarReader);
+
+        $errors = $this->installer->runPhaseOne(
+            $profile,
+            [],
+            [],
+            ['username' => 'admin', 'password' => 'admin123'],
+            $collector,
+            $this->createNonInteractiveIo(),
+            false,
+            $this->tempDir,
+        );
+
+        $this->assertSame([], $errors);
+
+        $configFile = $this->tempDir . '/config/packages/doctrine_mapping_types.yaml';
+        $this->assertFileExists($configFile);
+
+        $content = file_get_contents($configFile);
+
+        // Verify the YAML structure contains the required mapping types
+        $this->assertStringContainsString('doctrine:', $content);
+        $this->assertStringContainsString('dbal:', $content);
+        $this->assertStringContainsString('connections:', $content);
+        $this->assertStringContainsString('default:', $content);
+        $this->assertStringContainsString('mapping_types:', $content);
+        $this->assertStringContainsString('enum: string', $content);
+        $this->assertStringContainsString('bit: boolean', $content);
+    }
+
+    public function testPhaseOneCreatesConfigPackagesDirectoryIfMissing(): void
+    {
+        // Ensure config/packages does NOT exist before running
+        $this->assertDirectoryDoesNotExist($this->tempDir . '/config/packages');
+
+        $def = $this->createMockDefinition(
+            'database',
+            true,
+            [new ConfigParameter('DB_HOST', 'Host', ParameterType::String, defaultValue: 'localhost')],
+            ['DB_HOST'],
+        );
+
+        $profile = $this->createMockProfile([$def]);
+        $envVarReader = new ArrayEnvVarReader();
+        $collector = new ParameterCollector($envVarReader);
+
+        $errors = $this->installer->runPhaseOne(
+            $profile,
+            [],
+            [],
+            ['username' => 'admin', 'password' => 'admin123'],
+            $collector,
+            $this->createNonInteractiveIo(),
+            false,
+            $this->tempDir,
+        );
+
+        $this->assertSame([], $errors);
+        $this->assertDirectoryExists($this->tempDir . '/config/packages');
+        $this->assertFileExists($this->tempDir . '/config/packages/doctrine_mapping_types.yaml');
+    }
+
+    public function testPhaseOneDoctrineConfigExactContent(): void
+    {
+        $def = $this->createMockDefinition(
+            'database',
+            true,
+            [new ConfigParameter('DB_HOST', 'Host', ParameterType::String, defaultValue: 'localhost')],
+            ['DB_HOST'],
+        );
+
+        $profile = $this->createMockProfile([$def]);
+        $envVarReader = new ArrayEnvVarReader();
+        $collector = new ParameterCollector($envVarReader);
+
+        $errors = $this->installer->runPhaseOne(
+            $profile,
+            [],
+            [],
+            ['username' => 'admin', 'password' => 'admin123'],
+            $collector,
+            $this->createNonInteractiveIo(),
+            false,
+            $this->tempDir,
+        );
+
+        $this->assertSame([], $errors);
+
+        $expectedContent = <<<'YAML'
+doctrine:
+    dbal:
+        connections:
+            default:
+                mapping_types:
+                    enum: string
+                    bit: boolean
+
+YAML;
+
+        $actualContent = file_get_contents(
+            $this->tempDir . '/config/packages/doctrine_mapping_types.yaml',
+        );
+        $this->assertSame($expectedContent, $actualContent);
+    }
+
     public function testSkipValidationNonMatchingKeyStillValidates(): void
     {
         $failingDef = $this->createFailingDefinition(


### PR DESCRIPTION
## Summary

- The redesigned installer (#19033) only writes `.env.local` files, silently dropping the `mapping_types` generation that the old `ConfigWriter` included in its dynamic Doctrine config
- Without `bit: boolean` and `enum: string` mappings, introspecting schemas containing `BIT` or `ENUM` columns (e.g. CMF `plugin_cmf_customer_filter_definition` table) throws `Unknown database type "bit" requested` errors
- Writes a static `config/packages/doctrine_mapping_types.yaml` during Phase 1 (right after `.env.local`), restoring the mappings that were moved from `default.yaml` to installer-generated config in PR #7848

## Changes

**`bundles/InstallBundle/src/Installer.php`**
- Added `writeDoctrineConfig()` private method that writes the static YAML file via Symfony `Filesystem`
- Added call site in `runPhaseOne()` after `writeEnvLocal()`, with step dispatch and console output

**`tests/Unit/InstallBundle/InstallerTest.php`**
- `testPhaseOneWritesDoctrineConfigFile` — verifies file exists and contains expected YAML keys
- `testPhaseOneCreatesConfigPackagesDirectoryIfMissing` — verifies `config/packages/` directory creation
- `testPhaseOneDoctrineConfigExactContent` — verifies exact file content matches expected heredoc

All 27 unit tests pass (24 existing + 3 new).

## Related

- Follow-up to #19033 (installer redesign)
- Restores behavior removed in #7848