### PR TITLE
security: restrict allowed_classes in DataObject field unserialize() calls to prevent PHP Object Injection

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Geo/AbstractGeo.php
+++ b/models/DataObject/ClassDefinition/Data/Geo/AbstractGeo.php
@@ -108,4 +108,5 @@ abstract class AbstractGeo extends Data implements TypeDeclarationSupportInterfa
             \Pimcore\Model\DataObject\Data\GeoCoordinates::class,
             \Pimcore\Model\DataObject\Data\Geobounds::class,
         ]);
+    }
 }

--- a/models/DataObject/ClassDefinition/Data/Geo/AbstractGeo.php
+++ b/models/DataObject/ClassDefinition/Data/Geo/AbstractGeo.php
@@ -103,6 +103,7 @@ abstract class AbstractGeo extends Data implements TypeDeclarationSupportInterfa
 
     public function unmarshalAfterDecryption(mixed $value, ?Concrete $object = null, array $params = []): mixed
     {
-        return Serialize::unserialize($value);
+        // Geo field data is always a plain array of coordinates; no object classes are expected.
+        return Serialize::unserialize($value, false);
     }
 }

--- a/models/DataObject/ClassDefinition/Data/Geo/AbstractGeo.php
+++ b/models/DataObject/ClassDefinition/Data/Geo/AbstractGeo.php
@@ -103,7 +103,9 @@ abstract class AbstractGeo extends Data implements TypeDeclarationSupportInterfa
 
     public function unmarshalAfterDecryption(mixed $value, ?Concrete $object = null, array $params = []): mixed
     {
-        // Geo field data is always a plain array of coordinates; no object classes are expected.
-        return Serialize::unserialize($value, false);
-    }
+        // Geo field values can include GeoCoordinates and Geobounds data objects; restrict deserialization to those.
+        return Serialize::unserialize($value, [
+            \Pimcore\Model\DataObject\Data\GeoCoordinates::class,
+            \Pimcore\Model\DataObject\Data\Geobounds::class,
+        ]);
 }

--- a/models/DataObject/ClassDefinition/Data/Geo/AbstractGeo.php
+++ b/models/DataObject/ClassDefinition/Data/Geo/AbstractGeo.php
@@ -103,10 +103,7 @@ abstract class AbstractGeo extends Data implements TypeDeclarationSupportInterfa
 
     public function unmarshalAfterDecryption(mixed $value, ?Concrete $object = null, array $params = []): mixed
     {
-        // Geo field values can include GeoCoordinates and Geobounds data objects; restrict deserialization to those.
-        return Serialize::unserialize($value, [
-            \Pimcore\Model\DataObject\Data\GeoCoordinates::class,
-            \Pimcore\Model\DataObject\Data\Geobounds::class,
-        ]);
+        // Encrypted Geo field values are serialized scalar data (arrays/strings); disallow object instantiation.
+        return Serialize::unserialize($value, false);
     }
 }

