### PR TITLE
[Bug]: Add missing NO_AUTO_CACHE_CONTROL_HEADER for existing thumbnails

### DIFF
--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -578,6 +578,7 @@ class Service extends Model\Element\Service
                 'Expires' => date('D, d M Y H:i:s T', time() + $lifetime),
                 'Content-Type' => $storage->mimeType($storagePath),
                 'Content-Length' => $storage->fileSize($storagePath),
+                AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER => true,
             ]);
         } else {
             $thumbnail = Asset\Service::getImageThumbnailByArrayConfig($config);


### PR DESCRIPTION
## Summary
- Fixed missing `AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER` when serving existing thumbnails from storage
- This ensures consistent caching behavior between newly generated and existing thumbnails

## The Problem
When serving existing thumbnails (lines 569-581 in `getStreamedResponseForThumbnail()`), the response was missing the `NO_AUTO_CACHE_CONTROL_HEADER` that is properly set when generating new thumbnails (line 528 in `getStreamedResponseFromImageThumbnail()`).

Without this header, Symfony's `SessionListener` overrides the cache headers:
- Changes `Cache-Control` from `public, max-age=604800` to `private, max-age=0, must-revalidate`
- Breaks browser and CDN caching
- Forces every thumbnail request to hit PHP instead of being cached

## The Fix
Added `AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER => true` to the response headers array when serving existing thumbnails (line 581), matching the behavior of newly generated thumbnails.

## Test Plan
- [ ] Verify that existing thumbnails are served with `Cache-Control: public, max-age=604800` header
- [ ] Verify that the `NO_AUTO_CACHE_CONTROL_HEADER` prevents Symfony's SessionListener from overriding cache headers
- [ ] Confirm browser/CDN caching works correctly for existing thumbnails

🤖 Generated with [Claude Code](https://claude.com/claude-code)