### PR TITLE
Fix null argument exception in tree

### DIFF
--- a/models/DataObject/Traits/CompositeIndexTrait.php
+++ b/models/DataObject/Traits/CompositeIndexTrait.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Model\DataObject\Traits;
 
 use Doctrine\DBAL\Connection;
+use InvalidArgumentException;
 
 /**
  * @internal
@@ -57,7 +58,7 @@ trait CompositeIndexTrait
         foreach ($newIndicesFilteredByType as $newIndex) {
             $key = $newIndex['index_key'];
             self::assertValidIdentifier($key);
-            
+
             $columns = $newIndex['index_columns'];
             foreach ($columns as $column) {
                 self::assertValidIdentifier($column);
@@ -104,16 +105,16 @@ trait CompositeIndexTrait
     }
 
     /**
-     * @throws \InvalidArgumentException if the identifier contains disallowed characters
+     * @throws InvalidArgumentException if the identifier contains disallowed characters
      */
     public static function assertValidIdentifier(string $identifier): void
     {
         if ($identifier === '') {
-            throw new \InvalidArgumentException('Identifier must be a non-empty string.');
+            throw new InvalidArgumentException('Identifier must be a non-empty string.');
         }
 
         if (!preg_match('/^[a-zA-Z][a-zA-Z0-9_-]{0,63}$/', $identifier)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 sprintf(
                     'Invalid composite index identifier "%s": must start with a letter and contain only alphanumeric characters, underscores, and hyphens (max 64 chars).',
                     $identifier

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -1133,6 +1133,16 @@ class Service extends Model\AbstractModel
                 ),
                 new PimcoreClassDefinitionMatcher(Data\CustomDataCopyInterface::class)
             );
+
+            $deepCopy->prependTypeFilter(
+                new class implements TypeFilter {
+                    public function apply($element): CarbonPeriod
+                    {
+                        return CarbonPeriod::instance($element);
+                    }
+                },
+                new TypeMatcher(CarbonPeriod::class),
+            );
         }
 
         $deepCopy->addFilter(new SetNullFilter(), new PropertyNameMatcher('dao'));

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -95,7 +95,7 @@ class Service extends Model\AbstractModel
         $elementType = self::getElementType($element);
         $parentId = $element->getParentId();
         $parentElement = null;
-        if (isset($parentId)) {
+        if ($parentId) {
             $parentElement = self::getElementById($elementType, $parentId);
         }
 
@@ -123,7 +123,7 @@ class Service extends Model\AbstractModel
         $elementType = self::getElementType($element);
         $parentId = $element->getParentId();
         $parentElement = null;
-        if (isset($parentId)) {
+        if ($parentId) {
             $parentElement = self::getElementById($elementType, $parentId);
         }
 
@@ -1132,16 +1132,6 @@ class Service extends Model\AbstractModel
                     }
                 ),
                 new PimcoreClassDefinitionMatcher(Data\CustomDataCopyInterface::class)
-            );
-
-            $deepCopy->prependTypeFilter(
-                new class implements TypeFilter {
-                    public function apply($element): CarbonPeriod
-                    {
-                        return CarbonPeriod::instance($element);
-                    }
-                },
-                new TypeMatcher(CarbonPeriod::class),
             );
         }
 

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -95,7 +95,7 @@ class Service extends Model\AbstractModel
         $elementType = self::getElementType($element);
         $parentId = $element->getParentId();
         $parentElement = null;
-        if ($parentId) {
+        if ($parentId !== null && $parentId !== 0) {
             $parentElement = self::getElementById($elementType, $parentId);
         }
 
@@ -123,7 +123,7 @@ class Service extends Model\AbstractModel
         $elementType = self::getElementType($element);
         $parentId = $element->getParentId();
         $parentElement = null;
-        if ($parentId) {
+        if ($parentId !== null && $parentId !== 0) {
             $parentElement = self::getElementById($elementType, $parentId);
         }
 

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -94,7 +94,10 @@ class Service extends Model\AbstractModel
         $path = '';
         $elementType = self::getElementType($element);
         $parentId = $element->getParentId();
-        $parentElement = self::getElementById($elementType, $parentId);
+        $parentElement = null;
+        if (isset($parentId)) {
+            $parentElement = self::getElementById($elementType, $parentId);
+        }
 
         if ($parentElement) {
             $path = self::getTypePath($parentElement);
@@ -119,7 +122,10 @@ class Service extends Model\AbstractModel
         $path = '';
         $elementType = self::getElementType($element);
         $parentId = $element->getParentId();
-        $parentElement = self::getElementById($elementType, $parentId);
+        $parentElement = null;
+        if (isset($parentId)) {
+            $parentElement = self::getElementById($elementType, $parentId);
+        }
 
         if ($parentElement) {
             $path = self::getSortIndexPath($parentElement);


### PR DESCRIPTION
### Description
This PR fixes a `TypeError` in PHP 8.x occurring in `Pimcore\Model\Element\Service`. The error happens when `getTypePath` or `getSortIndexPath` is called on an element where `getParentId()` returns `null`, causing `getElementById()` to fail due to strict typing.

### Steps to reproduce
1. Use an element (e.g., a DataObject Folder or a specific Brand object as seen in the trace) that has no parent or where the parent reference is missing.
2. The Admin UI calls the endpoint `/admin/element/type-path`.
3. The system throws a 500 error.

### Actual behavior
The application crashes with the following error:
`Pimcore\Model\Element\Service::getElementById(): Argument #2 ($id) must be of type string|int, null given`

**Full Trace:**
```text
Status: 500 | URL: /admin/element/type-path
Message: Pimcore\Model\Element\Service::getElementById(): Argument #2 ($id) must be of type string|int, null given, called in /vendor/pimcore/pimcore/models/Element/Service.php on line 97
in /vendor/pimcore/pimcore/models/Element/Service.php:440
#0 /vendor/pimcore/pimcore/models/Element/Service.php(97): Pimcore\Model\Element\Service::getElementById('object', NULL)
#1 /vendor/pimcore/pimcore/models/Element/Service.php(100): Pimcore\Model\Element\Service::getTypePath(Object(Pimcore\Model\DataObject\Folder))
```

### Expected behavior
The service should verify if a `$parentId` exists before attempting to fetch the parent element, returning `null` gracefully if no parent is found.

### Solution
Implemented a check for `$parentId` before calling `getElementById()` in:
- `getTypePath()`
- `getSortIndexPath()`


### Checklist
- [x] My code follows the coding guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have confirmed that this fix resolves the reported TypeError
