### PR TITLE
[Task]: Add conflict for broken symfony/event-dispatcher version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -142,6 +142,7 @@
     "pimcore/web2print-tools-bundle": "<6.0",
     "sabre/dav": "4.2.2",
     "symfony/symfony": "*",
+    "symfony/event-dispatcher": "6.4.36 || 7.4.8",
     "symfony/web-link": "<6.0",
     "thecodingmachine/safe": "<2.0",
     "twig/twig": ">=3.9.0 <3.14.0",


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `12.3`
- Feature/Improvement: choose `2026.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`2026.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `12.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves issues with TraceableEventDispatcher

## Additional info
The symfony issues was reported here: https://github.com/symfony/symfony/issues/63844
This was fixed but not released yet: https://github.com/symfony/symfony/pull/63847