### PR TITLE
Pass recipients array to workflow notification email template

### DIFF
--- a/doc/07_Workflow_Management/01_Configuration/04_Notifications.md
+++ b/doc/07_Workflow_Management/01_Configuration/04_Notifications.md
@@ -46,7 +46,7 @@ Multiple notification settings with conditions allow sophisticated notifications
 - **Override the default template** at `@PimcoreCore/Workflow/NotificationEmail/notificationEmail.html.twig`
   or configure a custom template path in settings.
   Default parameters available in the template: `subjectType`, `subject`, `action`, `workflow`,
-  `workflowName`, `deeplink`, `note_description`, `translator`, `lang`.
+  `workflowName`, `deeplink`, `note_description`, `translator`, `lang`, `recipients`.
   For additional parameters, override the service `Pimcore\Workflow\Notification\NotificationEmailService`.
 
 - **Use a Pimcore Mail Document** for full access to Pimcore Mail Document features

--- a/doc/13_Upgrade_Notes/README.md
+++ b/doc/13_Upgrade_Notes/README.md
@@ -52,6 +52,7 @@ ORDER BY TABLE_NAME, COLUMN_NAME;
 - Removed legacy Admin UI (Classic UI) `EditmodeListener`.
 - Added support for PHP `8.5` and bumped minimum requirement of Symfony to `7.4`.
 - Dropped support for PHP `8.3` and Symfony `6`.
+- [Workflow] `Pimcore\Workflow\Notification\NotificationEmailService`: the protected methods `getHtmlBody()` and `getNotificationEmailParameters()` got a new optional parameter `array $recipients = []`. If you override one of these methods in a subclass, update its signature accordingly, otherwise PHP will fail with a fatal error. The recipients (`Pimcore\Model\User[]`) are now also available as `recipients` parameter in the notification email template.
 - [QuantityValue] Introduced foreign key constraints on `__unit` columns in object store, query, localized, objectbrick and fieldcollection tables for `QuantityValue`, `InputQuantityValue` and `QuantityValueRange` fields. These constraints reference `quantityvalue_units(id)` with `ON DELETE SET NULL` and `ON UPDATE CASCADE`, ensuring referential integrity. The migration automatically cleans up orphaned unit references (setting them to `NULL`) and changes the `__unit` column type from `varchar(64)` to `varchar(50)` to match the referenced `quantityvalue_units.id` column. If you have custom unit IDs longer than 50 characters, they will be truncated.
 
 #### Removed deprecated and discontinued bundles

--- a/lib/Workflow/Notification/NotificationEmailService.php
+++ b/lib/Workflow/Notification/NotificationEmailService.php
@@ -150,7 +150,8 @@ class NotificationEmailService extends AbstractNotificationService
                     $workflow,
                     $action,
                     $deeplink,
-                    $language
+                    $language,
+                    $recipients
                 ),
             ]
         );
@@ -190,11 +191,14 @@ class NotificationEmailService extends AbstractNotificationService
             )
         );
 
-        $mail->html($this->getHtmlBody($subjectType, $subject, $workflow, $action, $language, $mailPath, $deeplink));
+        $mail->html($this->getHtmlBody($subjectType, $subject, $workflow, $action, $language, $mailPath, $deeplink, $recipients));
 
         $mail->send();
     }
 
+    /**
+     * @param User[] $recipients
+     */
     protected function getHtmlBody(
         string $subjectType,
         ElementInterface $subject,
@@ -202,7 +206,8 @@ class NotificationEmailService extends AbstractNotificationService
         string $action,
         string $language,
         string $mailPath,
-        string $deeplink
+        string $deeplink,
+        array $recipients = []
     ): string {
         $translatorLocaleBackup = null;
         if ($this->translator instanceof LocaleAwareInterface) {
@@ -214,7 +219,7 @@ class NotificationEmailService extends AbstractNotificationService
             // allow retrieval of inherited values
             return DataObject\Service::useInheritedValues(true, fn () => $this->template->render(
                 $mailPath,
-                $this->getNotificationEmailParameters($subjectType, $subject, $workflow, $action, $deeplink, $language),
+                $this->getNotificationEmailParameters($subjectType, $subject, $workflow, $action, $deeplink, $language, $recipients),
             ));
         } finally {
             if ($this->translator instanceof LocaleAwareInterface) {
@@ -224,13 +229,17 @@ class NotificationEmailService extends AbstractNotificationService
         }
     }
 
+    /**
+     * @param User[] $recipients
+     */
     protected function getNotificationEmailParameters(
         string $subjectType,
         ElementInterface $subject,
         WorkflowInterface $workflow,
         string $action,
         string $deeplink,
-        string $language
+        string $language,
+        array $recipients = []
     ): array {
         $noteDescription = $this->getNoteInfo($subject->getId());
 
@@ -244,6 +253,7 @@ class NotificationEmailService extends AbstractNotificationService
             'note_description' => $noteDescription,
             'translator' => $this->translator,
             'lang' => $language,
+            'recipients' => $recipients,
         ];
     }
 }


### PR DESCRIPTION
Expose $recipients (User[]) to the Twig/document template via the 'recipients' parameter so workflow notification emails can reference the addressees (e.g. greet by name or list them) instead of being generic. Backwards compatible — defaults to [] on getHtmlBody and getNotificationEmailParameters so any existing subclass overrides keep working.

Refs upstream feature request: pass recipients to workflow email template (lib/Workflow/Notification/NotificationEmailService.php).

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `12.3`
- Feature/Improvement: choose `2026.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`2026.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `12.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #18315

## Additional info
Adds `'recipients' => $recipients` to the params array so Twig templates can do e.g. `{% for r in recipients %}{{ r.name }}{% endfor %}`.
