### PR TITLE
[Improvement] Add install step filtering for PaaS environments

### DIFF
--- a/bundles/InstallBundle/src/Command/InstallCommand.php
+++ b/bundles/InstallBundle/src/Command/InstallCommand.php
@@ -417,7 +417,7 @@ final class InstallCommand extends Command
 
                 $this->progressBar->setMaxSteps($event->getTotalSteps());
                 $this->progressBar->setMessage($event->getMessage());
-                $this->progressBar->setProgress($event->getStep());
+                $this->progressBar->setProgress($event->getStepNumber());
             },
         );
     }

--- a/bundles/InstallBundle/src/Event/InstallerStepEvent.php
+++ b/bundles/InstallBundle/src/Event/InstallerStepEvent.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 /**
@@ -14,24 +13,25 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\InstallBundle\Event;
 
+use Pimcore\Bundle\InstallBundle\Profile\InstallStep;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * @internal
  */
-class InstallerStepEvent extends Event
+final class InstallerStepEvent extends Event
 {
     public function __construct(
-        private readonly string $type,
+        private readonly InstallStep $step,
         private readonly string $message,
-        private readonly int $step,
+        private readonly int $stepNumber,
         private readonly int $totalSteps,
     ) {
     }
 
-    public function getType(): string
+    public function getStep(): InstallStep
     {
-        return $this->type;
+        return $this->step;
     }
 
     public function getMessage(): string
@@ -39,9 +39,9 @@ class InstallerStepEvent extends Event
         return $this->message;
     }
 
-    public function getStep(): int
+    public function getStepNumber(): int
     {
-        return $this->step;
+        return $this->stepNumber;
     }
 
     public function getTotalSteps(): int