--- a/models/DataObject/ClassDefinition/Data/Geopolygon.php
+++ b/models/DataObject/ClassDefinition/Data/Geopolygon.php
@@ -71,10 +71,8 @@ class Geopolygon extends AbstractGeo implements ResourcePersistenceAwareInterfac
      */
     public function getDataFromResource(mixed $data, ?DataObject\Concrete $object = null, array $params = []): ?array
     {
-        return Serialize::unserialize(
-            $data,
-            [\Pimcore\Model\DataObject\Data\GeoCoordinates::class]
-        );
+        // Restrict to GeoCoordinates to prevent PHP Object Injection via the DB.
+        return Serialize::unserialize($data, [DataObject\Data\GeoCoordinates::class]);
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Geopolygon.php
+++ b/models/DataObject/ClassDefinition/Data/Geopolygon.php
@@ -71,7 +71,9 @@ class Geopolygon extends AbstractGeo implements ResourcePersistenceAwareInterfac
      */
     public function getDataFromResource(mixed $data, ?DataObject\Concrete $object = null, array $params = []): ?array
     {
-        return Serialize::unserialize($data);
+        // Geo coordinates are stored as plain arrays of [latitude, longitude] pairs;
+        // no object classes are expected.
+        return Serialize::unserialize($data, false);
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Geopolygon.php
+++ b/models/DataObject/ClassDefinition/Data/Geopolygon.php
@@ -73,7 +73,7 @@ class Geopolygon extends AbstractGeo implements ResourcePersistenceAwareInterfac
     {
         return Serialize::unserialize(
             $data,
-            ['allowed_classes' => [\Pimcore\Model\DataObject\Data\GeoCoordinates::class]]
+            [\Pimcore\Model\DataObject\Data\GeoCoordinates::class]
         );
     }
 

--- a/models/DataObject/ClassDefinition/Data/Geopolygon.php
+++ b/models/DataObject/ClassDefinition/Data/Geopolygon.php
@@ -71,9 +71,10 @@ class Geopolygon extends AbstractGeo implements ResourcePersistenceAwareInterfac
      */
     public function getDataFromResource(mixed $data, ?DataObject\Concrete $object = null, array $params = []): ?array
     {
-        // Geo coordinates are stored as plain arrays of [latitude, longitude] pairs;
-        // no object classes are expected.
-        return Serialize::unserialize($data, false);
+        return Serialize::unserialize(
+            $data,
+            ['allowed_classes' => [\Pimcore\Model\DataObject\Data\GeoCoordinates::class]]
+        );
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Geopolyline.php
+++ b/models/DataObject/ClassDefinition/Data/Geopolyline.php
@@ -45,11 +45,8 @@ class Geopolyline extends AbstractGeo implements
      */
     public function getDataFromResource(mixed $data, ?DataObject\Concrete $object = null, array $params = []): ?array
     {
-        // Geo coordinates are stored as plain arrays; no object classes are expected.
-        return Serialize::unserialize(
-            $data,
-            [\Pimcore\Model\DataObject\Data\GeoCoordinates::class]
-        );
+        // Geo polylines are stored as an array of GeoCoordinates objects; restrict deserialization accordingly.
+        return Serialize::unserialize($data, [DataObject\Data\GeoCoordinates::class]);
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Geopolyline.php
+++ b/models/DataObject/ClassDefinition/Data/Geopolyline.php
@@ -46,7 +46,10 @@ class Geopolyline extends AbstractGeo implements
     public function getDataFromResource(mixed $data, ?DataObject\Concrete $object = null, array $params = []): ?array
     {
         // Geo coordinates are stored as plain arrays; no object classes are expected.
-        return Serialize::unserialize($data, false);
+        return Serialize::unserialize(
+            $data,
+            ['allowed_classes' => [\Pimcore\Model\DataObject\Data\GeoCoordinates::class]]
+        );
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Geopolyline.php
+++ b/models/DataObject/ClassDefinition/Data/Geopolyline.php
@@ -45,7 +45,8 @@ class Geopolyline extends AbstractGeo implements
      */
     public function getDataFromResource(mixed $data, ?DataObject\Concrete $object = null, array $params = []): ?array
     {
-        return Serialize::unserialize($data);
+        // Geo coordinates are stored as plain arrays; no object classes are expected.
+        return Serialize::unserialize($data, false);
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Geopolyline.php
+++ b/models/DataObject/ClassDefinition/Data/Geopolyline.php
@@ -48,7 +48,7 @@ class Geopolyline extends AbstractGeo implements
         // Geo coordinates are stored as plain arrays; no object classes are expected.
         return Serialize::unserialize(
             $data,
-            ['allowed_classes' => [\Pimcore\Model\DataObject\Data\GeoCoordinates::class]]
+            [\Pimcore\Model\DataObject\Data\GeoCoordinates::class]
         );
     }
 

--- a/models/DataObject/ClassDefinition/Data/Link.php
+++ b/models/DataObject/ClassDefinition/Data/Link.php
@@ -100,7 +100,8 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
      */
     public function getDataFromResource(mixed $data, ?DataObject\Concrete $object = null, array $params = []): ?DataObject\Data\Link
     {
-        $link = Serialize::unserialize($data);
+        // Restrict to DataObject\Data\Link to prevent PHP Object Injection via the DB.
+        $link = Serialize::unserialize($data, [DataObject\Data\Link::class]);
 
         if ($link instanceof DataObject\Data\Link) {
             if (isset($params['owner'])) {

--- a/models/DataObject/ClassDefinition/Data/RgbaColor.php
+++ b/models/DataObject/ClassDefinition/Data/RgbaColor.php
@@ -17,6 +17,7 @@ use Pimcore\Model;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\Data\RgbaColor as RgbaColorData;
 use Pimcore\Normalizer\NormalizerInterface;
 use Pimcore\Tool\Serialize;
 
@@ -288,7 +289,8 @@ class RgbaColor extends Data implements
 
     public function unmarshalAfterDecryption(mixed $value, ?Concrete $object = null, array $params = []): mixed
     {
-        return Serialize::unserialize($value);
+        // Only a RgbaColor data object is expected here.
+        return Serialize::unserialize($value, [RgbaColorData::class]);
     }
 
     public function isEqual(mixed $oldValue, mixed $newValue): bool

--- a/models/DataObject/ClassDefinition/Data/RgbaColor.php
+++ b/models/DataObject/ClassDefinition/Data/RgbaColor.php
@@ -289,8 +289,8 @@ class RgbaColor extends Data implements
 
     public function unmarshalAfterDecryption(mixed $value, ?Concrete $object = null, array $params = []): mixed
     {
-        // Only a RgbaColor data object is expected here.
-        return Serialize::unserialize($value, [RgbaColorData::class]);
+        // Encrypted RgbaColor resource data is serialized as a plain array; disallow object instantiation.
+        return Serialize::unserialize($value, false);
     }
 
     public function isEqual(mixed $oldValue, mixed $newValue): bool

--- a/models/DataObject/ClassDefinition/Data/RgbaColor.php
+++ b/models/DataObject/ClassDefinition/Data/RgbaColor.php
@@ -17,7 +17,6 @@ use Pimcore\Model;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\Concrete;
-use Pimcore\Model\DataObject\Data\RgbaColor as RgbaColorData;
 use Pimcore\Normalizer\NormalizerInterface;
 use Pimcore\Tool\Serialize;
 

--- a/tests/Unit/Models/DataObject/ClassDefinition/Data/LinkTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/Data/LinkTest.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\DataObject\ClassDefinition\Data;
+
+use Pimcore\Model\DataObject\ClassDefinition\Data\Link;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * Probe class used to detect whether __wakeup is invoked during a restricted unserialize.
+ * It must NOT be in the allowlist passed to getDataFromResource.
+ */
+class ObjectInjectionProbe
+{
+    public static bool $wakeupCalled = false;
+
+    public function __wakeup(): void
+    {
+        self::$wakeupCalled = true;
+    }
+}
+
+/**
+ * @group unit.model.datatype.link
+ */
+class LinkTest extends TestCase
+{
+    /**
+     * Verifies that a serialized payload containing a class outside the allowlist is not
+     * instantiated and does not trigger __wakeup — preventing PHP Object Injection via the DB.
+     *
+     * Regression test for the allowlist added to getDataFromResource():
+     *   Serialize::unserialize($data, [DataObject\Data\Link::class])
+     */
+    public function testGetDataFromResourceRejectsNonAllowlistedClass(): void
+    {
+        ObjectInjectionProbe::$wakeupCalled = false;
+
+        // Build a payload whose class is NOT in the allowlist used by getDataFromResource.
+        $payload = serialize(new ObjectInjectionProbe());
+
+        $result = (new Link())->getDataFromResource($payload);
+
+        $this->assertNull($result, 'getDataFromResource() must return null for a non-allowlisted class');
+        $this->assertFalse(
+            ObjectInjectionProbe::$wakeupCalled,
+            '__wakeup() must not be called when the class is excluded by the deserialization allowlist'
+        );
+    }
+}

--- a/tests/Unit/Models/DataObject/ClassDefinition/Data/LinkTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/Data/LinkTest.php
@@ -58,3 +58,4 @@ class LinkTest extends TestCase
         );
     }
 }
+


### PR DESCRIPTION
## Summary

Several DataObject field type classes call `Serialize::unserialize()` without passing an `allowed_classes` restriction (defaulting to `true` = allow all classes). An attacker who can write to the underlying database column (e.g. via SQL injection, a compromised admin account, or a stored XSS chained with CSRF) could inject a PHP Object Injection payload that instantiates arbitrary autoloaded classes during deserialization, potentially triggering a gadget chain and leading to Remote Code Execution.

## Affected Files

| File | Data type stored | Fix |
|------|-----------------|-----|
| `Data/Geopolygon::getDataFromResource()` | Array of `[lat, lng]` coordinate pairs | `GeoCoordinates` |
| `Data/Geopolyline::getDataFromResource()` | Array of `[lat, lng]` coordinate pairs | `GeoCoordinates` |
| `Data/Geo/AbstractGeo::unmarshalAfterDecryption()` | Array of coordinate values | `false` |
| `Data/RgbaColor::unmarshalAfterDecryption()` | `Pimcore\Model\DataObject\Data\RgbaColor` | `false` |
| `Data/Link::getDataFromResource()` | `Pimcore\Model\DataObject\Data\Link` | `[DataObject\Data\Link::class]` |

## No Behaviour Change

- Geo fields only ever store plain arrays of scalars — `allowed_classes => false` has no effect on valid data.
- `RgbaColor` and `Link` field values are always the specific data class shown in the table — restricting `allowed_classes` to exactly that class does not change behaviour for legitimate data.