### PR TITLE
[Bug, EC] PEES-1156: Guard against missing object in Localizedfield block context

### DIFF
--- a/models/DataObject/Localizedfield.php
+++ b/models/DataObject/Localizedfield.php
@@ -306,6 +306,11 @@ final class Localizedfield extends Model\AbstractModel implements
         } elseif (isset($context['containerType']) && $context['containerType'] === 'block') {
             $containerKey = $context['containerKey'];
             $object = $this->getObject();
+            if (!$object) {
+                // no object reference (e.g. while building cache tags for a block that contains
+                // localizedfields) - the block definition cannot be resolved without it
+                return null;
+            }
             $blockDefinition = $object->getClass()->getFieldDefinition($containerKey);
             $container = $blockDefinition;
         } else {
@@ -344,6 +349,11 @@ final class Localizedfield extends Model\AbstractModel implements
         } elseif (isset($context['containerType']) && $context['containerType'] === 'block') {
             $containerKey = $context['containerKey'];
             $object = $this->getObject();
+            if (!$object) {
+                // no object reference (e.g. while building cache tags for a block that contains
+                // localizedfields) - the block definition cannot be resolved without it
+                return [];
+            }
             /** @var Model\DataObject\ClassDefinition\Data\Block $block */
             $block = $object->getClass()->getFieldDefinition($containerKey);
             /** @var Model\DataObject\ClassDefinition\Data\Localizedfields $container */

--- a/tests/Unit/Models/DataObject/LocalizedfieldTest.php
+++ b/tests/Unit/Models/DataObject/LocalizedfieldTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\DataObject;
+
+use Pimcore\Model\DataObject\Localizedfield;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * Regression test for the "Call to a member function getClass() on null" fatal error that
+ * occurred when a Localizedfield carrying a block context has no object back-reference set
+ * (e.g. while building cache tags for a Block containing nested localizedfields).
+ *
+ * @see https://github.com/pimcore/service-operations/issues/837
+ *
+ * @group model.datatype.localizedfield
+ */
+class LocalizedfieldTest extends TestCase
+{
+    private function buildBlockContextField(): Localizedfield
+    {
+        $field = new Localizedfield();
+        $field->setContext([
+            'containerType' => 'block',
+            'containerKey' => 'testblock',
+            'fieldname' => 'testblock',
+        ]);
+
+        return $field;
+    }
+
+    /**
+     * getFieldDefinition() must not dereference a missing object in the block branch.
+     */
+    public function testGetFieldDefinitionReturnsNullWhenObjectMissingInBlockContext(): void
+    {
+        $field = $this->buildBlockContextField();
+
+        self::assertNull($field->getObject());
+        self::assertNull($field->getFieldDefinition('someField', $field->getContext()));
+    }
+
+    /**
+     * getInternalData() traverses getFieldDefinitions() (the frame that crashed at
+     * Localizedfield.php:348); with no object it must return the raw items instead of fataling.
+     */
+    public function testGetInternalDataDoesNotFatalWhenObjectMissingInBlockContext(): void
+    {
+        $field = $this->buildBlockContextField();
+
+        self::assertNull($field->getObject());
+        self::assertSame([], $field->getInternalData());
+    }
+}


### PR DESCRIPTION
## Problem

A fatal error is thrown when a data object with a `Block` field containing nested `Localizedfields` is cached (e.g. during `Cache::shutdown()`):

```
Error: Call to a member function getClass() on null
        at models/DataObject/Localizedfield.php:348
```

This surfaces as an HTTP 500 for the end user.

## Root cause

`Localizedfield::getFieldDefinition()` and `::getFieldDefinitions()` both contain a *block-context* branch that resolves the field definition via `$this->getObject()->getClass()`. Unlike the `fieldcollection` / `objectbrick` branches — which look up their definition via the static registries (`Fieldcollection\Definition::getByKey()`, `Objectbrick\Definition::getByKey()`) and need no object reference — the block branch depends on `$this->object` being set.

The cache-tag path reaches these methods with a block context set but **no object back-reference**:

```
Block::getCacheTags()
  -> Localizedfields::getCacheTags()
    -> Localizedfield::getInternalData()
      -> Localizedfield::getFieldDefinitions()   // $this->getObject() === null -> getClass() on null
```

## Fix

Add a null guard to both block branches, returning `null` / `[]` respectively — mirroring the robustness of the other container branches. This turns the fatal into a safe no-op for the cache-tag traversal.

## Test

Adds `tests/Unit/Models/DataObject/LocalizedfieldTest.php`, which reproduces the crash by exercising `getFieldDefinition()` and `getInternalData()` on a `Localizedfield` with a block context and no object reference. The test fails (fatal `getClass() on null`) before the fix and passes after.

Reference: pimcore/service-operations#837 (PEES-1156)

🤖 Generated with [Claude Code](https://claude.com/claude-code)