### PR TITLE
[Bug] Fix Video editable rendering states in Studio

### DIFF
--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -502,24 +502,8 @@ class Video extends Model\Document\Editable implements IdRewriterInterface, Edit
     private function getErrorCode(string $message = ''): string
     {
         $name = $this->getName();
-        $width = $this->getWidth();
-        // If contains at least one digit (0-9), then assume it is a value that can be calculated,
-        // otherwise it is likely be `auto`,`inherit`,etc..
-        if (preg_match('/[\d]/', (string) $width)) {
-            // when is numeric, assume there are no length units nor %, and considering the value as pixels
-            if (is_numeric($width)) {
-                $width .= 'px';
-            }
-            $width = 'calc(' . $width . ' - 1px)';
-        }
-
-        $height = $this->getHeight();
-        if (preg_match('/[\d]/', (string) $height)) {
-            if (is_numeric($height)) {
-                $height .= 'px';
-            }
-            $height = 'calc(' . $height . ' - 1px)';
-        }
+        $width = $this->getWidthWithUnit();
+        $height = $this->getHeightWithUnit();
 
         if ($this->isStudioRequest()) {
             // expose the message only to authenticated editmode requests or in debug mode,
@@ -541,7 +525,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface, Edit
 
         $code = '
         <div id="pimcore_video_' . $name . '" class="pimcore_editable_video">
-            <div class="pimcore_editable_video_error" style="text-align:center; width: ' . $width . '; height: ' . $height . '; border:1px solid #000; background: url(/bundles/pimcoreadmin/img/filetype-not-supported.svg) no-repeat center center #fff;">
+            <div class="pimcore_editable_video_error" style="box-sizing: border-box; text-align:center; width: ' . $width . '; height: ' . $height . '; border:1px solid #000; background: url(/bundles/pimcoreadmin/img/filetype-not-supported.svg) no-repeat center center #fff;">
                 ' . $message . '
             </div>
         </div>';
@@ -983,9 +967,10 @@ class Video extends Model\Document\Editable implements IdRewriterInterface, Edit
 
         if ($this->isStudioRequest()) {
             // keep the poster image so the studio preview shows something meaningful,
-            // in editmode studio-ui-bundle renders its own loading UI on top of the marker
+            // in editmode studio-ui-bundle renders its own loading UI on top of the marker.
+            // the poster fills the parent marker, which already carries the configured size
             $poster = $thumbnail !== null && $thumbnail !== ''
-                ? '<img src="' . $thumbnail . '" style="width: ' . $width . '; height: ' . $height . ';">'
+                ? '<img src="' . $thumbnail . '" style="width: 100%; height: 100%;">'
                 : '';
 
             return '

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -521,9 +521,10 @@ class Video extends Model\Document\Editable implements IdRewriterInterface, Edit
             $height = 'calc(' . $height . ' - 1px)';
         }
 
-        $request = Pimcore::getContainer()->get('request_stack')->getCurrentRequest();
-        if ($request !== null && $request->query->getBoolean('pimcore_studio')) {
-            $messageAttr = $message !== ''
+        if ($this->isStudioRequest()) {
+            // expose the message only to authenticated editmode requests or in debug mode,
+            // the query parameter alone could be set by anyone on a frontend request
+            $messageAttr = $message !== '' && ($this->getEditmode() || Pimcore::inDebugMode())
                 ? ' data-message="' . htmlspecialchars($message, ENT_QUOTES, 'UTF-8') . '"'
                 : '';
 
@@ -962,6 +963,17 @@ class Video extends Model\Document\Editable implements IdRewriterInterface, Edit
         return implode('', $durationParts);
     }
 
+    private function isStudioRequest(): bool
+    {
+        $request = Pimcore::getContainer()->get('request_stack')->getCurrentRequest();
+
+        return $request !== null
+            && (
+                $request->query->getBoolean('pimcore_studio')
+                || $request->query->getBoolean('pimcore_studio_preview')
+            );
+    }
+
     private function getProgressCode(?string $thumbnail = null): string
     {
         $uid = $this->getUniqId();
@@ -969,11 +981,16 @@ class Video extends Model\Document\Editable implements IdRewriterInterface, Edit
         $width = $this->getWidthWithUnit();
         $height = $this->getHeightWithUnit();
 
-        $request = Pimcore::getContainer()->get('request_stack')->getCurrentRequest();
-        if ($request !== null && $request->query->getBoolean('pimcore_studio')) {
+        if ($this->isStudioRequest()) {
+            // keep the poster image so the studio preview shows something meaningful,
+            // in editmode studio-ui-bundle renders its own loading UI on top of the marker
+            $poster = $thumbnail !== null && $thumbnail !== ''
+                ? '<img src="' . $thumbnail . '" style="width: ' . $width . '; height: ' . $height . ';">'
+                : '';
+
             return '
             <div id="pimcore_video_' . $name . '" class="pimcore_editable_video">
-                <div class="pimcore_editable_video_progress" style="width: ' . $width . '; height: ' . $height . ';"></div>
+                <div class="pimcore_editable_video_progress" style="width: ' . $width . '; height: ' . $height . ';">' . $poster . '</div>
             </div>';
         }
 

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -501,6 +501,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface, Edit
 
     private function getErrorCode(string $message = ''): string
     {
+        $name = $this->getName();
         $width = $this->getWidth();
         // If contains at least one digit (0-9), then assume it is a value that can be calculated,
         // otherwise it is likely be `auto`,`inherit`,etc..
@@ -520,13 +521,25 @@ class Video extends Model\Document\Editable implements IdRewriterInterface, Edit
             $height = 'calc(' . $height . ' - 1px)';
         }
 
+        $request = Pimcore::getContainer()->get('request_stack')->getCurrentRequest();
+        if ($request !== null && $request->query->getBoolean('pimcore_studio')) {
+            $messageAttr = $message !== ''
+                ? ' data-message="' . htmlspecialchars($message, ENT_QUOTES, 'UTF-8') . '"'
+                : '';
+
+            return '
+            <div id="pimcore_video_' . $name . '" class="pimcore_editable_video">
+                <div class="pimcore_editable_video_error"' . $messageAttr . ' style="width: ' . $width . '; height: ' . $height . ';"></div>
+            </div>';
+        }
+
         // only display error message in debug mode
         if (!Pimcore::inDebugMode()) {
             $message = '';
         }
 
         $code = '
-        <div id="pimcore_video_' . $this->getName() . '" class="pimcore_editable_video">
+        <div id="pimcore_video_' . $name . '" class="pimcore_editable_video">
             <div class="pimcore_editable_video_error" style="text-align:center; width: ' . $width . '; height: ' . $height . '; border:1px solid #000; background: url(/bundles/pimcoreadmin/img/filetype-not-supported.svg) no-repeat center center #fff;">
                 ' . $message . '
             </div>
@@ -952,8 +965,20 @@ class Video extends Model\Document\Editable implements IdRewriterInterface, Edit
     private function getProgressCode(?string $thumbnail = null): string
     {
         $uid = $this->getUniqId();
+        $name = $this->getName();
+        $width = $this->getWidthWithUnit();
+        $height = $this->getHeightWithUnit();
+
+        $request = Pimcore::getContainer()->get('request_stack')->getCurrentRequest();
+        if ($request !== null && $request->query->getBoolean('pimcore_studio')) {
+            return '
+            <div id="pimcore_video_' . $name . '" class="pimcore_editable_video">
+                <div class="pimcore_editable_video_progress" style="width: ' . $width . '; height: ' . $height . ';"></div>
+            </div>';
+        }
+
         $code = '
-        <div id="pimcore_video_' . $this->getName() . '" class="pimcore_editable_video">
+        <div id="pimcore_video_' . $name . '" class="pimcore_editable_video">
             <style type="text/css">
                 #' . $uid . ' .pimcore_editable_video_progress_status {
                     box-sizing:content-box;
@@ -972,7 +997,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface, Edit
                 }
             </style>
             <div class="pimcore_editable_video_progress" id="' . $uid . '">
-                <img src="' . $thumbnail . '" style="width: ' . $this->getWidthWithUnit() . '; height: ' . $this->getHeightWithUnit() . ';">
+                <img src="' . $thumbnail . '" style="width: ' . $width . '; height: ' . $height . ';">
                 <div class="pimcore_editable_video_progress_status"></div>
             </div>
         </div>';

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -960,7 +960,6 @@ class Video extends Model\Document\Editable implements IdRewriterInterface, Edit
 
     private function getProgressCode(?string $thumbnail = null): string
     {
-        $uid = $this->getUniqId();
         $name = $this->getName();
         $width = $this->getWidthWithUnit();
         $height = $this->getHeightWithUnit();
@@ -974,6 +973,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface, Edit
             </div>';
         }
 
+        $uid = $this->getUniqId();
         $code = '
         <div id="pimcore_video_' . $name . '" class="pimcore_editable_video">
             <style type="text/css">

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -506,8 +506,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface, Edit
         $height = $this->getHeightWithUnit();
 
         if ($this->isStudioRequest()) {
-            // expose the message only to authenticated editmode requests or in debug mode,
-            // the query parameter alone could be set by anyone on a frontend request
+            // message only in editmode/debug — the query param alone is spoofable
             $messageAttr = $message !== '' && ($this->getEditmode() || Pimcore::inDebugMode())
                 ? ' data-message="' . htmlspecialchars($message, ENT_QUOTES, 'UTF-8') . '"'
                 : '';
@@ -949,10 +948,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface, Edit
 
     private function isStudioRequest(): bool
     {
-        // true only inside the Studio document editor (editmode) iframe, where
-        // studio-ui-bundle renders the loading / error UI on top of a bare marker.
-        // the preview tab (pimcore_studio_preview) has no such overlay, so it falls
-        // through to the regular frontend rendering instead.
+        // only the Studio editor (editmode) iframe; the preview tab and frontend render normally
         $request = Pimcore::getContainer()->get('request_stack')->getCurrentRequest();
 
         return $request !== null && $request->query->getBoolean('pimcore_studio');
@@ -965,8 +961,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface, Edit
         $height = $this->getHeightWithUnit();
 
         if ($this->isStudioRequest()) {
-            // bare marker — studio-ui-bundle renders its own (opaque) loading UI on
-            // top of it; a poster here would only peek through the overlay's rounded corners
+            // bare marker — studio-ui-bundle draws the loading UI on top
             return '
             <div id="pimcore_video_' . $name . '" class="pimcore_editable_video">
                 <div class="pimcore_editable_video_progress" style="width: ' . $width . '; height: ' . $height . ';"></div>

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -949,13 +949,13 @@ class Video extends Model\Document\Editable implements IdRewriterInterface, Edit
 
     private function isStudioRequest(): bool
     {
+        // true only inside the Studio document editor (editmode) iframe, where
+        // studio-ui-bundle renders the loading / error UI on top of a bare marker.
+        // the preview tab (pimcore_studio_preview) has no such overlay, so it falls
+        // through to the regular frontend rendering instead.
         $request = Pimcore::getContainer()->get('request_stack')->getCurrentRequest();
 
-        return $request !== null
-            && (
-                $request->query->getBoolean('pimcore_studio')
-                || $request->query->getBoolean('pimcore_studio_preview')
-            );
+        return $request !== null && $request->query->getBoolean('pimcore_studio');
     }
 
     private function getProgressCode(?string $thumbnail = null): string
@@ -966,16 +966,11 @@ class Video extends Model\Document\Editable implements IdRewriterInterface, Edit
         $height = $this->getHeightWithUnit();
 
         if ($this->isStudioRequest()) {
-            // keep the poster image so the studio preview shows something meaningful,
-            // in editmode studio-ui-bundle renders its own loading UI on top of the marker.
-            // the poster fills the parent marker, which already carries the configured size
-            $poster = $thumbnail !== null && $thumbnail !== ''
-                ? '<img src="' . $thumbnail . '" style="width: 100%; height: 100%;">'
-                : '';
-
+            // bare marker — studio-ui-bundle renders its own (opaque) loading UI on
+            // top of it; a poster here would only peek through the overlay's rounded corners
             return '
             <div id="pimcore_video_' . $name . '" class="pimcore_editable_video">
-                <div class="pimcore_editable_video_progress" style="width: ' . $width . '; height: ' . $height . ';">' . $poster . '</div>
+                <div class="pimcore_editable_video_progress" style="width: ' . $width . '; height: ' . $height . ';"></div>
             </div>';
         }
 


### PR DESCRIPTION
Resolves pimcore/studio-ui-bundle#3407

Renders the Video editable's in-progress / error states correctly in the Studio document editor, without changing the public-frontend behavior on 12.x.

### Studio editor (editmode)
When the request comes from the Studio editor iframe (`?pimcore_studio=1`), `getProgressCode()` / `getErrorCode()` emit a **bare marker** div (just the configured size); studio-ui-bundle renders the loading / error / edit UI on top (pimcore/studio-ui-bundle#3486). The original error message is exposed as a `data-message` attribute, but only in editmode or debug mode (the query parameter alone could be set by anyone on a frontend request).

`isStudioRequest()` matches the **editmode iframe only** — the preview tab (`pimcore_studio_preview`) and the public frontend have no studio-ui overlay, so they fall through to the regular (classic) rendering instead of an empty marker.

### Frontend / preview (behavior unchanged)
The classic markup is kept (poster + `video-loading.gif`, `filetype-not-supported.svg`), still served from admin-ui-classic-bundle, which is present on 12.x. `getErrorCode()` was tidied to use `getWidthWithUnit()`/`getHeightWithUnit()` + `box-sizing: border-box` instead of `getWidth()` + `preg_match` + `calc(… - 1px)`, so the box renders at the exact configured size (this also fixes the studio marker rendering 1px smaller).

Companion PRs:
- pimcore/pimcore#19107 — 2026.1 variant (loading gif / not-supported svg ship from CoreBundle instead)
- pimcore/studio-backend-bundle#1810 — new thumbnail status endpoint
- pimcore/studio-ui-bundle#3486 — Studio-native loading / error UI + polling

Part of the pimcore/studio-ui-bundle#3407 cross-repo set — the companion PRs above should land together.
