### PR TITLE
fix : Update LinkGeneratorResolver.php to handle null value

### DIFF
--- a/models/DataObject/ClassDefinition/Helper/LinkGeneratorResolver.php
+++ b/models/DataObject/ClassDefinition/Helper/LinkGeneratorResolver.php
@@ -20,8 +20,12 @@ use Pimcore\Model\DataObject\ClassDefinition\LinkGeneratorInterface;
  */
 class LinkGeneratorResolver extends ClassResolver
 {
-    public static function resolveGenerator(string $generatorClass): ?object
+    public static function resolveGenerator(?string $generatorClass): ?LinkGeneratorInterface
     {
+        if ($generatorClass === null) {
+            return null;
+        }
+
         return self::resolve($generatorClass, static function ($generator) {
             return $generator instanceof LinkGeneratorInterface;
         });


### PR DESCRIPTION
Summary

Fix a "TypeError" in "ClassDefinition::getLinkGenerator()" when no link generator is configured.

The method "getLinkGeneratorReference()" returns "?string", but its result is passed directly to "LinkGeneratorResolver::resolveGenerator()", which expects a non-null "string". This change adds a null check before invoking the resolver, allowing "getLinkGenerator()" to return "null" instead of throwing a "TypeError".


<img width="1080" height="2400" alt="Screenshot_2026-06-23-23-53-18-24_320a9a695de7cdce83ed5281148d6f19" src="https://github.com/user-attachments/assets/d76d8413-ec08-4fb6-aa31-e09cae11dfd6" />
<img width="1080" height="2400" alt="Screenshot_2026-06-23-23-52-22-74_320a9a695de7cdce83ed5281148d6f19" src="https://github.com/user-attachments/assets/441a9495-7872-4783-84c0-b8bdfee2e758" />
<img width="1080" height="2400" alt="Screenshot_2026-06-23-23-51-21-06_320a9a695de7cdce83ed5281148d6f19" src="https://github.com/user-attachments/assets/7af25474-743b-431a-8056-446d227611f2" />
<img width="1080" height="2400" alt="Screenshot_2026-06-23-23-50-47-68_320a9a695de7cdce83ed5281148d6f19" src="https://github.com/user-attachments/assets/fe685296-2110-4083-934d-57f6e62671ac" />
mmary
