### PR TITLE
[Bugfix] Composite data types drop values when a sub-value is empty (NumericRange/DateRange/Geopoint/Geobounds) #18144

### DIFF
--- a/models/DataObject/ClassDefinition/Data/DateRange.php
+++ b/models/DataObject/ClassDefinition/Data/DateRange.php
@@ -80,11 +80,13 @@ class DateRange extends Data implements
         $startDateKey = $this->getName() . '__start_date';
         $endDateKey = $this->getName() . '__end_date';
 
-        if (isset($data[$startDateKey], $data[$endDateKey])) {
+        if (isset($data[$startDateKey])) {
             $startDate = $this->getDateFromTimestamp($data[$startDateKey]);
-            $endDate = $this->getDateFromTimestamp($data[$endDateKey]);
             $period = CarbonPeriod::create()->setStartDate($startDate);
-            $period->setEndDate($endDate);
+
+            if (isset($data[$endDateKey])) {
+                $period->setEndDate($this->getDateFromTimestamp($data[$endDateKey]));
+            }
 
             return $period;
         }

--- a/models/DataObject/ClassDefinition/Data/Geobounds.php
+++ b/models/DataObject/ClassDefinition/Data/Geobounds.php
@@ -76,9 +76,12 @@ class Geobounds extends AbstractGeo implements
     public function getDataFromResource(mixed $data, ?DataObject\Concrete $object = null, array $params = []): ?DataObject\Data\Geobounds
     {
         if (is_array($data) &&
-            $data[$this->getName() . '__NElongitude'] &&
-            $data[$this->getName() . '__NElatitude'] &&
-            $data[$this->getName() . '__SWlongitude'] && $data[$this->getName() . '__SWlatitude']
+            isset(
+                $data[$this->getName() . '__NElongitude'],
+                $data[$this->getName() . '__NElatitude'],
+                $data[$this->getName() . '__SWlongitude'],
+                $data[$this->getName() . '__SWlatitude']
+            )
         ) {
             $ne = new DataObject\Data\GeoCoordinates($data[$this->getName() . '__NElatitude'], $data[$this->getName() . '__NElongitude']);
             $sw = new DataObject\Data\GeoCoordinates($data[$this->getName() . '__SWlatitude'], $data[$this->getName() . '__SWlongitude']);

--- a/models/DataObject/ClassDefinition/Data/Geopoint.php
+++ b/models/DataObject/ClassDefinition/Data/Geopoint.php
@@ -56,8 +56,7 @@ class Geopoint extends AbstractGeo implements
     public function getDataFromResource(mixed $data, ?Concrete $object = null, array $params = []): ?DataObject\Data\GeoCoordinates
     {
         if (is_array($data) &&
-            $data[$this->getName() . '__longitude'] &&
-            $data[$this->getName() . '__latitude']
+            isset($data[$this->getName() . '__longitude'], $data[$this->getName() . '__latitude'])
         ) {
             $geopoint = new DataObject\Data\GeoCoordinates($data[$this->getName() . '__latitude'], $data[$this->getName() . '__longitude']);
 
@@ -108,8 +107,8 @@ class Geopoint extends AbstractGeo implements
      */
     public function getDataFromEditmode(mixed $data, ?DataObject\Concrete $object = null, array $params = []): ?DataObject\Data\GeoCoordinates
     {
-        if (is_array($data) && ($data['longitude'] || $data['latitude'])) {
-            return new DataObject\Data\GeoCoordinates($data['latitude'], $data['longitude']);
+        if (is_array($data) && (isset($data['longitude']) || isset($data['latitude']))) {
+            return new DataObject\Data\GeoCoordinates($data['latitude'] ?? null, $data['longitude'] ?? null);
         }
 
         return null;

--- a/models/DataObject/ClassDefinition/Data/NumericRange.php
+++ b/models/DataObject/ClassDefinition/Data/NumericRange.php
@@ -236,9 +236,15 @@ class NumericRange extends Data implements
      */
     public function getDataFromResource(mixed $data, ?DataObject\Concrete $object = null, array $params = []): ?DataObject\Data\NumericRange
     {
-        if (isset($data[$this->getName() . '__minimum'], $data[$this->getName() . '__maximum'])) {
-            $minimum = $data[$this->getName() . '__minimum'];
-            $maximum = $data[$this->getName() . '__maximum'];
+        $minimumKey = $this->getName() . '__minimum';
+        $maximumKey = $this->getName() . '__maximum';
+
+        if (array_key_exists($minimumKey, $data)
+            && array_key_exists($maximumKey, $data)
+            && !(is_null($data[$minimumKey]) && is_null($data[$maximumKey]))
+        ) {
+            $minimum = $data[$minimumKey];
+            $maximum = $data[$maximumKey];
 
             if (is_string($minimum)) {
                 $minimum = (float) $minimum;

--- a/tests/Unit/Models/DataObject/ClassDefinition/Data/DateRangeTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/Data/DateRangeTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\DataObject\ClassDefinition\Data;
+
+use Carbon\Carbon;
+use Carbon\CarbonPeriod;
+use Pimcore\Model\DataObject\ClassDefinition\Data\DateRange;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * @see https://github.com/pimcore/pimcore/issues/18144
+ */
+class DateRangeTest extends TestCase
+{
+    private const START = 1700000000;
+
+    private const END = 1700100000;
+
+    private function buildField(): DateRange
+    {
+        $field = new DateRange();
+        $field->setName('range');
+
+        return $field;
+    }
+
+    public function testGetDataFromResourceWithBothDates(): void
+    {
+        $result = $this->buildField()->getDataFromResource([
+            'range__start_date' => self::START,
+            'range__end_date' => self::END,
+        ]);
+
+        $this->assertInstanceOf(CarbonPeriod::class, $result);
+        $this->assertSame(self::START, $result->getStartDate()->getTimestamp());
+        $this->assertSame(self::END, $result->getEndDate()->getTimestamp());
+    }
+
+    /**
+     * Regression test for #18144: an open-ended range (start set, end null) must not be dropped.
+     */
+    public function testGetDataFromResourceWithStartDateOnly(): void
+    {
+        $result = $this->buildField()->getDataFromResource([
+            'range__start_date' => self::START,
+            'range__end_date' => null,
+        ]);
+
+        $this->assertInstanceOf(CarbonPeriod::class, $result);
+        $this->assertSame(self::START, $result->getStartDate()->getTimestamp());
+        $this->assertNull($result->getEndDate());
+    }
+
+    public function testGetDataFromResourceReturnsNullWhenStartDateMissing(): void
+    {
+        $result = $this->buildField()->getDataFromResource([
+            'range__start_date' => null,
+            'range__end_date' => null,
+        ]);
+
+        $this->assertNull($result);
+    }
+
+    public function testGetDataFromResourceReturnsNullWhenColumnsMissing(): void
+    {
+        $this->assertNull($this->buildField()->getDataFromResource([]));
+    }
+
+    /**
+     * Full persistence round-trip for an open-ended range as performed on save/load.
+     */
+    public function testResourceRoundTripForOpenEndedRange(): void
+    {
+        $field = $this->buildField();
+
+        $period = CarbonPeriod::create()->setStartDate(Carbon::createFromTimestamp(self::START));
+
+        $resource = $field->getDataForResource($period);
+        $this->assertSame(self::START, $resource['range__start_date']);
+        $this->assertNull($resource['range__end_date']);
+
+        $result = $field->getDataFromResource($resource);
+        $this->assertInstanceOf(CarbonPeriod::class, $result);
+        $this->assertSame(self::START, $result->getStartDate()->getTimestamp());
+        $this->assertNull($result->getEndDate());
+    }
+}

--- a/tests/Unit/Models/DataObject/ClassDefinition/Data/GeoboundsTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/Data/GeoboundsTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\DataObject\ClassDefinition\Data;
+
+use Pimcore\Model\DataObject\ClassDefinition\Data\Geobounds;
+use Pimcore\Model\DataObject\Data\Geobounds as GeoboundsValue;
+use Pimcore\Model\DataObject\Data\GeoCoordinates;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * @see https://github.com/pimcore/pimcore/issues/18144
+ */
+class GeoboundsTest extends TestCase
+{
+    private function buildField(): Geobounds
+    {
+        $field = new Geobounds();
+        $field->setName('bounds');
+
+        return $field;
+    }
+
+    public function testGetDataFromResourceWithCoordinates(): void
+    {
+        $result = $this->buildField()->getDataFromResource([
+            'bounds__NElongitude' => 13.0,
+            'bounds__NElatitude' => 52.0,
+            'bounds__SWlongitude' => 12.0,
+            'bounds__SWlatitude' => 51.0,
+        ]);
+
+        $this->assertInstanceOf(GeoboundsValue::class, $result);
+        $this->assertSame(13.0, $result->getNorthEast()->getLongitude());
+        $this->assertSame(51.0, $result->getSouthWest()->getLatitude());
+    }
+
+    /**
+     * Regression test for #18144: a coordinate of 0 must not drop the whole bounds value.
+     */
+    public function testGetDataFromResourceKeepsZeroCoordinates(): void
+    {
+        $result = $this->buildField()->getDataFromResource([
+            'bounds__NElongitude' => 0.0,
+            'bounds__NElatitude' => 0.0,
+            'bounds__SWlongitude' => 0.0,
+            'bounds__SWlatitude' => 0.0,
+        ]);
+
+        $this->assertInstanceOf(GeoboundsValue::class, $result);
+        $this->assertSame(0.0, $result->getNorthEast()->getLongitude());
+        $this->assertSame(0.0, $result->getNorthEast()->getLatitude());
+        $this->assertSame(0.0, $result->getSouthWest()->getLongitude());
+        $this->assertSame(0.0, $result->getSouthWest()->getLatitude());
+    }
+
+    public function testGetDataFromResourceReturnsNullWhenCoordinatesNull(): void
+    {
+        $result = $this->buildField()->getDataFromResource([
+            'bounds__NElongitude' => null,
+            'bounds__NElatitude' => null,
+            'bounds__SWlongitude' => null,
+            'bounds__SWlatitude' => null,
+        ]);
+
+        $this->assertNull($result);
+    }
+
+    public function testResourceRoundTripKeepsZeroCoordinates(): void
+    {
+        $field = $this->buildField();
+        $value = new GeoboundsValue(
+            new GeoCoordinates(0.0, 0.0),
+            new GeoCoordinates(0.0, 0.0)
+        );
+
+        $resource = $field->getDataForResource($value);
+        $result = $field->getDataFromResource($resource);
+
+        $this->assertInstanceOf(GeoboundsValue::class, $result);
+        $this->assertSame(0.0, $result->getNorthEast()->getLatitude());
+        $this->assertSame(0.0, $result->getSouthWest()->getLongitude());
+    }
+}

--- a/tests/Unit/Models/DataObject/ClassDefinition/Data/GeopointTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/Data/GeopointTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\DataObject\ClassDefinition\Data;
+
+use Pimcore\Model\DataObject\ClassDefinition\Data\Geopoint;
+use Pimcore\Model\DataObject\Data\GeoCoordinates;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * @see https://github.com/pimcore/pimcore/issues/18144
+ */
+class GeopointTest extends TestCase
+{
+    private function buildField(): Geopoint
+    {
+        $field = new Geopoint();
+        $field->setName('point');
+
+        return $field;
+    }
+
+    public function testGetDataFromResourceWithCoordinates(): void
+    {
+        $result = $this->buildField()->getDataFromResource([
+            'point__longitude' => 13.0,
+            'point__latitude' => 52.0,
+        ]);
+
+        $this->assertInstanceOf(GeoCoordinates::class, $result);
+        $this->assertSame(13.0, $result->getLongitude());
+        $this->assertSame(52.0, $result->getLatitude());
+    }
+
+    /**
+     * Regression test for #18144: a coordinate of 0 (prime meridian / equator) must not be dropped.
+     */
+    public function testGetDataFromResourceKeepsZeroLongitude(): void
+    {
+        $result = $this->buildField()->getDataFromResource([
+            'point__longitude' => 0.0,
+            'point__latitude' => 52.0,
+        ]);
+
+        $this->assertInstanceOf(GeoCoordinates::class, $result);
+        $this->assertSame(0.0, $result->getLongitude());
+        $this->assertSame(52.0, $result->getLatitude());
+    }
+
+    public function testGetDataFromResourceKeepsNullIsland(): void
+    {
+        $result = $this->buildField()->getDataFromResource([
+            'point__longitude' => 0.0,
+            'point__latitude' => 0.0,
+        ]);
+
+        $this->assertInstanceOf(GeoCoordinates::class, $result);
+        $this->assertSame(0.0, $result->getLongitude());
+        $this->assertSame(0.0, $result->getLatitude());
+    }
+
+    public function testGetDataFromResourceReturnsNullWhenCoordinatesNull(): void
+    {
+        $result = $this->buildField()->getDataFromResource([
+            'point__longitude' => null,
+            'point__latitude' => null,
+        ]);
+
+        $this->assertNull($result);
+    }
+
+    public function testResourceRoundTripKeepsZeroCoordinates(): void
+    {
+        $field = $this->buildField();
+
+        $resource = $field->getDataForResource(new GeoCoordinates(0.0, 0.0));
+        $this->assertSame(['point__longitude' => 0.0, 'point__latitude' => 0.0], $resource);
+
+        $result = $field->getDataFromResource($resource);
+        $this->assertInstanceOf(GeoCoordinates::class, $result);
+        $this->assertSame(0.0, $result->getLongitude());
+        $this->assertSame(0.0, $result->getLatitude());
+    }
+}

--- a/tests/Unit/Models/DataObject/ClassDefinition/Data/NumericRangeTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/Data/NumericRangeTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\DataObject\ClassDefinition\Data;
+
+use Pimcore\Model\DataObject\ClassDefinition\Data\NumericRange;
+use Pimcore\Model\DataObject\Data\NumericRange as NumericRangeValue;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * @see https://github.com/pimcore/pimcore/issues/18144
+ */
+class NumericRangeTest extends TestCase
+{
+    private function buildField(): NumericRange
+    {
+        $field = new NumericRange();
+        $field->setName('range');
+
+        return $field;
+    }
+
+    public function testGetDataFromResourceWithBothBounds(): void
+    {
+        $result = $this->buildField()->getDataFromResource([
+            'range__minimum' => 5.0,
+            'range__maximum' => 10.0,
+        ]);
+
+        $this->assertInstanceOf(NumericRangeValue::class, $result);
+        $this->assertSame(5.0, $result->getMinimum());
+        $this->assertSame(10.0, $result->getMaximum());
+    }
+
+    /**
+     * Regression test for #18144: a range with only the minimum set must not be dropped.
+     */
+    public function testGetDataFromResourceWithMinimumOnly(): void
+    {
+        $result = $this->buildField()->getDataFromResource([
+            'range__minimum' => 5.0,
+            'range__maximum' => null,
+        ]);
+
+        $this->assertInstanceOf(NumericRangeValue::class, $result);
+        $this->assertSame(5.0, $result->getMinimum());
+        $this->assertNull($result->getMaximum());
+    }
+
+    /**
+     * Regression test for #18144: a range with only the maximum set must not be dropped.
+     */
+    public function testGetDataFromResourceWithMaximumOnly(): void
+    {
+        $result = $this->buildField()->getDataFromResource([
+            'range__minimum' => null,
+            'range__maximum' => 10.0,
+        ]);
+
+        $this->assertInstanceOf(NumericRangeValue::class, $result);
+        $this->assertNull($result->getMinimum());
+        $this->assertSame(10.0, $result->getMaximum());
+    }
+
+    public function testGetDataFromResourceKeepsZeroBound(): void
+    {
+        $result = $this->buildField()->getDataFromResource([
+            'range__minimum' => 0.0,
+            'range__maximum' => null,
+        ]);
+
+        $this->assertInstanceOf(NumericRangeValue::class, $result);
+        $this->assertSame(0.0, $result->getMinimum());
+        $this->assertNull($result->getMaximum());
+    }
+
+    public function testGetDataFromResourceCastsStringBounds(): void
+    {
+        $result = $this->buildField()->getDataFromResource([
+            'range__minimum' => '5',
+            'range__maximum' => null,
+        ]);
+
+        $this->assertInstanceOf(NumericRangeValue::class, $result);
+        $this->assertSame(5.0, $result->getMinimum());
+        $this->assertNull($result->getMaximum());
+    }
+
+    public function testGetDataFromResourceReturnsNullWhenBothBoundsNull(): void
+    {
+        $result = $this->buildField()->getDataFromResource([
+            'range__minimum' => null,
+            'range__maximum' => null,
+        ]);
+
+        $this->assertNull($result);
+    }
+
+    public function testGetDataFromResourceReturnsNullWhenColumnsMissing(): void
+    {
+        $this->assertNull($this->buildField()->getDataFromResource([]));
+    }
+
+    /**
+     * Full persistence round-trip for a partial range as performed on save/load.
+     */
+    public function testResourceRoundTripForPartialRange(): void
+    {
+        $field = $this->buildField();
+
+        $resource = $field->getDataForResource(new NumericRangeValue(5.0, null));
+        $this->assertSame(['range__minimum' => 5.0, 'range__maximum' => null], $resource);
+
+        $result = $field->getDataFromResource($resource);
+        $this->assertInstanceOf(NumericRangeValue::class, $result);
+        $this->assertSame(5.0, $result->getMinimum());
+        $this->assertNull($result->getMaximum());
+    }
+}


### PR DESCRIPTION
## Changes in this pull request
Several composite data types dropped the **whole** value when reading it back from the database if one sub-value was `NULL` (or `0`). This is the read-path (`getDataForResource`/`getDataFromResource`) part of the bug; the Studio write-path counterpart is in https://github.com/pimcore/studio-backend-bundle/pull/1905.

**NumericRange / DateRange — partial range lost (the originally reported case)**
`getDataFromResource()` used `isset()` on *both* columns, which is `false` as soon as one bound is `NULL`. A range with only a minimum/maximum (resp. only a start date) was therefore returned as `NULL` on reload. Published objects were unaffected only because a partial range cannot pass `checkValidity()` to be published, so the loss was observable on unpublished objects.
- `NumericRange::getDataFromResource()` — `array_key_exists()` per column, `NULL` only when **both** bounds are `NULL` (mirrors `QuantityValueRange`).
- `DateRange::getDataFromResource()` — anchor on the start date, set the end date only when present (matches how `getDataForResource()` already persists a `NULL` end date).

**Geopoint / Geobounds — `0` coordinate lost**
`getDataFromResource()` used truthy checks on the coordinate columns, so a longitude/latitude of `0` (prime meridian, equator, "Null Island") was treated as empty and the whole value dropped — for **published and unpublished** objects alike. `Geopoint::getDataFromEditmode()` had the same issue for a `(0, 0)` point.
- `Geopoint` / `Geobounds` `getDataFromResource()` — use `isset()` (null-aware, `0`-safe). `Geobounds` now matches its own `getDataFromEditmode()`, which already used null checks.

Unit tests added for all four types (partial/`0`/null cases + full resource round-trips).

### How to reproduce
1. Add a `NumericRange` (or `DateRange`) field to a class; create an **unpublished** object, set only the minimum (resp. only the start date), save (keep unpublished), reload → value was gone.
2. Add a `Geopoint`; set longitude `0` and any latitude, save, reload → value was gone.

## Additional info
- Reported issue: https://github.com/pimcore/pimcore/issues/18144
- Studio (write-path) counterpart, targeting `2025.4`: https://github.com/pimcore/studio-backend-bundle/pull/1905

Resolves https://github.com/pimcore/pimcore/issues/18144