### PR TITLE
[Task] Fix broken markdown link in admin session token allowed-classes doc

### DIFF
--- a/doc/19_Development_Tools_and_Details/10_Security_Authentication/06_Session_Token_Allowed_Classes.md
+++ b/doc/19_Development_Tools_and_Details/10_Security_Authentication/06_Session_Token_Allowed_Classes.md
@@ -29,5 +29,4 @@ pimcore:
 ```
 
 The classes listed here are **merged** with Pimcore's built-in defaults, so you do not need to repeat the core
-classes. This mirrors the [`tmp_store.unserialize_allowed_classes`](../43_Tmp_Store.md#extending-allowed-classes-for-unserialization)
-mechanism used for the Tmp Store.
+classes. This mirrors the `tmp_store.unserialize_allowed_classes` mechanism used for the Tmp Store.


### PR DESCRIPTION
The doc page added in #19191 (`06_Session_Token_Allowed_Classes.md`) contains a relative cross-link to `../43_Tmp_Store.md#…` that the Docusaurus docs-generator build can't resolve, breaking the **Documentation (Reusable)** workflow on `12.3` / `2026.1` / `2026.x`.

Fix: drop the cross-link, keep the plain `tmp_store.unserialize_allowed_classes` reference. Forward-merges cleanly (doc blob is identical on all three branches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)