### PR TITLE
WorkflowState\Dao: scope delete() by workflow

### DIFF
--- a/models/Element/WorkflowState/Dao.php
+++ b/models/Element/WorkflowState/Dao.php
@@ -66,6 +66,7 @@ class Dao extends Model\Dao\AbstractDao
         $this->db->delete('element_workflow_state', [
             'cid' => $this->model->getCid(),
             'ctype' => $this->model->getCtype(),
+            'workflow' => $this->model->getWorkflow(),
         ]);
     }
 }

--- a/tests/Model/Element/WorkflowStateTest.php
+++ b/tests/Model/Element/WorkflowStateTest.php
@@ -18,16 +18,14 @@ use Pimcore\Tests\Support\Test\ModelTestCase;
 use Pimcore\Tests\Support\Util\TestHelper;
 
 /**
+ * Class WorkflowStateTest
+ *
+ * @package Pimcore\Tests\Model\Element
+ *
  * @group model.element.workflowstate
  */
 class WorkflowStateTest extends ModelTestCase
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-        TestHelper::cleanUp();
-    }
-
     /**
      * Deleting one WorkflowState row must not delete other rows that belong
      * to the same element under a different workflow.

--- a/tests/Model/Element/WorkflowStateTest.php
+++ b/tests/Model/Element/WorkflowStateTest.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\Element;
+
+use Pimcore\Model\Element\WorkflowState;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+use Pimcore\Tests\Support\Util\TestHelper;
+
+/**
+ * @group model.element.workflowstate
+ */
+class WorkflowStateTest extends ModelTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        TestHelper::cleanUp();
+    }
+
+    /**
+     * Deleting one WorkflowState row must not delete other rows that belong
+     * to the same element under a different workflow.
+     */
+    public function testDeleteIsScopedToWorkflow(): void
+    {
+        $object = TestHelper::createEmptyObject();
+
+        $first = new WorkflowState();
+        $first->setCid($object->getId());
+        $first->setCtype('object');
+        $first->setWorkflow('workflow_a');
+        $first->setPlace('place_a');
+        $first->save();
+
+        $second = new WorkflowState();
+        $second->setCid($object->getId());
+        $second->setCtype('object');
+        $second->setWorkflow('workflow_b');
+        $second->setPlace('place_b');
+        $second->save();
+
+        $loaded = WorkflowState::getByPrimary($object->getId(), 'object', 'workflow_a');
+        $this->assertNotNull($loaded);
+        $loaded->delete();
+
+        $this->assertNull(
+            WorkflowState::getByPrimary($object->getId(), 'object', 'workflow_a'),
+            'The targeted row should be deleted.'
+        );
+
+        $survivor = WorkflowState::getByPrimary($object->getId(), 'object', 'workflow_b');
+        $this->assertNotNull($survivor, 'The other workflow\'s row must not be deleted.');
+        $this->assertSame('place_b', $survivor->getPlace());
+    }
+}


### PR DESCRIPTION
Without the workflow column in the WHERE clause, deleting one WorkflowState row would wipe every workflow's row for the same element. Adds a regression test that creates two WorkflowState rows for the same element under different workflow names and verifies the unrelated row survives the delete.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `12.3`
- Feature/Improvement: choose `2026.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`2026.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `12.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info

`WorkflowState\Dao::delete()` only filters by `cid` and `ctype`, omitting `workflow`. As a result, deleting one `WorkflowState` row wipes every workflow's row for the same element — not just the targeted one.

There are no in-tree callers of `WorkflowState::delete()` today, so the bug is currently dormant, but the contract is wrong (`WorkflowState` is uniquely keyed by `(cid, ctype, workflow)`, so a delete on a loaded model should be scoped to that primary key).

## Change

- Add `workflow` to the WHERE clause of `Dao::delete()`.
- Add `tests/Model/Element/WorkflowStateTest.php` with a regression test that creates two `WorkflowState` rows for the same element under different workflow names, deletes one, and asserts the other survives.

