### PR TITLE
Fix example in `01_Loading_Service_Definitions.md`

### DIFF
--- a/doc/20_Extending_Pimcore/13_Bundle_Developers_Guide/01_Loading_Service_Definitions.md
+++ b/doc/20_Extending_Pimcore/13_Bundle_Developers_Guide/01_Loading_Service_Definitions.md
@@ -29,8 +29,8 @@ class AppExtension extends Extension
         // create a YamlFileLoader - this could also be a XmlFileLoader if you want to load XML 
         $loader = new YamlFileLoader(
             $container,
-            // looks in src/MyBundle/Resources/config
-            new FileLocator(__DIR__ . '/../Resources/config')
+            // looks in "config" folder in the bundle root
+            new FileLocator(__DIR__ . '/../../config')
         );
 
         // load services.yaml


### PR DESCRIPTION
The whole doc uses `config/services.yaml`, but in the example the comment says `src/MyBundle/Resources/config` but it loads from `src/Resources/config` while it should be `config/services.yaml`.