### PR TITLE
Fix: normalize Unicode form of asset keys to prevent broken thumbnails after folder move

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -18,6 +18,7 @@ use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
 use League\Flysystem\UnableToMoveFile;
 use League\Flysystem\UnableToProvideChecksum;
+use Normalizer;
 use Pimcore;
 use Pimcore\Cache;
 use Pimcore\Cache\RuntimeCache;
@@ -1762,7 +1763,7 @@ class Asset extends Element\AbstractElement
                 $storage = Storage::get($storageName);
 
                 try {
-                    $storage->move($oldThumbnailsPath, $newThumbnailsPath);
+                    $this->moveThumbnailPath($storage, $oldThumbnailsPath, $newThumbnailsPath);
                 } catch (UnableToMoveFile $e) {
                     //update children, if unable to move parent
                     //if there is an error, we can ignore it
@@ -1770,6 +1771,38 @@ class Asset extends Element\AbstractElement
                 }
             }
         }
+    }
+
+    /**
+     * Moves a thumbnail directory/file, retrying with alternate Unicode normalization
+     * forms of the source path if the initial attempt fails to find it. This covers
+     * cases where the DB-stored path and the on-disk directory name ended up in
+     * different Unicode normalization forms - e.g. because the original folder/file
+     * name was created on a macOS client, which reports accented names in decomposed
+     * (NFD) form, while other parts of the stack normalize to precomposed (NFC).
+     *
+     * @throws UnableToMoveFile
+     */
+    private function moveThumbnailPath(FilesystemOperator $storage, string $oldPath, string $newPath): void
+    {
+        $candidates = array_unique(array_filter([
+            $oldPath,
+            Normalizer::normalize($oldPath, Normalizer::FORM_C) ?: null,
+            Normalizer::normalize($oldPath, Normalizer::FORM_D) ?: null,
+        ]));
+
+        $lastException = null;
+        foreach ($candidates as $candidate) {
+            try {
+                $storage->move($candidate, $newPath);
+
+                return;
+            } catch (UnableToMoveFile $e) {
+                $lastException = $e;
+            }
+        }
+
+        throw $lastException;
     }
 
     private function clearFolderThumbnails(Asset $asset): void

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -28,6 +28,7 @@ use Doctrine\DBAL\Query\QueryBuilder as DoctrineQueryBuilder;
 use Exception;
 use InvalidArgumentException;
 use League\Csv\EscapeFormula;
+use Normalizer;
 use Pimcore;
 use Pimcore\Db;
 use Pimcore\Event\SystemEvents;
@@ -973,6 +974,13 @@ class Service extends Model\AbstractModel
         ]);
         Pimcore::getEventDispatcher()->dispatch($event, SystemEvents::SERVICE_PRE_GET_VALID_KEY);
         $key = trim($event->getArgument('key'));
+
+        // normalize to NFC, otherwise keys created from a decomposed (NFD) source - e.g. filenames
+        // from macOS filesystems - would be stored differently than their precomposed form, causing
+        // path mismatches (e.g. broken thumbnails) when compared against paths built elsewhere
+        if (Normalizer::isNormalized($key, Normalizer::FORM_C) === false) {
+            $key = Normalizer::normalize($key, Normalizer::FORM_C) ?: $key;
+        }
 
         // replace all control/format/private/surrogate/unassigned and 4 byte unicode characters
         $key = preg_replace(['/\p{C}/u', '/[\x{10000}-\x{10FFFF}]/u'], ['', '-'], $key);

--- a/tests/Model/Asset/AssetTest.php
+++ b/tests/Model/Asset/AssetTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Tests\Model\Asset;
 
 use Exception;
+use Normalizer;
 use Pimcore\Model\Asset;
 use Pimcore\Tests\Support\Test\ModelTestCase;
 use Pimcore\Tests\Support\Util\TestHelper;
@@ -239,6 +240,41 @@ class AssetTest extends ModelTestCase
         }
 
         $this->assertFalse(is_resource($stream1));
