### PR TITLE
[Security] Restrict allowed classes when unserializing the admin session token

### DIFF
--- a/bundles/CoreBundle/src/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Configuration.php
@@ -1252,6 +1252,11 @@ final class Configuration implements ConfigurationInterface
                             ->end()
                         ->end()
                     ->end()
+                        ->arrayNode('session_token_allowed_classes')
+                            ->info('Additional PHP classes allowed when unserializing the admin session security token (e.g. custom authenticator tokens). The built-in Symfony/Pimcore token and user classes are always allowed.')
+                            ->scalarPrototype()->end()
+                            ->defaultValue([])
+                        ->end()
                 ->end()
             ->end();
     }

--- a/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php
+++ b/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php
@@ -65,6 +65,8 @@ final class PimcoreCoreExtension extends ConfigurableExtension implements Prepen
 
         $container->setParameter('pimcore.tmp_store.unserialize_allowed_classes', $config['tmp_store']['unserialize_allowed_classes']);
 
+        $container->setParameter('pimcore.security.session_token_allowed_classes', $config['security']['session_token_allowed_classes']);
+
         $container->setParameter('pimcore.translations.admin_translation_mapping', $config['translations']['admin_translation_mapping']);
 
         $container->setParameter('pimcore.web_profiler.toolbar.excluded_routes', $config['web_profiler']['toolbar']['excluded_routes']);

