### PR TITLE
Refactor getDataFromEditmode to use the associative array

### DIFF
--- a/models/DataObject/ClassDefinition/Data/UrlSlug.php
+++ b/models/DataObject/ClassDefinition/Data/UrlSlug.php
@@ -90,13 +90,13 @@ class UrlSlug extends Data implements CustomResourcePersistingInterface, LazyLoa
     {
         $result = [];
         if (is_array($data)) {
-            foreach ($data as $siteId => $item) {
-                $siteId = $item[0];
-                $slug = $item[1];
-                $slug = new Model\DataObject\Data\UrlSlug($slug, (int) $siteId);
+            foreach ($data as $item) {
+                $siteId = $item['siteId'] ?? 0;
+                $slugStr = $item['slug'] ?? '';
+                $slug = new Model\DataObject\Data\UrlSlug($slugStr, (int) $siteId);
 
-                if ($item[2]) {
-                    $slug->setPreviousSlug($item[2]);
+                if (isset($item['previousSlug'])) {
+                    $slug->setPreviousSlug($item['previousSlug']);
                 }
 
                 $result[] = $slug;

--- a/models/DataObject/ClassDefinition/Data/UrlSlug.php
+++ b/models/DataObject/ClassDefinition/Data/UrlSlug.php
@@ -95,11 +95,9 @@ class UrlSlug extends Data implements CustomResourcePersistingInterface, LazyLoa
                 $slugStr = $item['slug'] ?? $item[1] ?? '';
                 $slug = new Model\DataObject\Data\UrlSlug($slugStr, (int) $siteId);
 
-                if ($item['previousSlug'] ?? false) {
-                    $slug->setPreviousSlug($item['previousSlug']);
-                }
-                if ($item[2] ?? false) {
-                    $slug->setPreviousSlug($item[2]);
+                $previousSlug = $item['previousSlug'] ?? $item[2] ?? null;
+                if ($previousSlug) {
+                    $slug->setPreviousSlug($previousSlug);
                 }
 
                 $result[] = $slug;

--- a/models/DataObject/ClassDefinition/Data/UrlSlug.php
+++ b/models/DataObject/ClassDefinition/Data/UrlSlug.php
@@ -91,12 +91,15 @@ class UrlSlug extends Data implements CustomResourcePersistingInterface, LazyLoa
         $result = [];
         if (is_array($data)) {
             foreach ($data as $item) {
-                $siteId = $item['siteId'] ?? 0;
-                $slugStr = $item['slug'] ?? '';
+                $siteId = $item['siteId'] ?? $item[0] ?? 0;
+                $slugStr = $item['slug'] ?? $item[1] ?? '';
                 $slug = new Model\DataObject\Data\UrlSlug($slugStr, (int) $siteId);
 
-                if (isset($item['previousSlug'])) {
+                if ($item['previousSlug'] ?? false) {
                     $slug->setPreviousSlug($item['previousSlug']);
+                }
+                if ($item[2] ?? false) {
+                    $slug->setPreviousSlug($item[2]);
                 }
 
                 $result[] = $slug;


### PR DESCRIPTION
There is a regression/inconsistency in the `Pimcore\Model\DataObject\ClassDefinition\Data\UrlSlug` class. The method (` getDataForEditmode`) prepares data for the Admin UI and produces an associative array, but the method that processes the return value (`getDataFromEditmode`) expects a numeric array.
