### PR TITLE
Forward-merge 2026.1 into 2026.x

### DIFF
--- a/doc/13_Upgrade_Notes/README.md
+++ b/doc/13_Upgrade_Notes/README.md
@@ -190,6 +190,12 @@ Install profiles can implement additional interfaces for advanced control:
 - `PostInstallHookInterface` — run custom PHP code near the end of phase 2, before finalization steps such as cache clearing and install marker cleanup
 - `DataSourceInterface` — import SQL dumps or other data during installation
 
+### Doctrine `enum` Mapping Type Removed
+
+The `enum: string` Doctrine mapping type is no longer registered; only the `bit: boolean` mapping remains. The minimum `doctrine/dbal` requirement was raised to `^4.4`, where the explicit `enum` mapping is no longer needed.
+
+**Action required for existing installations:** Please check your Doctrine configuration for any registered mapping types and remove the `enum: string` mapping if it is present.
+
 ### [OpenSearch / Elasticsearch DSN Configuration]
 
 Search engine configuration now uses DSN-based env vars instead of separate host/port/authentication parameters:


### PR DESCRIPTION
Forward-merge of `2026.1` into `2026.x`.

Brings the single outstanding commit from `2026.1`:
- #19198 — docs(upgrade-notes): note removal of doctrine `enum` mapping_type

No code changes; documentation only. Merge made with `--no-ff` to preserve the forward-merge history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)