### PR TITLE
[Bug]: Prevent/handle eager db connection resolution during bootstrap

### DIFF
--- a/doc/11_Deployment_Recommendations/02_Deployment_Tools.md
+++ b/doc/11_Deployment_Recommendations/02_Deployment_Tools.md
@@ -7,6 +7,24 @@ description: Configuration management, class definitions, and console commands f
 
 Pimcore provides the following tools to support deployment processes.
 
+:::tip Deployment hint
+
+For deployments without database access (e.g. CI pipelines), Doctrine ORM cache warm-up
+fails because it tries to detect the database version. Configure the server version
+explicitly in the default DBAL connection:
+
+```yaml
+doctrine:
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                ...
+                server_version: mariadb-10.11.0
+```
+
+:::
+
 ## Pimcore Configurations
 
 Pimcore has two categories of configuration:

--- a/lib/Composer.php
+++ b/lib/Composer.php
@@ -17,7 +17,6 @@ use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\Installer\PackageEvent;
 use Composer\Script\Event;
 use RuntimeException;
-use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 use Throwable;
@@ -222,50 +221,6 @@ class Composer
         return preg_replace("/\033\[[^m]*m/", '', $string);
     }
 
-    private static function getConfiguredCacheBaseDir(Event $event): string
-    {
-        $rootPath = static::getRootPath($event);
-
-        $appCacheDir = self::readEnvVar('APP_CACHE_DIR');
-        if (null !== $appCacheDir) {
-            return self::normalizeCacheBaseDir($rootPath, $appCacheDir);
-        }
-
-        $pimcoreCacheDir = self::readEnvVar('PIMCORE_SYMFONY_CACHE_DIRECTORY');
-        if (null !== $pimcoreCacheDir) {
-            return self::normalizeCacheBaseDir($rootPath, $pimcoreCacheDir);
-        }
-
-        return $rootPath . '/var/cache';
-    }
-
-    private static function normalizeCacheBaseDir(string $rootPath, string $cacheBaseDir): string
-    {
-        if (Path::isAbsolute($cacheBaseDir)) {
-            return $cacheBaseDir;
-        }
-
-        return $rootPath . '/' . ltrim($cacheBaseDir, '/\\');
-    }
-
-    private static function getConfiguredCacheDir(Event $event): string
-    {
-        $cacheBaseDir = self::getConfiguredCacheBaseDir($event);
-        $environment = self::readEnvVar('APP_ENV') ?? 'dev';
-
-        return $cacheBaseDir . '/' . $environment;
-    }
-
-    private static function readEnvVar(string $envVar): ?string
-    {
-        $value = getenv($envVar);
-        if (false === $value || '' === $value) {
-            $value = $_SERVER[$envVar] ?? $_ENV[$envVar] ?? null;
-        }
-
-        return null === $value || '' === $value ? null : $value;
-    }
-
     /**
      *
      * The following is copied from \Sensio\Bundle\DistributionBundle\Composer\ScriptHandler
@@ -321,18 +276,6 @@ class Composer
         $consoleDir = static::getConsoleDir($event, 'clear the cache');
 
         if (null === $consoleDir) {
-            return;
-        }
-
-        // Nothing to clear on a fresh project. During create-project, the
-        // cache directory usually does not exist yet. Running cache:clear
-        // would bootstrap the kernel and can fail before installation is done.
-        $cacheDir = self::getConfiguredCacheDir($event);
-        if (!is_dir($cacheDir) && !$options['symfony-cache-warmup']) {
-            $event->getIO()->write(
-                '<comment>Skipping cache:clear: no compiled cache found.</comment>'
-            );
-
             return;
         }
 

--- a/lib/Composer.php
+++ b/lib/Composer.php
@@ -226,7 +226,7 @@ class Composer
         $rootPath = static::getRootPath($event);
 
         foreach (['PIMCORE_SYMFONY_CACHE_DIRECTORY', 'APP_CACHE_DIR'] as $envVar) {
-            $value = static::readEnvVar($envVar);
+            $value = self::readEnvVar($envVar);
             if (null !== $value) {
                 if (!str_starts_with($value, '/') && !preg_match('/^[A-Za-z]:[\\\\\/]/', $value)) {
                     $value = $rootPath . '/' . ltrim($value, '/\\');
@@ -310,7 +310,7 @@ class Composer
         // Nothing to clear on a fresh project. During create-project, the
         // cache directory usually does not exist yet. Running cache:clear
         // would bootstrap the kernel and can fail before installation is done.
-        $cacheDir = static::getConfiguredCacheBaseDir($event);
+        $cacheDir = self::getConfiguredCacheBaseDir($event);
         if (!is_dir($cacheDir)) {
             $event->getIO()->write(
                 '<comment>Skipping cache:clear: no compiled cache found.</comment>'

--- a/lib/Composer.php
+++ b/lib/Composer.php
@@ -17,6 +17,7 @@ use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\Installer\PackageEvent;
 use Composer\Script\Event;
 use RuntimeException;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 use Throwable;
@@ -228,7 +229,7 @@ class Composer
         foreach (['APP_CACHE_DIR', 'PIMCORE_SYMFONY_CACHE_DIRECTORY'] as $envVar) {
             $value = self::readEnvVar($envVar);
             if (null !== $value) {
-                if (!str_starts_with($value, '/') && !preg_match('/^[A-Za-z]:[\\\\\/]/', $value)) {
+                if (!Path::isAbsolute($value)) {
                     $value = $rootPath . '/' . ltrim($value, '/\\');
                 }
 

--- a/lib/Composer.php
+++ b/lib/Composer.php
@@ -279,6 +279,18 @@ class Composer
             return;
         }
 
+        // Nothing to clear on a fresh project. During create-project, the
+        // cache directory usually does not exist yet. Running cache:clear
+        // would bootstrap the kernel and can fail before installation is done.
+        $cacheDir = static::getRootPath($event) . '/var/cache';
+        if (!is_dir($cacheDir)) {
+            $event->getIO()->write(
+                '<comment>Skipping cache:clear: no compiled cache found.</comment>'
+            );
+
+            return;
+        }
+
         $command = ['cache:clear'];
         if (!$options['symfony-cache-warmup']) {
             $command[] = '--no-warmup';

--- a/lib/Composer.php
+++ b/lib/Composer.php
@@ -225,7 +225,7 @@ class Composer
     {
         $rootPath = static::getRootPath($event);
 
-        foreach (['PIMCORE_SYMFONY_CACHE_DIRECTORY', 'APP_CACHE_DIR'] as $envVar) {
+        foreach (['APP_CACHE_DIR', 'PIMCORE_SYMFONY_CACHE_DIRECTORY'] as $envVar) {
             $value = self::readEnvVar($envVar);
             if (null !== $value) {
                 if (!str_starts_with($value, '/') && !preg_match('/^[A-Za-z]:[\\\\\/]/', $value)) {
@@ -311,7 +311,7 @@ class Composer
         // cache directory usually does not exist yet. Running cache:clear
         // would bootstrap the kernel and can fail before installation is done.
         $cacheDir = self::getConfiguredCacheBaseDir($event);
-        if (!is_dir($cacheDir)) {
+        if (!is_dir($cacheDir) && !$options['symfony-cache-warmup']) {
             $event->getIO()->write(
                 '<comment>Skipping cache:clear: no compiled cache found.</comment>'
             );

--- a/lib/Composer.php
+++ b/lib/Composer.php
@@ -231,18 +231,6 @@ class Composer
             return self::normalizeCacheBaseDir($rootPath, $appCacheDir);
         }
 
-        if (!defined('PIMCORE_SYMFONY_CACHE_DIRECTORY')) {
-            $customConstantsFile = $rootPath . '/config/pimcore/constants.php';
-            if (file_exists($customConstantsFile)) {
-                // @phpstan-ignore-next-line
-                include_once $customConstantsFile;
-            }
-        }
-
-        if (defined('PIMCORE_SYMFONY_CACHE_DIRECTORY')) {
-            return self::normalizeCacheBaseDir($rootPath, (string) constant('PIMCORE_SYMFONY_CACHE_DIRECTORY'));
-        }
-
         $pimcoreCacheDir = self::readEnvVar('PIMCORE_SYMFONY_CACHE_DIRECTORY');
         if (null !== $pimcoreCacheDir) {
             return self::normalizeCacheBaseDir($rootPath, $pimcoreCacheDir);
@@ -258,6 +246,14 @@ class Composer
         }
 
         return $rootPath . '/' . ltrim($cacheBaseDir, '/\\');
+    }
+
+    private static function getConfiguredCacheDir(Event $event): string
+    {
+        $cacheBaseDir = self::getConfiguredCacheBaseDir($event);
+        $environment = self::readEnvVar('APP_ENV') ?? 'dev';
+
+        return $cacheBaseDir . '/' . $environment;
     }
 
     private static function readEnvVar(string $envVar): ?string
@@ -331,7 +327,7 @@ class Composer
         // Nothing to clear on a fresh project. During create-project, the
         // cache directory usually does not exist yet. Running cache:clear
         // would bootstrap the kernel and can fail before installation is done.
-        $cacheDir = self::getConfiguredCacheBaseDir($event);
+        $cacheDir = self::getConfiguredCacheDir($event);
         if (!is_dir($cacheDir) && !$options['symfony-cache-warmup']) {
             $event->getIO()->write(
                 '<comment>Skipping cache:clear: no compiled cache found.</comment>'

--- a/lib/Composer.php
+++ b/lib/Composer.php
@@ -240,10 +240,7 @@ class Composer
         }
 
         if (defined('PIMCORE_SYMFONY_CACHE_DIRECTORY')) {
-            $pimcoreCacheDir = constant('PIMCORE_SYMFONY_CACHE_DIRECTORY');
-            if (is_string($pimcoreCacheDir) && '' !== $pimcoreCacheDir) {
-                return self::normalizeCacheBaseDir($rootPath, $pimcoreCacheDir);
-            }
+            return self::normalizeCacheBaseDir($rootPath, (string) constant('PIMCORE_SYMFONY_CACHE_DIRECTORY'));
         }
 
         $pimcoreCacheDir = self::readEnvVar('PIMCORE_SYMFONY_CACHE_DIRECTORY');

--- a/lib/Composer.php
+++ b/lib/Composer.php
@@ -221,6 +221,34 @@ class Composer
         return preg_replace("/\033\[[^m]*m/", '', $string);
     }
 
+    private static function getConfiguredCacheBaseDir(Event $event): string
+    {
+        $rootPath = static::getRootPath($event);
+
+        foreach (['PIMCORE_SYMFONY_CACHE_DIRECTORY', 'APP_CACHE_DIR'] as $envVar) {
+            $value = static::readEnvVar($envVar);
+            if (null !== $value) {
+                if (!str_starts_with($value, '/') && !preg_match('/^[A-Za-z]:[\\\\\/]/', $value)) {
+                    $value = $rootPath . '/' . ltrim($value, '/\\');
+                }
+
+                return $value;
+            }
+        }
+
+        return $rootPath . '/var/cache';
+    }
+
+    private static function readEnvVar(string $envVar): ?string
+    {
+        $value = getenv($envVar);
+        if (false === $value || '' === $value) {
+            $value = $_SERVER[$envVar] ?? $_ENV[$envVar] ?? null;
+        }
+
+        return null === $value || '' === $value ? null : $value;
+    }
+
     /**
      *
      * The following is copied from \Sensio\Bundle\DistributionBundle\Composer\ScriptHandler
@@ -282,7 +310,7 @@ class Composer
         // Nothing to clear on a fresh project. During create-project, the
         // cache directory usually does not exist yet. Running cache:clear
         // would bootstrap the kernel and can fail before installation is done.
-        $cacheDir = static::getRootPath($event) . '/var/cache';
+        $cacheDir = static::getConfiguredCacheBaseDir($event);
         if (!is_dir($cacheDir)) {
             $event->getIO()->write(
                 '<comment>Skipping cache:clear: no compiled cache found.</comment>'

--- a/lib/Composer.php
+++ b/lib/Composer.php
@@ -226,18 +226,41 @@ class Composer
     {
         $rootPath = static::getRootPath($event);
 
-        foreach (['APP_CACHE_DIR', 'PIMCORE_SYMFONY_CACHE_DIRECTORY'] as $envVar) {
-            $value = self::readEnvVar($envVar);
-            if (null !== $value) {
-                if (!Path::isAbsolute($value)) {
-                    $value = $rootPath . '/' . ltrim($value, '/\\');
-                }
+        $appCacheDir = self::readEnvVar('APP_CACHE_DIR');
+        if (null !== $appCacheDir) {
+            return self::normalizeCacheBaseDir($rootPath, $appCacheDir);
+        }
 
-                return $value;
+        if (!defined('PIMCORE_SYMFONY_CACHE_DIRECTORY')) {
+            $customConstantsFile = $rootPath . '/config/pimcore/constants.php';
+            if (file_exists($customConstantsFile)) {
+                // @phpstan-ignore-next-line
+                include_once $customConstantsFile;
             }
         }
 
+        if (defined('PIMCORE_SYMFONY_CACHE_DIRECTORY')) {
+            $pimcoreCacheDir = constant('PIMCORE_SYMFONY_CACHE_DIRECTORY');
+            if (is_string($pimcoreCacheDir) && '' !== $pimcoreCacheDir) {
+                return self::normalizeCacheBaseDir($rootPath, $pimcoreCacheDir);
+            }
+        }
+
+        $pimcoreCacheDir = self::readEnvVar('PIMCORE_SYMFONY_CACHE_DIRECTORY');
+        if (null !== $pimcoreCacheDir) {
+            return self::normalizeCacheBaseDir($rootPath, $pimcoreCacheDir);
+        }
+
         return $rootPath . '/var/cache';
+    }
+
+    private static function normalizeCacheBaseDir(string $rootPath, string $cacheBaseDir): string
+    {
+        if (Path::isAbsolute($cacheBaseDir)) {
+            return $cacheBaseDir;
+        }
+
+        return $rootPath . '/' . ltrim($cacheBaseDir, '/\\');
     }
 
     private static function readEnvVar(string $envVar): ?string

--- a/lib/Console/Application.php
+++ b/lib/Console/Application.php
@@ -108,14 +108,13 @@ final class Application extends \Symfony\Bundle\FrameworkBundle\Console\Applicat
         });
 
         $dispatcher->addListener(ConsoleEvents::TERMINATE, function (ConsoleTerminateEvent $event) use ($kernel) {
-            $maintenanceModeHelper = $kernel->getContainer()->get(MaintenanceModeHelperInterface::class);
-
             if ($event->getInput()->getOption('maintenance-mode')) {
                 $event->getOutput()->writeln('Deactivating maintenance mode...');
                 //BC Layer for Admin::activateMaintenanceMode, if the maintenance file already exists
                 if (Admin::isInMaintenanceMode()) {
                     Admin::deactivateMaintenanceMode();
                 }
+                $maintenanceModeHelper = $kernel->getContainer()->get(MaintenanceModeHelperInterface::class);
                 $maintenanceModeHelper->deactivate();
             }
         });

--- a/lib/Console/Application.php
+++ b/lib/Console/Application.php
@@ -65,8 +65,9 @@ final class Application extends \Symfony\Bundle\FrameworkBundle\Console\Applicat
 
         $this->setDispatcher($dispatcher);
 
-        $maintenanceModeHelper = $kernel->getContainer()->get(MaintenanceModeHelperInterface::class);
-        $dispatcher->addListener(ConsoleEvents::COMMAND, function (ConsoleCommandEvent $event) use ($kernel, $maintenanceModeHelper) {
+        $dispatcher->addListener(ConsoleEvents::COMMAND, function (ConsoleCommandEvent $event) use ($kernel) {
+            $maintenanceModeHelper = $kernel->getContainer()->get(MaintenanceModeHelperInterface::class);
+
             // skip if maintenance mode is on and the flag is not set
             if (($maintenanceModeHelper->isActive() || Admin::isInMaintenanceMode()) &&
                 !$event->getInput()->getOption('ignore-maintenance-mode')
@@ -106,7 +107,9 @@ final class Application extends \Symfony\Bundle\FrameworkBundle\Console\Applicat
             }
         });
 
-        $dispatcher->addListener(ConsoleEvents::TERMINATE, function (ConsoleTerminateEvent $event) use ($maintenanceModeHelper) {
+        $dispatcher->addListener(ConsoleEvents::TERMINATE, function (ConsoleTerminateEvent $event) use ($kernel) {
+            $maintenanceModeHelper = $kernel->getContainer()->get(MaintenanceModeHelperInterface::class);
+
             if ($event->getInput()->getOption('maintenance-mode')) {
                 $event->getOutput()->writeln('Deactivating maintenance mode...');
                 //BC Layer for Admin::activateMaintenanceMode, if the maintenance file already exists

--- a/lib/Tool/MaintenanceModeHelper.php
+++ b/lib/Tool/MaintenanceModeHelper.php
@@ -29,7 +29,11 @@ class MaintenanceModeHelper implements MaintenanceModeHelperInterface
 
     protected const OFF = 'OFF';
 
-    public function __construct(protected RequestStack $requestStack, protected Connection $db)
+    public function __construct(
+        protected RequestStack $requestStack,
+        /** @deprecated - will be removed in Pimcore 2027.1.0 **/
+        protected Connection $db
+    )
     {
     }
 

