### PR TITLE
Workflow: roll back marking when post-transition save fails

### DIFF
--- a/lib/Workflow/Manager.php
+++ b/lib/Workflow/Manager.php
@@ -223,18 +223,42 @@ class Manager
     ): Marking {
         $this->notesSubscriber->setAdditionalData($additionalData);
 
-        $marking = $workflow->apply($subject, $transition, $additionalData);
+        $markingStore = $workflow->getMarkingStore();
+        $previousMarking = $markingStore->getMarking($subject);
+        $previousPublishedState = ($subject instanceof Concrete || $subject instanceof PageSnippet)
+            ? $subject->isPublished()
+            : null;
 
-        $this->notesSubscriber->setAdditionalData([]);
+        try {
+            $marking = $workflow->apply($subject, $transition, $additionalData);
+        } finally {
+            $this->notesSubscriber->setAdditionalData([]);
+        }
 
         $transition = $this->getTransitionByName($workflow->getName(), $transition);
         $changePublishedState = $transition instanceof Transition ? $transition->getChangePublishedState() : null;
 
         if ($saveSubject) {
-            if ($changePublishedState === ChangePublishedStateSubscriber::SAVE_VERSION) {
-                $subject->saveVersion();
-            } else {
-                $subject->save();
+            try {
+                if ($changePublishedState === ChangePublishedStateSubscriber::SAVE_VERSION) {
+                    $subject->saveVersion();
+                } else {
+                    $subject->save();
+                }
+            } catch (\Throwable $e) {
+                // Roll back the workflow place and published state when the
+                // post-transition save fails (e.g. due to a mandatory field
+                // validation error on a force_published transition). Otherwise
+                // marking stores that persist immediately (such as the
+                // state_table store) leave the subject in an inconsistent state.
+                $markingStore->setMarking($subject, $previousMarking);
+                if ($previousPublishedState !== null
+                    && ($subject instanceof Concrete || $subject instanceof PageSnippet)
+                ) {
+                    $subject->setPublished($previousPublishedState);
+                }
+
+                throw $e;
             }
         }
 
@@ -267,6 +291,7 @@ class Manager
         $this->eventDispatcher->dispatch($event, WorkflowEvents::PRE_GLOBAL_ACTION);
 
         $markingStore = $workflow->getMarkingStore();
+        $previousMarking = $markingStore->getMarking($subject);
 
         if (!empty($globalActionObj->getTos())) {
             $places = [];
@@ -281,7 +306,16 @@ class Manager
         $this->notesSubscriber->setAdditionalData([]);
 
         if ($saveSubject && $subject instanceof ElementInterface) {
-            $subject->save();
+            try {
+                $subject->save();
+            } catch (\Throwable $e) {
+                // Roll back the workflow place if the save fails so marking
+                // stores that persist immediately do not leave the subject in
+                // an inconsistent state (see pimcore/pimcore#18178).
+                $markingStore->setMarking($subject, $previousMarking);
+
+                throw $e;
+            }
         }
 
         return $markingStore->getMarking($subject);

--- a/lib/Workflow/Manager.php
+++ b/lib/Workflow/Manager.php
@@ -223,11 +223,18 @@ class Manager
     ): Marking {
         $this->notesSubscriber->setAdditionalData($additionalData);
 
+        // Only snapshot when we are going to save: rolling back is the sole
+        // consumer, and reading the marking can hit the database (e.g. the
+        // state_table store).
         $markingStore = $workflow->getMarkingStore();
-        $previousMarking = $markingStore->getMarking($subject);
-        $previousPublishedState = ($subject instanceof Concrete || $subject instanceof PageSnippet)
-            ? $subject->isPublished()
-            : null;
+        $previousMarking = null;
+        $previousPublishedState = null;
+        if ($saveSubject) {
+            $previousMarking = $markingStore->getMarking($subject);
+            if ($subject instanceof Concrete || $subject instanceof PageSnippet) {
+                $previousPublishedState = $subject->isPublished();
+            }
+        }
 
         try {
             $marking = $workflow->apply($subject, $transition, $additionalData);
@@ -251,10 +258,10 @@ class Manager
                 // validation error on a force_published transition). Otherwise
                 // marking stores that persist immediately (such as the
                 // state_table store) leave the subject in an inconsistent state.
-                $markingStore->setMarking($subject, $previousMarking);
-                if ($previousPublishedState !== null
-                    && ($subject instanceof Concrete || $subject instanceof PageSnippet)
-                ) {
+                if ($previousMarking !== null) {
+                    $markingStore->setMarking($subject, $previousMarking);
+                }
+                if ($previousPublishedState !== null) {
                     $subject->setPublished($previousPublishedState);
                 }
 
@@ -291,7 +298,11 @@ class Manager
         $this->eventDispatcher->dispatch($event, WorkflowEvents::PRE_GLOBAL_ACTION);
 
         $markingStore = $workflow->getMarkingStore();
-        $previousMarking = $markingStore->getMarking($subject);
+        // Only snapshot when the save below can actually run and fail, so that
+        // read-only global actions do not pay for an extra marking-store read.
+        $previousMarking = ($saveSubject && $subject instanceof ElementInterface)
+            ? $markingStore->getMarking($subject)
+            : null;
 
         if (!empty($globalActionObj->getTos())) {
             $places = [];
@@ -312,7 +323,9 @@ class Manager
                 // Roll back the workflow place if the save fails so marking
                 // stores that persist immediately do not leave the subject in
                 // an inconsistent state (see pimcore/pimcore#18178).
-                $markingStore->setMarking($subject, $previousMarking);
+                if ($previousMarking !== null) {
+                    $markingStore->setMarking($subject, $previousMarking);
+                }
 
                 throw $e;
             }

--- a/lib/Workflow/Manager.php
+++ b/lib/Workflow/Manager.php
@@ -258,9 +258,7 @@ class Manager
                 // validation error on a force_published transition). Otherwise
                 // marking stores that persist immediately (such as the
                 // state_table store) leave the subject in an inconsistent state.
-                if ($previousMarking !== null) {
-                    $markingStore->setMarking($subject, $previousMarking);
-                }
+                $markingStore->setMarking($subject, $previousMarking);
                 if ($previousPublishedState !== null) {
                     $subject->setPublished($previousPublishedState);
                 }

--- a/tests/Unit/Workflow/ManagerTest.php
+++ b/tests/Unit/Workflow/ManagerTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Tests\Unit\Workflow;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\Element\ValidationException;
+use Pimcore\Tests\Support\Test\TestCase;
+use Pimcore\Workflow\EventSubscriber\ChangePublishedStateSubscriber;
+use Pimcore\Workflow\EventSubscriber\NotesSubscriber;
+use Pimcore\Workflow\ExpressionService;
+use Pimcore\Workflow\Manager;
+use Pimcore\Workflow\Transition as PimcoreTransition;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Workflow\Definition;
+use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface;
+use Symfony\Component\Workflow\Registry;
+use Symfony\Component\Workflow\StateMachine;
+
+class ManagerTest extends TestCase
+{
+    /**
+     * Regression test for https://github.com/pimcore/pimcore/issues/18178
+     *
+     * When a transition with changePublishedState=force_published is applied
+     * to a Concrete object with empty mandatory fields, the post-transition
+     * save() throws a ValidationException. Marking stores that persist
+     * immediately (e.g. the state_table store) would otherwise leave the
+     * subject in an inconsistent state where the workflow place advanced but
+     * the subject itself was not updated. The Manager must roll back both
+     * the marking and the published state.
+     */
+    public function testRollsBackMarkingAndPublishedStateWhenSaveFails(): void
+    {
+        // Marking store that persists immediately, like StateTableMarkingStore.
+        $store = new class() implements MarkingStoreInterface {
+            public array $persisted = ['start' => 1];
+
+            public function getMarking(object $subject): Marking
+            {
+                return new Marking($this->persisted);
+            }
+
+            public function setMarking(object $subject, Marking $marking, array $context = []): void
+            {
+                $this->persisted = $marking->getPlaces();
+            }
+        };
+
+        $transition = new PimcoreTransition('go', 'start', 'end', [
+            'changePublishedState' => ChangePublishedStateSubscriber::FORCE_PUBLISHED,
+        ]);
+        $definition = new Definition(['start', 'end'], [$transition]);
+
+        $workflowEventDispatcher = new EventDispatcher();
+        $workflowEventDispatcher->addSubscriber(new ChangePublishedStateSubscriber());
+
+        $workflow = new StateMachine($definition, $store, $workflowEventDispatcher, 'test_wf');
+
+        $subject = $this->createMock(Concrete::class);
+        $subject->method('isPublished')->willReturn(false);
+
+        $publishedStates = [];
+        $subject->method('setPublished')->willReturnCallback(
+            function (bool $value) use (&$publishedStates, $subject): Concrete {
+                $publishedStates[] = $value;
+
+                return $subject;
+            }
+        );
+        $subject->method('save')->willThrowException(new ValidationException('mandatory field missing'));
+
+        $manager = $this->buildManager($workflowEventDispatcher, $transition);
+
+        $this->assertSame(['start' => 1], $store->persisted);
+
+        $thrown = null;
+        try {
+            $manager->applyWithAdditionalData($workflow, $subject, 'go', [], true);
+        } catch (ValidationException $e) {
+            $thrown = $e;
+        }
+
+        $this->assertInstanceOf(ValidationException::class, $thrown);
+        $this->assertSame(
+            ['start' => 1],
+            $store->persisted,
+            'Marking should be rolled back when the post-transition save fails.'
+        );
+        $this->assertSame(
+            [true, false],
+            $publishedStates,
+            'Published state should be forced to true by the event listener and then rolled back to false.'
+        );
+    }
+
+    public function testHappyPathPersistsMarkingAndDoesNotRollBack(): void
+    {
+        $store = new class() implements MarkingStoreInterface {
+            public array $persisted = ['start' => 1];
+
+            public function getMarking(object $subject): Marking
+            {
+                return new Marking($this->persisted);
+            }
+
+            public function setMarking(object $subject, Marking $marking, array $context = []): void
+            {
+                $this->persisted = $marking->getPlaces();
+            }
+        };
+
+        $transition = new PimcoreTransition('go', 'start', 'end', [
+            'changePublishedState' => ChangePublishedStateSubscriber::FORCE_PUBLISHED,
+        ]);
+        $definition = new Definition(['start', 'end'], [$transition]);
+
+        $workflowEventDispatcher = new EventDispatcher();
+        $workflowEventDispatcher->addSubscriber(new ChangePublishedStateSubscriber());
+
+        $workflow = new StateMachine($definition, $store, $workflowEventDispatcher, 'test_wf');
+
+        $subject = $this->createMock(Concrete::class);
+        $subject->method('isPublished')->willReturn(false);
+        $subject->expects($this->once())->method('save');
+
+        $manager = $this->buildManager($workflowEventDispatcher, $transition);
+
+        $manager->applyWithAdditionalData($workflow, $subject, 'go', [], true);
+
+        $this->assertSame(['end' => 1], $store->persisted);
+    }
+
+    private function buildManager(EventDispatcher $eventDispatcher, PimcoreTransition $transition): Manager&MockObject
+    {
+        $notesSubscriber = $this->createMock(NotesSubscriber::class);
+        $expressionService = $this->createMock(ExpressionService::class);
+        $registry = new Registry();
+
+        $manager = $this->getMockBuilder(Manager::class)
+            ->setConstructorArgs([$registry, $notesSubscriber, $expressionService, $eventDispatcher])
+            ->onlyMethods(['getTransitionByName'])
+            ->getMock();
+        $manager->method('getTransitionByName')->willReturn($transition);
+
+        return $manager;
+    }
+}

--- a/tests/Unit/Workflow/ManagerTest.php
+++ b/tests/Unit/Workflow/ManagerTest.php
@@ -1,18 +1,14 @@
 <?php
-
 declare(strict_types=1);
 
 /**
- * Pimcore
- *
- * This source file is available under two different licenses:
- * - GNU General Public License version 3 (GPLv3)
- * - Pimcore Commercial License (PCL)
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
  * Full copyright and license information is available in
  * LICENSE.md which is distributed with this source code.
  *
- *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
- *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
  */
 
 namespace Pimcore\Tests\Unit\Workflow;
@@ -35,6 +31,8 @@ use Symfony\Component\Workflow\StateMachine;
 
 class ManagerTest extends TestCase
 {
+    private const WORKFLOW_NAME = 'test_wf';
+
     /**
      * Regression test for https://github.com/pimcore/pimcore/issues/18178
      *
@@ -48,30 +46,10 @@ class ManagerTest extends TestCase
      */
     public function testRollsBackMarkingAndPublishedStateWhenSaveFails(): void
     {
-        // Marking store that persists immediately, like StateTableMarkingStore.
-        $store = new class() implements MarkingStoreInterface {
-            public array $persisted = ['start' => 1];
-
-            public function getMarking(object $subject): Marking
-            {
-                return new Marking($this->persisted);
-            }
-
-            public function setMarking(object $subject, Marking $marking, array $context = []): void
-            {
-                $this->persisted = $marking->getPlaces();
-            }
-        };
-
-        $transition = new PimcoreTransition('go', 'start', 'end', [
-            'changePublishedState' => ChangePublishedStateSubscriber::FORCE_PUBLISHED,
-        ]);
-        $definition = new Definition(['start', 'end'], [$transition]);
-
-        $workflowEventDispatcher = new EventDispatcher();
-        $workflowEventDispatcher->addSubscriber(new ChangePublishedStateSubscriber());
-
-        $workflow = new StateMachine($definition, $store, $workflowEventDispatcher, 'test_wf');
+        $store = $this->createImmediateMarkingStore();
+        $transition = $this->createForcePublishedTransition();
+        $eventDispatcher = $this->createEventDispatcher();
+        $workflow = $this->createWorkflow($store, $transition, $eventDispatcher);
 
         $subject = $this->createMock(Concrete::class);
         $subject->method('isPublished')->willReturn(false);
@@ -86,11 +64,12 @@ class ManagerTest extends TestCase
         );
         $subject->method('save')->willThrowException(new ValidationException('mandatory field missing'));
 
-        $manager = $this->buildManager($workflowEventDispatcher, $transition);
+        $manager = $this->buildManager($eventDispatcher, $transition);
 
         $this->assertSame(['start' => 1], $store->persisted);
 
         $thrown = null;
+
         try {
             $manager->applyWithAdditionalData($workflow, $subject, 'go', [], true);
         } catch (ValidationException $e) {
@@ -112,7 +91,79 @@ class ManagerTest extends TestCase
 
     public function testHappyPathPersistsMarkingAndDoesNotRollBack(): void
     {
-        $store = new class() implements MarkingStoreInterface {
+        $store = $this->createImmediateMarkingStore();
+        $transition = $this->createForcePublishedTransition();
+        $eventDispatcher = $this->createEventDispatcher();
+        $workflow = $this->createWorkflow($store, $transition, $eventDispatcher);
+
+        $subject = $this->createMock(Concrete::class);
+        $subject->method('isPublished')->willReturn(false);
+        $subject->expects($this->once())->method('save');
+
+        $manager = $this->buildManager($eventDispatcher, $transition);
+
+        $manager->applyWithAdditionalData($workflow, $subject, 'go', [], true);
+
+        $this->assertSame(['end' => 1], $store->persisted);
+    }
+
+    /**
+     * A global action can move the subject to a new place directly, so it is
+     * exposed to the same inconsistency as a transition when the subsequent
+     * save() fails.
+     */
+    public function testGlobalActionRollsBackMarkingWhenSaveFails(): void
+    {
+        $store = $this->createImmediateMarkingStore();
+        $eventDispatcher = $this->createEventDispatcher();
+        $workflow = $this->createWorkflow($store, $this->createForcePublishedTransition(), $eventDispatcher);
+
+        $subject = $this->createMock(Concrete::class);
+        $subject->method('save')->willThrowException(new ValidationException('mandatory field missing'));
+
+        $manager = $this->buildManager($eventDispatcher);
+        $manager->addGlobalAction(self::WORKFLOW_NAME, 'finish', ['to' => ['end']]);
+
+        $thrown = null;
+
+        try {
+            $manager->applyGlobalAction($workflow, $subject, 'finish', [], true);
+        } catch (ValidationException $e) {
+            $thrown = $e;
+        }
+
+        $this->assertInstanceOf(ValidationException::class, $thrown);
+        $this->assertSame(
+            ['start' => 1],
+            $store->persisted,
+            'Marking should be rolled back when the save after a global action fails.'
+        );
+    }
+
+    public function testGlobalActionHappyPathPersistsMarking(): void
+    {
+        $store = $this->createImmediateMarkingStore();
+        $eventDispatcher = $this->createEventDispatcher();
+        $workflow = $this->createWorkflow($store, $this->createForcePublishedTransition(), $eventDispatcher);
+
+        $subject = $this->createMock(Concrete::class);
+        $subject->expects($this->once())->method('save');
+
+        $manager = $this->buildManager($eventDispatcher);
+        $manager->addGlobalAction(self::WORKFLOW_NAME, 'finish', ['to' => ['end']]);
+
+        $marking = $manager->applyGlobalAction($workflow, $subject, 'finish', [], true);
+
+        $this->assertSame(['end' => 1], $store->persisted);
+        $this->assertSame(['end' => 1], $marking->getPlaces());
+    }
+
+    /**
+     * Marking store that persists immediately, like StateTableMarkingStore.
+     */
+    private function createImmediateMarkingStore(): MarkingStoreInterface
+    {
+        return new class() implements MarkingStoreInterface {
             public array $persisted = ['start' => 1];
 
             public function getMarking(object $subject): Marking
@@ -125,30 +176,40 @@ class ManagerTest extends TestCase
                 $this->persisted = $marking->getPlaces();
             }
         };
-
-        $transition = new PimcoreTransition('go', 'start', 'end', [
-            'changePublishedState' => ChangePublishedStateSubscriber::FORCE_PUBLISHED,
-        ]);
-        $definition = new Definition(['start', 'end'], [$transition]);
-
-        $workflowEventDispatcher = new EventDispatcher();
-        $workflowEventDispatcher->addSubscriber(new ChangePublishedStateSubscriber());
-
-        $workflow = new StateMachine($definition, $store, $workflowEventDispatcher, 'test_wf');
-
-        $subject = $this->createMock(Concrete::class);
-        $subject->method('isPublished')->willReturn(false);
-        $subject->expects($this->once())->method('save');
-
-        $manager = $this->buildManager($workflowEventDispatcher, $transition);
-
-        $manager->applyWithAdditionalData($workflow, $subject, 'go', [], true);
-
-        $this->assertSame(['end' => 1], $store->persisted);
     }
 
-    private function buildManager(EventDispatcher $eventDispatcher, PimcoreTransition $transition): Manager&MockObject
+    private function createForcePublishedTransition(): PimcoreTransition
     {
+        return new PimcoreTransition('go', 'start', 'end', [
+            'changePublishedState' => ChangePublishedStateSubscriber::FORCE_PUBLISHED,
+        ]);
+    }
+
+    private function createEventDispatcher(): EventDispatcher
+    {
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addSubscriber(new ChangePublishedStateSubscriber());
+
+        return $eventDispatcher;
+    }
+
+    private function createWorkflow(
+        MarkingStoreInterface $store,
+        PimcoreTransition $transition,
+        EventDispatcher $eventDispatcher
+    ): StateMachine {
+        return new StateMachine(
+            new Definition(['start', 'end'], [$transition]),
+            $store,
+            $eventDispatcher,
+            self::WORKFLOW_NAME
+        );
+    }
+
+    private function buildManager(
+        EventDispatcher $eventDispatcher,
+        ?PimcoreTransition $transition = null
+    ): Manager&MockObject {
         $notesSubscriber = $this->createMock(NotesSubscriber::class);
         $expressionService = $this->createMock(ExpressionService::class);
         $registry = new Registry();


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `12.3`
- Feature/Improvement: choose `2026.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`2026.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `12.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #18178

When a workflow transition is applied with `changePublishedState:
force_published` and the subject has empty mandatory fields, the save
following the transition throws a ValidationException. Marking stores
that persist immediately (e.g. `state_table`) had already written the
new place, so the subject was left in an inconsistent state: the
workflow place advanced while the subject itself remained unchanged
and unpublished.

Wrap the post-transition save in try/catch and restore the previous
marking (and previous published state, for Concrete/PageSnippet) on
failure. Applies to both `applyWithAdditionalData` and
`applyGlobalAction`.

## Additional info