--- a/bundles/InstallBundle/src/Installer.php
+++ b/bundles/InstallBundle/src/Installer.php
@@ -202,82 +202,141 @@ final class Installer
         SymfonyStyle $io,
         string $projectRoot,
     ): array {
+        $this->resolveSkippedSteps($profile);
         $this->calculateTotalSteps($profile);
         $errors = [];
 
-        $this->dispatchStep(InstallStep::BootKernel, 'Booting application kernel...');
-        $kernel = $this->bootRealKernel($projectRoot);
-
-        $error = $this->executeStepSetupDatabase($kernel, $profile);
-        if ($error !== null) {
-            return [$error];
-        }
-
-        $error = $this->executeStepImportDataSource($kernel, $profile, $io);
-        if ($error !== null) {
-            return [$error];
-        }
-
-        $error = $this->executeStepCreateAdmin($kernel, $adminCredentials);
-        if ($error !== null) {
-            return [$error];
-        }
-
-        $error = $this->executeStepRegisterBundles($profile);
-        if ($error !== null) {
-            return [$error];
-        }
-
-        $error = $this->executeStepRebootKernel($kernel, $projectRoot);
-        if ($error !== null) {
-            return [$error];
-        }
-        // Kernel reference updated after reboot
         $kernel = $this->lastBootedKernel;
 
-        $error = $this->executeStepInstallBundles($profile, $io);
-        if ($error !== null) {
-            return [$error];
+        if ($this->isStepSkipped(InstallStep::BootKernel)) {
+            $this->skipStep(InstallStep::BootKernel, 'Booting application kernel...');
+        } else {
+            $this->dispatchStep(InstallStep::BootKernel, 'Booting application kernel...');
+            $kernel = $this->bootRealKernel($projectRoot);
         }
 
-        $error = $this->executeStepInstallAssets();
-        if ($error !== null) {
-            return [$error];
+        if ($this->isStepSkipped(InstallStep::SetupDatabase)) {
+            $this->skipStep(InstallStep::SetupDatabase, 'Setting up database...');
+        } else {
+            $error = $this->executeStepSetupDatabase($kernel, $profile);
+            if ($error !== null) {
+                return [$error];
+            }
         }
 
-        $error = $this->executeStepRebuildClasses();
-        if ($error !== null) {
-            $errors[] = $error;
+        if ($this->isStepSkipped(InstallStep::ImportData)) {
+            $this->skipStep(InstallStep::ImportData, 'Importing data...');
+        } else {
+            $error = $this->executeStepImportDataSource($kernel, $profile, $io);
+            if ($error !== null) {
+                return [$error];
+            }
         }
 
-        $error = $this->executeStepMarkMigrations();
-        if ($error !== null) {
-            $errors[] = $error;
+        if ($this->isStepSkipped(InstallStep::CreateAdmin)) {
+            $this->skipStep(InstallStep::CreateAdmin, 'Creating admin user...');
+        } else {
+            $error = $this->executeStepCreateAdmin($kernel, $adminCredentials);
+            if ($error !== null) {
+                return [$error];
+            }
         }
 
-        $error = $this->executeStepPostInstallCommands(
-            $profile,
-            $cliPostInstallProviders,
-            $kernel,
-            $io,
-        );
-        if ($error !== null) {
-            return array_merge($errors, [$error]);
+        if ($this->isStepSkipped(InstallStep::RegisterBundles)) {
+            $this->skipStep(InstallStep::RegisterBundles, 'Registering bundles...');
+        } else {
+            $error = $this->executeStepRegisterBundles($profile);
+            if ($error !== null) {
+                return [$error];
+            }
         }
 
-        $error = $this->executeStepRunMaintenance();
-        if ($error !== null) {
-            $errors[] = $error;
+        if ($this->isStepSkipped(InstallStep::RebootKernel)) {
+            $this->skipStep(InstallStep::RebootKernel, 'Rebooting kernel...');
+        } else {
+            $error = $this->executeStepRebootKernel($kernel, $projectRoot);
+            if ($error !== null) {
+                return [$error];
+            }
+            // Kernel reference updated after reboot
+            $kernel = $this->lastBootedKernel;
         }
 
-        $error = $this->executeStepProfilePostInstall($profile, $kernel, $io);
-        if ($error !== null) {
-            return array_merge($errors, [$error]);
+        if ($this->isStepSkipped(InstallStep::InstallBundles)) {
+            $this->skipStep(InstallStep::InstallBundles, 'Installing bundles...');
+        } else {
+            $error = $this->executeStepInstallBundles($profile, $io);
+            if ($error !== null) {
+                return [$error];
+            }
         }
 
-        $this->dispatchStep(InstallStep::Finalize, 'Finalizing installation...');
-        $this->clearKernelCacheDir($kernel);
-        $this->cleanupNeedsInstallMarker();
+        if ($this->isStepSkipped(InstallStep::InstallAssets)) {
+            $this->skipStep(InstallStep::InstallAssets, 'Installing assets...');
+        } else {
+            $error = $this->executeStepInstallAssets();
+            if ($error !== null) {
+                return [$error];
+            }
+        }
+
+        if ($this->isStepSkipped(InstallStep::RebuildClasses)) {
+            $this->skipStep(InstallStep::RebuildClasses, 'Rebuilding class definitions...');
+        } else {
+            $error = $this->executeStepRebuildClasses();
+            if ($error !== null) {
+                $errors[] = $error;
+            }
+        }
+
+        if ($this->isStepSkipped(InstallStep::MarkMigrations)) {
+            $this->skipStep(InstallStep::MarkMigrations, 'Marking migrations as done...');
+        } else {
+            $error = $this->executeStepMarkMigrations();
+            if ($error !== null) {
+                $errors[] = $error;
+            }
+        }
+
+        if ($this->isStepSkipped(InstallStep::PostInstallCommands)) {
+            $this->skipStep(InstallStep::PostInstallCommands, 'Running post-install commands...');
+        } else {
+            $error = $this->executeStepPostInstallCommands(
+                $profile,
+                $cliPostInstallProviders,
+                $kernel,
+                $io,
+            );
+            if ($error !== null) {
+                return array_merge($errors, [$error]);
+            }
+        }
+
+        if ($this->isStepSkipped(InstallStep::RunMaintenance)) {
+            $this->skipStep(InstallStep::RunMaintenance, 'Running maintenance...');
+        } else {
+            $error = $this->executeStepRunMaintenance();
+            if ($error !== null) {
+                $errors[] = $error;
+            }
+        }
+
+        if ($this->isStepSkipped(InstallStep::ProfilePostInstall)) {
+            $this->skipStep(InstallStep::ProfilePostInstall, 'Running profile post-install...');
+        } else {
+            $error = $this->executeStepProfilePostInstall($profile, $kernel, $io);
+            if ($error !== null) {
+                return array_merge($errors, [$error]);
+            }
+        }
+
+        if ($this->isStepSkipped(InstallStep::Finalize)) {
+            $this->skipStep(InstallStep::Finalize, 'Finalizing installation...');
+        } else {
+            $this->dispatchStep(InstallStep::Finalize, 'Finalizing installation...');
+            $this->clearKernelCacheDir($kernel);
+            $this->cleanupNeedsInstallMarker();
+        }
 
         return $errors;
     }

--- a/bundles/InstallBundle/src/Installer.php
+++ b/bundles/InstallBundle/src/Installer.php
@@ -842,24 +842,62 @@ YAML;
     {
         $steps = 0;
 
-        $steps++; // boot_kernel
-        $steps++; // setup_database
-
-        if ($profile->getDataSource() !== null) {
-            $steps++; // import_data
+        // Phase 2 steps
+        if (!$this->isStepSkipped(InstallStep::BootKernel)) {
+            $steps++;
         }
 
-        $steps++; // create_admin
-        $steps++; // register_bundles
-        $steps++; // reboot_kernel
-        $steps++; // install_bundles
-        $steps++; // install_assets
-        $steps++; // rebuild_classes
-        $steps++; // mark_migrations
-        $steps++; // post_install_commands
-        $steps++; // run_maintenance
-        $steps++; // profile_post_install
-        $steps++; // finalize
+        if (!$this->isStepSkipped(InstallStep::SetupDatabase)) {
+            $steps++;
+        }
+
+        if (!$this->isStepSkipped(InstallStep::ImportData) && $profile->getDataSource() !== null) {
+            $steps++;
+        }
+
+        if (!$this->isStepSkipped(InstallStep::CreateAdmin)) {
+            $steps++;
+        }
+
+        if (!$this->isStepSkipped(InstallStep::RegisterBundles)) {
+            $steps++;
+        }
+
+        if (!$this->isStepSkipped(InstallStep::RebootKernel)) {
+            $steps++;
+        }
+
+        if (!$this->isStepSkipped(InstallStep::InstallBundles)) {
+            $steps++;
+        }
+
+        if (!$this->isStepSkipped(InstallStep::InstallAssets)) {
+            $steps++;
+        }
+
+        if (!$this->isStepSkipped(InstallStep::RebuildClasses)) {
+            $steps++;
+        }
+
+        if (!$this->isStepSkipped(InstallStep::MarkMigrations)) {
+            $steps++;
+        }
+
+        if (!$this->isStepSkipped(InstallStep::PostInstallCommands)) {
+            $steps++;
+        }
+
+        if (!$this->isStepSkipped(InstallStep::RunMaintenance)) {
+            $steps++;
+        }
+
+        if (!$this->isStepSkipped(InstallStep::ProfilePostInstall)) {
+            $steps++;
+        }
+
+        if (!$this->isStepSkipped(InstallStep::Finalize)) {
+            $steps++;
+        }
 
         $this->totalSteps = $steps;
     }

--- a/bundles/InstallBundle/src/Installer.php
+++ b/bundles/InstallBundle/src/Installer.php
@@ -148,7 +148,7 @@ final class Installer
             return $credentialErrors;
         }
 
-        $this->dispatchStep('write_env', 'Writing .env.local...');
+        $this->dispatchStep(InstallStep::WriteEnv, 'Writing .env.local...');
         $writeErrors = $this->writeEnvLocal($result['resolved'], $projectRoot, $io);
 
         if ($writeErrors !== []) {
@@ -157,7 +157,7 @@ final class Installer
 
         $io->text('  <info>✓</info> .env.local written');
 
-        $this->dispatchStep('write_doctrine_config', 'Writing Doctrine mapping types config...');
+        $this->dispatchStep(InstallStep::WriteDoctrineConfig, 'Writing Doctrine mapping types config...');
         $this->writeDoctrineConfig($projectRoot);
         $io->text('  <info>✓</info> Doctrine mapping types config written');
 
@@ -189,7 +189,7 @@ final class Installer
         $this->calculateTotalSteps($profile);
         $errors = [];
 
-        $this->dispatchStep('boot_kernel', 'Booting application kernel...');
+        $this->dispatchStep(InstallStep::BootKernel, 'Booting application kernel...');
         $kernel = $this->bootRealKernel($projectRoot);
 
         $error = $this->executeStepSetupDatabase($kernel, $profile);
@@ -259,7 +259,7 @@ final class Installer
             return array_merge($errors, [$error]);
         }
 
-        $this->dispatchStep('finalize', 'Finalizing installation...');
+        $this->dispatchStep(InstallStep::Finalize, 'Finalizing installation...');
         $this->clearKernelCacheDir($kernel);
         $this->cleanupNeedsInstallMarker();
 
@@ -287,7 +287,7 @@ final class Installer
     ): array {
         $resolvedByDefinition = [];
         $errors = [];
-        $this->dispatchStep('collect_validate', 'Collecting and validating configuration...');
+        $this->dispatchStep(InstallStep::CollectAndValidate, 'Collecting and validating configuration...');
 
         foreach ($activeDefinitions as $key => $definition) {
             $io->section($definition->getLabel());
@@ -439,13 +439,13 @@ YAML;
      * Fatal steps should cause the caller to return early; non-fatal errors are collected.
      */
     private function executeStep(
-        string $stepType,
+        InstallStep $step,
         string $stepMessage,
         string $details,
         callable $action,
         bool $fatal = true,
     ): ?string {
-        $this->dispatchStep($stepType, $stepMessage);
+        $this->dispatchStep($step, $stepMessage);
 
         try {
             $action();
@@ -467,7 +467,7 @@ YAML;
         $hasDataSource = $profile->getDataSource() !== null;
 
         return $this->executeStep(
-            'setup_database',
+            InstallStep::SetupDatabase,
             'Setting up database...',
             'Schema created',
             function () use ($kernel, $hasDataSource): void {
@@ -492,7 +492,7 @@ YAML;
         }
 
         return $this->executeStep(
-            'import_data',
+            InstallStep::ImportData,
             'Importing data...',
             $dataSource->getLabel(),
             function () use ($dataSource, $kernel, $io): void {
@@ -510,7 +510,7 @@ YAML;
         array $credentials,
     ): ?string {
         return $this->executeStep(
-            'create_admin',
+            InstallStep::CreateAdmin,
             'Creating admin user...',
             'Admin user created',
             function () use ($kernel, $credentials): void {
@@ -523,7 +523,7 @@ YAML;
     private function executeStepRegisterBundles(InstallProfileInterface $profile): ?string
     {
         return $this->executeStep(
-            'register_bundles',
+            InstallStep::RegisterBundles,
             'Registering bundles...',
             sprintf('%d bundles registered', count($profile->getBundles())),
             function () use ($profile): void {
@@ -537,7 +537,7 @@ YAML;
         string $projectRoot,
     ): ?string {
         return $this->executeStep(
-            'reboot_kernel',
+            InstallStep::RebootKernel,
             'Rebooting kernel...',
             'Kernel rebooted',
             function () use ($kernel, $projectRoot): void {
@@ -553,7 +553,7 @@ YAML;
         SymfonyStyle $io,
     ): ?string {
         return $this->executeStep(
-            'install_bundles',
+            InstallStep::InstallBundles,
             'Installing bundles...',
             'Bundles installed',
             function () use ($profile, $io): void {
@@ -565,7 +565,7 @@ YAML;
     private function executeStepInstallAssets(): ?string
     {
         return $this->executeStep(
-            'install_assets',
+            InstallStep::InstallAssets,
             'Installing assets...',
             'Assets installed',
             function (): void {
@@ -577,7 +577,7 @@ YAML;
     private function executeStepRebuildClasses(): ?string
     {
         return $this->executeStep(
-            'rebuild_classes',
+            InstallStep::RebuildClasses,
             'Rebuilding class definitions...',
             'Classes rebuilt',
             function (): void {
@@ -590,7 +590,7 @@ YAML;
     private function executeStepMarkMigrations(): ?string
     {
         return $this->executeStep(
-            'mark_migrations',
+            InstallStep::MarkMigrations,
             'Marking migrations as done...',
             'Migrations marked',
             function (): void {
@@ -620,7 +620,7 @@ YAML;
         }
 
         return $this->executeStep(
-            'post_install_commands',
+            InstallStep::PostInstallCommands,
             'Running post-install commands...',
             sprintf('%d commands executed', count($postInstallCommands)),
             function () use ($postInstallCommands, $io): void {
@@ -635,7 +635,7 @@ YAML;
     private function executeStepRunMaintenance(): ?string
     {
         return $this->executeStep(
-            'run_maintenance',
+            InstallStep::RunMaintenance,
             'Running maintenance...',
             'Maintenance completed',
             function (): void {
@@ -655,7 +655,7 @@ YAML;
         }
 
         return $this->executeStep(
-            'profile_post_install',
+            InstallStep::ProfilePostInstall,
             'Running profile post-install...',
             'Profile postInstall() completed',
             function () use ($kernel, $profile, $io): void {
@@ -789,11 +789,11 @@ YAML;
         $this->totalSteps = $steps;
     }
 
-    private function dispatchStep(string $type, string $message): void
+    private function dispatchStep(InstallStep $step, string $message): void
     {
         $this->stepCounter++;
 
-        $event = new InstallerStepEvent($type, $message, $this->stepCounter, $this->totalSteps);
+        $event = new InstallerStepEvent($step, $message, $this->stepCounter, $this->totalSteps);
         $this->eventDispatcher->dispatch($event, InstallEvents::EVENT_NAME_STEP);
     }
 }

--- a/bundles/InstallBundle/src/Installer.php
+++ b/bundles/InstallBundle/src/Installer.php
@@ -26,6 +26,8 @@ use Pimcore\Bundle\InstallBundle\Event\InstallerStepEvent;
 use Pimcore\Bundle\InstallBundle\Event\InstallEvents;
 use Pimcore\Bundle\InstallBundle\Profile\DataSource\DataSourceInterface;
 use Pimcore\Bundle\InstallBundle\Profile\InstallProfileInterface;
+use Pimcore\Bundle\InstallBundle\Profile\InstallStep;
+use Pimcore\Bundle\InstallBundle\Profile\InstallStepFilterInterface;
 use Pimcore\Bundle\InstallBundle\PostInstall\PostInstallRunner;
 use Pimcore\Bundle\InstallBundle\Profile\PostInstallCommandsProviderInterface;
 use Pimcore\Bundle\InstallBundle\Profile\PostInstallHookInterface;
@@ -57,6 +59,9 @@ final class Installer
     private int $totalSteps = 0;
 
     private ?KernelInterface $lastBootedKernel = null;
+
+    /** @var InstallStep[] */
+    private array $skippedSteps = [];
 
     /**
      * @param (\Closure(string): EnvWriter)|null $envWriterFactory
@@ -659,6 +664,23 @@ YAML;
                 $profile->postInstall($context);
             },
         );
+    }
+
+    private function resolveSkippedSteps(InstallProfileInterface $profile): void
+    {
+        $this->skippedSteps = $profile instanceof InstallStepFilterInterface
+            ? $profile->getSkippedInstallSteps()
+            : [];
+    }
+
+    private function isStepSkipped(InstallStep $step): bool
+    {
+        return in_array($step, $this->skippedSteps, true);
+    }
+
+    private function skipStep(InstallStep $step, string $message): void
+    {
+        $this->logger->info(sprintf('Skipping step "%s": %s', $step->value, $message));
     }
 
     private function bootRealKernel(string $projectRoot): KernelInterface

--- a/bundles/InstallBundle/src/Installer.php
+++ b/bundles/InstallBundle/src/Installer.php
@@ -112,54 +112,70 @@ final class Installer
         bool $interactive,
         string $projectRoot,
     ): array {
-        $activeDefinitions = $this->definitionResolver->mergeDefinitions(
-            $profile->getEnvVarDefinitions(),
-            $extraDefinitions,
-        );
+        $this->resolveSkippedSteps($profile);
 
-        $categoryErrors = $this->definitionResolver->validateDefinitionCategories($activeDefinitions);
-        if ($categoryErrors !== []) {
-            return $categoryErrors;
+        $result = ['resolved' => [], 'errors' => []];
+
+        if ($this->isStepSkipped(InstallStep::CollectAndValidate)) {
+            $this->skipStep(InstallStep::CollectAndValidate, 'Collecting and validating configuration...');
+        } else {
+            $activeDefinitions = $this->definitionResolver->mergeDefinitions(
+                $profile->getEnvVarDefinitions(),
+                $extraDefinitions,
+            );
+
+            $categoryErrors = $this->definitionResolver->validateDefinitionCategories($activeDefinitions);
+            if ($categoryErrors !== []) {
+                return $categoryErrors;
+            }
+
+            $this->definitionResolver->warnOnMissingBundles($profile, $io, $projectRoot);
+
+            $bundleErrors = $this->definitionResolver->validateProfileBundles($profile);
+            if ($bundleErrors !== []) {
+                return $bundleErrors;
+            }
+
+            $this->definitionResolver->displayDefinitionSummary($activeDefinitions, $io);
+
+            $result = $this->collectAndValidateDefinitions(
+                $activeDefinitions,
+                $parameterCollector,
+                $io,
+                $interactive,
+                $skipValidation,
+            );
+
+            if ($result['errors'] !== []) {
+                return $result['errors'];
+            }
+
+            $credentialErrors = $this->databaseSetup->validateAdminCredentials($adminCredentials);
+            if ($credentialErrors !== []) {
+                return $credentialErrors;
+            }
         }
 
-        $this->definitionResolver->warnOnMissingBundles($profile, $io, $projectRoot);
+        if ($this->isStepSkipped(InstallStep::WriteEnv)) {
+            $this->skipStep(InstallStep::WriteEnv, 'Writing .env.local...');
+        } else {
+            $this->dispatchStep(InstallStep::WriteEnv, 'Writing .env.local...');
+            $writeErrors = $this->writeEnvLocal($result['resolved'], $projectRoot, $io);
 
-        $bundleErrors = $this->definitionResolver->validateProfileBundles($profile);
-        if ($bundleErrors !== []) {
-            return $bundleErrors;
+            if ($writeErrors !== []) {
+                return $writeErrors;
+            }
+
+            $io->text('  <info>✓</info> .env.local written');
         }
 
-        $this->definitionResolver->displayDefinitionSummary($activeDefinitions, $io);
-
-        $result = $this->collectAndValidateDefinitions(
-            $activeDefinitions,
-            $parameterCollector,
-            $io,
-            $interactive,
-            $skipValidation,
-        );
-
-        if ($result['errors'] !== []) {
-            return $result['errors'];
+        if ($this->isStepSkipped(InstallStep::WriteDoctrineConfig)) {
+            $this->skipStep(InstallStep::WriteDoctrineConfig, 'Writing Doctrine mapping types config...');
+        } else {
+            $this->dispatchStep(InstallStep::WriteDoctrineConfig, 'Writing Doctrine mapping types config...');
+            $this->writeDoctrineConfig($projectRoot);
+            $io->text('  <info>✓</info> Doctrine mapping types config written');
         }
-
-        $credentialErrors = $this->databaseSetup->validateAdminCredentials($adminCredentials);
-        if ($credentialErrors !== []) {
-            return $credentialErrors;
-        }
-
-        $this->dispatchStep(InstallStep::WriteEnv, 'Writing .env.local...');
-        $writeErrors = $this->writeEnvLocal($result['resolved'], $projectRoot, $io);
-
-        if ($writeErrors !== []) {
-            return $writeErrors;
-        }
-
-        $io->text('  <info>✓</info> .env.local written');
-
-        $this->dispatchStep(InstallStep::WriteDoctrineConfig, 'Writing Doctrine mapping types config...');
-        $this->writeDoctrineConfig($projectRoot);
-        $io->text('  <info>✓</info> Doctrine mapping types config written');
 
         return [];
     }

--- a/bundles/InstallBundle/src/Installer.php
+++ b/bundles/InstallBundle/src/Installer.php
@@ -113,6 +113,8 @@ final class Installer
         string $projectRoot,
     ): array {
         $this->resolveSkippedSteps($profile);
+        $this->calculatePhaseOneTotalSteps();
+        $this->stepCounter = 0;
 
         $result = ['resolved' => [], 'errors' => []];
 
@@ -203,17 +205,26 @@ final class Installer
         string $projectRoot,
     ): array {
         $this->resolveSkippedSteps($profile);
-        $this->calculateTotalSteps($profile);
+        $this->calculatePhaseTwoTotalSteps($profile);
+        $this->stepCounter = 0;
         $errors = [];
-
-        $kernel = $this->lastBootedKernel;
 
         if ($this->isStepSkipped(InstallStep::BootKernel)) {
             $this->skipStep(InstallStep::BootKernel, 'Booting application kernel...');
+
+            if ($this->lastBootedKernel === null) {
+                throw new \LogicException(
+                    'Cannot skip BootKernel: no kernel was booted previously.'
+                    . ' BootKernel can only be skipped when a kernel is already available'
+                    . ' (e.g. from a previous phase or custom bootstrap).',
+                );
+            }
         } else {
             $this->dispatchStep(InstallStep::BootKernel, 'Booting application kernel...');
-            $kernel = $this->bootRealKernel($projectRoot);
+            $this->bootRealKernel($projectRoot);
         }
+
+        $kernel = $this->lastBootedKernel;
 
         if ($this->isStepSkipped(InstallStep::SetupDatabase)) {
             $this->skipStep(InstallStep::SetupDatabase, 'Setting up database...');
@@ -746,6 +757,29 @@ YAML;
         $this->skippedSteps = $profile instanceof InstallStepFilterInterface
             ? $profile->getSkippedInstallSteps()
             : [];
+
+        $this->enforceStepDependencies();
+    }
+
+    /**
+     * Enforce implicit step dependencies.
+     *
+     * Some steps depend on earlier steps having run. When a prerequisite step
+     * is skipped, its dependent steps must also be skipped to avoid runtime
+     * errors (e.g. writing an empty .env.local, or passing a null kernel).
+     */
+    private function enforceStepDependencies(): void
+    {
+        // WriteEnv depends on CollectAndValidate: without collected data,
+        // writing .env.local would create an empty file or overwrite existing values.
+        if ($this->isStepSkipped(InstallStep::CollectAndValidate)
+            && !$this->isStepSkipped(InstallStep::WriteEnv)) {
+            $this->skippedSteps[] = InstallStep::WriteEnv;
+            $this->logger->info(
+                'Implicitly skipping WriteEnv because CollectAndValidate is skipped'
+                . ' (no collected values to write)',
+            );
+        }
     }
 
     private function isStepSkipped(InstallStep $step): bool
@@ -838,7 +872,26 @@ YAML;
         }
     }
 
-    private function calculateTotalSteps(InstallProfileInterface $profile): void
+    private function calculatePhaseOneTotalSteps(): void
+    {
+        $steps = 0;
+
+        if (!$this->isStepSkipped(InstallStep::CollectAndValidate)) {
+            $steps++;
+        }
+
+        if (!$this->isStepSkipped(InstallStep::WriteEnv)) {
+            $steps++;
+        }
+
+        if (!$this->isStepSkipped(InstallStep::WriteDoctrineConfig)) {
+            $steps++;
+        }
+
+        $this->totalSteps = $steps;
+    }
+
+    private function calculatePhaseTwoTotalSteps(InstallProfileInterface $profile): void
     {
         $steps = 0;
 

--- a/bundles/InstallBundle/src/Profile/InstallStep.php
+++ b/bundles/InstallBundle/src/Profile/InstallStep.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\InstallBundle\Profile;
+
+enum InstallStep: string
+{
+    // Phase 1
+    /** Collects and validates environment variable values. External service connections. */
+    case CollectAndValidate = 'collect_validate';
+
+    /** Writes collected env vars to .env.local. File operation. */
+    case WriteEnv = 'write_env';
+
+    /** Writes doctrine_mapping_types.yaml config. File operation. */
+    case WriteDoctrineConfig = 'write_doctrine_config';
+
+    // Phase 2
+    /** Boots the real application kernel. Runtime operation. */
+    case BootKernel = 'boot_kernel';
+
+    /** Creates database schema, infrastructure tables, and seed data. Database operation. */
+    case SetupDatabase = 'setup_database';
+
+    /** Imports data from the profile's data source. Database operation. Conditional — only runs if getDataSource() is non-null. */
+    case ImportData = 'import_data';
+
+    /** Creates or replaces the admin user. Database operation. */
+    case CreateAdmin = 'create_admin';
+
+    /** Writes bundle FQCNs to config/bundles.php. File operation. */
+    case RegisterBundles = 'register_bundles';
+
+    /** Clears cache and reboots kernel with newly registered bundles. File + runtime operation. */
+    case RebootKernel = 'reboot_kernel';
+
+    /** Runs pimcore:bundle:install for each profile bundle. Database + subprocess. */
+    case InstallBundles = 'install_bundles';
+
+    /** Runs assets:install. File operation + subprocess. */
+    case InstallAssets = 'install_assets';
+
+    /** Runs pimcore:deployment:classes-rebuild. File + database + subprocess. Non-fatal. */
+    case RebuildClasses = 'rebuild_classes';
+
+    /** Marks all Pimcore migrations as executed. Database + subprocess. Non-fatal. */
+    case MarkMigrations = 'mark_migrations';
+
+    /** Executes post-install commands from profile, bundle installers, and CLI providers. Mixed + subprocess. */
+    case PostInstallCommands = 'post_install_commands';
+
+    /** Runs pimcore:maintenance. Mixed + subprocess. Non-fatal. */
+    case RunMaintenance = 'run_maintenance';
+
+    /** Runs profile's postInstall() hook. Conditional — only runs if profile implements PostInstallHookInterface. */
+    case ProfilePostInstall = 'profile_post_install';
+
+    /** Clears cache and removes needs-install.lock marker. File operation. */
+    case Finalize = 'finalize';
+}

--- a/bundles/InstallBundle/src/Profile/InstallStepFilterInterface.php
+++ b/bundles/InstallBundle/src/Profile/InstallStepFilterInterface.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\InstallBundle\Profile;
+
+/**
+ * Optional interface for install profiles that need to skip certain install steps.
+ *
+ * Profiles that implement this interface can declare which steps should be
+ * excluded from the installation process. This is useful for PaaS environments
+ * where certain steps (e.g., writing .env.local, installing assets) are handled
+ * by the deployment pipeline rather than the installer.
+ *
+ * Profiles that don't need step filtering should simply not implement
+ * this interface — all steps will execute normally.
+ *
+ * Note: Skipping steps with dependencies on other steps may cause failures.
+ * See the documentation for step dependency information.
+ */
+interface InstallStepFilterInterface
+{
+    /**
+     * Returns install steps that should be skipped during installation.
+     *
+     * @return InstallStep[]
+     */
+    public function getSkippedInstallSteps(): array;
+}

--- a/tests/Unit/InstallBundle/Event/InstallerStepEventTest.php
+++ b/tests/Unit/InstallBundle/Event/InstallerStepEventTest.php
@@ -1,0 +1,109 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\InstallBundle\Event;
+
+use Pimcore\Bundle\InstallBundle\Event\InstallerStepEvent;
+use Pimcore\Bundle\InstallBundle\Profile\InstallStep;
+use Pimcore\Tests\Support\Test\TestCase;
+use ReflectionClass;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * @internal
+ */
+final class InstallerStepEventTest extends TestCase
+{
+    public function testClassIsFinal(): void
+    {
+        $reflection = new ReflectionClass(InstallerStepEvent::class);
+
+        $this->assertTrue($reflection->isFinal());
+    }
+
+    public function testExtendsSymfonyEvent(): void
+    {
+        $event = new InstallerStepEvent(
+            InstallStep::WriteEnv,
+            'Writing .env.local...',
+            1,
+            3,
+        );
+
+        $this->assertInstanceOf(Event::class, $event);
+    }
+
+    public function testGetStepReturnsInstallStepEnum(): void
+    {
+        $event = new InstallerStepEvent(
+            InstallStep::CollectAndValidate,
+            'Collecting configuration...',
+            1,
+            5,
+        );
+
+        $this->assertSame(InstallStep::CollectAndValidate, $event->getStep());
+        $this->assertInstanceOf(InstallStep::class, $event->getStep());
+    }
+
+    public function testGetMessageReturnsMessage(): void
+    {
+        $event = new InstallerStepEvent(
+            InstallStep::WriteDoctrineConfig,
+            'Writing Doctrine config...',
+            2,
+            10,
+        );
+
+        $this->assertSame('Writing Doctrine config...', $event->getMessage());
+    }
+
+    public function testGetStepNumberReturnsStepNumber(): void
+    {
+        $event = new InstallerStepEvent(
+            InstallStep::BootKernel,
+            'Booting kernel...',
+            3,
+            10,
+        );
+
+        $this->assertSame(3, $event->getStepNumber());
+    }
+
+    public function testGetTotalStepsReturnsTotalSteps(): void
+    {
+        $event = new InstallerStepEvent(
+            InstallStep::Finalize,
+            'Finalizing...',
+            10,
+            10,
+        );
+
+        $this->assertSame(10, $event->getTotalSteps());
+    }
+
+    public function testConstructorSetsAllProperties(): void
+    {
+        $step = InstallStep::SetupDatabase;
+        $message = 'Setting up database...';
+        $stepNumber = 5;
+        $totalSteps = 14;
+
+        $event = new InstallerStepEvent($step, $message, $stepNumber, $totalSteps);
+
+        $this->assertSame($step, $event->getStep());
+        $this->assertSame($message, $event->getMessage());
+        $this->assertSame($stepNumber, $event->getStepNumber());
+        $this->assertSame($totalSteps, $event->getTotalSteps());
+    }
+}

--- a/tests/Unit/InstallBundle/Event/InstallerStepEventTest.php
+++ b/tests/Unit/InstallBundle/Event/InstallerStepEventTest.php
@@ -43,55 +43,6 @@ final class InstallerStepEventTest extends TestCase
         $this->assertInstanceOf(Event::class, $event);
     }
 
-    public function testGetStepReturnsInstallStepEnum(): void
-    {
-        $event = new InstallerStepEvent(
-            InstallStep::CollectAndValidate,
-            'Collecting configuration...',
-            1,
-            5,
-        );
-
-        $this->assertSame(InstallStep::CollectAndValidate, $event->getStep());
-        $this->assertInstanceOf(InstallStep::class, $event->getStep());
-    }
-
-    public function testGetMessageReturnsMessage(): void
-    {
-        $event = new InstallerStepEvent(
-            InstallStep::WriteDoctrineConfig,
-            'Writing Doctrine config...',
-            2,
-            10,
-        );
-
-        $this->assertSame('Writing Doctrine config...', $event->getMessage());
-    }
-
-    public function testGetStepNumberReturnsStepNumber(): void
-    {
-        $event = new InstallerStepEvent(
-            InstallStep::BootKernel,
-            'Booting kernel...',
-            3,
-            10,
-        );
-
-        $this->assertSame(3, $event->getStepNumber());
-    }
-
-    public function testGetTotalStepsReturnsTotalSteps(): void
-    {
-        $event = new InstallerStepEvent(
-            InstallStep::Finalize,
-            'Finalizing...',
-            10,
-            10,
-        );
-
-        $this->assertSame(10, $event->getTotalSteps());
-    }
-
     public function testConstructorSetsAllProperties(): void
     {
         $step = InstallStep::SetupDatabase;

--- a/tests/Unit/InstallBundle/InstallerTest.php
+++ b/tests/Unit/InstallBundle/InstallerTest.php
@@ -1350,28 +1350,7 @@ YAML;
         array $bundles = [],
         bool $includeDefaultMarkerDefs = true,
     ): InstallProfileInterface {
-        $allDefs = $definitions;
-
-        if ($includeDefaultMarkerDefs) {
-            $hasSearchEngine = false;
-            $hasMessengerTransport = false;
-
-            foreach ($allDefs as $def) {
-                if ($def instanceof SearchEngineDefinitionInterface) {
-                    $hasSearchEngine = true;
-                }
-                if ($def instanceof MessengerTransportDefinitionInterface) {
-                    $hasMessengerTransport = true;
-                }
-            }
-
-            if (!$hasSearchEngine) {
-                $allDefs[] = $this->createNoopSearchEngineDefinition();
-            }
-            if (!$hasMessengerTransport) {
-                $allDefs[] = $this->createNoopMessengerTransportDefinition();
-            }
-        }
+        $allDefs = $this->resolveDefinitionsWithMarkerDefs($definitions, $includeDefaultMarkerDefs);
 
         return new class($allDefs, $bundles, $skippedSteps) implements InstallProfileInterface, InstallStepFilterInterface {
             /**
@@ -1424,8 +1403,45 @@ YAML;
     }
 
     // -----------------------------------------------------------------------
-    // Original helper methods
+    // Helper methods
     // -----------------------------------------------------------------------
+
+    /**
+     * Resolves definitions with optional marker definitions for search engine and messenger transport.
+     *
+     * @param list<EnvVarDefinitionInterface> $definitions
+     *
+     * @return list<EnvVarDefinitionInterface>
+     */
+    private function resolveDefinitionsWithMarkerDefs(
+        array $definitions,
+        bool $includeDefaultMarkerDefs,
+    ): array {
+        if (!$includeDefaultMarkerDefs) {
+            return $definitions;
+        }
+
+        $hasSearchEngine = false;
+        $hasMessengerTransport = false;
+
+        foreach ($definitions as $def) {
+            if ($def instanceof SearchEngineDefinitionInterface) {
+                $hasSearchEngine = true;
+            }
+            if ($def instanceof MessengerTransportDefinitionInterface) {
+                $hasMessengerTransport = true;
+            }
+        }
+
+        if (!$hasSearchEngine) {
+            $definitions[] = $this->createNoopSearchEngineDefinition();
+        }
+        if (!$hasMessengerTransport) {
+            $definitions[] = $this->createNoopMessengerTransportDefinition();
+        }
+
+        return $definitions;
+    }
 
     /**
      * Creates a mock definition that passes validation.
@@ -1572,28 +1588,10 @@ YAML;
         array $bundles = [],
         bool $includeDefaultMarkerDefs = true,
     ): InstallProfileInterface {
-        $allDefs = array_merge($definitions, $extraDefinitions);
-
-        if ($includeDefaultMarkerDefs) {
-            $hasSearchEngine = false;
-            $hasMessengerTransport = false;
-
-            foreach ($allDefs as $def) {
-                if ($def instanceof SearchEngineDefinitionInterface) {
-                    $hasSearchEngine = true;
-                }
-                if ($def instanceof MessengerTransportDefinitionInterface) {
-                    $hasMessengerTransport = true;
-                }
-            }
-
-            if (!$hasSearchEngine) {
-                $allDefs[] = $this->createNoopSearchEngineDefinition();
-            }
-            if (!$hasMessengerTransport) {
-                $allDefs[] = $this->createNoopMessengerTransportDefinition();
-            }
-        }
+        $allDefs = $this->resolveDefinitionsWithMarkerDefs(
+            array_merge($definitions, $extraDefinitions),
+            $includeDefaultMarkerDefs,
+        );
 
         return new class($allDefs, $bundles) implements InstallProfileInterface {
             public function __construct(

--- a/tests/Unit/InstallBundle/InstallerTest.php
+++ b/tests/Unit/InstallBundle/InstallerTest.php
@@ -1337,6 +1337,111 @@ YAML;
         $this->assertNotContains(InstallStep::WriteDoctrineConfig, $receivedSteps);
     }
 
+    public function testPhaseOneSkipCollectAndValidateImplicitlySkipsWriteEnv(): void
+    {
+        $eventDispatcher = new EventDispatcher();
+
+        /** @var list<InstallStep> $receivedSteps */
+        $receivedSteps = [];
+        $eventDispatcher->addListener(
+            InstallEvents::EVENT_NAME_STEP,
+            static function (InstallerStepEvent $event) use (&$receivedSteps): void {
+                $receivedSteps[] = $event->getStep();
+            },
+        );
+
+        $installer = $this->createInstaller(eventDispatcher: $eventDispatcher);
+
+        $def = $this->createMockDefinition(
+            'database',
+            true,
+            [new ConfigParameter('DB_HOST', 'Host', ParameterType::String, defaultValue: 'localhost')],
+            ['DB_HOST'],
+        );
+
+        // Only skip CollectAndValidate — WriteEnv should be implicitly skipped too
+        $profile = $this->createMockProfileWithSkippedSteps(
+            [$def],
+            [InstallStep::CollectAndValidate],
+        );
+
+        $envVarReader = new ArrayEnvVarReader();
+        $collector = new ParameterCollector($envVarReader);
+
+        $errors = $installer->runPhaseOne(
+            $profile,
+            [],
+            [],
+            ['username' => 'admin', 'password' => 'admin123'],
+            $collector,
+            $this->createNonInteractiveIo(),
+            false,
+            $this->tempDir,
+        );
+
+        $this->assertSame([], $errors);
+
+        // WriteEnv implicitly skipped — no .env.local should be created
+        $this->assertFileDoesNotExist($this->tempDir . '/.env.local');
+
+        // Only WriteDoctrineConfig should fire (CollectAndValidate + WriteEnv both skipped)
+        $this->assertCount(1, $receivedSteps);
+        $this->assertSame(InstallStep::WriteDoctrineConfig, $receivedSteps[0]);
+        $this->assertNotContains(InstallStep::CollectAndValidate, $receivedSteps);
+        $this->assertNotContains(InstallStep::WriteEnv, $receivedSteps);
+    }
+
+    public function testPhaseOneTotalStepsReflectsSkippedSteps(): void
+    {
+        $eventDispatcher = new EventDispatcher();
+
+        /** @var list<InstallerStepEvent> $receivedEvents */
+        $receivedEvents = [];
+        $eventDispatcher->addListener(
+            InstallEvents::EVENT_NAME_STEP,
+            static function (InstallerStepEvent $event) use (&$receivedEvents): void {
+                $receivedEvents[] = $event;
+            },
+        );
+
+        $installer = $this->createInstaller(eventDispatcher: $eventDispatcher);
+
+        $def = $this->createMockDefinition(
+            'database',
+            true,
+            [new ConfigParameter('DB_HOST', 'Host', ParameterType::String, defaultValue: 'localhost')],
+            ['DB_HOST'],
+        );
+
+        // Skip WriteEnv — should leave 2 active steps
+        $profile = $this->createMockProfileWithSkippedSteps(
+            [$def],
+            [InstallStep::WriteEnv],
+        );
+
+        $envVarReader = new ArrayEnvVarReader();
+        $collector = new ParameterCollector($envVarReader);
+
+        $installer->runPhaseOne(
+            $profile,
+            [],
+            [],
+            ['username' => 'admin', 'password' => 'admin123'],
+            $collector,
+            $this->createNonInteractiveIo(),
+            false,
+            $this->tempDir,
+        );
+
+        // 2 events dispatched (CollectAndValidate, WriteDoctrineConfig)
+        $this->assertCount(2, $receivedEvents);
+
+        // Total steps should be 2, not 3
+        foreach ($receivedEvents as $event) {
+            $this->assertSame(2, $event->getTotalSteps());
+        }
+    }
+
     /**
      * Creates a mock profile implementing both InstallProfileInterface and InstallStepFilterInterface.
      *

--- a/tests/Unit/InstallBundle/InstallerTest.php
+++ b/tests/Unit/InstallBundle/InstallerTest.php
@@ -20,14 +20,19 @@ use Pimcore\Bundle\InstallBundle\EnvVarDefinition\EnvVarDefinitionInterface;
 use Pimcore\Bundle\InstallBundle\EnvVarDefinition\MessengerTransportDefinitionInterface;
 use Pimcore\Bundle\InstallBundle\EnvVarDefinition\ParameterType;
 use Pimcore\Bundle\InstallBundle\EnvVarDefinition\SearchEngineDefinitionInterface;
+use Pimcore\Bundle\InstallBundle\Event\InstallerStepEvent;
+use Pimcore\Bundle\InstallBundle\Event\InstallEvents;
 use Pimcore\Bundle\InstallBundle\Installer;
 use Pimcore\Bundle\InstallBundle\Profile\DataSource\DataSourceInterface;
 use Pimcore\Bundle\InstallBundle\Profile\InstallProfileInterface;
+use Pimcore\Bundle\InstallBundle\Profile\InstallStep;
+use Pimcore\Bundle\InstallBundle\Profile\InstallStepFilterInterface;
 use Pimcore\Tests\Support\Test\TestCase;
 use Pimcore\Tests\Unit\InstallBundle\Support\InstallBundleTestHelperTrait;
 use Pimcore\Tests\Unit\InstallBundle\Support\NoopMessengerTransportDefinition;
 use Pimcore\Tests\Unit\InstallBundle\Support\NoopSearchEngineDefinition;
 use Pimcore\Tests\Unit\InstallBundle\Support\NoopSearchEngineDefinitionThatFails;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
  * Integration tests for the Installer's Phase 1 (runPhaseOne).
@@ -1062,6 +1067,365 @@ YAML;
         $this->assertNotEmpty($errors);
         $this->assertStringContainsString('Connection refused', $errors[0]);
     }
+
+    // -----------------------------------------------------------------------
+    // Install step filtering tests
+    // -----------------------------------------------------------------------
+
+    public function testPhaseOneSkipWriteEnvDoesNotWriteEnvLocal(): void
+    {
+        $def = $this->createMockDefinition(
+            'database',
+            true,
+            [new ConfigParameter('DB_HOST', 'Host', ParameterType::String, defaultValue: 'localhost')],
+            ['DB_HOST'],
+        );
+
+        $profile = $this->createMockProfileWithSkippedSteps(
+            [$def],
+            [InstallStep::WriteEnv],
+        );
+
+        $envVarReader = new ArrayEnvVarReader();
+        $collector = new ParameterCollector($envVarReader);
+
+        $errors = $this->installer->runPhaseOne(
+            $profile,
+            [],
+            [],
+            ['username' => 'admin', 'password' => 'admin123'],
+            $collector,
+            $this->createNonInteractiveIo(),
+            false,
+            $this->tempDir,
+        );
+
+        $this->assertSame([], $errors);
+        $this->assertFileDoesNotExist($this->tempDir . '/.env.local');
+
+        // Doctrine config should still be written
+        $this->assertFileExists($this->tempDir . '/config/packages/doctrine_mapping_types.yaml');
+    }
+
+    public function testPhaseOneSkipWriteDoctrineConfigDoesNotWriteConfig(): void
+    {
+        $def = $this->createMockDefinition(
+            'database',
+            true,
+            [new ConfigParameter('DB_HOST', 'Host', ParameterType::String, defaultValue: 'localhost')],
+            ['DB_HOST'],
+        );
+
+        $profile = $this->createMockProfileWithSkippedSteps(
+            [$def],
+            [InstallStep::WriteDoctrineConfig],
+        );
+
+        $envVarReader = new ArrayEnvVarReader();
+        $collector = new ParameterCollector($envVarReader);
+
+        $errors = $this->installer->runPhaseOne(
+            $profile,
+            [],
+            [],
+            ['username' => 'admin', 'password' => 'admin123'],
+            $collector,
+            $this->createNonInteractiveIo(),
+            false,
+            $this->tempDir,
+        );
+
+        $this->assertSame([], $errors);
+        $this->assertFileDoesNotExist($this->tempDir . '/config/packages/doctrine_mapping_types.yaml');
+
+        // .env.local should still be written
+        $this->assertFileExists($this->tempDir . '/.env.local');
+        $envContent = file_get_contents($this->tempDir . '/.env.local');
+        $this->assertStringContainsString('DB_HOST="localhost"', $envContent);
+    }
+
+    public function testPhaseOneSkipCollectAndValidateBypassesValidation(): void
+    {
+        $failingDef = $this->createFailingDefinition(
+            'database',
+            true,
+            [new ConfigParameter('DB_HOST', 'Host', ParameterType::String, defaultValue: 'localhost')],
+            ['Connection refused'],
+        );
+
+        $profile = $this->createMockProfileWithSkippedSteps(
+            [$failingDef],
+            [InstallStep::CollectAndValidate],
+        );
+
+        $envVarReader = new ArrayEnvVarReader();
+        $collector = new ParameterCollector($envVarReader);
+
+        $errors = $this->installer->runPhaseOne(
+            $profile,
+            [],
+            [],
+            ['username' => 'admin', 'password' => 'admin123'],
+            $collector,
+            $this->createNonInteractiveIo(),
+            false,
+            $this->tempDir,
+        );
+
+        // No errors — validation was bypassed
+        $this->assertSame([], $errors);
+    }
+
+    public function testPhaseOneSkipAllStepsWritesNothing(): void
+    {
+        $def = $this->createMockDefinition(
+            'database',
+            true,
+            [new ConfigParameter('DB_HOST', 'Host', ParameterType::String, defaultValue: 'localhost')],
+            ['DB_HOST'],
+        );
+
+        $profile = $this->createMockProfileWithSkippedSteps(
+            [$def],
+            [InstallStep::CollectAndValidate, InstallStep::WriteEnv, InstallStep::WriteDoctrineConfig],
+        );
+
+        $envVarReader = new ArrayEnvVarReader();
+        $collector = new ParameterCollector($envVarReader);
+
+        $errors = $this->installer->runPhaseOne(
+            $profile,
+            [],
+            [],
+            ['username' => 'admin', 'password' => 'admin123'],
+            $collector,
+            $this->createNonInteractiveIo(),
+            false,
+            $this->tempDir,
+        );
+
+        $this->assertSame([], $errors);
+        $this->assertFileDoesNotExist($this->tempDir . '/.env.local');
+        $this->assertFileDoesNotExist($this->tempDir . '/config/packages/doctrine_mapping_types.yaml');
+    }
+
+    public function testPhaseOneWithoutInstallStepFilterInterfaceRunsAllSteps(): void
+    {
+        $def = $this->createMockDefinition(
+            'database',
+            true,
+            [new ConfigParameter('DB_HOST', 'Host', ParameterType::String, defaultValue: 'localhost')],
+            ['DB_HOST'],
+        );
+
+        // Use a normal profile without InstallStepFilterInterface
+        $profile = $this->createMockProfile([$def]);
+
+        $envVarReader = new ArrayEnvVarReader();
+        $collector = new ParameterCollector($envVarReader);
+
+        $errors = $this->installer->runPhaseOne(
+            $profile,
+            [],
+            [],
+            ['username' => 'admin', 'password' => 'admin123'],
+            $collector,
+            $this->createNonInteractiveIo(),
+            false,
+            $this->tempDir,
+        );
+
+        $this->assertSame([], $errors);
+
+        // Both files should be written — all steps ran
+        $this->assertFileExists($this->tempDir . '/.env.local');
+        $envContent = file_get_contents($this->tempDir . '/.env.local');
+        $this->assertStringContainsString('DB_HOST="localhost"', $envContent);
+
+        $this->assertFileExists($this->tempDir . '/config/packages/doctrine_mapping_types.yaml');
+    }
+
+    public function testPhaseOneEventsUseInstallStepEnum(): void
+    {
+        $eventDispatcher = new EventDispatcher();
+
+        /** @var list<InstallerStepEvent> $receivedEvents */
+        $receivedEvents = [];
+        $eventDispatcher->addListener(
+            InstallEvents::EVENT_NAME_STEP,
+            static function (InstallerStepEvent $event) use (&$receivedEvents): void {
+                $receivedEvents[] = $event;
+            },
+        );
+
+        $installer = $this->createInstaller(eventDispatcher: $eventDispatcher);
+
+        $def = $this->createMockDefinition(
+            'database',
+            true,
+            [new ConfigParameter('DB_HOST', 'Host', ParameterType::String, defaultValue: 'localhost')],
+            ['DB_HOST'],
+        );
+
+        $profile = $this->createMockProfile([$def]);
+        $envVarReader = new ArrayEnvVarReader();
+        $collector = new ParameterCollector($envVarReader);
+
+        $installer->runPhaseOne(
+            $profile,
+            [],
+            [],
+            ['username' => 'admin', 'password' => 'admin123'],
+            $collector,
+            $this->createNonInteractiveIo(),
+            false,
+            $this->tempDir,
+        );
+
+        $this->assertNotEmpty($receivedEvents);
+
+        foreach ($receivedEvents as $event) {
+            $this->assertInstanceOf(InstallStep::class, $event->getStep());
+        }
+    }
+
+    public function testPhaseOneSkippedStepsDoNotProduceEvents(): void
+    {
+        $eventDispatcher = new EventDispatcher();
+
+        /** @var list<InstallStep> $receivedSteps */
+        $receivedSteps = [];
+        $eventDispatcher->addListener(
+            InstallEvents::EVENT_NAME_STEP,
+            static function (InstallerStepEvent $event) use (&$receivedSteps): void {
+                $receivedSteps[] = $event->getStep();
+            },
+        );
+
+        $installer = $this->createInstaller(eventDispatcher: $eventDispatcher);
+
+        $def = $this->createMockDefinition(
+            'database',
+            true,
+            [new ConfigParameter('DB_HOST', 'Host', ParameterType::String, defaultValue: 'localhost')],
+            ['DB_HOST'],
+        );
+
+        $profile = $this->createMockProfileWithSkippedSteps(
+            [$def],
+            [InstallStep::WriteEnv, InstallStep::WriteDoctrineConfig],
+        );
+
+        $envVarReader = new ArrayEnvVarReader();
+        $collector = new ParameterCollector($envVarReader);
+
+        $installer->runPhaseOne(
+            $profile,
+            [],
+            [],
+            ['username' => 'admin', 'password' => 'admin123'],
+            $collector,
+            $this->createNonInteractiveIo(),
+            false,
+            $this->tempDir,
+        );
+
+        // Only CollectAndValidate should fire — WriteEnv and WriteDoctrineConfig are skipped
+        $this->assertCount(1, $receivedSteps);
+        $this->assertSame(InstallStep::CollectAndValidate, $receivedSteps[0]);
+        $this->assertNotContains(InstallStep::WriteEnv, $receivedSteps);
+        $this->assertNotContains(InstallStep::WriteDoctrineConfig, $receivedSteps);
+    }
+
+    /**
+     * Creates a mock profile implementing both InstallProfileInterface and InstallStepFilterInterface.
+     *
+     * @param list<EnvVarDefinitionInterface> $definitions
+     * @param list<InstallStep> $skippedSteps
+     * @param list<class-string> $bundles
+     */
+    private function createMockProfileWithSkippedSteps(
+        array $definitions,
+        array $skippedSteps,
+        array $bundles = [],
+        bool $includeDefaultMarkerDefs = true,
+    ): InstallProfileInterface {
+        $allDefs = $definitions;
+
+        if ($includeDefaultMarkerDefs) {
+            $hasSearchEngine = false;
+            $hasMessengerTransport = false;
+
+            foreach ($allDefs as $def) {
+                if ($def instanceof SearchEngineDefinitionInterface) {
+                    $hasSearchEngine = true;
+                }
+                if ($def instanceof MessengerTransportDefinitionInterface) {
+                    $hasMessengerTransport = true;
+                }
+            }
+
+            if (!$hasSearchEngine) {
+                $allDefs[] = $this->createNoopSearchEngineDefinition();
+            }
+            if (!$hasMessengerTransport) {
+                $allDefs[] = $this->createNoopMessengerTransportDefinition();
+            }
+        }
+
+        return new class($allDefs, $bundles, $skippedSteps) implements InstallProfileInterface, InstallStepFilterInterface {
+            /**
+             * @param list<EnvVarDefinitionInterface> $definitions
+             * @param list<class-string> $bundles
+             * @param list<InstallStep> $skippedSteps
+             */
+            public function __construct(
+                private readonly array $definitions,
+                private readonly array $bundles,
+                private readonly array $skippedSteps,
+            ) {
+            }
+
+            public function getName(): string
+            {
+                return 'test-profile-with-skipped-steps';
+            }
+
+            public function getDescription(): string
+            {
+                return 'Test profile with skipped install steps';
+            }
+
+            public function getBundles(): array
+            {
+                return $this->bundles;
+            }
+
+            public function getEnvVarDefinitions(): array
+            {
+                return $this->definitions;
+            }
+
+            public function getDataSource(): ?DataSourceInterface
+            {
+                return null;
+            }
+
+            public function getPostInstallCommands(): array
+            {
+                return [];
+            }
+
+            public function getSkippedInstallSteps(): array
+            {
+                return $this->skippedSteps;
+            }
+        };
+    }
+
+    // -----------------------------------------------------------------------
+    // Original helper methods
+    // -----------------------------------------------------------------------
 
     /**
      * Creates a mock definition that passes validation.

--- a/tests/Unit/InstallBundle/Integration/InstallerProfilesIntegrationTest.php
+++ b/tests/Unit/InstallBundle/Integration/InstallerProfilesIntegrationTest.php
@@ -26,6 +26,7 @@ use Pimcore\Bundle\InstallBundle\EnvVarDefinition\SearchEngineDefinitionInterfac
 use Pimcore\Bundle\InstallBundle\Installer;
 use Pimcore\Bundle\InstallBundle\Profile\DataSource\DataSourceInterface;
 use Pimcore\Bundle\InstallBundle\Profile\InstallProfileInterface;
+use Pimcore\Bundle\InstallBundle\Profile\InstallStep;
 use Pimcore\Tests\Support\Test\TestCase;
 use Pimcore\Tests\Unit\InstallBundle\Support\InstallBundleTestHelperTrait;
 use Pimcore\Tests\Unit\InstallBundle\Support\NoopMessengerTransportDefinition;
@@ -251,7 +252,7 @@ final class InstallerProfilesIntegrationTest extends TestCase
         $dispatcher->addListener(
             'pimcore.installer.step',
             function ($event) use (&$dispatchedSteps): void {
-                $dispatchedSteps[] = $event->getType();
+                $dispatchedSteps[] = $event->getStep();
             },
         );
 
@@ -279,9 +280,10 @@ final class InstallerProfilesIntegrationTest extends TestCase
             $this->tempDir,
         );
 
-        // Phase 1 dispatches steps for 'collect_validate' and 'write_env'
-        $this->assertContains('collect_validate', $dispatchedSteps);
-        $this->assertContains('write_env', $dispatchedSteps);
+        // Phase 1 dispatches steps for collect/validate, write env, and write doctrine config
+        $this->assertContains(InstallStep::CollectAndValidate, $dispatchedSteps);
+        $this->assertContains(InstallStep::WriteEnv, $dispatchedSteps);
+        $this->assertContains(InstallStep::WriteDoctrineConfig, $dispatchedSteps);
     }
 
     /**

--- a/tests/Unit/InstallBundle/Profile/InstallStepTest.php
+++ b/tests/Unit/InstallBundle/Profile/InstallStepTest.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\InstallBundle\Profile;
+
+use Pimcore\Bundle\InstallBundle\Profile\InstallStep;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * @internal
+ */
+final class InstallStepTest extends TestCase
+{
+    /**
+     * @return list<array{0: InstallStep, 1: string}>
+     */
+    public static function allCasesProvider(): array
+    {
+        return [
+            [InstallStep::CollectAndValidate, 'collect_validate'],
+            [InstallStep::WriteEnv, 'write_env'],
+            [InstallStep::WriteDoctrineConfig, 'write_doctrine_config'],
+            [InstallStep::BootKernel, 'boot_kernel'],
+            [InstallStep::SetupDatabase, 'setup_database'],
+            [InstallStep::ImportData, 'import_data'],
+            [InstallStep::CreateAdmin, 'create_admin'],
+            [InstallStep::RegisterBundles, 'register_bundles'],
+            [InstallStep::RebootKernel, 'reboot_kernel'],
+            [InstallStep::InstallBundles, 'install_bundles'],
+            [InstallStep::InstallAssets, 'install_assets'],
+            [InstallStep::RebuildClasses, 'rebuild_classes'],
+            [InstallStep::MarkMigrations, 'mark_migrations'],
+            [InstallStep::PostInstallCommands, 'post_install_commands'],
+            [InstallStep::RunMaintenance, 'run_maintenance'],
+            [InstallStep::ProfilePostInstall, 'profile_post_install'],
+            [InstallStep::Finalize, 'finalize'],
+        ];
+    }
+
+    public function testAllSeventeenCasesExist(): void
+    {
+        $cases = InstallStep::cases();
+
+        $this->assertCount(17, $cases);
+    }
+
+    /**
+     * @dataProvider allCasesProvider
+     */
+    public function testBackedStringValue(InstallStep $step, string $expectedValue): void
+    {
+        $this->assertSame($expectedValue, $step->value);
+    }
+
+    /**
+     * @dataProvider allCasesProvider
+     */
+    public function testFromReturnsCorrectCase(InstallStep $expectedStep, string $value): void
+    {
+        $this->assertSame($expectedStep, InstallStep::from($value));
+    }
+
+    public function testFromThrowsValueErrorForInvalidString(): void
+    {
+        $this->expectException(\ValueError::class);
+
+        InstallStep::from('nonexistent_step');
+    }
+
+    public function testTryFromReturnsNullForInvalidString(): void
+    {
+        $this->assertNull(InstallStep::tryFrom('nonexistent_step'));
+    }
+
+    public function testTryFromReturnsEnumForValidString(): void
+    {
+        $result = InstallStep::tryFrom('write_env');
+
+        $this->assertSame(InstallStep::WriteEnv, $result);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an `InstallStepFilterInterface` that install profiles can implement to skip specific installation steps (e.g., `WriteEnv`, `InstallAssets`, `RunMaintenance`) — designed for PaaS environments where these steps are handled by the deployment pipeline
- Introduces an `InstallStep` backed string enum (17 cases) replacing all string literals for type-safe step identification throughout the installer
- **Breaking change:** `InstallerStepEvent` is now `final`, uses `InstallStep` enum for the type property, and renames `getStep()` → `getStepNumber()` to avoid confusion with the new enum

## Usage

```php
final readonly class PaaSProfile implements InstallProfileInterface, InstallStepFilterInterface
{
    public function getSkippedInstallSteps(): array
    {
        return [
            InstallStep::WriteEnv,
            InstallStep::WriteDoctrineConfig,
            InstallStep::InstallAssets,
            InstallStep::RunMaintenance,
        ];
    }
    // ... rest of profile
}
```

## Related

Built on top of #19033 (InstallBundle profile-first architecture)
