### PR TITLE
[BUG] Classificationstore multiselect inheritance is backwards.

### DIFF
--- a/models/DataObject/Classificationstore.php
+++ b/models/DataObject/Classificationstore.php
@@ -490,7 +490,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
         foreach ($a1 as $key => $value) {
             if (array_key_exists($key, $a2)) {
                 if (is_array($value)) {
-                    $a2[$key] = $this->mergeArrays($a2[$key], $value);
+                    $a2[$key] = $this->mergeArrays($value, $a2[$key]);
                 } else {
                     $a2[$key] = $value;
                 }

--- a/tests/Unit/Models/DataObject/ClassificationstoreTest.php
+++ b/tests/Unit/Models/DataObject/ClassificationstoreTest.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\DataObject;
+
+use Pimcore\Model\DataObject\Classificationstore;
+use Pimcore\Tests\Support\Test\TestCase;
+use ReflectionMethod;
+
+class ClassificationstoreTest extends TestCase
+{
+    /**
+     * Regression: the recursive call inside mergeArrays() was passing arguments
+     * in the wrong order ($a2[$key], $value) instead of ($value, $a2[$key]),
+     * which flipped the merge precedence for nested arrays so that parent[0]
+     * overwrote child[0] in numeric arrays.
+     *
+     * Realistic Classification Store structure: groupId → keyId → locale/default.
+     */
+    public function testMergeArraysPreservesChildMultiselectValues(): void
+    {
+        $store = new Classificationstore();
+
+        $method = new ReflectionMethod($store, 'mergeArrays');
+        $method->setAccessible(true);
+
+        // Simulate: $a1 = child (accumulated fieldsArray), $a2 = parent items
+        // Child should win on conflicts
+        $child = [
+            1 => [  // groupId
+                100 => [  // keyId
+                    'default' => ['Breathable', 'Coated', 'Seamless'],
+                ],
+            ],
+        ];
+
+        $parent = [
+            1 => [
+                100 => [
+                    'default' => ['Abrasion-Resistant'],
+                ],
+            ],
+        ];
+
+        $result = $method->invoke($store, $child, $parent);
+
+        // Child values should be preserved, not overwritten by parent
+        $this->assertSame(
+            ['Breathable', 'Coated', 'Seamless'],
+            $result[1][100]['default'],
+            'Child multiselect values should not be overwritten by parent values during inheritance merge'
+        );
+    }
+
+    public function testMergeArraysChildInheritsParentOnlyKeys(): void
+    {
+        $store = new Classificationstore();
+
+        $method = new ReflectionMethod($store, 'mergeArrays');
+        $method->setAccessible(true);
+
+        // Child has one key, parent has a different key — both should appear
+        $child = [
+            1 => [
+                100 => ['default' => ['Red']],
+            ],
+        ];
+
+        $parent = [
+            1 => [
+                200 => ['default' => ['Steel']],
+            ],
+        ];
+
+        $result = $method->invoke($store, $child, $parent);
+
+        $this->assertSame(['Red'], $result[1][100]['default']);
+        $this->assertSame(['Steel'], $result[1][200]['default']);
+    }
+}


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `12.3`
- Feature/Improvement: choose `2026.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`2026.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `12.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Fixes an issue where classificationstore multiselect arrays would inherit the parent values over the child values.


## Additional info
