### PR TITLE
[Bug, EC] Fix exhausted generator traversion

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1659,18 +1659,17 @@ class Asset extends Element\AbstractElement
             $movedFiles = [];
 
             $children = $storage->listContents($oldPath, true)->toArray();
-            $totalChildren = count($children);
+            $fileChildren = array_filter($children, fn($c) => $c instanceof \League\Flysystem\FileAttributes);
+            $totalChildren = count($fileChildren);
 
             if ($totalChildren > 0) {
-                /** @var \League\Flysystem\StorageAttributes $child */
-                foreach ($children as $child) {
-                    if ($child instanceof \League\Flysystem\FileAttributes) {
-                        $src  = $child['path'];
-                        $dest = str_replace($oldPath, $newPath, '/' . $src);
+                /** @var \League\Flysystem\FileAttributes $child */
+                foreach ($fileChildren as $child) {
+                    $src  = $child['path'];
+                    $dest = str_replace($oldPath, $newPath, '/' . $src);
 
-                        $storage->move($src, $dest);
-                        $movedFiles[$dest] = $src;
-                    }
+                    $storage->move($src, $dest);
+                    $movedFiles[$dest] = $src;
                 }
 
                 $movedCount = count($movedFiles);

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1657,8 +1657,9 @@ class Asset extends Element\AbstractElement
 
         try {
             $movedFiles = [];
-            $children = $storage->listContents($oldPath, true);
-            $totalChildren = iterator_count($children);
+
+            $children = $storage->listContents($oldPath, true)->toArray();
+            $totalChildren = count($children);
 
             if ($totalChildren > 0) {
                 /** @var \League\Flysystem\StorageAttributes $child */

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1663,7 +1663,6 @@ class Asset extends Element\AbstractElement
             $totalChildren = count($fileChildren);
 
             if ($totalChildren > 0) {
-                /** @var \League\Flysystem\FileAttributes $child */
                 foreach ($fileChildren as $child) {
                     $src  = $child['path'];
                     $dest = str_replace($oldPath, $newPath, '/' . $src);

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1657,28 +1657,33 @@ class Asset extends Element\AbstractElement
 
         try {
             $movedFiles = [];
+            $createdDirs = [];
 
             $children = $storage->listContents($oldPath, true)->toArray();
-            $fileChildren = array_filter($children, fn($c) => $c instanceof \League\Flysystem\FileAttributes);
-            $totalChildren = count($fileChildren);
+            $totalChildren = count($children);
 
             if ($totalChildren > 0) {
-                foreach ($fileChildren as $child) {
+                foreach ($children as $child) {
                     $src  = $child['path'];
                     $dest = str_replace($oldPath, $newPath, '/' . $src);
 
-                    $storage->move($src, $dest);
-                    $movedFiles[$dest] = $src;
+                    if ($child instanceof \League\Flysystem\FileAttributes) {
+                        $storage->move($src, $dest);
+                        $movedFiles[$dest] = $src;
+                    } elseif ($child instanceof \League\Flysystem\DirectoryAttributes) {
+                        $storage->createDirectory($dest);
+                        $createdDirs[] = $dest;
+                    }
                 }
 
-                $movedCount = count($movedFiles);
+                $movedCount = count($movedFiles) + count($createdDirs);
 
                 if ($movedCount === $totalChildren) {
                     $storage->deleteDirectory($oldPath);
                 } else {
                     \Pimcore\Logger::info(
                         sprintf(
-                            'Moved %d/%d files from %s to %s. No exception was thrown for %d files,
+                            'Moved %d/%d children from %s to %s. No exception was thrown for %d children,
                             so the source directory was not deleted.',
                             $movedCount, $totalChildren, $oldPath, $newPath, $totalChildren - $movedCount
                         )
@@ -1692,9 +1697,12 @@ class Asset extends Element\AbstractElement
                 return;
             }
 
-            // rollback moved files
+            // rollback moved files and created directories
             foreach ($movedFiles as $src => $dest) {
                 $storage->move($src, $dest);
+            }
+            foreach ($createdDirs as $dir) {
+                $storage->deleteDirectory($dir);
             }
 
             // trigger database rollback

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1659,36 +1659,36 @@ class Asset extends Element\AbstractElement
             $movedFiles = [];
             $createdDirs = [];
 
-            $children = $storage->listContents($oldPath, true)->toArray();
-            $totalChildren = count($children);
+            $children = $storage->listContents($oldPath, true);
+            $totalChildren = 0;
 
-            if ($totalChildren > 0) {
-                foreach ($children as $child) {
-                    $src  = $child['path'];
-                    $dest = str_replace($oldPath, $newPath, '/' . $src);
+            foreach ($children as $child) {
+                $src  = $child['path'];
+                $dest = str_replace($oldPath, $newPath, '/' . $src);
 
-                    if ($child instanceof \League\Flysystem\FileAttributes) {
-                        $storage->move($src, $dest);
-                        $movedFiles[$dest] = $src;
-                    } elseif ($child instanceof \League\Flysystem\DirectoryAttributes) {
-                        $storage->createDirectory($dest);
-                        $createdDirs[] = $dest;
-                    }
+                if ($child instanceof \League\Flysystem\FileAttributes) {
+                    $storage->move($src, $dest);
+                    $movedFiles[$dest] = $src;
+                } elseif ($child instanceof \League\Flysystem\DirectoryAttributes) {
+                    $storage->createDirectory($dest);
+                    $createdDirs[] = $dest;
                 }
 
-                $movedCount = count($movedFiles) + count($createdDirs);
+                $totalChildren++;
+            }
 
-                if ($movedCount === $totalChildren) {
-                    $storage->deleteDirectory($oldPath);
-                } else {
-                    \Pimcore\Logger::info(
-                        sprintf(
-                            'Moved %d/%d children from %s to %s. No exception was thrown for %d children,
-                            so the source directory was not deleted.',
-                            $movedCount, $totalChildren, $oldPath, $newPath, $totalChildren - $movedCount
-                        )
-                    );
-                }
+            $movedCount = count($movedFiles) + count($createdDirs);
+
+            if ($movedCount === $totalChildren) {
+                $storage->deleteDirectory($oldPath);
+            } else {
+                \Pimcore\Logger::info(
+                    sprintf(
+                        'Moved %d/%d children from %s to %s. No exception was thrown for %d children,
+                        so the source directory was not deleted.',
+                        $movedCount, $totalChildren, $oldPath, $newPath, $totalChildren - $movedCount
+                    )
+                );
             }
         } catch (Throwable $e) {
             Logger::error(sprintf('Asset Move to %s failed: %s', $newPath, $e->getMessage()));

--- a/tests/Model/Asset/AssetTest.php
+++ b/tests/Model/Asset/AssetTest.php
@@ -270,8 +270,9 @@ class AssetTest extends ModelTestCase
         $image->setParentId($sub->getId());
         $image->save();
 
-        $destParent = Asset\Service::createFolderByPath('/test-fallback-dest-' . uniqid());
-        $oldPath    = $srcRoot->getRealFullPath();
+        $destParent          = Asset\Service::createFolderByPath('/test-fallback-dest-' . uniqid());
+        $oldPath             = $srcRoot->getRealFullPath();
+        $imageOldStoragePath = $image->getRealFullPath();
 
         // Wrap the real storage: throw UnableToMoveFile only for the top-level
         // folder move so that the file-by-file fallback in updateChildPaths() is
@@ -346,6 +347,21 @@ class AssetTest extends ModelTestCase
         $this->assertTrue(
             $realStorage->directoryExists($newPath . '/empty'),
             'Empty subdirectory must be recreated at the destination during the fallback move.'
+        );
+
+        // Verify that the nested asset file was actually relocated to the new
+        // subtree and is no longer at its old path.  A path-mapping bug could
+        // still pass the directory checks above while silently losing the file.
+        $imageNewStoragePath = str_replace($oldPath, $newPath, $imageOldStoragePath);
+
+        $this->assertFalse(
+            $realStorage->fileExists($imageOldStoragePath),
+            'Image file must no longer exist at the source path after the fallback move.'
+        );
+
+        $this->assertTrue(
+            $realStorage->fileExists($imageNewStoragePath),
+            'Image file must be present at the destination path after the fallback move.'
         );
     }
 

--- a/tests/Model/Asset/AssetTest.php
+++ b/tests/Model/Asset/AssetTest.php
@@ -14,10 +14,14 @@ declare(strict_types=1);
 namespace Pimcore\Tests\Model\Asset;
 
 use Exception;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\UnableToMoveFile;
+use Pimcore;
 use Pimcore\Model\Asset;
 use Pimcore\Tests\Support\Test\ModelTestCase;
 use Pimcore\Tests\Support\Util\TestHelper;
 use Pimcore\Tool\Storage;
+use Psr\Container\ContainerInterface;
 
 /**
  * Class AssetTest
@@ -244,6 +248,92 @@ class AssetTest extends ModelTestCase
     public function reloadAsset(): void
     {
         $this->testAsset = Asset::getById($this->testAsset->getId(), ['force' => true]);
+    }
+
+    /**
+     * Regression test for the updateChildPaths() fallback path:
+     * when a single storage->move() of a folder fails with UnableToMoveFile,
+     * the method must move all descendant files individually and then delete
+     * the source directory — even when the folder tree contains nested
+     * subdirectories (which listContents() returns as DirectoryAttributes that
+     * must not be counted against the moved-file total).
+     */
+    public function testFolderMoveWithNestedSubdirectoriesFallback(): void
+    {
+        // Build: /src-root/sub/image.jpg
+        $srcRoot = Asset\Service::createFolderByPath('/test-fallback-src-' . uniqid());
+        $sub     = Asset\Service::createFolderByPath($srcRoot->getFullPath() . '/sub');
+        TestHelper::createImageAsset('image', $sub->getId(), true, 'assets/images/image1.jpg');
+
+        $destParent = Asset\Service::createFolderByPath('/test-fallback-dest-' . uniqid());
+        $oldPath    = $srcRoot->getRealFullPath();
+
+        // Wrap the real storage: throw UnableToMoveFile only for the top-level
+        // folder move so that the file-by-file fallback in updateChildPaths() is
+        // exercised. All other calls (listContents, individual file moves,
+        // deleteDirectory) are delegated to the real storage.
+        $realStorage = Storage::get('asset');
+
+        $mockStorage = $this->createMock(FilesystemOperator::class);
+
+        $mockStorage->method('move')
+            ->willReturnCallback(
+                function (string $source, string $dest) use ($realStorage, $oldPath): void {
+                    if ($source === $oldPath) {
+                        throw UnableToMoveFile::fromLocationTo($source, $dest);
+                    }
+                    $realStorage->move($source, $dest);
+                }
+            );
+
+        $mockStorage->method('listContents')
+            ->willReturnCallback(
+                fn (string $path, bool $deep = false) => $realStorage->listContents($path, $deep)
+            );
+
+        $mockStorage->method('deleteDirectory')
+            ->willReturnCallback(fn (string $path) => $realStorage->deleteDirectory($path));
+
+        $mockStorage->method('directoryExists')
+            ->willReturnCallback(fn (string $path) => $realStorage->directoryExists($path));
+
+        $mockStorage->method('fileExists')
+            ->willReturnCallback(fn (string $path) => $realStorage->fileExists($path));
+
+        // Inject mock storage via the Storage service's internal locator
+        $storageService = Pimcore::getContainer()->get(Storage::class);
+        $locatorProp    = new \ReflectionProperty(Storage::class, 'locator');
+        $locatorProp->setAccessible(true);
+        $realLocator = $locatorProp->getValue($storageService);
+
+        $mockLocator = $this->createMock(ContainerInterface::class);
+        $mockLocator->method('get')
+            ->willReturnCallback(
+                fn (string $id) => $id === 'pimcore.asset.storage'
+                    ? $mockStorage
+                    : $realLocator->get($id)
+            );
+
+        $locatorProp->setValue($storageService, $mockLocator);
+
+        try {
+            $srcRoot->setParentId($destParent->getId());
+            $srcRoot->save();
+        } finally {
+            // Always restore the real locator
+            $locatorProp->setValue($storageService, $realLocator);
+        }
+
+        $this->assertFalse(
+            $realStorage->directoryExists($oldPath),
+            'Source directory must be deleted after all files are moved via the fallback path.'
+        );
+
+        $newPath = $srcRoot->getRealFullPath();
+        $this->assertTrue(
+            $realStorage->directoryExists($newPath),
+            'Destination directory must exist after the fallback move.'
+        );
     }
 
     /**

--- a/tests/Model/Asset/AssetTest.php
+++ b/tests/Model/Asset/AssetTest.php
@@ -260,10 +260,13 @@ class AssetTest extends ModelTestCase
      */
     public function testFolderMoveWithNestedSubdirectoriesFallback(): void
     {
-        // Build: /src-root/sub/image.jpg
-        $srcRoot = Asset\Service::createFolderByPath('/test-fallback-src-' . uniqid());
-        $sub     = Asset\Service::createFolderByPath($srcRoot->getFullPath() . '/sub');
-        $image   = TestHelper::createImageAsset('image', null, true, 'assets/images/image1.jpg');
+        // Build:
+        //   /src-root/sub/image.jpg   (file inside a nested subfolder)
+        //   /src-root/empty/          (empty nested subfolder — no files)
+        $srcRoot  = Asset\Service::createFolderByPath('/test-fallback-src-' . uniqid());
+        $sub      = Asset\Service::createFolderByPath($srcRoot->getFullPath() . '/sub');
+        $emptyDir = Asset\Service::createFolderByPath($srcRoot->getFullPath() . '/empty');
+        $image    = TestHelper::createImageAsset('image', null, true, 'assets/images/image1.jpg');
         $image->setParentId($sub->getId());
         $image->save();
 
@@ -295,6 +298,9 @@ class AssetTest extends ModelTestCase
 
         $mockStorage->method('deleteDirectory')
             ->willReturnCallback(fn (string $path) => $realStorage->deleteDirectory($path));
+
+        $mockStorage->method('createDirectory')
+            ->willReturnCallback(fn (string $path) => $realStorage->createDirectory($path));
 
         $mockStorage->method('directoryExists')
             ->willReturnCallback(fn (string $path) => $realStorage->directoryExists($path));
@@ -335,6 +341,11 @@ class AssetTest extends ModelTestCase
         $this->assertTrue(
             $realStorage->directoryExists($newPath),
             'Destination directory must exist after the fallback move.'
+        );
+
+        $this->assertTrue(
+            $realStorage->directoryExists($newPath . '/empty'),
+            'Empty subdirectory must be recreated at the destination during the fallback move.'
         );
     }
 

--- a/tests/Model/Asset/AssetTest.php
+++ b/tests/Model/Asset/AssetTest.php
@@ -438,12 +438,11 @@ class AssetTest extends ModelTestCase
 
         $locatorProp->setValue($storageService, $mockLocator);
 
+        $this->expectException(UnableToMoveFile::class);
+
         try {
             $srcRoot->setParentId($destParent->getId());
             $srcRoot->save();
-            $this->fail('Expected an exception to be thrown during the partial fallback move.');
-        } catch (\Throwable) {
-            // Expected — the second file move throws, rolling back the partial move
         } finally {
             $locatorProp->setValue($storageService, $realLocator);
         }

--- a/tests/Model/Asset/AssetTest.php
+++ b/tests/Model/Asset/AssetTest.php
@@ -263,7 +263,9 @@ class AssetTest extends ModelTestCase
         // Build: /src-root/sub/image.jpg
         $srcRoot = Asset\Service::createFolderByPath('/test-fallback-src-' . uniqid());
         $sub     = Asset\Service::createFolderByPath($srcRoot->getFullPath() . '/sub');
-        TestHelper::createImageAsset('image', $sub->getId(), true, 'assets/images/image1.jpg');
+        $image   = TestHelper::createImageAsset('image', null, true, 'assets/images/image1.jpg');
+        $image->setParentId($sub->getId());
+        $image->save();
 
         $destParent = Asset\Service::createFolderByPath('/test-fallback-dest-' . uniqid());
         $oldPath    = $srcRoot->getRealFullPath();

--- a/tests/Model/Asset/AssetTest.php
+++ b/tests/Model/Asset/AssetTest.php
@@ -350,6 +350,109 @@ class AssetTest extends ModelTestCase
     }
 
     /**
+     * Verifies that the updateChildPaths() rollback correctly removes any
+     * destination directories that were created before a mid-move failure.
+     * Without this, a failed partial move leaves orphaned directories behind
+     * at the destination while the source tree is still intact.
+     */
+    public function testFolderMoveRollbackCleansUpCreatedDirectories(): void
+    {
+        // Build:
+        //   /src-root/empty/    (empty subfolder — createDirectory at dest must be rolled back)
+        //   /src-root/file1.jpg (first file — moved to dest before the failure, must be moved back)
+        //   /src-root/file2.jpg (second file — its move will throw, triggering rollback)
+        $srcRoot  = Asset\Service::createFolderByPath('/test-rollback-src-' . uniqid());
+        Asset\Service::createFolderByPath($srcRoot->getFullPath() . '/empty');
+
+        $file1 = TestHelper::createImageAsset('file1', null, true, 'assets/images/image1.jpg');
+        $file1->setParentId($srcRoot->getId());
+        $file1->save();
+
+        $file2 = TestHelper::createImageAsset('file2', null, true, 'assets/images/image2.jpg');
+        $file2->setParentId($srcRoot->getId());
+        $file2->save();
+
+        $destParent  = Asset\Service::createFolderByPath('/test-rollback-dest-' . uniqid());
+        $oldPath     = $srcRoot->getRealFullPath();
+        $newRootPath = $destParent->getRealFullPath() . '/' . $srcRoot->getKey();
+
+        $realStorage = Storage::get('asset');
+
+        $fallbackFileMoveCount = 0;
+        $mockStorage = $this->createMock(FilesystemOperator::class);
+
+        $mockStorage->method('move')
+            ->willReturnCallback(
+                function (string $source, string $dest) use ($realStorage, $oldPath, &$fallbackFileMoveCount): void {
+                    if ($source === $oldPath) {
+                        // Force the file-by-file fallback path
+                        throw UnableToMoveFile::fromLocationTo($source, $dest);
+                    }
+
+                    if ($fallbackFileMoveCount >= 1) {
+                        // Fail on the second file move inside the fallback to trigger rollback
+                        throw UnableToMoveFile::fromLocationTo($source, $dest);
+                    }
+
+                    $realStorage->move($source, $dest);
+                    $fallbackFileMoveCount++;
+                }
+            );
+
+        $mockStorage->method('listContents')
+            ->willReturnCallback(
+                fn (string $path, bool $deep = false) => $realStorage->listContents($path, $deep)
+            );
+
+        $mockStorage->method('deleteDirectory')
+            ->willReturnCallback(fn (string $path) => $realStorage->deleteDirectory($path));
+
+        $mockStorage->method('createDirectory')
+            ->willReturnCallback(fn (string $path) => $realStorage->createDirectory($path));
+
+        $mockStorage->method('directoryExists')
+            ->willReturnCallback(fn (string $path) => $realStorage->directoryExists($path));
+
+        $mockStorage->method('fileExists')
+            ->willReturnCallback(fn (string $path) => $realStorage->fileExists($path));
+
+        $storageService = Pimcore::getContainer()->get(Storage::class);
+        $locatorProp    = new \ReflectionProperty(Storage::class, 'locator');
+        $locatorProp->setAccessible(true);
+        $realLocator = $locatorProp->getValue($storageService);
+
+        $mockLocator = $this->createMock(ContainerInterface::class);
+        $mockLocator->method('get')
+            ->willReturnCallback(
+                fn (string $id) => $id === 'pimcore.asset.storage'
+                    ? $mockStorage
+                    : $realLocator->get($id)
+            );
+
+        $locatorProp->setValue($storageService, $mockLocator);
+
+        try {
+            $srcRoot->setParentId($destParent->getId());
+            $srcRoot->save();
+            $this->fail('Expected an exception to be thrown during the partial fallback move.');
+        } catch (\Throwable) {
+            // Expected — the second file move throws, rolling back the partial move
+        } finally {
+            $locatorProp->setValue($storageService, $realLocator);
+        }
+
+        $this->assertFalse(
+            $realStorage->directoryExists($newRootPath . '/empty'),
+            'Destination directory created before the failure must be deleted by rollback.'
+        );
+
+        $this->assertTrue(
+            $realStorage->directoryExists($oldPath),
+            'Source directory must still exist after a rolled-back partial move.'
+        );
+    }
+
+    /**
      * Verifies that an asset can be saved with custom user modification id.
      *
      */

--- a/tests/Model/Asset/AssetTest.php
+++ b/tests/Model/Asset/AssetTest.php
@@ -383,14 +383,21 @@ class AssetTest extends ModelTestCase
 
         $mockStorage->method('move')
             ->willReturnCallback(
-                function (string $source, string $dest) use ($realStorage, $oldPath, &$fallbackFileMoveCount): void {
+                function (string $source, string $dest) use ($realStorage, $oldPath, $newRootPath, &$fallbackFileMoveCount): void {
                     if ($source === $oldPath) {
                         // Force the file-by-file fallback path
                         throw UnableToMoveFile::fromLocationTo($source, $dest);
                     }
 
+                    // Rollback moves go from destination back to source — always allow them
+                    // through so the rollback loop itself is not disrupted by the mock.
+                    if (str_starts_with($source, $newRootPath)) {
+                        $realStorage->move($source, $dest);
+                        return;
+                    }
+
                     if ($fallbackFileMoveCount >= 1) {
-                        // Fail on the second file move inside the fallback to trigger rollback
+                        // Fail on the second forward file move to trigger rollback
                         throw UnableToMoveFile::fromLocationTo($source, $dest);
                     }
 

--- a/tests/Model/Asset/AssetTest.php
+++ b/tests/Model/Asset/AssetTest.php
@@ -370,15 +370,20 @@ class AssetTest extends ModelTestCase
      * destination directories that were created before a mid-move failure.
      * Without this, a failed partial move leaves orphaned directories behind
      * at the destination while the source tree is still intact.
+     *
+     * The tree contains multiple nested subdirectory levels so that the
+     * directory-rollback loop is exercised for more than one $createdDirs entry.
      */
     public function testFolderMoveRollbackCleansUpCreatedDirectories(): void
     {
         // Build:
-        //   /src-root/empty/    (empty subfolder — createDirectory at dest must be rolled back)
+        //   /src-root/sub/      (subfolder — createDirectory at dest must be rolled back)
+        //   /src-root/sub/deep/ (nested subfolder — verifies the loop runs for multiple dirs)
         //   /src-root/file1.jpg (first file — moved to dest before the failure, must be moved back)
         //   /src-root/file2.jpg (second file — its move will throw, triggering rollback)
-        $srcRoot  = Asset\Service::createFolderByPath('/test-rollback-src-' . uniqid());
-        Asset\Service::createFolderByPath($srcRoot->getFullPath() . '/empty');
+        $srcRoot = Asset\Service::createFolderByPath('/test-rollback-src-' . uniqid());
+        Asset\Service::createFolderByPath($srcRoot->getFullPath() . '/sub');
+        Asset\Service::createFolderByPath($srcRoot->getFullPath() . '/sub/deep');
 
         $file1 = TestHelper::createImageAsset('file1', null, true, 'assets/images/image1.jpg');
         $file1->setParentId($srcRoot->getId());
@@ -472,8 +477,13 @@ class AssetTest extends ModelTestCase
         );
 
         $this->assertFalse(
-            $realStorage->directoryExists($newRootPath . '/empty'),
-            'Destination directory created before the failure must be deleted by rollback.'
+            $realStorage->directoryExists($newRootPath . '/sub'),
+            'Destination directory "sub" created before the failure must be deleted by rollback.'
+        );
+
+        $this->assertFalse(
+            $realStorage->directoryExists($newRootPath . '/sub/deep'),
+            'Nested destination directory "sub/deep" created before the failure must be deleted by rollback.'
         );
 
         $this->assertTrue(

--- a/tests/Model/Asset/AssetTest.php
+++ b/tests/Model/Asset/AssetTest.php
@@ -438,14 +438,22 @@ class AssetTest extends ModelTestCase
 
         $locatorProp->setValue($storageService, $mockLocator);
 
-        $this->expectException(UnableToMoveFile::class);
+        $caughtException = null;
 
         try {
             $srcRoot->setParentId($destParent->getId());
             $srcRoot->save();
+        } catch (UnableToMoveFile $e) {
+            $caughtException = $e;
         } finally {
             $locatorProp->setValue($storageService, $realLocator);
         }
+
+        $this->assertInstanceOf(
+            UnableToMoveFile::class,
+            $caughtException,
+            'Expected save() to throw UnableToMoveFile after a partial move failure.'
+        );
 
         $this->assertFalse(
             $realStorage->directoryExists($newRootPath . '/empty'),

--- a/tests/Model/Asset/AssetTest.php
+++ b/tests/Model/Asset/AssetTest.php
@@ -457,6 +457,21 @@ class AssetTest extends ModelTestCase
             $realStorage->directoryExists($oldPath),
             'Source directory must still exist after a rolled-back partial move.'
         );
+
+        // Verify the file that was successfully moved before the failure was
+        // restored to the source — and is no longer present at the destination.
+        $file1StoragePath = $file1->getRealFullPath();
+        $file1DestPath    = str_replace($oldPath, $newRootPath, $file1StoragePath);
+
+        $this->assertTrue(
+            $realStorage->fileExists($file1StoragePath),
+            'File moved before the failure must be restored to the source by rollback.'
+        );
+
+        $this->assertFalse(
+            $realStorage->fileExists($file1DestPath),
+            'File moved before the failure must no longer exist at the destination after rollback.'
+        );
     }
 
     /**


### PR DESCRIPTION
[Bug, EC] PEES-1103: Error message "Cannot traverse an already closed…generator" pops up when moving folder with assets

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `12.3`
- Feature/Improvement: choose `2026.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`2026.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `12.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves: [[Bug, EC] Fix exhausted generator traversion](https://github.com/pimcore/service-operations/issues/815)

## Additional info
