### PR TITLE
[Bug] Align install.sql with migrations to fix fresh vs migrated schema drift

### DIFF
--- a/bundles/InstallBundle/dump/install.sql
+++ b/bundles/InstallBundle/dump/install.sql
@@ -8,8 +8,8 @@ CREATE TABLE `assets` (
   `filename` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT '',
   `path` varchar(765) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL, /* path in utf8 (3-byte) using the full key length of 3072 bytes */
   `mimetype` varchar(190) DEFAULT NULL,
-  `creationDate` INT(11) UNSIGNED DEFAULT '0',
-  `modificationDate` INT(11) UNSIGNED DEFAULT '0',
+  `creationDate` INT(11) UNSIGNED NOT NULL DEFAULT '0',
+  `modificationDate` INT(11) UNSIGNED NOT NULL DEFAULT '0',
   `dataModificationDate` INT(11) UNSIGNED DEFAULT NULL,
   `userOwner` int(11) unsigned DEFAULT NULL,
   `userModification` int(11) unsigned DEFAULT NULL,
@@ -41,7 +41,7 @@ CREATE TABLE `assets_image_thumbnail_cache` (
     `cid` int(11) unsigned NOT NULL,
     `name` varchar(190) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
     `filename` varchar(190) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
-    `modificationDate` INT(11) UNSIGNED DEFAULT '0',
+    `modificationDate` INT(11) UNSIGNED NOT NULL DEFAULT '0',
     `filesize` INT(11) UNSIGNED DEFAULT NULL,
     `width` SMALLINT UNSIGNED DEFAULT NULL,
     `height` SMALLINT UNSIGNED DEFAULT NULL,
@@ -81,8 +81,8 @@ CREATE TABLE `documents` (
   `path` varchar(765) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL, /* path in utf8 (3-byte) using the full key length of 3072 bytes */
   `index` int(11) unsigned DEFAULT '0',
   `published` tinyint(1) unsigned DEFAULT '1',
-  `creationDate` INT(11) UNSIGNED DEFAULT '0',
-  `modificationDate` INT(11) UNSIGNED DEFAULT '0',
+  `creationDate` INT(11) UNSIGNED NOT NULL DEFAULT '0',
+  `modificationDate` INT(11) UNSIGNED NOT NULL DEFAULT '0',
   `userOwner` int(11) unsigned DEFAULT NULL,
   `userModification` int(11) unsigned DEFAULT NULL,
   `versionCount` INT UNSIGNED NOT NULL DEFAULT '0',
@@ -201,8 +201,8 @@ CREATE TABLE `edit_lock` (
 DROP TABLE IF EXISTS `email_blocklist`;
 CREATE TABLE `email_blocklist` (
   `address` varchar(190) NOT NULL DEFAULT '',
-  `creationDate` INT(11) UNSIGNED DEFAULT '0',
-  `modificationDate` INT(11) UNSIGNED DEFAULT '0',
+  `creationDate` INT(11) UNSIGNED NOT NULL DEFAULT '0',
+  `modificationDate` INT(11) UNSIGNED NOT NULL DEFAULT '0',
   PRIMARY KEY (`address`)
 ) DEFAULT CHARSET=utf8mb4;
 
@@ -275,8 +275,8 @@ CREATE TABLE `objects` (
   `path` varchar(765) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL, /* path in utf8 (3-byte) using the full key length of 3072 bytes */
   `index` int(11) unsigned DEFAULT '0',
   `published` tinyint(1) unsigned DEFAULT '1',
-  `creationDate` INT(11) UNSIGNED DEFAULT '0',
-  `modificationDate` INT(11) UNSIGNED DEFAULT '0',
+  `creationDate` INT(11) UNSIGNED NOT NULL DEFAULT '0',
+  `modificationDate` INT(11) UNSIGNED NOT NULL DEFAULT '0',
   `userOwner` int(11) unsigned DEFAULT NULL,
   `userModification` int(11) unsigned DEFAULT NULL,
   `classId` VARCHAR(50) NULL DEFAULT NULL,
@@ -408,8 +408,8 @@ CREATE TABLE `translations_messages` (
   `type` varchar(10) DEFAULT NULL,
   `language` varchar(10) NOT NULL DEFAULT '',
   `text` text,
-  `creationDate` INT(11) UNSIGNED DEFAULT '0',
-  `modificationDate` INT(11) UNSIGNED DEFAULT '0',
+  `creationDate` INT(11) UNSIGNED NOT NULL DEFAULT '0',
+  `modificationDate` INT(11) UNSIGNED NOT NULL DEFAULT '0',
   `userOwner` int(11) unsigned DEFAULT NULL,
   `userModification` int(11) unsigned DEFAULT NULL,
   PRIMARY KEY (`key`,`language`),
@@ -437,7 +437,7 @@ CREATE TABLE `users` (
   `lastname` varchar(255) DEFAULT NULL,
   `email` varchar(255) DEFAULT NULL,
   `language` varchar(10) DEFAULT 'en',
-  `datetimeLocale` varchar(10) DEFAULT '',
+  `datetimeLocale` varchar(10) DEFAULT NULL,
   `contentLanguages` LONGTEXT NULL,
   `admin` tinyint(1) unsigned DEFAULT '0',
   `active` tinyint(1) unsigned DEFAULT '1',


### PR DESCRIPTION
### Bug

A freshly installed Pimcore database does not match a database that was migrated up from an older version, because `bundles/InstallBundle/dump/install.sql` does not reflect the cumulative end-state of the Doctrine migrations. On a fresh install the migrations are flagged as already-executed (they never run), so any drift between the dump and the migrations becomes a permanent schema difference.

Reported in pimcore/platform-version#166.

### Changes

`bundles/InstallBundle/dump/install.sql` only — aligned the dump with the migration end-state:

- **`creationDate` / `modificationDate` → `NOT NULL`** (11 columns). `Version20240916105500` sets these to `INT(11) UNSIGNED NOT NULL DEFAULT '0'` on `assets`, `assets_image_thumbnail_cache` (`modificationDate` only), `documents`, `email_blocklist`, `objects` and `translations_messages`, but the dump still declared them nullable.
- **`users.datetimeLocale` → `DEFAULT NULL`**. `Version20240606165618` adds the column without a default (so migrated DBs get `DEFAULT NULL`), while the dump declared `DEFAULT ''`.

Tables/columns the migrations do **not** touch (`website_settings`, `sites`, `classificationstore_*`, `gridconfigs`, `importconfigs`) were intentionally left unchanged.

### Verification

Static comparison of all 62 DDL-bearing migrations against `install.sql`. These were the only divergences that survive chronological supersession; type / `UNSIGNED` / `DEFAULT` already matched — only nullability (and the one default) drifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
