### PR TITLE
[Document Editor] Deprecate editable dialog width/height configuration options

### DIFF
--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,5 +1,14 @@
 # Upgrade Notes
 
+## Pimcore 12.3.10
+
+### Deprecations
+
+#### [Document Editor]
+
+The `width` and `height` options of `Pimcore\Extension\Document\Areabrick\EditableDialogBoxConfiguration` are deprecated and will be removed in 2027.1. 
+Editable dialog boxes work differently in the new Studio UI, so these options no longer have any effect.
+
 ## Pimcore 12.3.6
 
 ### [Assets]

--- a/lib/Extension/Document/Areabrick/EditableDialogBoxConfiguration.php
+++ b/lib/Extension/Document/Areabrick/EditableDialogBoxConfiguration.php
@@ -19,8 +19,14 @@ class EditableDialogBoxConfiguration implements JsonSerializable
 {
     protected ?string $id = null;
 
+    /**
+     * @deprecated since 12.3, will be removed in 2027.1. The option has no effect in the new Studio UI.
+     */
     protected ?int $width = 550;
 
+    /**
+     * @deprecated since 12.3, will be removed in 2027.1. The option has no effect in the new Studio UI.
+     */
     protected ?int $height = 370;
 
     protected array $items = [];
@@ -42,31 +48,57 @@ class EditableDialogBoxConfiguration implements JsonSerializable
         return $this;
     }
 
+    /**
+     * @deprecated since 12.3, will be removed in 2027.1. The option has no effect in the new Studio UI.
+     */
     public function getWidth(): ?int
     {
         return $this->width;
     }
 
     /**
+     * @deprecated since 12.3, will be removed in 2027.1. The option has no effect in the new Studio UI.
+     *
      * @return $this
      */
     public function setWidth(?int $width): static
     {
+        trigger_deprecation(
+            'pimcore/pimcore',
+            '12.3',
+            'Setting the "width" option of %s is deprecated and will be removed in 2027.1. '
+            . 'The option has no effect in the new Studio UI.',
+            self::class
+        );
+
         $this->width = $width;
 
         return $this;
     }
 
+    /**
+     * @deprecated since 12.3, will be removed in 2027.1. The option has no effect in the new Studio UI.
+     */
     public function getHeight(): ?int
     {
         return $this->height;
     }
 
     /**
+     * @deprecated since 12.3, will be removed in 2027.1. The option has no effect in the new Studio UI.
+     *
      * @return $this
      */
     public function setHeight(?int $height): static
     {
+        trigger_deprecation(
+            'pimcore/pimcore',
+            '12.3',
+            'Setting the "height" option of %s is deprecated and will be removed in 2027.1. '
+            . 'The option has no effect in the new Studio UI.',
+            self::class
+        );
+
         $this->height = $height;
 
         return $this;


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `12.3`
- Feature/Improvement: choose `2026.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`2026.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `12.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/19158
## Additional info
- add missing deprecation notice for properties which are not relevant in studio anymore