--- a/lib/Tool/MaintenanceModeHelper.php
+++ b/lib/Tool/MaintenanceModeHelper.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Tool;
 
+use Doctrine\DBAL\Connection;
 use Exception;
 use InvalidArgumentException;
 use Pimcore;
@@ -28,7 +29,7 @@ class MaintenanceModeHelper implements MaintenanceModeHelperInterface
 
     protected const OFF = 'OFF';
 
-    public function __construct(protected RequestStack $requestStack)
+    public function __construct(protected RequestStack $requestStack, protected Connection $db)
     {
     }
 

--- a/lib/Tool/MaintenanceModeHelper.php
+++ b/lib/Tool/MaintenanceModeHelper.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Pimcore\Tool;
 
-use Doctrine\DBAL\Connection;
 use Exception;
 use InvalidArgumentException;
 use Pimcore;
@@ -29,7 +28,7 @@ class MaintenanceModeHelper implements MaintenanceModeHelperInterface
 
     protected const OFF = 'OFF';
 
-    public function __construct(protected RequestStack $requestStack, protected Connection $db)
+    public function __construct(protected RequestStack $requestStack)
     {
     }
 
@@ -85,9 +84,6 @@ class MaintenanceModeHelper implements MaintenanceModeHelperInterface
         } catch (Exception $exception) {
             // The cache entry is not set, we try to load it from the database
             try {
-                if (!$this->db->isConnected()) {
-                    $this->db->getNativeConnection();
-                }
                 $tmpStore = TmpStore::get(self::ENTRY_ID);
             } catch (Exception $e) {
                 return null;


### PR DESCRIPTION
Resolves https://github.com/pimcore/pimcore/issues/19144
Part of https://github.com/pimcore/internal-improvements/issues/15

### Additional information
We identified two things, that can trigger the need of a db connection in a scenario where there might not be one available yet:

1.) `cache:clear` triggers cache warm up, `ProxyCacheWarmer` can try to determine the db server version, if the version is not explicitly set. `cache:clear` itself gets triggered by our composer scripts on `create-project`, but it is just the trigger, not the problem itself. 
2.) `Pimcore\Console\Application` class eagerly invokes `MaintenanceModeHelperInterface`. `MaintenanceModeHelperInterface` invokes the db connection in the constructor, which can lead to problems. 

### Solution
For 1.)
- Created a follow up to re evaluate the need of custom composer scripts, or at least the need of `cache:clear` in there. Usually you might want to have something like that in a separate deploy step. 
~~- Implemented a check to skip `cache:clear` based on the existence of the cache directory. If there is no cache directory, then we dont need to clear it.~~
- Set `server_version` config in demo-enterprise and skeleton- done in separate prs in the corresponding repositories. 
- Add a hint to the documentation for deployments. 

For 2.) 
- Resolve `MaintenanceModeHelperInterface` in the listener, not in the Application's constructor. 
- Remove db connection in `MaintenanceModeHelper`, it is not needed, since `TmpStore::get` throws anyway, if db is not reachable -> needs to be done in a follow up, since it is a bc break: https://github.com/pimcore/pimcore/issues/19153

