### PR TITLE
[Bug] Harden exception handling in `Helper::upsert`

### DIFF
--- a/lib/Db/Helper.php
+++ b/lib/Db/Helper.php
@@ -14,11 +14,15 @@ declare(strict_types=1);
 namespace Pimcore\Db;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Exception as DriverExceptionInterface;
 use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Exception;
 use LogicException;
 use Pimcore\Model\Element\ValidationException;
+use Throwable;
 
 class Helper
 {
@@ -31,6 +35,7 @@ class Helper
      * The values for the specified keys are read from the $data parameter.
      *
      * @return int|string|null last insert id or null if the insert was not successful or it was an update.
+     * @throws DBALException
      */
     public static function upsert(
         Connection $connection,
@@ -48,17 +53,58 @@ class Helper
             } catch (DriverException) {
                 return null;
             }
-        } catch (\Doctrine\DBAL\Exception\UniqueConstraintViolationException $exception) {
-            $critera = [];
-            foreach ($keys as $key) {
-                $key = $quoteIdentifiers ? $connection->quoteIdentifier($key) : $key;
-                $critera[$key] = $data[$key] ?? throw new LogicException(sprintf('Key "%s" passed for upsert not found in data', $key));
+        } catch (UniqueConstraintViolationException) {
+            self::upsertUpdateFallback($connection, $table, $data, $keys, $quoteIdentifiers);
+
+            return null;
+        } catch (DBALException $exception) {
+            if (!self::isDuplicateKeyException($exception)) {
+                throw $exception;
             }
 
-            $connection->update($table, $data, $critera);
+            self::upsertUpdateFallback($connection, $table, $data, $keys, $quoteIdentifiers);
 
             return null;
         }
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @param string[] $keys
+     * @throws DBALException
+     */
+    private static function upsertUpdateFallback(
+        Connection $connection,
+        string $table,
+        array $data,
+        array $keys,
+        bool $quoteIdentifiers
+    ): void {
+        $criteria = [];
+        foreach ($keys as $key) {
+            $key = $quoteIdentifiers ? $connection->quoteIdentifier($key) : $key;
+            $criteria[$key] = $data[$key] ?? throw new LogicException(sprintf('Key "%s" passed for upsert not found in data', $key));
+        }
+
+        $connection->update($table, $data, $criteria);
+    }
+
+    private static function isDuplicateKeyException(Throwable $exception): bool
+    {
+        if ((int) $exception->getCode() === 1062) {
+            return true;
+        }
+
+        if ($exception instanceof DriverExceptionInterface && $exception->getSQLState() === '23000') {
+            return true;
+        }
+
+        $previous = $exception->getPrevious();
+        if ($previous instanceof Throwable) {
+            return self::isDuplicateKeyException($previous);
+        }
+
+        return false;
     }
 
     public static function fetchPairs(Connection $db, string $sql, array $params = [], array $types = []): array

--- a/lib/Db/Helper.php
+++ b/lib/Db/Helper.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Pimcore\Db;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Driver\Exception as DriverExceptionInterface;
 use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Exception\DriverException;
@@ -27,7 +26,6 @@ use Throwable;
 class Helper
 {
     /**
-     *
      * @param array<string, mixed> $data The data to be inserted or updated into the database table.
      * Array key corresponds to the database column, array value to the actual value.
      * @param string[] $keys If the table needs to be updated, the columns listed in this parameter will be used as criteria/condition for the where clause.
@@ -35,7 +33,11 @@ class Helper
      * The values for the specified keys are read from the $data parameter.
      *
      * @return int|string|null last insert id or null if the insert was not successful or it was an update.
-     * @throws DBALException
+     *
+     * @throws DBALException If the INSERT fails for a reason other than a duplicate-key violation
+     *                       (e.g. deadlock, lock-wait timeout, FK violation, connection loss) and
+     *                       if the UPDATE fallback itself fails.
+     * @throws LogicException If a column listed in $keys is not present in $data.
      */
     public static function upsert(
         Connection $connection,
@@ -58,6 +60,15 @@ class Helper
 
             return null;
         } catch (DBALException $exception) {
+            // DBAL normally converts a duplicate-key insert into
+            // UniqueConstraintViolationException, but in some setups
+            // (custom middleware, transaction/connection edge cases, lost
+            // connection during the statement) the driver-level exception
+            // can propagate without being re-classified. Fall back to the
+            // update path only when we can positively identify a duplicate-
+            // key error by MySQL/MariaDB vendor code; re-throw everything
+            // else (deadlocks, lock-wait timeouts, FK violations, NOT NULL
+            // violations, connection loss, ...).
             if (!self::isDuplicateKeyException($exception)) {
                 throw $exception;
             }
@@ -71,7 +82,9 @@ class Helper
     /**
      * @param array<string, mixed> $data
      * @param string[] $keys
-     * @throws DBALException
+     *
+     * @throws DBALException If the UPDATE fails.
+     * @throws LogicException If a column listed in $keys is not present in $data.
      */
     private static function upsertUpdateFallback(
         Connection $connection,
@@ -89,13 +102,21 @@ class Helper
         $connection->update($table, $data, $criteria);
     }
 
+    /**
+     * Pimcore only supports MySQL-family databases (MySQL, MariaDB, Percona,
+     * AWS Aurora) — see the system requirements — so no other vendors are
+     * considered here.
+     */
+    private const DUPLICATE_KEY_VENDOR_CODES = [
+        1062,
+        1557,
+        1569,
+        1586,
+    ];
+
     private static function isDuplicateKeyException(Throwable $exception): bool
     {
-        if ((int) $exception->getCode() === 1062) {
-            return true;
-        }
-
-        if ($exception instanceof DriverExceptionInterface && $exception->getSQLState() === '23000') {
+        if (in_array((int) $exception->getCode(), self::DUPLICATE_KEY_VENDOR_CODES, true)) {
             return true;
         }
 

--- a/lib/Db/Helper.php
+++ b/lib/Db/Helper.php
@@ -26,6 +26,27 @@ use Throwable;
 class Helper
 {
     /**
+     * MySQL / MariaDB vendor error codes that DBAL maps to
+     * UniqueConstraintViolationException.
+     *
+     * Pimcore only supports MySQL-family databases (MySQL, MariaDB, Percona,
+     * AWS Aurora) — see the system requirements — so no other vendors are
+     * considered here.
+     *
+     * @var int[]
+     */
+    private const array DUPLICATE_KEY_VENDOR_CODES = [
+        // ER_DUP_ENTRY
+        1062,
+        // ER_FOREIGN_DUPLICATE_KEY
+        1557,
+        // ER_DUP_ENTRY_WITH_KEY_NAME
+        1569,
+        // ER_DUP_ENTRY_AUTOINCREMENT_CASE
+        1586,
+    ];
+
+    /**
      * @param array<string, mixed> $data The data to be inserted or updated into the database table.
      * Array key corresponds to the database column, array value to the actual value.
      * @param string[] $keys If the table needs to be updated, the columns listed in this parameter will be used as criteria/condition for the where clause.
@@ -101,18 +122,6 @@ class Helper
 
         $connection->update($table, $data, $criteria);
     }
-
-    /**
-     * Pimcore only supports MySQL-family databases (MySQL, MariaDB, Percona,
-     * AWS Aurora) — see the system requirements — so no other vendors are
-     * considered here.
-     */
-    private const DUPLICATE_KEY_VENDOR_CODES = [
-        1062,
-        1557,
-        1569,
-        1586,
-    ];
 
     private static function isDuplicateKeyException(Throwable $exception): bool
     {

--- a/tests/Unit/Db/HelperTest.php
+++ b/tests/Unit/Db/HelperTest.php
@@ -18,6 +18,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Exception as DriverExceptionInterface;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Exception\DeadlockException;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Exception;
 use PHPUnit\Framework\TestCase;
@@ -119,6 +120,29 @@ class HelperTest extends TestCase
         $connection->expects(self::never())->method('update');
 
         $this->expectException(DeadlockException::class);
+
+        Helper::upsert($connection, 'tmp_store', ['id' => 'maintenance.pid', 'data' => 'foo'], ['id']);
+    }
+
+    /**
+     * Regression test: a non-duplicate-key exception that happens to share
+     * SQLSTATE 23000 (e.g. a MySQL foreign-key violation, code 1452) must
+     * NOT trigger the update fallback and must be re-thrown unchanged.
+     */
+    public function testUpsertRethrowsNonDuplicateIntegrityViolationsWithSqlState23000(): void
+    {
+        $fkViolation = new ForeignKeyConstraintViolationException(self::makeDriverException(1452, '23000'), null);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('quoteIdentifier')->willReturnCallback(static fn (string $id): string => '`' . $id . '`');
+
+        $connection->expects(self::once())
+            ->method('insert')
+            ->willThrowException($fkViolation);
+
+        $connection->expects(self::never())->method('update');
+
+        $this->expectException(ForeignKeyConstraintViolationException::class);
 
         Helper::upsert($connection, 'tmp_store', ['id' => 'maintenance.pid', 'data' => 'foo'], ['id']);
     }

--- a/tests/Unit/Db/HelperTest.php
+++ b/tests/Unit/Db/HelperTest.php
@@ -54,18 +54,21 @@ class HelperTest extends TestCase
     }
 
     /**
-     * Regression test: a raw driver-level exception (not converted to
-     * UniqueConstraintViolationException by DBAL) carrying SQLSTATE 23000 /
-     * vendor code 1062 must still trigger the update fallback.
+     * Regression test: a generic DBAL exception (not converted to
+     * UniqueConstraintViolationException by DBAL) carrying vendor code 1062
+     * must still trigger the update fallback. This can happen e.g. when
+     * custom middleware short-circuits DBAL's exception conversion.
      */
-    public function testUpsertFallsBackOnRawDriverDuplicateKeyException(): void
+    public function testUpsertFallsBackOnGenericDbalDuplicateKeyException(): void
     {
+        $dbalException = new class('duplicate', 1062) extends RuntimeException implements DBALException {};
+
         $connection = $this->createMock(Connection::class);
         $connection->method('quoteIdentifier')->willReturnCallback(static fn (string $id): string => '`' . $id . '`');
 
         $connection->expects(self::once())
             ->method('insert')
-            ->willThrowException(self::makeDriverException(1062, '23000'));
+            ->willThrowException($dbalException);
 
         $connection->expects(self::once())
             ->method('update')

--- a/tests/Unit/Db/HelperTest.php
+++ b/tests/Unit/Db/HelperTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Db;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Exception as DriverExceptionInterface;
+use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\DBAL\Exception\DeadlockException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Pimcore\Db\Helper;
+use RuntimeException;
+use Throwable;
+
+/**
+ * @internal
+ */
+class HelperTest extends TestCase
+{
+    public function testUpsertFallsBackToUpdateOnUniqueConstraintViolationException(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('quoteIdentifier')->willReturnCallback(static fn (string $id): string => '`' . $id . '`');
+
+        $connection->expects(self::once())
+            ->method('insert')
+            ->willThrowException(new UniqueConstraintViolationException('dup', self::makeDriverException(1062, '23000')));
+
+        $connection->expects(self::once())
+            ->method('update')
+            ->with(
+                'tmp_store',
+                self::callback(static fn (array $data): bool => $data === ['`id`' => 'maintenance.pid', '`data`' => 'foo']),
+                ['`id`' => 'maintenance.pid'],
+            )
+            ->willReturn(1);
+
+        self::assertNull(
+            Helper::upsert($connection, 'tmp_store', ['id' => 'maintenance.pid', 'data' => 'foo'], ['id']),
+        );
+    }
+
+    /**
+     * Regression test: a raw driver-level exception (not converted to
+     * UniqueConstraintViolationException by DBAL) carrying SQLSTATE 23000 /
+     * vendor code 1062 must still trigger the update fallback.
+     */
+    public function testUpsertFallsBackOnRawDriverDuplicateKeyException(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('quoteIdentifier')->willReturnCallback(static fn (string $id): string => '`' . $id . '`');
+
+        $connection->expects(self::once())
+            ->method('insert')
+            ->willThrowException(self::makeDriverException(1062, '23000'));
+
+        $connection->expects(self::once())
+            ->method('update')
+            ->with(
+                'tmp_store',
+                self::anything(),
+                ['`id`' => 'maintenance.pid'],
+            )
+            ->willReturn(1);
+
+        self::assertNull(
+            Helper::upsert($connection, 'tmp_store', ['id' => 'maintenance.pid', 'data' => 'foo'], ['id']),
+        );
+    }
+
+    /**
+     * Regression test: a wrapped DBAL exception whose previous is a 1062
+     * driver exception must also trigger the update fallback.
+     */
+    public function testUpsertFallsBackWhenDuplicateKeyIsInPreviousException(): void
+    {
+        $driverException = self::makeDriverException(1062, '23000');
+        $dbalException = new class('wrap', 0, $driverException) extends RuntimeException implements DBALException {};
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('quoteIdentifier')->willReturnCallback(static fn (string $id): string => '`' . $id . '`');
+
+        $connection->expects(self::once())
+            ->method('insert')
+            ->willThrowException($dbalException);
+
+        $connection->expects(self::once())
+            ->method('update')
+            ->willReturn(1);
+
+        self::assertNull(
+            Helper::upsert($connection, 'tmp_store', ['id' => 'maintenance.pid', 'data' => 'foo'], ['id']),
+        );
+    }
+
+    /**
+     * @throws DBALException
+     */
+    public function testUpsertRethrowsNonDuplicateKeyDbalExceptions(): void
+    {
+        $deadlock = new DeadlockException('deadlock', self::makeDriverException(1213, '40001'));
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('quoteIdentifier')->willReturnCallback(static fn (string $id): string => '`' . $id . '`');
+
+        $connection->expects(self::once())
+            ->method('insert')
+            ->willThrowException($deadlock);
+
+        $connection->expects(self::never())->method('update');
+
+        $this->expectException(DeadlockException::class);
+
+        Helper::upsert($connection, 'tmp_store', ['id' => 'maintenance.pid', 'data' => 'foo'], ['id']);
+    }
+
+    private static function makeDriverException(int $code, string $sqlState): Exception|DriverExceptionInterface
+    {
+        return new class($code, $sqlState) extends Exception implements DriverExceptionInterface {
+            public function __construct(int $code, private readonly string $sqlState)
+            {
+                parent::__construct('driver exception', $code);
+            }
+
+            public function getSQLState(): ?string
+            {
+                return $this->sqlState;
+            }
+        };
+    }
+}

--- a/tests/Unit/Db/HelperTest.php
+++ b/tests/Unit/Db/HelperTest.php
@@ -23,7 +23,6 @@ use Exception;
 use PHPUnit\Framework\TestCase;
 use Pimcore\Db\Helper;
 use RuntimeException;
-use Throwable;
 
 /**
  * @internal
@@ -37,7 +36,7 @@ class HelperTest extends TestCase
 
         $connection->expects(self::once())
             ->method('insert')
-            ->willThrowException(new UniqueConstraintViolationException('dup', self::makeDriverException(1062, '23000')));
+            ->willThrowException(new UniqueConstraintViolationException(self::makeDriverException(1062, '23000'), null));
 
         $connection->expects(self::once())
             ->method('update')
@@ -106,12 +105,9 @@ class HelperTest extends TestCase
         );
     }
 
-    /**
-     * @throws DBALException
-     */
     public function testUpsertRethrowsNonDuplicateKeyDbalExceptions(): void
     {
-        $deadlock = new DeadlockException('deadlock', self::makeDriverException(1213, '40001'));
+        $deadlock = new DeadlockException(self::makeDriverException(1213, '40001'), null);
 
         $connection = $this->createMock(Connection::class);
         $connection->method('quoteIdentifier')->willReturnCallback(static fn (string $id): string => '`' . $id . '`');


### PR DESCRIPTION
A reported pimcore:maintenance failure shows a raw Doctrine\DBAL\Driver\PDO\Exception (SQLSTATE 23000, code 1062) propagating through Helper::upsert() instead of the converted UniqueConstraintViolationException that DBAL normally produces. 
Harden the exception handling to catch and inspect DBALException as well. 

Resolves https://github.com/pimcore/service-operations/issues/825