### PR TITLE
Deprecate passing custom renderlet params as attributes

### DIFF
--- a/bundles/CoreBundle/config/event_listeners.yaml
+++ b/bundles/CoreBundle/config/event_listeners.yaml
@@ -133,3 +133,9 @@ services:
             $debugToolbarListener: '@?web_profiler.debug_toolbar'
 
     Pimcore\Bundle\CoreBundle\EventListener\MessengerClearRuntimeCacheListener: ~
+
+    #
+    # DEPRECATIONS
+    #
+
+    Pimcore\Bundle\CoreBundle\EventListener\DeprecatedRenderletAttributesListener: ~

--- a/bundles/CoreBundle/src/EventListener/DeprecatedRenderletAttributesListener.php
+++ b/bundles/CoreBundle/src/EventListener/DeprecatedRenderletAttributesListener.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\CoreBundle\EventListener;
+
+use Pimcore\Bundle\CoreBundle\Request\DeprecatedRenderletAttributeBag;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * @internal
+ */
+class DeprecatedRenderletAttributesListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest'],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        $request = $event->getRequest();
+
+        if ('renderlet' !== $request->attributes->get('pimcore_request_source')) {
+            return;
+        }
+
+        $request->attributes = new DeprecatedRenderletAttributeBag(
+            parameters: $request->attributes->all(),
+            deprecated: $request->query->keys(),
+        );
+    }
+}

