### PR TITLE
docs(upgrade-notes): note removal of doctrine enum mapping_type

### DIFF
--- a/doc/13_Upgrade_Notes/README.md
+++ b/doc/13_Upgrade_Notes/README.md
@@ -190,6 +190,21 @@ Install profiles can implement additional interfaces for advanced control:
 - `PostInstallHookInterface` — run custom PHP code near the end of phase 2, before finalization steps such as cache clearing and install marker cleanup
 - `DataSourceInterface` — import SQL dumps or other data during installation
 
+### Doctrine `enum` Mapping Type Removed
+
+The installer-generated `config/packages/doctrine_mapping_types.yaml` no longer registers the `enum: string` mapping type. Only the `bit: boolean` mapping is still generated and required. The minimum `doctrine/dbal` requirement was raised to `^4.4`, where the explicit `enum` mapping is no longer needed.
+
+**Action required for existing installations:** This file is written only once during installation and is **not** migrated automatically on upgrade. Open your `config/packages/doctrine_mapping_types.yaml` and remove the `enum: string` line if it is present, so that the mapping section reads:
+
+```yaml
+doctrine:
+    dbal:
+        connections:
+            default:
+                mapping_types:
+                    bit: boolean
+```
+
 ### [OpenSearch / Elasticsearch DSN Configuration]
 
 Search engine configuration now uses DSN-based env vars instead of separate host/port/authentication parameters:

--- a/doc/13_Upgrade_Notes/README.md
+++ b/doc/13_Upgrade_Notes/README.md
@@ -192,18 +192,9 @@ Install profiles can implement additional interfaces for advanced control:
 
 ### Doctrine `enum` Mapping Type Removed
 
-The installer-generated `config/packages/doctrine_mapping_types.yaml` no longer registers the `enum: string` mapping type. Only the `bit: boolean` mapping is still generated and required. The minimum `doctrine/dbal` requirement was raised to `^4.4`, where the explicit `enum` mapping is no longer needed.
+The `enum: string` Doctrine mapping type is no longer registered; only the `bit: boolean` mapping remains. The minimum `doctrine/dbal` requirement was raised to `^4.4`, where the explicit `enum` mapping is no longer needed.
 
-**Action required for existing installations:** This file is written only once during installation and is **not** migrated automatically on upgrade. Open your `config/packages/doctrine_mapping_types.yaml` and remove the `enum: string` line if it is present, so that the mapping section reads:
-
-```yaml
-doctrine:
-    dbal:
-        connections:
-            default:
-                mapping_types:
-                    bit: boolean
-```
+**Action required for existing installations:** Please check your Doctrine configuration for any registered mapping types and remove the `enum: string` mapping if it is present.
 
 ### [OpenSearch / Elasticsearch DSN Configuration]
 


### PR DESCRIPTION
## Description

Follow-up documentation for #19044, which removed the `enum: string` Doctrine mapping type from the installer-generated `config/packages/doctrine_mapping_types.yaml` (only `bit: boolean` remains).

This adds an entry to the 2026.1.0 Upgrade Notes explaining the change and, importantly, instructing users to **manually remove** the `enum: string` line from their existing `config/packages/doctrine_mapping_types.yaml`, since that file is written only once at install time and is not migrated automatically on upgrade.

## Affected

- `doc/13_Upgrade_Notes/README.md`

## Related

- #19044

🤖 Generated with [Claude Code](https://claude.com/claude-code)