+    }
+
+    /**
+     * Regression test for PEES-1245: a thumbnail directory can end up on disk in a
+     * different Unicode normalization form than the path Asset::relocateThumbnails()
+     * computes from the DB (e.g. because the original folder name came from a macOS
+     * client, which reports accented characters in decomposed/NFD form, while the DB
+     * path is in precomposed/NFC form). Without the retry in moveThumbnailPath(), the
+     * move silently fails and the thumbnail is stranded at the old path.
+     *
+     * @see \Pimcore\Model\Asset::moveThumbnailPath()
+     */
+    public function testMoveThumbnailPathRecoversFromUnicodeNormalizationMismatch(): void
+    {
+        $storage = Storage::get('thumbnail');
+
+        $basePath = '/pimcore-test-' . uniqid() . '/café/123';
+        $nfcOldPath = Normalizer::normalize($basePath, Normalizer::FORM_C);
+        $nfdOldPath = Normalizer::normalize($basePath, Normalizer::FORM_D);
+        $this->assertNotSame($nfcOldPath, $nfdOldPath, 'Test fixture setup issue: NFC and NFD forms should differ in bytes.');
+
+        // the thumbnail physically exists under the NFD form of the path ...
+        $storage->write($nfdOldPath . '/dummy-thumb.jpg', 'thumbnail-content');
+
+        // ... while relocateThumbnails() computes the NFC form as the source to move from
+        $newPath = '/pimcore-test-' . uniqid() . '/moved/123';
+
+        $reflection = new \ReflectionMethod(Asset::class, 'moveThumbnailPath');
+        $reflection->setAccessible(true);
+        $reflection->invoke(new Asset\Image(), $storage, $nfcOldPath, $newPath);
+
+        $this->assertTrue($storage->fileExists($newPath . '/dummy-thumb.jpg'));
+        $this->assertFalse($storage->fileExists($nfdOldPath . '/dummy-thumb.jpg'));
+
+        $storage->deleteDirectory($newPath);
     }
 
     public function testSvgThumbnailFallbackUsesOriginalAssetPathOnGenerationFailure(): void

--- a/tests/Service/Element/ServiceTest.php
+++ b/tests/Service/Element/ServiceTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Service\Element;
 
+use Normalizer;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\Element\Service;
 use Pimcore\Tests\Support\Test\TestCase;
@@ -98,6 +99,23 @@ class ServiceTest extends TestCase
             $childIds,
             'The copied object must appear in the already-loaded children listing'
         );
+    }
+
+    /**
+     * Regression test: macOS reports accented filenames in decomposed (NFD) Unicode form.
+     * If that form is stored verbatim, paths built elsewhere from the same characters in
+     * precomposed (NFC) form no longer match, which breaks operations relying on path
+     * comparisons (e.g. relocating thumbnails after a folder move).
+     *
+     * @see \Pimcore\Model\Element\Service::getValidKey()
+     */
+    public function testGetValidKeyNormalizesToNfc(): void
+    {
+        $nfd = Normalizer::normalize('café', Normalizer::FORM_D);
+        $nfc = Normalizer::normalize('café', Normalizer::FORM_C);
+
+        $this->assertNotSame($nfd, $nfc, 'Test fixture setup issue: NFD and NFC forms should differ in bytes.');
+        $this->assertSame($nfc, Service::getValidKey($nfd, 'asset'));
     }
 
     public function testCloneMe(): void


### PR DESCRIPTION
## Summary

Fixes [PEES-1245](https://pimcore.atlassian.net/browse/PEES-1245) / [service-operations#932](https://github.com/pimcore/service-operations/issues/932): moving an asset folder whose name (or a subfolder's name) contains accented characters breaks image thumbnails after the move. Moving the folder back to its original location restores the thumbnails.

**Root cause:** macOS reports accented filenames in decomposed (NFD) Unicode form (e.g. `é` = `e` + combining accent), which can end up stored/compared differently than the precomposed (NFC) form used elsewhere in the stack. This causes `Asset::relocateThumbnails()` to fail to locate the on-disk thumbnail directory after a folder move — the `UnableToMoveFile` exception is silently swallowed, leaving thumbnails stranded at the old path.

**Changes:**
- `Element\Service::getValidKey()` now normalizes new keys to NFC, so newly created/uploaded folder and file names never enter the DB in decomposed form going forward.
- `Asset::relocateThumbnails()` now retries the thumbnail move via a new `moveThumbnailPath()` helper, trying NFC/NFD variants of the source path if the initial move fails, before falling back to the existing tolerant error handling. This covers folders/files that already exist with a normalization mismatch, not just newly created ones.
- Added a regression test asserting `getValidKey()` normalizes an NFD input to NFC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)