### PR TITLE
[Security] Restrict allowed_classes in Authentication::safelyUnserialize() to prevent PHP Object Injection

### DIFF
--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -109,7 +109,47 @@ class Authentication
             ini_set('unserialize_callback_func', $prevUnserializeHandler);
         }
 
+        if ($token !== null && !($token instanceof TokenInterface)) {
+            Logger::warning('Security token from session is not a TokenInterface instance — rejecting.', ['key' => 'pimcore_admin', 'type' => get_debug_type($token)]);
+
+            return null;
+        }
+
+        if ($token instanceof TokenInterface && static::containsIncompleteClass($token)) {
+            Logger::warning('Security token from session contains __PHP_Incomplete_Class — rejecting.', ['key' => 'pimcore_admin']);
+
+            return null;
+        }
+
         return $token;
+    }
+
+    private static function containsIncompleteClass(mixed $value, array &$visited = []): bool
+    {
+        if (!is_object($value) && !is_array($value)) {
+            return false;
+        }
+
+        $id = is_object($value) ? spl_object_id($value) : null;
+        if ($id !== null) {
+            if (in_array($id, $visited, true)) {
+                return false;
+            }
+            $visited[] = $id;
+        }
+
+        if (is_object($value) && $value instanceof \__PHP_Incomplete_Class) {
+            return true;
+        }
+
+        $items = is_array($value) ? $value : (array) $value;
+        foreach ($items as $item) {
+            if (static::containsIncompleteClass($item, $visited)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -88,11 +88,15 @@ class Authentication
         // already-loaded classes. Providing an explicit allowed_classes list
         // significantly reduces that attack surface.
         $allowedClasses = [
+            // token classes
             PostAuthenticationToken::class,
-            AbstractToken::class,
             \Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken::class,
             \Symfony\Component\Security\Core\Authentication\Token\RememberMeToken::class,
             \Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken::class,
+
+            // user classes contained within the token
+            \Pimcore\Security\User\User::class,
+            \Pimcore\Model\User::class,
         ];
 
         try {

--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -86,10 +86,13 @@ class Authentication
         // The unserialize_callback_func guard above catches *unknown* class names
         // but does NOT prevent Object Injection via gadget chains built from
         // already-loaded classes. Providing an explicit allowed_classes list
-        // eliminates that attack surface.
+        // significantly reduces that attack surface.
         $allowedClasses = [
             PostAuthenticationToken::class,
             AbstractToken::class,
+            \Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken::class,
+            \Symfony\Component\Security\Core\Authentication\Token\RememberMeToken::class,
+            \Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken::class,
         ];
 
         try {

--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -91,7 +91,8 @@ class Authentication
             \Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken::class,
             \Symfony\Component\Security\Core\Authentication\Token\RememberMeToken::class,
             \Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken::class,
-
+            \Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorToken::class,
+            
             // user classes contained within the token
             \Pimcore\Security\User\User::class,
             \Pimcore\Model\User::class,

--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -24,7 +24,6 @@ use Pimcore\Model\Exception\NotFoundException;
 use Pimcore\Model\User;
 use Pimcore\Security\User\UserProvider;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;

--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -115,7 +115,7 @@ class Authentication
             return null;
         }
 
-        if ($token instanceof TokenInterface && static::containsIncompleteClass($token)) {
+        if ($token instanceof TokenInterface && self::containsIncompleteClass($token)) {
             Logger::warning('Security token from session contains __PHP_Incomplete_Class — rejecting.', ['key' => 'pimcore_admin']);
 
             return null;
@@ -144,7 +144,7 @@ class Authentication
 
         $items = is_array($value) ? $value : (array) $value;
         foreach ($items as $item) {
-            if (static::containsIncompleteClass($item, $visited)) {
+            if (self::containsIncompleteClass($item, $visited)) {
                 return true;
             }
         }

--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -82,11 +82,10 @@ class Authentication
             return $prevErrorHandler ? $prevErrorHandler($type, $msg, $file, $line, $context) : false;
         });
 
-        // Restrict deserialization to known Symfony security token classes.
+        // Restrict deserialization to the token + user classes we expect in the admin session.
         // The unserialize_callback_func guard above catches *unknown* class names
-        // but does NOT prevent Object Injection via gadget chains built from
-        // already-loaded classes. Providing an explicit allowed_classes list
-        // significantly reduces that attack surface.
+        // but does NOT prevent Object Injection via gadget chains built from already-loaded classes.
+        // Providing an explicit allowed_classes list significantly reduces that attack surface.
         $allowedClasses = [
             // token classes
             PostAuthenticationToken::class,

--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -124,27 +124,32 @@ class Authentication
         return $token;
     }
 
-    private static function containsIncompleteClass(mixed $value, array &$visited = []): bool
+    private static function containsIncompleteClass(mixed $value, array &$visited = [], int $depth = 0): bool
     {
         if (!is_object($value) && !is_array($value)) {
             return false;
         }
 
-        $id = is_object($value) ? spl_object_id($value) : null;
-        if ($id !== null) {
-            if (in_array($id, $visited, true)) {
-                return false;
-            }
-            $visited[] = $id;
+        // Protect against cyclic references / overly deep structures in crafted serialized payloads.
+        if ($depth > 64) {
+            return true;
         }
 
-        if (is_object($value) && $value instanceof \__PHP_Incomplete_Class) {
-            return true;
+        if (is_object($value)) {
+            $id = spl_object_id($value);
+            if (isset($visited[$id])) {
+                return false;
+            }
+            $visited[$id] = true;
+
+            if ($value instanceof \__PHP_Incomplete_Class) {
+                return true;
+            }
         }
 
         $items = is_array($value) ? $value : (array) $value;
         foreach ($items as $item) {
-            if (self::containsIncompleteClass($item, $visited)) {
+            if (self::containsIncompleteClass($item, $visited, $depth + 1)) {
                 return true;
             }
         }

--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -24,8 +24,10 @@ use Pimcore\Model\Exception\NotFoundException;
 use Pimcore\Model\User;
 use Pimcore\Security\User\UserProvider;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
 
 class Authentication
 {
@@ -80,8 +82,18 @@ class Authentication
             return $prevErrorHandler ? $prevErrorHandler($type, $msg, $file, $line, $context) : false;
         });
 
+        // Restrict deserialization to known Symfony security token classes.
+        // The unserialize_callback_func guard above catches *unknown* class names
+        // but does NOT prevent Object Injection via gadget chains built from
+        // already-loaded classes. Providing an explicit allowed_classes list
+        // eliminates that attack surface.
+        $allowedClasses = [
+            PostAuthenticationToken::class,
+            AbstractToken::class,
+        ];
+
         try {
-            $token = unserialize($serializedToken);
+            $token = unserialize($serializedToken, ['allowed_classes' => $allowedClasses]);
         } catch (ErrorException $e) {
             if (0x37313BC !== $e->getCode()) {
                 throw $e;


### PR DESCRIPTION
## Summary

`Authentication::safelyUnserialize()` reads the admin security token from the PHP session and calls `unserialize()` **without an `allowed_classes` restriction**.

The existing `unserialize_callback_func` guard catches only *unknown* (not-yet-loaded) classes. It does **not** prevent PHP Object Injection via gadget chains built from classes that are already loaded in the process — which in a Pimcore/Symfony application includes Doctrine, Monolog, Guzzle, and dozens of other libraries with exploitable `__destruct`/`__wakeup` methods.

## Attack scenario

1. Attacker can write to the PHP session store (e.g., compromised Redis session backend, session fixation + writable session directory, or SSRF to session store).
2. Attacker crafts a serialized payload using gadget classes already loaded by Pimcore/Symfony/Doctrine.
3. On the next admin request, `Authentication::safelyUnserialize()` deserializes the token → gadget chain fires → **Remote Code Execution**.

## Fix

Restrict `allowed_classes` to the Symfony token classes that Pimcore actually serializes into the admin session (`PostAuthenticationToken`, `AbstractToken`). Any other class in the serialized string will be deserialized as `__PHP_Incomplete_Class` without executing its constructor or magic methods.

## Files changed

- `lib/Tool/Authentication.php` — add explicit `allowed_classes` to `unserialize()`