### PR TITLE
[Bug] Fix nullable context column mapping for JobRun (#19176)

### DIFF
--- a/bundles/GenericExecutionEngineBundle/src/Entity/JobRun.php
+++ b/bundles/GenericExecutionEngineBundle/src/Entity/JobRun.php
@@ -66,7 +66,7 @@ class JobRun
     #[ORM\Column(type: 'text')]
     private ?string $serializedJob;
 
-    #[ORM\Column(type: 'json')]
+    #[ORM\Column(type: 'json', nullable: true)]
     private ?array $context = null;
 
     #[ORM\Column(nullable: false)]


### PR DESCRIPTION
"[Bug] Fix nullable context column mapping for JobRun (#19176)" --body "## Summary
- Add \`nullable: true\` to the \`context\` column's ORM attribute in \`JobRun\` entity
- Aligns the Doctrine mapping with the Installer schema (\`'notnull' => false\`) and the PHP property type (\`?array\`)

## Problem
The \`context\` column in the \`generic_execution_engine_job_run\` table was defined as nullable in the Installer but non-nullable in the Doctrine entity mapping. This caused an integrity constraint violation (\`Column 'context' cannot be null\`) when creating a JobRun without context (e.g. asset ZIP export).

## Test plan
- [ ] Trigger a JobRun creation without context (e.g. Studio asset ZIP export)
- [ ] Run \`bin/console doctrine:schema:validate\` — no mapping warnings for the \`context\` column"