--- a/bundles/CoreBundle/src/Request/DeprecatedRenderletAttributeBag.php
+++ b/bundles/CoreBundle/src/Request/DeprecatedRenderletAttributeBag.php
@@ -29,7 +29,7 @@ final class DeprecatedRenderletAttributeBag extends ParameterBag
     public function all(?string $key = null): array
     {
         if (null !== $key && in_array($key, $this->deprecated, true)) {
-            trigger_deprecation('pimcore/pimcore', '2026.2', 'Fetching the custom "%s" renderlet parameter from "attributes" is deprecated and will be removed in Pimcore 2027.0. Fetch it from "query" instead.', $key);
+            trigger_deprecation('pimcore/pimcore', '2026.3', 'Fetching the custom "%s" renderlet parameter from "attributes" is deprecated and will be removed in Pimcore 2027.0. Fetch it from "query" instead.', $key);
         }
 
         return parent::all($key);
@@ -39,7 +39,7 @@ final class DeprecatedRenderletAttributeBag extends ParameterBag
     public function get(string $key, mixed $default = null): mixed
     {
         if (in_array($key, $this->deprecated, true)) {
-            trigger_deprecation('pimcore/pimcore', '2026.2', 'Fetching the custom "%s" renderlet parameter from "attributes" is deprecated and will be removed in Pimcore 2027.0. Fetch it from "query" instead.', $key);
+            trigger_deprecation('pimcore/pimcore', '2026.3', 'Fetching the custom "%s" renderlet parameter from "attributes" is deprecated and will be removed in Pimcore 2027.0. Fetch it from "query" instead.', $key);
         }
 
         return parent::get($key, $default);
@@ -49,7 +49,7 @@ final class DeprecatedRenderletAttributeBag extends ParameterBag
     public function has(string $key): bool
     {
         if (in_array($key, $this->deprecated, true)) {
-            trigger_deprecation('pimcore/pimcore', '2026.2', 'Fetching the custom "%s" renderlet parameter from "attributes" is deprecated and will be removed in Pimcore 2027.0. Fetch it from "query" instead.', $key);
+            trigger_deprecation('pimcore/pimcore', '2026.3', 'Fetching the custom "%s" renderlet parameter from "attributes" is deprecated and will be removed in Pimcore 2027.0. Fetch it from "query" instead.', $key);
         }
 
         return parent::has($key);

--- a/bundles/CoreBundle/src/Request/DeprecatedRenderletAttributeBag.php
+++ b/bundles/CoreBundle/src/Request/DeprecatedRenderletAttributeBag.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Request;
+
+use Symfony\Component\HttpFoundation\ParameterBag;
+
+/**
+ * @internal
+ */
+final class DeprecatedRenderletAttributeBag extends ParameterBag
+{
+    public function __construct(array $parameters, private readonly array $deprecated)
+    {
+        parent::__construct($parameters);
+    }
+
+    #[\Override]
+    public function all(?string $key = null): array
+    {
+        if (null !== $key && in_array($key, $this->deprecated, true)) {
+            trigger_deprecation('pimcore/pimcore', '2026.2', 'Fetching the custom "%s" renderlet parameter from "attributes" is deprecated and will be removed in Pimcore 2027.0. Fetch it from "query" instead.', $key);
+        }
+
+        return parent::all($key);
+    }
+
+    #[\Override]
+    public function get(string $key, mixed $default = null): mixed
+    {
+        if (in_array($key, $this->deprecated, true)) {
+            trigger_deprecation('pimcore/pimcore', '2026.2', 'Fetching the custom "%s" renderlet parameter from "attributes" is deprecated and will be removed in Pimcore 2027.0. Fetch it from "query" instead.', $key);
+        }
+
+        return parent::get($key, $default);
+    }
+
+    #[\Override]
+    public function has(string $key): bool
+    {
+        if (in_array($key, $this->deprecated, true)) {
+            trigger_deprecation('pimcore/pimcore', '2026.2', 'Fetching the custom "%s" renderlet parameter from "attributes" is deprecated and will be removed in Pimcore 2027.0. Fetch it from "query" instead.', $key);
+        }
+
+        return parent::has($key);
+    }
+}

--- a/doc/13_Upgrade_Notes/README.md
+++ b/doc/13_Upgrade_Notes/README.md
@@ -20,6 +20,9 @@
 ### [Assets]
 - [Thumbnails] The cache lifetime used for the `Cache-Control` and `Expires` HTTP headers when a thumbnail is delivered on-the-fly through the thumbnail service is now configurable via `pimcore.assets.thumbnails.cache_lifetime` (in seconds). It defaults to `604800` (one week), which preserves the previous hard-coded behavior.
 
+### [Documents]
+- [Renderlets] Custom renderlet configuration parameters are now passed to renderlet controllers as query parameters. Accessing these custom parameters via request attributes is deprecated and will be removed in Pimcore 2027. Update custom renderlet controllers from `$request->attributes->get('myParam')` to `$request->query->get('myParam')`.
+
 ### [DataObject]
 - [Relations] The `ownername` column has been widened from `VARCHAR(70)` to `VARCHAR(190)` in the per-class relation tables (`object_relations_*`), the advanced-relation metadata tables (`object_metadata_*`) and `object_url_slugs`. The generated `ownername` for a localized field nested inside an object brick or field collection (e.g. `/objectbrick~<field>/<brickKey>/localizedfield~localizedfield`) can exceed 70 characters, which caused "Data too long for column 'ownername'" on save under strict SQL mode. Existing installations are updated automatically by the migration `Version20260721000000`; no code or configuration changes are required.
 


### PR DESCRIPTION
## Changes in this pull request  
Deprecates fetching custom renderlet parameters from the `attributes` request bag.

## Additional info
This is a follow-up of #18712. 

It was originally planned to deprecate this in Pimcore 12 and remove the deprecated behavior in Pimcore 2026. 
Now it will be deprecated in Pimcore 2026 and removed in Pimcore 2027.

> [!NOTE]  
> Apparently, **the fix in Pimcore 11 was incomplete** (see [this comment](https://github.com/pimcore/pimcore/pull/18712#issuecomment-3414093085)). 
> However, the broken behavior was in the “Admin UI Classic Bundle,” which is no longer supported. 
> I had a quick look at the Studio backend, and **it seems the bug is still there and needs to be fixed first!** 
> Since I’m not familiar with Studio yet, this will probably have to be fixed by someone else.