### PR TITLE
[Bug] Handle NoHandlerForMessageException when dispatching DependencyTargetsChangedMessage

### DIFF
--- a/models/Dependency/Dao.php
+++ b/models/Dependency/Dao.php
@@ -24,6 +24,7 @@ use Pimcore\Model;
 use Pimcore\Model\Element;
 use Pimcore\ValueObject\Element\DependencyTarget;
 use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
+use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
 
 /**
  * @internal
@@ -320,6 +321,10 @@ class Dao extends Model\Dao\AbstractDao
             Pimcore::getContainer()->get('messenger.bus.pimcore-core')->dispatch(
                 new DependencyTargetsChangedMessage($addedTargets, $removedTargets)
             );
+        } catch (NoHandlerForMessageException) {
+            // No handler is registered for this message, e.g. when the
+            // pimcore/generic-data-index-bundle is not enabled. This is a
+            // supported setup, so treat the missing handler as a no-op.
         } catch (Exception $e) {
             Logger::error('Failed to dispatch DependencyTargetsChangedMessage: ' . $e->getMessage());
         }


### PR DESCRIPTION


<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `12.3`
- Feature/Improvement: choose `2026.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`2026.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `12.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #19190

## Additional info