--- a/doc/19_Development_Tools_and_Details/10_Security_Authentication/06_Session_Token_Allowed_Classes.md
+++ b/doc/19_Development_Tools_and_Details/10_Security_Authentication/06_Session_Token_Allowed_Classes.md
@@ -1,0 +1,33 @@
+# Admin Session Token Allowed Classes
+
+When Pimcore restores a backend user from the session, it deserializes the security token stored under the
+`_security_pimcore_admin` session key. To prevent PHP object-injection attacks (an attacker who can write to the
+session store planting a serialized gadget chain), the deserialization is restricted to a fixed set of expected
+classes via PHP's [`allowed_classes`](https://www.php.net/manual/en/function.unserialize.php) option — any other
+class is reduced to `__PHP_Incomplete_Class` and its magic methods (`__wakeup`/`__destruct`/…) are never executed.
+
+The built-in allowlist covers the standard token graph:
+
+- `Pimcore\Security\User\User` and `Pimcore\Model\User`
+- `Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken`
+- `Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken`
+- `Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorToken` (when `scheb/2fa-bundle` is installed)
+- `Pimcore\Bundle\AdminBundle\Security\Authentication\Token\TwoFactorRequiredToken` — the classic
+  `admin-ui-classic-bundle` `/admin/login` firewall (Pimcore < 2026.1 / LTS) stores this while 2FA is pending
+
+## Extending the Allowlist
+
+If you use a **custom authenticator** that stores a different token class in the session, register the additional
+class(es); otherwise the session token will be rejected and the user silently logged out:
+
+```yaml
+# config/packages/pimcore.yaml
+pimcore:
+    security:
+        session_token_allowed_classes:
+            - App\Security\Token\MyCustomToken
+```
+
+The classes listed here are **merged** with Pimcore's built-in defaults, so you do not need to repeat the core
+classes. This mirrors the [`tmp_store.unserialize_allowed_classes`](../43_Tmp_Store.md#extending-allowed-classes-for-unserialization)
+mechanism used for the Tmp Store.

--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -15,7 +15,6 @@ namespace Pimcore\Tool;
 
 use Defuse\Crypto\Crypto;
 use Defuse\Crypto\Exception\CryptoException;
-use ErrorException;
 use Exception;
 use Pimcore;
 use Pimcore\Config;
@@ -23,9 +22,12 @@ use Pimcore\Logger;
 use Pimcore\Model\Exception\NotFoundException;
 use Pimcore\Model\User;
 use Pimcore\Security\User\UserProvider;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
 
 class Authentication
 {
@@ -70,37 +72,62 @@ class Authentication
 
     protected static function safelyUnserialize(string $serializedToken): mixed
     {
-        $token = null;
-        $prevUnserializeHandler = ini_set('unserialize_callback_func', __CLASS__.'::handleUnserializeCallback');
-        $prevErrorHandler = set_error_handler(static function (int $type, string $msg, string $file, int $line, array $context = []) use (&$prevErrorHandler) {
-            if (__FILE__ === $file) {
-                throw new ErrorException($msg, 0x37313BC, $type, $file, $line);
-            }
+        // Restrict deserialization to the known session-token object graph. Any other class
+        // (e.g. a PHP object-injection gadget planted in the session store) is reduced to
+        // __PHP_Incomplete_Class, so none of its magic methods (__wakeup/__destruct/...) run.
+        $token = @unserialize($serializedToken, ['allowed_classes' => self::getSessionTokenAllowedClasses()]);
 
-            return $prevErrorHandler ? $prevErrorHandler($type, $msg, $file, $line, $context) : false;
-        });
+        // A tampered or foreign payload deserializes to false or an incomplete class; the
+        // caller additionally requires an instanceof TokenInterface, so we just drop it here.
+        if ($token === false || $token instanceof \__PHP_Incomplete_Class) {
+            Logger::warning('Failed to safely unserialize the security token from the session.', ['key' => 'pimcore_admin']);
 
-        try {
-            $token = unserialize($serializedToken);
-        } catch (ErrorException $e) {
-            if (0x37313BC !== $e->getCode()) {
-                throw $e;
-            }
-            Logger::warning('Failed to unserialize the security token from the session.', ['key' => 'pimcore_admin', 'received' => $serializedToken, 'exception' => $e]);
-        } finally {
-            restore_error_handler();
-            ini_set('unserialize_callback_func', $prevUnserializeHandler);
+            return null;
         }
 
         return $token;
     }
 
     /**
+     * Classes that legitimately occur in a serialized "pimcore_admin" session security token.
+     * Custom authenticators can extend this list via the
+     * `pimcore.security.session_token_allowed_classes` container parameter.
+     *
+     * @return array<int, class-string>
+     *
      * @internal
      */
-    public static function handleUnserializeCallback(string $class): never
+    public static function getSessionTokenAllowedClasses(): array
     {
-        throw new ErrorException('Class not found: '.$class, 0x37313BC);
+        $allowedClasses = [
+            \Pimcore\Security\User\User::class,
+            User::class,
+            PostAuthenticationToken::class,
+            UsernamePasswordToken::class,
+            // The classic admin-ui-classic-bundle "/admin/login" firewall (Pimcore < 2026.1 and the
+            // LTS line) stores a PostAuthenticationToken normally, or this subclass while 2FA is
+            // pending. Referenced by name because admin-ui-classic-bundle is not a core dependency.
+            'Pimcore\\Bundle\\AdminBundle\\Security\\Authentication\\Token\\TwoFactorRequiredToken',
+        ];
+
+        // scheb/2fa stores a TwoFactorToken (wrapping the authenticated token) during the 2FA step.
+        if (class_exists(\Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorToken::class)) {
+            $allowedClasses[] = \Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorToken::class;
+        }
+
+        if (Pimcore::hasContainer()) {
+            try {
+                $extraAllowedClasses = (array) Pimcore::getContainer()->getParameter('pimcore.security.session_token_allowed_classes');
+                $allowedClasses = array_merge(
+                    $allowedClasses,
+                    array_values(array_filter($extraAllowedClasses, 'is_string'))
+                );
+            } catch (InvalidArgumentException) {
+                // parameter not configured – use defaults
+            }
+        }
+
+        return $allowedClasses;
     }
 
     protected static function refreshUser(TokenInterface $token, UserProvider $provider): ?TokenInterface

--- a/tests/Unit/Tool/AuthenticationTest.php
+++ b/tests/Unit/Tool/AuthenticationTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Tool;
+
+use Pimcore\Model\User as PimcoreUser;
+use Pimcore\Security\User\User as SecurityUser;
+use Pimcore\Tests\Support\Test\TestCase;
+use Pimcore\Tool\Authentication;
+use ReflectionMethod;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+
+/**
+ * Regression tests for GHSA-46p3-pxr2-m4j9 — Authentication::safelyUnserialize() must not
+ * instantiate arbitrary classes when deserializing the pimcore_admin session token.
+ */
+class AuthenticationTest extends TestCase
+{
+    private function safelyUnserialize(string $payload): mixed
+    {
+        $method = new ReflectionMethod(Authentication::class, 'safelyUnserialize');
+        $method->setAccessible(true);
+
+        return $method->invoke(null, $payload);
+    }
+
+    /**
+     * Security regression: a serialized object-injection gadget must NOT have its magic
+     * methods (__wakeup/__destruct) triggered during deserialization, and must not be
+     * returned as a live instance.
+     */
+    public function testGadgetClassIsNotInstantiated(): void
+    {
+        // Building the payload constructs and destructs a temporary, which flips the flag;
+        // reset it AFTER the payload exists so we only observe deserialization side effects.
+        $payload = serialize(new AuthDeserializeCanary());
+        AuthDeserializeCanary::$fired = false;
+
+        $result = $this->safelyUnserialize($payload);
+
+        $this->assertFalse(
+            AuthDeserializeCanary::$fired,
+            'A non-allowlisted class must not have its magic methods executed during unserialize().'
+        );
+        $this->assertNotInstanceOf(AuthDeserializeCanary::class, $result);
+        $this->assertNull($result, 'A foreign/tampered payload must be rejected (null).');
+    }
+
+    /**
+     * A gadget nested inside an otherwise-allowed token graph must also be neutralised
+     * (reduced to __PHP_Incomplete_Class) without firing its magic methods.
+     */
+    public function testNestedGadgetInsideAllowedTokenIsNeutralised(): void
+    {
+        $token = new UsernamePasswordToken(
+            $this->createSecurityUser('admin'),
+            'pimcore_admin',
+            ['gadget' => new AuthDeserializeCanary()]
+        );
+
+        $payload = serialize($token);
+        AuthDeserializeCanary::$fired = false;
+
+        $result = $this->safelyUnserialize($payload);
+
+        $this->assertFalse(AuthDeserializeCanary::$fired, 'Nested gadget magic methods must not run.');
+        $this->assertInstanceOf(TokenInterface::class, $result);
+    }
+
+    /**
+     * Functional regression: a legitimate session token (the common case) must still
+     * deserialize into a real TokenInterface so admins are not logged out.
+     */
+    public function testAllowedSecurityTokenSurvivesDeserialization(): void
+    {
+        $token = new UsernamePasswordToken($this->createSecurityUser('admin'), 'pimcore_admin');
+        $payload = serialize($token);
+
+        $result = $this->safelyUnserialize($payload);
+
+        $this->assertInstanceOf(TokenInterface::class, $result);
+        $this->assertNotInstanceOf(\__PHP_Incomplete_Class::class, $result->getUser());
+        $this->assertInstanceOf(SecurityUser::class, $result->getUser());
+        $this->assertSame('admin', $result->getUser()->getUserIdentifier());
+    }
+
+    public function testAllowedClassListContainsExpectedTokenAndUserClasses(): void
+    {
+        $allowed = Authentication::getSessionTokenAllowedClasses();
+
+        $this->assertContains(SecurityUser::class, $allowed);
+        $this->assertContains(PimcoreUser::class, $allowed);
+        $this->assertContains(UsernamePasswordToken::class, $allowed);
+        $this->assertContains(
+            \Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken::class,
+            $allowed
+        );
+        // The classic admin-ui-classic-bundle login (Pimcore < 2026.1 / LTS) stores this subclass
+        // while 2FA is pending; it must be allowlisted so those sessions are not invalidated.
+        $this->assertContains(
+            'Pimcore\\Bundle\\AdminBundle\\Security\\Authentication\\Token\\TwoFactorRequiredToken',
+            $allowed
+        );
+    }
+
+    private function createSecurityUser(string $name): SecurityUser
+    {
+        $pimcoreUser = new PimcoreUser();
+        $pimcoreUser->setId(1);
+        $pimcoreUser->setName($name);
+
+        return new SecurityUser($pimcoreUser);
+    }
+}
+
+/**
+ * Canary "gadget": records whether its magic methods were ever executed.
+ */
+class AuthDeserializeCanary
+{
+    public static bool $fired = false;
+
+    public function __wakeup(): void
+    {
+        self::$fired = true;
+    }
+
+    public function __destruct()
+    {
+        self::$fired = true;
+    }
+}

--- a/tests/Unit/Tool/AuthenticationTest.php
+++ b/tests/Unit/Tool/AuthenticationTest.php
@@ -64,11 +64,10 @@ class AuthenticationTest extends TestCase
      */
     public function testNestedGadgetInsideAllowedTokenIsNeutralised(): void
     {
-        $token = new UsernamePasswordToken(
-            $this->createSecurityUser('admin'),
-            'pimcore_admin',
-            ['gadget' => new AuthDeserializeCanary()]
-        );
+        $token = new UsernamePasswordToken($this->createSecurityUser('admin'), 'pimcore_admin');
+        // Token attributes are part of the serialized graph; roles must stay strings, so the
+        // gadget is nested via an attribute rather than the roles constructor argument.
+        $token->setAttribute('gadget', new AuthDeserializeCanary());
 
         $payload = serialize($token);
         AuthDeserializeCanary::$fired = false;


### PR DESCRIPTION
### What

`Authentication::safelyUnserialize()` guarded the `_security_pimcore_admin` session token with `ini_set('unserialize_callback_func', …)`, which PHP only invokes for **undefined** classes — so any autoloadable class still instantiated and ran its magic methods, leaving a PHP object-injection sink (CWE-502) reachable by an attacker able to write the session store.

This replaces the callback with `unserialize()`'s `allowed_classes` option, restricted to the known session-token graph (Pimcore + Symfony token/user classes, scheb `TwoFactorToken`, and the classic `admin-ui-classic-bundle` `TwoFactorRequiredToken`). Custom authenticators can extend the list via the new `pimcore.security.session_token_allowed_classes` parameter.

Includes a regression test and documentation.

### Advisory

https://github.com/pimcore/pimcore/security/advisories/GHSA-46p3-pxr2-m4j9 (private until published)