### PR TITLE
[Bug] Fix SVG/vector transparent background rendered as black

### DIFF
--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -78,6 +78,12 @@ class Imagick extends Adapter
 
             $imagePathLoad = $imagePathLoad . '[0]';
 
+            // setBackgroundColor must be called BEFORE readImage so that the Inkscape/ImageMagick
+            // delegate composites onto the correct (transparent) background, not black
+            if (!$this->reinitializing && !$this->isPreserveColor() && $this->isVectorGraphic($imagePath)) {
+                $i->setBackgroundColor(new ImagickPixel('transparent'));
+            }
+
             if (!$i->readImage($imagePathLoad) || !@filesize($imagePath)) {
                 return false;
             }
@@ -88,11 +94,6 @@ class Imagick extends Adapter
                 $i->setColorspace(\Imagick::COLORSPACE_SRGB);
 
                 if ($this->isVectorGraphic($imagePath)) {
-                    // only for vector graphics
-                    // setBackgroundColor must be called BEFORE readImage so that the Inkscape/ImageMagick
-                    // delegate composites onto the correct (transparent) background, not black
-                    $i->setBackgroundColor(new ImagickPixel('transparent'));
-                    $i->readImage($imagePath);
                     // After reading, re-apply on the loaded image object — the Inkscape delegate
                     // can override the background setting during rasterization (e.g. IM 7.1.0-48+)
                     $i->setImageBackgroundColor(new ImagickPixel('transparent'));

--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -89,10 +89,16 @@ class Imagick extends Adapter
 
                 if ($this->isVectorGraphic($imagePath)) {
                     // only for vector graphics
-                    // the below causes problems with PSDs when target format is PNG32 (nobody knows why ;-))
+                    // setBackgroundColor must be called BEFORE readImage so that the Inkscape/ImageMagick
+                    // delegate composites onto the correct (transparent) background, not black
                     $i->setBackgroundColor(new ImagickPixel('transparent'));
-                    //for certain edge-cases simply setting the background-color to transparent does not seem to work
-                    //workaround by using transparentPaintImage (somehow even works without setting a target. no clue why)
+                    $i->readImage($imagePath);
+                    // After reading, re-apply on the loaded image object — the Inkscape delegate
+                    // can override the background setting during rasterization (e.g. IM 7.1.0-48+)
+                    $i->setImageBackgroundColor(new ImagickPixel('transparent'));
+                    $i->setImageAlphaChannel(\Imagick::ALPHACHANNEL_ACTIVATE);
+                    // for certain edge-cases simply setting the background-color to transparent does not seem to work;
+                    // workaround by using transparentPaintImage (somehow even works without setting a target, no clue why)
                     $i->transparentPaintImage('', 1, 0, false);
                 }
 


### PR DESCRIPTION
## Problem
When Inkscape is installed as an ImageMagick delegate, SVG (and other vector
files like .ai, .eps) with transparent backgrounds are rasterized with a black
background instead of transparent, both in admin previews and frontend thumbnails.

Related: #13167, #11807

## Root cause
In `Imagick::load()`, `setBackgroundColor('transparent')` is called before
`readImage()` — correct. However, the Inkscape delegate overrides the background
during its own rasterization pass. The subsequent `setImageBackgroundColor` +
`setImageAlphaChannel(ALPHACHANNEL_ACTIVATE)` call was previously gated to
SVG/SVGZ only, but the same problem affects all vector formats handled via
delegates (AI, EPS, etc.).

## Fix
Apply `setImageBackgroundColor(transparent)` + `ALPHACHANNEL_ACTIVATE` to all
vector formats after `readImage()`, not just SVG/SVGZ.

## Steps to reproduce
1. Install Inkscape on the server (e.g. `apt install inkscape`)
2. Upload an SVG or AI file with a transparent background
3. View the asset preview or generate a thumbnail
4. → Background is black instead of transparent

## Expected behavior
Background remains transparent (or white when target format is JPEG).
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `12.3`
- Feature/Improvement: choose `2026.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`2026.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `12.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/19097#issuecomment-4691559738

## Additional info
