### PR TITLE
Add missing `ownername` condition when fetching objectbrick relations

### DIFF
--- a/models/DataObject/Objectbrick/Data/Dao.php
+++ b/models/DataObject/Objectbrick/Data/Dao.php
@@ -337,7 +337,8 @@ class Dao extends Model\Dao\AbstractDao
             $classId = $this->model->getObject()->getClassId();
         }
 
-        $params = [$field, $id, $field, $id, $field, $id];
+        $ownername = $this->model->getFieldname();
+        $params = [$field, $id, $field, $id, $field, $ownername, $id];
 
         $dest = 'dest_id';
         $src = 'src_id';
@@ -350,6 +351,7 @@ class Dao extends Model\Dao\AbstractDao
             FROM objects o, object_relations_' . $classId . " r
             WHERE r.fieldname= ?
             AND r.ownertype = 'objectbrick'
+            AND r.ownername = ?
             AND r." . $src . ' = ?
             AND o.id = r.' . $dest . "
             AND (position = '" . $this->model->getType() . "' OR position IS NULL OR position = '')
@@ -359,6 +361,7 @@ class Dao extends Model\Dao\AbstractDao
             FROM assets a, object_relations_' . $classId . " r
             WHERE r.fieldname= ?
             AND r.ownertype = 'objectbrick'
+            AND r.ownername = ?
             AND r." . $src . ' = ?
             AND a.id = r.' . $dest . "
             AND (position = '" . $this->model->getType() . "' OR position IS NULL OR position = '')
@@ -368,6 +371,7 @@ class Dao extends Model\Dao\AbstractDao
             FROM documents d, object_relations_' . $classId . " r
             WHERE r.fieldname= ?
             AND r.ownertype = 'objectbrick'
+            AND r.ownername = ?
             AND r." . $src . ' = ?
             AND d.id = r.' . $dest . "
             AND (position = '" . $this->model->getType() . "' OR position IS NULL OR position = '')

--- a/models/DataObject/Objectbrick/Data/Dao.php
+++ b/models/DataObject/Objectbrick/Data/Dao.php
@@ -337,8 +337,8 @@ class Dao extends Model\Dao\AbstractDao
             $classId = $this->model->getObject()->getClassId();
         }
 
-        $ownername = $this->model->getFieldname();
-        $params = [$field, $id, $field, $id, $field, $ownername, $id];
+        $ownerName = $this->model->getFieldname();
+        $params = [$field, $ownerName, $id, $field, $ownerName, $id, $field, $ownerName, $id];
 
         $dest = 'dest_id';
         $src = 'src_id';


### PR DESCRIPTION
<!--
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `12.3`
- Feature/Improvement: choose `2026.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`2026.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/` 
- [x] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `12.3` (see Readme.md for the list of supported versions)
- [x] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
## Issue & reproduction

The query to which resolves objectbrick relations is faulty. It is missing the condition check for the `owner` of the 
the object brick. This means the query always returns all the relations which exist for this object and just the first is always used in the backend.

| src_id | dest_id | fieldname   | ownertype   | ownername | position                 |
| ------ | ------- | ----------- | ----------- | --------- | ------------------------ |
| 800    | **1195** *    | threadedRod | objectbrick | mounting1 | ThreadedRod |
| 800    | 1194    | threadedRod | objectbrick | mounting2 | ThreadedRod              |

*is used for all the occurrences of this object type 

#### Object Definition

<img width="1438" height="1116" alt="image" src="https://github.com/user-attachments/assets/c0d99ce8-1e2f-46f6-b4c4-22dc44f65af0" />

#### Issue in backend

<img width="1530" height="849" alt="image" src="https://github.com/user-attachments/assets/71b3ffe4-bc78-48ee-9350-efaf8211d469" />

## Changes in this pull request  

Fix the query which resolves the relations. Add missing `ownername` condition when fetching objectbrick relations.

## Additional info
- Only tested with classic UI