### PR TITLE
Remove service definition for non-existing service

### DIFF
--- a/bundles/CoreBundle/config/templating_twig.yaml
+++ b/bundles/CoreBundle/config/templating_twig.yaml
@@ -81,5 +81,3 @@ services:
     Twig\Extension\SandboxExtension:
         arguments:
             $policy: '@Pimcore\Twig\Sandbox\SecurityPolicy'
-
-    Pimcore\Twig\Extension\AdminExtension: ~


### PR DESCRIPTION
## Changes in this pull request  
This class was moved to `Pimcore\Bundle\AdminBundle\Twig\Extension\AdminExtension` and does not exist in this repo anymore.