### PR TITLE
fix: prevent fatal error in UserProvider::refreshUser when user no longer exists

### DIFF
--- a/lib/Security/User/UserProvider.php
+++ b/lib/Security/User/UserProvider.php
@@ -38,8 +38,12 @@ class UserProvider implements UserProviderInterface
             throw new UnsupportedUserException();
         }
 
-        /** @var PimcoreUser $refreshedPimcoreUser */
         $refreshedPimcoreUser = PimcoreUser::getById($user->getId());
+
+        if ($refreshedPimcoreUser === null) {
+            // the user no longer exists (e.g. was deleted) - invalidate the session gracefully
+            throw new UserNotFoundException(sprintf('User with ID %s was not found', $user->getId()));
+        }
 
         if ($user->getLastPasswordReset() !== $refreshedPimcoreUser->getLastPasswordReset()) {
             // password was changed since the session was created, so we invalidate the session

--- a/lib/Security/User/UserProvider.php
+++ b/lib/Security/User/UserProvider.php
@@ -42,15 +42,35 @@ class UserProvider implements UserProviderInterface
 
         if ($refreshedPimcoreUser === null) {
             // the user no longer exists (e.g. was deleted) - invalidate the session gracefully
-            throw new UserNotFoundException(sprintf('User with ID %s was not found', $user->getId()));
+            throw $this->createSessionInvalidatingException(
+                $user,
+                sprintf('User with ID %s was not found', $user->getId())
+            );
         }
 
         if ($user->getLastPasswordReset() !== $refreshedPimcoreUser->getLastPasswordReset()) {
             // password was changed since the session was created, so we invalidate the session
-            throw new UnsupportedUserException('User is valid but password was changed');
+            throw $this->createSessionInvalidatingException(
+                $user,
+                'User is valid but password was changed'
+            );
         }
 
         return $this->buildUser($refreshedPimcoreUser);
+    }
+
+    /**
+     * A session can only be invalidated by throwing a UserNotFoundException: ContextListener
+     * treats an UnsupportedUserException as "let's try the next user provider" and throws a
+     * RuntimeException once the provider list is exhausted - which, in a stock installation
+     * where this is the only user provider, means a 500 instead of a redirect to the login.
+     */
+    private function createSessionInvalidatingException(User $user, string $message): UserNotFoundException
+    {
+        $exception = new UserNotFoundException($message);
+        $exception->setUserIdentifier($user->getUserIdentifier());
+
+        return $exception;
     }
 
     protected function buildUser(PimcoreUser $pimcoreUser): User

--- a/tests/Unit/Security/User/UserProviderTest.php
+++ b/tests/Unit/Security/User/UserProviderTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Security\User;
+
+use Pimcore\Model\User as PimcoreUser;
+use Pimcore\Security\User\User;
+use Pimcore\Security\User\UserProvider;
+use Pimcore\Tests\Support\Test\TestCase;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+
+class UserProviderTest extends TestCase
+{
+    private const USERNAME = 'user-provider-test-user';
+
+    protected UserProvider $userProvider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->userProvider = new UserProvider();
+        $this->deleteTestUser();
+    }
+
+    public function _after(): void
+    {
+        $this->deleteTestUser();
+    }
+
+    public function testRefreshUserReturnsUserFromDatabase(): void
+    {
+        $pimcoreUser = $this->createTestUser();
+
+        $refreshedUser = $this->userProvider->refreshUser(new User($pimcoreUser));
+
+        $this->assertInstanceOf(User::class, $refreshedUser);
+        $this->assertSame($pimcoreUser->getId(), $refreshedUser->getId());
+        $this->assertSame(self::USERNAME, $refreshedUser->getUserIdentifier());
+    }
+
+    public function testRefreshUserThrowsUserNotFoundExceptionIfUserWasDeleted(): void
+    {
+        $pimcoreUser = $this->createTestUser();
+        $user = new User($pimcoreUser);
+
+        // the session outlives the user it was created for
+        $pimcoreUser->delete();
+
+        $this->expectException(UserNotFoundException::class);
+
+        $this->userProvider->refreshUser($user);
+    }
+
+    public function testRefreshUserThrowsUserNotFoundExceptionIfPasswordWasChanged(): void
+    {
+        $pimcoreUser = $this->createTestUser();
+
+        // a session which was created before the password of the user was reset
+        $userFromSession = new PimcoreUser();
+        $userFromSession->setId($pimcoreUser->getId());
+        $userFromSession->setName(self::USERNAME);
+        $userFromSession->setLastPasswordReset(time());
+
+        $this->expectException(UserNotFoundException::class);
+
+        $this->userProvider->refreshUser(new User($userFromSession));
+    }
+
+    public function testRefreshUserThrowsUnsupportedUserExceptionForNonPimcoreUsers(): void
+    {
+        $this->expectException(UnsupportedUserException::class);
+
+        $this->userProvider->refreshUser(new InMemoryUser(self::USERNAME, null));
+    }
+
+    protected function createTestUser(): PimcoreUser
+    {
+        $user = PimcoreUser::create([
+            'parentId' => 0,
+            'name' => self::USERNAME,
+            'active' => true,
+        ]);
+
+        $this->assertNotNull(PimcoreUser::getById($user->getId()));
+
+        return $user;
+    }
+
+    protected function deleteTestUser(): void
+    {
+        $user = PimcoreUser::getByName(self::USERNAME);
+
+        if ($user instanceof PimcoreUser) {
+            $user->delete();
+        }
+    }
+}


### PR DESCRIPTION
PimcoreUser::getById() returns null when the session/remember-me cookie points at a user that has been deleted. The subsequent call to getLastPasswordReset() then triggered "Call to a member function getLastPasswordReset() on null".

Throw a UserNotFoundException instead, which Symfony's ContextListener handles by gracefully clearing the stale session rather than producing a 500 error.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `12.3`
- Feature/Improvement: choose `2026.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`2026.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `12.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info
