### PR TITLE
feat: add TemplateProviderInterface extension point to ControllerDataProvider

### DIFF
--- a/bundles/CoreBundle/config/services.yaml
+++ b/bundles/CoreBundle/config/services.yaml
@@ -3,12 +3,6 @@ services:
         autowire: true
         autoconfigure: true
 
-    _instanceof:
-        # all services implementing the TemplateProviderInterface contribute
-        # additional selectable templates to the ControllerDataProvider
-        Pimcore\Controller\Config\TemplateProviderInterface:
-            tags: ['pimcore.template_provider']
-
     #
     # SECURITY
     #

--- a/bundles/CoreBundle/config/services.yaml
+++ b/bundles/CoreBundle/config/services.yaml
@@ -3,6 +3,12 @@ services:
         autowire: true
         autoconfigure: true
 
+    _instanceof:
+        # all services implementing the TemplateProviderInterface contribute
+        # additional selectable templates to the ControllerDataProvider
+        Pimcore\Controller\Config\TemplateProviderInterface:
+            tags: ['pimcore.template_provider']
+
     #
     # SECURITY
     #
@@ -65,6 +71,7 @@ services:
         public : true
         arguments:
             $serviceControllers: '%pimcore.service_controllers%'
+            $templateProviders: !tagged_iterator pimcore.template_provider
 
     #
     # HTTP/REST clients

--- a/doc/01_Documents/02_Templates/README.md
+++ b/doc/01_Documents/02_Templates/README.md
@@ -57,6 +57,29 @@ That template is used for auto-rendering when the controller does not return a r
 See [MVC in Pimcore](../01_MVC_in_Pimcore.md) for details on how documents resolve
 their controller and template.
 
+### The Template Dropdown
+
+The template selector shown in a document's settings (and when configuring static routes)
+is populated by scanning for `*.twig` files in the project's `templates/` directory and in
+the `templates/` (or `Resources/views/`) directory of every registered bundle, except bundles
+whose namespace starts with `Symfony`, `Doctrine`, `Pimcore`, or `Sensio` (so Pimcore's own
+bundle templates are not listed). Project templates are listed by their relative path
+(`content/default.html.twig`), bundle templates with the Twig namespace notation
+(`@AppBundle/content/default.html.twig`).
+
+To add templates that live outside those scanned paths (e.g. dynamically generated ones),
+implement `Pimcore\Controller\Config\TemplateProviderInterface` and tag the service with
+`pimcore.template_provider`:
+
+```yaml
+services:
+    App\Templating\MyTemplateProvider:
+        tags: ['pimcore.template_provider']
+```
+
+Each name returned by `getTemplates()` must use the same notation as the scanned templates
+(a project-relative path or a `@Namespace/...` name) and is merged into the dropdown.
+
 ## Editables
 
 Editables are the bridge between templates and Pimcore Studio.

--- a/lib/Controller/Config/ControllerDataProvider.php
+++ b/lib/Controller/Config/ControllerDataProvider.php
@@ -167,6 +167,10 @@ class ControllerDataProvider
             $templates[] = $templateProvider->getTemplates();
         }
 
+        if ($templates === []) {
+            return $this->templates = [];
+        }
+
         return $this->templates = array_values(array_unique(array_merge(...$templates)));
     }
 

--- a/lib/Controller/Config/ControllerDataProvider.php
+++ b/lib/Controller/Config/ControllerDataProvider.php
@@ -45,10 +45,19 @@ class ControllerDataProvider
         '*.twig',
     ];
 
