### PR TITLE
[Bug, InstallBundle] Decouple InstallerKernel from MicroKernelTrait private API

### DIFF
--- a/bundles/InstallBundle/src/InstallerKernel.php
+++ b/bundles/InstallBundle/src/InstallerKernel.php
@@ -18,9 +18,9 @@ use Symfony\Bundle\DebugBundle\DebugBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Bundle\MonologBundle\MonologBundle;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
-use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
 /**
  * @internal
@@ -73,23 +73,45 @@ class InstallerKernel extends Kernel
         return $bundles;
     }
 
-    protected function configureContainer(ContainerConfigurator $configurator): void
+    /**
+     * Overrides MicroKernelTrait::registerContainerConfiguration() to load the
+     * installer container configuration directly via the LoaderInterface, instead
+     * of going through MicroKernelTrait's private configureContainer() method.
+     *
+     * MicroKernelTrait::configureContainer() is a private method whose signature
+     * has changed between Symfony versions (e.g. between 7.3 and 7.4). Overriding
+     * it via the trait composition therefore couples this kernel to a non-public
+     * API of Symfony. The installer kernel only needs to register a small, fixed
+     * set of configuration files and is CLI-only (no HTTP routing), so we can
+     * bypass the trait's container/routing wiring entirely and rely solely on
+     * the public Symfony Kernel contract (registerContainerConfiguration()).
+     */
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
-        $configurator->parameters()->set('secret', uniqid('installer-', true));
-        $configurator->import('@PimcoreInstallBundle/config/config.yaml');
+        // Register the synthetic "kernel" service. This is normally done by
+        // MicroKernelTrait::registerContainerConfiguration() and is required so
+        // that other services may depend on the kernel via DI.
+        $loader->load(function (ContainerBuilder $container): void {
+            if (!$container->hasDefinition('kernel')) {
+                $container->register('kernel', static::class)
+                    ->addTag('controller.service_arguments')
+                    ->setAutoconfigured(true)
+                    ->setSynthetic(true)
+                    ->setPublic(true);
+            }
 
-        // load installer config files if available
+            $container->setParameter('secret', uniqid('installer-', true));
+        });
+
+        $loader->load('@PimcoreInstallBundle/config/config.yaml');
+
+        // Load installer config files if available
         foreach (['php', 'yaml', 'yml', 'xml'] as $extension) {
             $file = sprintf('%s/config/installer.%s', $this->getProjectDir(), $extension);
 
             if (file_exists($file)) {
-                $configurator->import($file);
+                $loader->load($file);
             }
         }
-    }
-
-    protected function configureRoutes(RoutingConfigurator $routes): void
-    {
-        // nothing to do
     }
 }

--- a/bundles/InstallBundle/src/InstallerKernel.php
+++ b/bundles/InstallBundle/src/InstallerKernel.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\InstallBundle;
 
+use Exception;
 use Symfony\Bundle\DebugBundle\DebugBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
@@ -74,17 +75,7 @@ class InstallerKernel extends Kernel
     }
 
     /**
-     * Overrides MicroKernelTrait::registerContainerConfiguration() to load the
-     * installer container configuration directly via the LoaderInterface, instead
-     * of going through MicroKernelTrait's private configureContainer() method.
-     *
-     * MicroKernelTrait::configureContainer() is a private method whose signature
-     * has changed between Symfony versions (e.g. between 7.3 and 7.4). Overriding
-     * it via the trait composition therefore couples this kernel to a non-public
-     * API of Symfony. The installer kernel only needs to register a small, fixed
-     * set of configuration files and is CLI-only (no HTTP routing), so we can
-     * bypass the trait's container/routing wiring entirely and rely solely on
-     * the public Symfony Kernel contract (registerContainerConfiguration()).
+     * @throws Exception
      */
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
@@ -105,7 +96,6 @@ class InstallerKernel extends Kernel
 
         $loader->load('@PimcoreInstallBundle/config/config.yaml');
 
-        // Load installer config files if available
         foreach (['php', 'yaml', 'yml', 'xml'] as $extension) {
             $file = sprintf('%s/config/installer.%s', $this->getProjectDir(), $extension);
 


### PR DESCRIPTION
## Summary

`InstallerKernel` previously overrode `MicroKernelTrait::configureContainer()`, which is a **private** method of Symfony. Its signature changed between Symfony 7.3 and 7.4 (from `(ContainerConfigurator, LoaderInterface, ContainerBuilder)` to `(ContainerConfigurator)`), breaking the installer kernel and forcing emergency adapters.

This PR decouples `InstallerKernel` from that private API by overriding the public `registerContainerConfiguration(LoaderInterface \$loader)` method instead and loading the installer container configuration directly via `LoaderInterface`. The behavior is unchanged.

## Why this works

- `registerContainerConfiguration(LoaderInterface): void` is part of the **public** `KernelInterface` contract and has been signature-stable across Symfony 6.4, 7.0–7.4 and beyond.
- `\$loader->load(\$file)` and `\$loader->load(Closure)` are the original Symfony container-loading APIs and have been unchanged for many major versions.
- The synthetic ``kernel`` service registration (normally done inside `MicroKernelTrait::registerContainerConfiguration()`) is reproduced inline so other services can still depend on the kernel via DI.
- `configureRoutes()` was a no-op and is removed: `InstallerKernel` is CLI-only (used only by `bin/pimcore-install`) and has no HTTP routes.

## Compatibility

- Compatible with Symfony 6.4 and 7.x including 7.4 (the version that introduced the breakage).
- `InstallerKernel` is marked `@internal` and is not intended to be extended outside of Pimcore — no BC concern.