### PR TITLE
[Docs] Fix links to removed System Setup and Hosting pages

### DIFF
--- a/doc/02_Assets/01_Working_with_Thumbnails/02_Video_Thumbnails.md
+++ b/doc/02_Assets/01_Working_with_Thumbnails/02_Video_Thumbnails.md
@@ -10,8 +10,8 @@ a custom preview image from the video.
 
 > **IMPORTANT**
 > To use all the following functionalities, you must install FFMPEG on the server.
-> For details, see
-> [Additional Tools Installation](https://github.com/pimcore/platform-version/blob/2026.x/doc/03_Getting_Started/01_Installation/02_System_Setup_and_Hosting/07_Additional_Tools_Installation.md).
+> It is pre-installed in the official [Pimcore Docker images](https://hub.docker.com/r/pimcore/pimcore); for details, see
+> [System Requirements](https://github.com/pimcore/platform-version/blob/2026.x/doc/03_Getting_Started/01_Installation/01_System_Requirements.md#additional-server-software).
 
 ## Explanation of the Transformations
 

--- a/doc/02_Assets/01_Working_with_Thumbnails/03_Asset_Document_Thumbnails.md
+++ b/doc/02_Assets/01_Working_with_Thumbnails/03_Asset_Document_Thumbnails.md
@@ -11,9 +11,9 @@ PDF, XLS(X), ODT, ODS, ODP, and many others.
 You can use existing image thumbnail configurations to create a thumbnail of your choice.
 
 This feature requires Ghostscript and at least
-[Gotenberg](https://github.com/pimcore/platform-version/blob/2026.x/doc/03_Getting_Started/01_Installation/02_System_Setup_and_Hosting/07_Additional_Tools_Installation.md#gotenberg)
+[Gotenberg](https://github.com/pimcore/platform-version/blob/2026.x/doc/03_Getting_Started/01_Installation/03_Advanced_Installation_Topics/README.md#gotenberg)
 or
-[LibreOffice](https://github.com/pimcore/platform-version/blob/2026.x/doc/03_Getting_Started/01_Installation/02_System_Setup_and_Hosting/07_Additional_Tools_Installation.md#libreoffice-pdftotext-inkscape)
+[LibreOffice](https://github.com/pimcore/platform-version/blob/2026.x/doc/03_Getting_Started/01_Installation/03_Advanced_Installation_Topics/README.md#libreoffice)
 to be installed on the server.
 
 > **Important**

--- a/doc/02_Assets/02_Restricting_Public_Asset_Access.md
+++ b/doc/02_Assets/02_Restricting_Public_Asset_Access.md
@@ -64,8 +64,8 @@ location ~ ^/cache-buster\-[\d]+/protected(.*) {
 }
 ```
 
-A full configuration example can be found on the
-[Nginx Configuration](https://github.com/pimcore/platform-version/blob/2026.x/doc/03_Getting_Started/01_Installation/02_System_Setup_and_Hosting/02_Nginx_Configuration.md) page.
+A full configuration example can be found in the skeleton
+[nginx.conf](https://github.com/pimcore/skeleton/blob/2026.x/.docker/nginx.conf).
 
 
 Because of this rule, all assets located within `/protected` (including all their thumbnails)
@@ -116,8 +116,8 @@ location ~ ^/cache-buster\-[\d]+/protected(.*) {
 }
 ```
 
-A full configuration example can be found on the
-[Nginx Configuration](https://github.com/pimcore/platform-version/blob/2026.x/doc/03_Getting_Started/01_Installation/02_System_Setup_and_Hosting/02_Nginx_Configuration.md) page.
+A full configuration example can be found in the skeleton
+[nginx.conf](https://github.com/pimcore/skeleton/blob/2026.x/.docker/nginx.conf).
 
 
 In the application, define a route in `config/routes.yaml` and a controller action that handles the request:

--- a/doc/02_Assets/03_Accessing_Assets_via_WebDAV.md
+++ b/doc/02_Assets/03_Accessing_Assets_via_WebDAV.md
@@ -13,7 +13,7 @@ Use any Pimcore user as credentials. Permissions for asset access are based on t
 ## Nginx Configuration
 
 Make sure to have the following changes in your project
-[Nginx configuration](https://github.com/pimcore/platform-version/blob/2026.x/doc/03_Getting_Started/01_Installation/02_System_Setup_and_Hosting/02_Nginx_Configuration.md):
+[Nginx configuration](https://github.com/pimcore/skeleton/blob/2026.x/.docker/nginx.conf):
 
 ```nginx
 location ~* ^(?!/admin|/asset/webdav)(.+?)\.(?:css|js|jpg|jpeg|gif|png|svg|ico|woff|woff2|xml)$ {


### PR DESCRIPTION
Part of pimcore/product-management#1149, as suggested in https://github.com/pimcore/product-management/issues/1149#issuecomment-4863189462.

## What's changed

The *Nginx Configuration* and *Additional Tools Installation* pages are removed from the platform-version docs in pimcore/platform-version#174. This updates the four asset doc pages that deep-linked them:

- *Accessing Assets via WebDAV* and *Restricting Public Asset Access* now point to the skeleton [.docker/nginx.conf](https://github.com/pimcore/skeleton/blob/2026.x/.docker/nginx.conf)
- *Video Thumbnails* now points to the *Additional Server Software* section of System Requirements (FFMPEG is pre-installed in the official Docker images)
- *Asset Document Thumbnails* now points to the Gotenberg/LibreOffice sections in Advanced Installation Topics

Should be merged together with pimcore/platform-version#174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)