### PR TITLE
[Feature]: Allow passing arguments to Calculated Value calculator

### DIFF
--- a/doc/03_Objects/01_Object_Classes/01_Data_Types/10_Calculated_Value_Type.md
+++ b/doc/03_Objects/01_Object_Classes/01_Data_Types/10_Calculated_Value_Type.md
@@ -162,6 +162,30 @@ class Calculator implements CalculatorClassInterface
 
 The calculator class sums the x and y values from the corresponding language tab.
 
+#### Passing arguments to the calculator class
+
+Optionally, additional data can be configured for the calculator class in the class definition (field
+`calculatorData`). The value is a free-form string (e.g. a plain value, a comma-separated list or a JSON
+encoded structure) and is exposed to the calculator through the context via `$context->getCalculatorData()`.
+This allows reusing the same calculator class for simple variations without having to define a dedicated
+calculator class per variation.
+
+```php
+public function compute(Concrete $object, CalculatedValue $context): string
+{
+    $factor = (float) ($context->getCalculatorData() ?? '1');
+    $language = $context->getPosition();
+
+    return (string) (($object->getXValue($language) + $object->getYValue($language)) * $factor);
+}
+```
+
+When using the expression calculator type, the value is also available on the `data` variable:
+
+```
+data.getCalculatorData()
+```
+
 Implement the `getCalculatedValueForEditMode` method in addition to `compute`.
 This method provides the display value in object edit mode:
 

--- a/models/DataObject/ClassDefinition/Data/CalculatedValue.php
+++ b/models/DataObject/ClassDefinition/Data/CalculatedValue.php
@@ -59,6 +59,11 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
     public string $calculatorClass;
 
     /**
+     * @internal
+     */
+    public ?string $calculatorData = null;
+
+    /**
      * Column length
      *
      * @internal
@@ -128,6 +133,16 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
     public function setCalculatorExpression(?string $calculatorExpression): void
     {
         $this->calculatorExpression = $calculatorExpression;
+    }
+
+    public function getCalculatorData(): ?string
+    {
+        return $this->calculatorData;
+    }
+
+    public function setCalculatorData(?string $calculatorData): void
+    {
+        $this->calculatorData = $calculatorData;
     }
 
     /**

--- a/models/DataObject/Data/CalculatedValue.php
+++ b/models/DataObject/Data/CalculatedValue.php
@@ -36,6 +36,8 @@ class CalculatedValue implements OwnerAwareFieldInterface
 
     protected mixed $keyDefinition = null;
 
+    protected ?string $calculatorData = null;
+
     /**
      * CalculatedValue constructor.
      *
@@ -101,5 +103,15 @@ class CalculatedValue implements OwnerAwareFieldInterface
     public function getKeyId(): ?int
     {
         return $this->keyId;
+    }
+
+    public function getCalculatorData(): ?string
+    {
+        return $this->calculatorData;
+    }
+
+    public function setCalculatorData(?string $calculatorData): void
+    {
+        $this->calculatorData = $calculatorData;
     }
 }

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -1197,6 +1197,8 @@ class Service extends Model\Element\Service
             return null;
         }
 
+        $data->setCalculatorData($fd->getCalculatorData());
+
         return DataObject\Service::useInheritedValues(true, static function () use ($fd, $object, $data) {
             switch ($fd->getCalculatorType()) {
                 case DataObject\ClassDefinition\Data\CalculatedValue::CALCULATOR_TYPE_CLASS:
@@ -1253,6 +1255,8 @@ class Service extends Model\Element\Service
         ) {
             $object = $object->getObject();
         }
+
+        $data->setCalculatorData($fd->getCalculatorData());
 
         return DataObject\Service::useInheritedValues(true, static function () use ($object, $fd, $data) {
             switch ($fd->getCalculatorType()) {

--- a/tests/Unit/Models/DataObject/ClassDefinition/Data/CalculatedValueTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/Data/CalculatedValueTest.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Tests\Unit\Model\DataObject\ClassDefinition\Data;
+
+use Pimcore\Model\DataObject\ClassDefinition\Data\CalculatedValue as CalculatedValueDefinition;
+use Pimcore\Model\DataObject\Data\CalculatedValue as CalculatedValueData;
+use Pimcore\Tests\Support\Test\TestCase;
+
+class CalculatedValueTest extends TestCase
+{
+    public function testCalculatorDataDefaultsToNullOnFieldDefinition(): void
+    {
+        $fd = new CalculatedValueDefinition();
+
+        $this->assertNull($fd->getCalculatorData());
+    }
+
+    public function testCalculatorDataCanBeSetAndReadOnFieldDefinition(): void
+    {
+        $fd = new CalculatedValueDefinition();
+        $fd->setCalculatorData('{"factor":2}');
+
+        $this->assertSame('{"factor":2}', $fd->getCalculatorData());
+    }
+
+    public function testCalculatorDataCanBeResetToNullOnFieldDefinition(): void
+    {
+        $fd = new CalculatedValueDefinition();
+        $fd->setCalculatorData('something');
+        $fd->setCalculatorData(null);
+
+        $this->assertNull($fd->getCalculatorData());
+    }
+
+    public function testCalculatorDataDefaultsToNullOnRuntimeData(): void
+    {
+        $data = new CalculatedValueData('myField');
+
+        $this->assertNull($data->getCalculatorData());
+    }
+
+    public function testCalculatorDataCanBeSetAndReadOnRuntimeData(): void
+    {
+        $data = new CalculatedValueData('myField');
+        $data->setCalculatorData('arg-value');
+
+        $this->assertSame('arg-value', $data->getCalculatorData());
+    }
+}

--- a/tests/Unit/Models/DataObject/ClassDefinition/Data/CalculatedValueTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/Data/CalculatedValueTest.php
@@ -2,22 +2,22 @@
 declare(strict_types=1);
 
 /**
- * Pimcore
- *
- * This source file is available under two different licenses:
- * - GNU General Public License version 3 (GPLv3)
- * - Pimcore Commercial License (PCL)
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
  * Full copyright and license information is available in
  * LICENSE.md which is distributed with this source code.
  *
- *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
- *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
  */
 
 namespace Pimcore\Tests\Unit\Model\DataObject\ClassDefinition\Data;
 
