### PR TITLE
security: restrict allowed_classes in Site::setDomains() and setLocalizedErrorDocuments() deserialization

### DIFF
--- a/models/Site.php
+++ b/models/Site.php
@@ -224,7 +224,7 @@ final class Site extends AbstractModel
     public function setDomains(array|string $domains): static
     {
         if (is_string($domains)) {
-            $domains = Serialize::unserialize($domains);
+            $domains = Serialize::unserialize($domains, false);
         }
         if (is_array($domains)) {
             $domains = array_filter($domains);
@@ -303,7 +303,7 @@ final class Site extends AbstractModel
     public function setLocalizedErrorDocuments(array|string $localizedErrorDocuments): static
     {
         if (is_string($localizedErrorDocuments)) {
-            $localizedErrorDocuments = Serialize::unserialize($localizedErrorDocuments);
+            $localizedErrorDocuments = Serialize::unserialize($localizedErrorDocuments, false);
         }
         $this->localizedErrorDocuments = $localizedErrorDocuments;
 


### PR DESCRIPTION
## Summary

`Site::setDomains()` and `Site::setLocalizedErrorDocuments()` call `Serialize::unserialize()` without passing an `$allowedClasses` argument. This means the call falls through to PHP's default `allowed_classes => true`, which permits deserialization of any autoloaded PHP class.

### Affected call sites

| File | Method | Stored data |
|------|--------|-------------|
| `models/Site.php:227` | `setDomains()` | Array of domain name strings |
| `models/Site.php:306` | `setLocalizedErrorDocuments()` | Array of document IDs (integers) |

Neither field legitimately stores PHP objects, so passing `false` as `$allowedClasses` is safe and backwards-compatible.

### Fix

```php
// Before
$domains = Serialize::unserialize($domains);

// After
$domains = Serialize::unserialize($domains, false);
```

### Why this matters

The site domain and error document config is loaded from the database. If an attacker can influence these database rows (e.g., via a compromised admin account, SQL injection, or a secondary vulnerability), the bare `unserialize()` provides a PHP Object Injection vector. Restricting to `false` closes this path.

This is a minimal, surgical fix. No change to the public API.