-    public function __construct(KernelInterface $kernel, array $serviceControllers)
+    /**
+     * @var iterable<TemplateProviderInterface>
+     */
+    private iterable $templateProviders;
+
+    /**
+     * @param iterable<TemplateProviderInterface> $templateProviders
+     */
+    public function __construct(KernelInterface $kernel, array $serviceControllers, iterable $templateProviders = [])
     {
         $this->kernel = $kernel;
         $this->serviceControllers = $serviceControllers;
+        $this->templateProviders = $templateProviders;
     }
 
     /**
@@ -154,7 +163,11 @@ class ControllerDataProvider
             }
         }
 
-        return $this->templates = array_merge(...$templates);
+        foreach ($this->templateProviders as $templateProvider) {
+            $templates[] = $templateProvider->getTemplates();
+        }
+
+        return $this->templates = array_values(array_unique(array_merge(...$templates)));
     }
 
     /**

--- a/lib/Controller/Config/ControllerDataProvider.php
+++ b/lib/Controller/Config/ControllerDataProvider.php
@@ -142,8 +142,13 @@ class ControllerDataProvider
     }
 
     /**
-     * Builds a list of all available templates in bundles, in app/Resources/views, and Symfony locations
+     * Builds the list of selectable templates by scanning for `*.twig` files in the project's
+     * `templates/` directory and in the `templates/` (or `Resources/views/`) directory of every
+     * registered bundle, except bundles excluded by {@see self::isValidNamespace()} (Symfony,
+     * Doctrine, Pimcore, Sensio). Templates contributed by {@see TemplateProviderInterface}
+     * implementations are merged in as well; the resulting list is deduplicated.
      *
+     * @return string[]
      */
     public function getTemplates(): array
     {

--- a/lib/Controller/Config/TemplateProviderInterface.php
+++ b/lib/Controller/Config/TemplateProviderInterface.php
@@ -24,9 +24,10 @@ namespace Pimcore\Controller\Config;
  * bundles. Implement this interface to contribute templates that live outside
  * those scanned paths (e.g. dynamically generated ones).
  *
- * Services implementing this interface are automatically tagged with
- * `pimcore.template_provider` (autoconfiguration is enabled for CoreBundle
- * services) and collected by {@see ControllerDataProvider}.
+ * Implementations are collected by {@see ControllerDataProvider} via the
+ * `pimcore.template_provider` service tag. CoreBundle service definitions may
+ * receive this tag through autoconfiguration, but services defined outside of
+ * that scope must add the `pimcore.template_provider` tag explicitly.
  */
 interface TemplateProviderInterface
 {

--- a/lib/Controller/Config/TemplateProviderInterface.php
+++ b/lib/Controller/Config/TemplateProviderInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Controller\Config;
+
+/**
+ * Extension point for contributing additional selectable templates to the
+ * template list built by {@see ControllerDataProvider::getTemplates()} (used
+ * to configure the template for documents and static routes).
+ *
+ * The {@see ControllerDataProvider} builds its template list by scanning the
+ * project's `templates/` directory and the template directories of non-core
+ * bundles. Implement this interface to contribute templates that live outside
+ * those scanned paths (e.g. dynamically generated ones).
+ *
+ * Services implementing this interface are automatically tagged with
+ * `pimcore.template_provider` (autoconfiguration is enabled for CoreBundle
+ * services) and collected by {@see ControllerDataProvider}.
+ */
+interface TemplateProviderInterface
+{
+    /**
+     * Returns additional selectable template names.
+     *
+     * Each entry must use the same notation as the values returned by
+     * {@see ControllerDataProvider::getTemplates()}: either a bare,
+     * project-relative path (e.g. `content/foo.html.twig`) or a
+     * Twig-namespaced name (e.g. `@SomeNamespace/foo.html.twig`).
+     *
+     * @return string[]
+     */
+    public function getTemplates(): array;
+}

--- a/lib/Controller/Config/TemplateProviderInterface.php
+++ b/lib/Controller/Config/TemplateProviderInterface.php
@@ -25,9 +25,8 @@ namespace Pimcore\Controller\Config;
  * those scanned paths (e.g. dynamically generated ones).
  *
  * Implementations are collected by {@see ControllerDataProvider} via the
- * `pimcore.template_provider` service tag. CoreBundle service definitions may
- * receive this tag through autoconfiguration, but services defined outside of
- * that scope must add the `pimcore.template_provider` tag explicitly.
+ * `pimcore.template_provider` service tag, so every implementation must be
+ * tagged with `pimcore.template_provider` to be picked up.
  */
 interface TemplateProviderInterface
 {

--- a/tests/Unit/Controller/Config/ControllerDataProviderTest.php
+++ b/tests/Unit/Controller/Config/ControllerDataProviderTest.php
@@ -102,13 +102,20 @@ class ControllerDataProviderTest extends TestCase
 
     public function testGetTemplatesIsMemoised(): void
     {
+        $templateProvider = $this->createMock(TemplateProviderInterface::class);
+        $templateProvider
+            ->expects($this->once())
+            ->method('getTemplates')
+            ->willReturn(['@Agent/memoised.html.twig']);
+
         $provider = new ControllerDataProvider(
             $this->createKernel(),
             [],
-            [$this->createTemplateProvider(['@Agent/memoised.html.twig'])]
+            [$templateProvider]
         );
 
-        $this->assertSame($provider->getTemplates(), $provider->getTemplates());
+        $this->assertSame(['@Agent/memoised.html.twig'], $provider->getTemplates());
+        $this->assertSame(['@Agent/memoised.html.twig'], $provider->getTemplates());
     }
 
     public function testGetTemplatesWorksWithoutTemplateProviders(): void

--- a/tests/Unit/Controller/Config/ControllerDataProviderTest.php
+++ b/tests/Unit/Controller/Config/ControllerDataProviderTest.php
@@ -114,8 +114,11 @@ class ControllerDataProviderTest extends TestCase
             [$templateProvider]
         );
 
-        $this->assertSame(['@Agent/memoised.html.twig'], $provider->getTemplates());
-        $this->assertSame(['@Agent/memoised.html.twig'], $provider->getTemplates());
+        $firstCallTemplates = $provider->getTemplates();
+        $this->assertContains('@Agent/memoised.html.twig', $firstCallTemplates);
+
+        $secondCallTemplates = $provider->getTemplates();
+        $this->assertSame($firstCallTemplates, $secondCallTemplates);
     }
 
     public function testGetTemplatesWorksWithoutTemplateProviders(): void

--- a/tests/Unit/Controller/Config/ControllerDataProviderTest.php
+++ b/tests/Unit/Controller/Config/ControllerDataProviderTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Controller\Config;
+
+use Pimcore\Controller\Config\ControllerDataProvider;
+use Pimcore\Controller\Config\TemplateProviderInterface;
+use Pimcore\Tests\Support\Test\TestCase;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class ControllerDataProviderTest extends TestCase
+{
+    private function createKernel(): KernelInterface
+    {
+        $kernel = $this->createMock(KernelInterface::class);
+        // no project bundles -> getTemplates() only relies on the project
+        // templates scan plus the registered template providers
+        $kernel->method('getBundles')->willReturn([]);
+
+        return $kernel;
+    }
+
+    private function createTemplateProvider(array $templates): TemplateProviderInterface
+    {
+        return new class($templates) implements TemplateProviderInterface {
+            public function __construct(private array $templates)
+            {
+            }
+
+            public function getTemplates(): array
+            {
+                return $this->templates;
+            }
+        };
+    }
+
+    public function testGetTemplatesIncludesTemplateProviderTemplates(): void
+    {
+        $provider = new ControllerDataProvider(
+            $this->createKernel(),
+            [],
+            [$this->createTemplateProvider(['@Agent/generated/foo.html.twig'])]
+        );
+
+        $templates = $provider->getTemplates();
+
+        $this->assertContains('@Agent/generated/foo.html.twig', $templates);
+    }
+
+    public function testGetTemplatesMergesMultipleTemplateProviders(): void
+    {
+        $provider = new ControllerDataProvider(
+            $this->createKernel(),
+            [],
+            [
+                $this->createTemplateProvider(['content/one.html.twig']),
+                $this->createTemplateProvider(['@Agent/two.html.twig']),
+            ]
+        );
+
+        $templates = $provider->getTemplates();
+
+        $this->assertContains('content/one.html.twig', $templates);
+        $this->assertContains('@Agent/two.html.twig', $templates);
+    }
+
+    public function testGetTemplatesDeduplicatesProviderTemplates(): void
+    {
+        $duplicate = 'content/duplicate.html.twig';
+
+        $provider = new ControllerDataProvider(
+            $this->createKernel(),
+            [],
+            [
+                $this->createTemplateProvider([$duplicate, '@Agent/unique.html.twig']),
+                $this->createTemplateProvider([$duplicate]),
+            ]
+        );
+
+        $templates = $provider->getTemplates();
+
+        $this->assertSame(
+            [$duplicate],
+            array_values(array_filter($templates, static fn (string $t): bool => $t === $duplicate)),
+            'Duplicate template names contributed by providers must be collapsed to a single entry.'
+        );
+        $this->assertContains('@Agent/unique.html.twig', $templates);
+        // returned list must be a plain, re-indexed array
+        $this->assertSame(array_values($templates), $templates);
+    }
+
+    public function testGetTemplatesIsMemoised(): void
+    {
+        $provider = new ControllerDataProvider(
+            $this->createKernel(),
+            [],
+            [$this->createTemplateProvider(['@Agent/memoised.html.twig'])]
+        );
+
+        $this->assertSame($provider->getTemplates(), $provider->getTemplates());
+    }
+
+    public function testGetTemplatesWorksWithoutTemplateProviders(): void
+    {
+        $provider = new ControllerDataProvider($this->createKernel(), []);
+
+        // backward compatibility: the template providers argument is optional
+        $this->assertIsArray($provider->getTemplates());
+    }
+}


### PR DESCRIPTION
Lets bundles contribute additional selectable templates (for documents and static routes) via a 'pimcore.template_provider' tagged service, instead of relying solely on the filesystem scan.