### PR TITLE
[Deprecation, Kernel] Deprecate overriding configureContainer/configureRoutes

### DIFF
--- a/doc/13_Upgrade_Notes/README.md
+++ b/doc/13_Upgrade_Notes/README.md
@@ -260,3 +260,22 @@ Update your code to use `Twig\Environment` directly instead of `EngineInterface`
 
 -   The space between QuantityValue value and unit is going to be removed. Please make sure any custom code that relies on the space is updated accordingly.
 
+### Deprecated Kernel Extension Hooks
+
+Overriding `Pimcore\Kernel::configureContainer()` and `Pimcore\Kernel::configureRoutes()` is now deprecated and will be removed in **Pimcore 2027.1**.
+
+These methods were exposed as `protected` on `Pimcore\Kernel` via trait aliases of `Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait`'s **private** methods. Symfony does not consider them part of its public API and has changed their signatures between minor versions, which can break Pimcore subclasses on Symfony upgrades.
+
+**Migration:**
+
+Replace overrides of `configureContainer()` with one of the following stable, public extension points:
+
+-   Move container configuration to `config/packages/*.yaml` (or `config/packages/<env>/*.yaml`).
+-   Add a [compiler pass](https://symfony.com/doc/current/service_container/compiler_passes.html) for programmatic container manipulation.
+-   Override the public `Pimcore\Kernel::registerContainerConfiguration(LoaderInterface $loader)` method directly. Call `parent::registerContainerConfiguration($loader)` first, then load additional configuration via `$loader->load(...)`.
+
+Replace overrides of `configureRoutes()` with one of the following:
+
+-   Move routes to `config/routes/*.yaml`.
+-   Register a custom routing loader as a service tagged `routing.loader`.
+

--- a/lib/Kernel.php
+++ b/lib/Kernel.php
@@ -71,6 +71,8 @@ abstract class Kernel extends SymfonyKernel
 
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
+        $this->triggerKernelHookDeprecations();
+
         $bundleConfigLocator = new BundleConfigLocator($this);
         foreach ($bundleConfigLocator->locate('config') as $bundleConfig) {
             $loader->load($bundleConfig);
@@ -121,6 +123,46 @@ abstract class Kernel extends SymfonyKernel
                 }
             }
         });
+    }
+
+    /**
+     * Emits deprecation notices when subclasses override configureContainer() or
+     * configureRoutes(). These methods are exposed via the MicroKernelTrait `as protected`
+     * aliases on this class. They are private in MicroKernelTrait, are not part of
+     * Symfony's public extension API, and their signatures have changed between
+     * Symfony minor versions. Subclasses should override the public
+     * registerContainerConfiguration() (and use a routing loader for routes) instead.
+     */
+    private function triggerKernelHookDeprecations(): void
+    {
+        foreach (['configureContainer', 'configureRoutes'] as $method) {
+            try {
+                $declaringClass = (new \ReflectionMethod($this, $method))->getDeclaringClass()->getName();
+            } catch (\ReflectionException) {
+                continue;
+            }
+
+            // The method is declared either by this class (via the trait alias) or
+            // by MicroKernelTrait itself. In both cases no subclass is overriding it.
+            if ($declaringClass === self::class || $declaringClass === MicroKernelTrait::class) {
+                continue;
+            }
+
+            $replacement = $method === 'configureContainer'
+                ? 'Override the public registerContainerConfiguration(LoaderInterface $loader) method instead, or move the configuration to config/packages/*.yaml or a compiler pass.'
+                : 'Register a routing loader service tagged "routing.loader" instead, or add the routes to config/routes/*.yaml.';
+
+            trigger_deprecation(
+                'pimcore/pimcore',
+                '2026.1',
+                'Overriding %s::%s() is deprecated since Pimcore 2026.1 and will be removed in 2027.1. ' .
+                'It relies on a private method of Symfony\\Bundle\\FrameworkBundle\\Kernel\\MicroKernelTrait '
+                . 'whose signature is not part of Symfony\'s public API. %s',
+                $declaringClass,
+                $method,
+                $replacement
+            );
+        }
     }
 
     public function boot(): void


### PR DESCRIPTION
## Summary

`Pimcore\Kernel` exposes Symfony's `MicroKernelTrait::configureContainer()` and `configureRoutes()` as `protected` via trait aliases:

```php
use MicroKernelTrait {
    configureContainer as protected;
    configureRoutes   as protected;
}
```

These methods are **private** in `MicroKernelTrait` and are **not part of Symfony's public extension API**. Their signatures have changed between Symfony minor versions (most recently between 7.3 and 7.4 — `configureContainer` went from `(ContainerConfigurator, LoaderInterface, ContainerBuilder)` back to `(ContainerConfigurator)`), which breaks any Pimcore subclass that overrides them and forces emergency adapters in Pimcore on every such change.

This PR emits a deprecation notice when a subclass overrides either method, pointing users to the stable, public replacements. Actual removal of the trait aliases is planned for **Pimcore 2027.1**.

## Implementation

- `lib/Kernel.php`: a private helper `triggerKernelHookDeprecations()` is invoked from `registerContainerConfiguration()`. It uses `\ReflectionMethod::getDeclaringClass()` to detect whether the method is declared by a subclass (vs. by `Pimcore\Kernel` itself or by `MicroKernelTrait`). The deprecation only fires when an actual subclass override is present, so projects that do not use these extension points see no noise.
- `doc/13_Upgrade_Notes/README.md`: new **\"Deprecated Kernel Extension Hooks\"** section documenting the deprecation and the migration paths.

## Migration paths (also documented in upgrade notes)

Replace overrides of `configureContainer()` with one of:
-   `config/packages/*.yaml` (or environment-specific variants)
-   a [compiler pass](https://symfony.com/doc/current/service_container/compiler_passes.html)
-   overriding the public `Pimcore\Kernel::registerContainerConfiguration(LoaderInterface \$loader)` directly (call `parent::registerContainerConfiguration(\$loader)` first)

Replace overrides of `configureRoutes()` with one of:
-   `config/routes/*.yaml`
-   a custom routing loader service tagged `routing.loader`