+use Pimcore\Model\DataObject\ClassDefinition\CalculatorClassInterface;
 use Pimcore\Model\DataObject\ClassDefinition\Data\CalculatedValue as CalculatedValueDefinition;
+use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\Data\CalculatedValue as CalculatedValueData;
+use Pimcore\Model\DataObject\Service;
 use Pimcore\Tests\Support\Test\TestCase;
 
 class CalculatedValueTest extends TestCase
@@ -59,5 +59,102 @@ class CalculatedValueTest extends TestCase
         $data->setCalculatorData('arg-value');
 
         $this->assertSame('arg-value', $data->getCalculatorData());
+    }
+
+    public function testCalculatorDataIsPassedToCalculatorClass(): void
+    {
+        $data = $this->createContext(
+            $this->createClassCalculatorDefinition('{"factor":2}')
+        );
+
+        $this->assertSame(
+            'computed:{"factor":2}',
+            Service::getCalculatedFieldValue(new Concrete(), $data)
+        );
+    }
+
+    public function testCalculatorDataIsPassedToCalculatorClassInEditMode(): void
+    {
+        $data = $this->createContext(
+            $this->createClassCalculatorDefinition('{"factor":2}')
+        );
+
+        $this->assertSame(
+            'editmode:{"factor":2}',
+            Service::getCalculatedFieldValueForEditMode(new Concrete(), [], $data)
+        );
+    }
+
+    public function testCalculatorDataIsNullOnContextIfNotConfigured(): void
+    {
+        $data = $this->createContext(
+            $this->createClassCalculatorDefinition(null)
+        );
+
+        $this->assertSame(
+            'computed:',
+            Service::getCalculatedFieldValue(new Concrete(), $data)
+        );
+    }
+
+    public function testStaleCalculatorDataOnContextIsOverwritten(): void
+    {
+        $data = $this->createContext(
+            $this->createClassCalculatorDefinition(null)
+        );
+        $data->setCalculatorData('stale');
+
+        $this->assertSame(
+            'computed:',
+            Service::getCalculatedFieldValue(new Concrete(), $data)
+        );
+        $this->assertNull($data->getCalculatorData());
+    }
+
+    public function testCalculatorDataIsPassedToExpression(): void
+    {
+        $fd = new CalculatedValueDefinition();
+        $fd->setCalculatorType(CalculatedValueDefinition::CALCULATOR_TYPE_EXPRESSION);
+        $fd->setCalculatorExpression('data.getCalculatorData()');
+        $fd->setCalculatorData('expression-arg');
+
+        $data = $this->createContext($fd);
+
+        $this->assertSame(
+            'expression-arg',
+            Service::getCalculatedFieldValue(new Concrete(), $data)
+        );
+    }
+
+    private function createClassCalculatorDefinition(?string $calculatorData): CalculatedValueDefinition
+    {
+        $fd = new CalculatedValueDefinition();
+        $fd->setCalculatorType(CalculatedValueDefinition::CALCULATOR_TYPE_CLASS);
+        $fd->setCalculatorClass(CalculatorDataTestCalculator::class);
+        $fd->setCalculatorData($calculatorData);
+
+        return $fd;
+    }
+
+    private function createContext(CalculatedValueDefinition $fd): CalculatedValueData
+    {
+        $data = new CalculatedValueData('myField');
+        // pass the field definition as key definition so that no class definition lookup is needed
+        $data->setContextualData('object', null, null, null, null, null, $fd);
+
+        return $data;
+    }
+}
+
+class CalculatorDataTestCalculator implements CalculatorClassInterface
+{
+    public function compute(Concrete $object, CalculatedValueData $context): string
+    {
+        return 'computed:' . $context->getCalculatorData();
+    }
+
+    public function getCalculatedValueForEditMode(Concrete $object, CalculatedValueData $context): string
+    {
+        return 'editmode:' . $context->getCalculatorData();
     }
 }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `12.3`
- Feature/Improvement: choose `2026.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`2026.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `12.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #https://github.com/pimcore/pimcore/issues/18314 

Adds an optional `calculatorData` string on the CalculatedValue field
definition that is propagated into the runtime CalculatedValue context
object, so calculator classes and expressions can read it via
`$context->getCalculatorData()` / `data.getCalculatorData()`. This brings
parity with OptionsProvider's `optionsProviderData` and lets one
calculator class handle simple variations instead of needing a
dedicated class per variant.

## Additional info
