### PR TITLE
[Documentation] Clarify application log storage in cluster setups & document maintenance/file object behavior

### DIFF
--- a/bundles/ApplicationLoggerBundle/config/pimcore/config.yaml
+++ b/bundles/ApplicationLoggerBundle/config/pimcore/config.yaml
@@ -1,7 +1,9 @@
 flysystem:
     storages:
         pimcore.application_log.storage:
-            # Storage for application logs
+            # Storage for application log file objects.
+            # In multi-server setups (e.g. HA clusters) this must point to a storage
+            # shared by all servers, as file objects are written and read by any of them.
             adapter: 'local'
             visibility: private
             options:

--- a/doc/09_Development_Tools/02_Logging/01_Application_Logger.md
+++ b/doc/09_Development_Tools/02_Logging/01_Application_Logger.md
@@ -97,8 +97,13 @@ pimcore:
 ### Mail Notifications
 
 When `send_log_summary` is enabled, the defined receivers receive log entries by email
-during the regular Pimcore maintenance cycle. The `filter_priority` controls which log
-messages are included (e.g. only errors and above).
+during the regular Pimcore maintenance cycle (see [Maintenance Tasks](#maintenance-tasks)).
+The `filter_priority` controls which log messages are included (e.g. only errors and above).
+Entries are sent in batches of at most 100 entries per email.
+
+Note that every maintenance run flags all existing log entries as processed, regardless of
+whether mail notifications are enabled. When you enable `send_log_summary`, you therefore
+only receive entries logged from that point on — historical entries are never emailed.
 
 ### Log Archival
 
@@ -106,12 +111,39 @@ The archive function automatically creates database tables (`application_logs_ar
 for log entry archival. In the example above, log entries move to archive tables after 30 days.
 Archive tables are automatically deleted after the `delete_archive_threshold` (default: 6 months).
 
+:::caution
+
+When log entries are moved to the archive tables, their referenced file objects
+(see [File Object Storage](#file-object-storage)) are **deleted from storage** at the same
+time. The archived database rows keep the file object path, but the file itself no longer
+exists — file object attachments are therefore only available for `archive_treshold` days,
+not for the lifetime of the archive tables.
+
+:::
+
+### Maintenance Tasks
+
+Log archival, the deletion of old archive tables and file objects, and the mail
+notifications are all executed as
+[maintenance tasks](../../10_Extending_Pimcore/03_Custom_Extension_Guides/07_Maintenance_Tasks.md).
+None of these run unless the Pimcore maintenance command (`pimcore:maintenance`)
+is executed regularly, e.g. via cron job.
+
 ### File Object Storage
 
 While log entries themselves are stored in the database, attached file objects
 (see [Special Context Variables](#special-context-variables)) are stored on a
 [Flysystem](https://flysystem.thephpleague.com/docs/) storage named
-`pimcore.application_log.storage`. By default, this points to a local directory:
+`pimcore.application_log.storage`. Files are written to a date-based path within
+the storage (`Y/m/d/fileobject_<uniqueId>`), unless a custom filename is passed
+as second constructor argument to `FileObject`.
+
+If writing to the storage fails, the failure is silently ignored — only a warning
+is written to the system log, and the log entry is still created with a file object
+path that does not exist. A misconfigured storage therefore does not surface as an
+error when logging, but as file objects that cannot be opened in the log viewer.
+
+By default, the storage points to a local directory:
 
 ```yaml
 flysystem:
@@ -361,6 +393,16 @@ class TestController
         // ...
     }
 }
+```
+
+The `fileObject` context variable accepts either a `FileObject` instance (which writes
+the given data to the [file object storage](#file-object-storage)) or a string path
+pointing to an already existing file on that storage:
+
+```php
+$logger->error('my error message', [
+    'fileObject' => 'path/to/existing-file.txt', // path on the application log storage
+]);
 ```
 
 In the Application Logger grid, the new row appears as *my error message* with a related object.

--- a/doc/09_Development_Tools/02_Logging/01_Application_Logger.md
+++ b/doc/09_Development_Tools/02_Logging/01_Application_Logger.md
@@ -106,6 +106,47 @@ The archive function automatically creates database tables (`application_logs_ar
 for log entry archival. In the example above, log entries move to archive tables after 30 days.
 Archive tables are automatically deleted after the `delete_archive_threshold` (default: 6 months).
 
+### File Object Storage
+
+While log entries themselves are stored in the database, attached file objects
+(see [Special Context Variables](#special-context-variables)) are stored on a
+[Flysystem](https://flysystem.thephpleague.com/docs/) storage named
+`pimcore.application_log.storage`. By default, this points to a local directory:
+
+```yaml
+flysystem:
+    storages:
+        pimcore.application_log.storage:
+            adapter: 'local'
+            visibility: private
+            options:
+                directory: "%kernel.project_dir%/var/application-logger"
+```
+
+:::caution Cluster / multi-server setups
+
+When running Pimcore on multiple application servers (e.g. in a High Availability cluster),
+the default local storage does not work: each server writes file objects to its own local
+directory, so a server handling the request to view a log entry's file object cannot read
+files that were written by another server, resulting in errors in the log viewer.
+
+In such setups, configure `pimcore.application_log.storage` to use a storage location
+shared by all servers — either a shared/network filesystem mounted on every server or a
+remote Flysystem adapter such as S3:
+
+```yaml
+flysystem:
+    storages:
+        pimcore.application_log.storage:
+            adapter: 'aws'
+            visibility: private
+            options:
+                client: 'my_aws_s3_client_service'
+                bucket: 'application-log'
+```
+
+:::
+
 ## How to Create Log Entries
 
 The Application Logger is a PSR-3 compatible component available as service


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `12.3`
- Feature/Improvement: choose `2026.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`2026.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `12.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #18435

Documents that the `pimcore.application_log.storage` Flysystem storage defaults to a
local directory (`var/application-logger`) and must point to a shared location in
multi-server / High Availability setups, since file objects written by one server are
read by other servers through the log viewer (`LogController::showFileObjectAction()`).

Changes in `doc/09_Development_Tools/02_Logging/01_Application_Logger.md`:

- New **File Object Storage** section documenting the `pimcore.application_log.storage`
  storage, its local default, the date-based storage path (`Y/m/d/fileobject_<uniqueId>`
  unless a custom filename is passed to `FileObject`), and a caution block for
  cluster/HA setups with an S3 adapter example.
- Documented that storage write failures are silently ignored (warning in the system
  log only), so a misconfigured storage surfaces as unopenable file objects in the log
  viewer rather than as logging errors.
- **Log Archival**: added a caution that archiving deletes the referenced file objects
  from storage — attachments only live for `archive_treshold` days, not for the
  lifetime of the archive tables.
- New **Maintenance Tasks** section stating that archival, archive cleanup, and mail
  summaries only run when `pimcore:maintenance` is executed regularly.
- **Mail Notifications**: documented the 100-entries-per-mail batching and that every
  maintenance run flags all entries as processed regardless of settings, so enabling
  `send_log_summary` only emails entries logged from that point on.
- **Special Context Variables**: documented that the `fileObject` context variable also
  accepts a string path to an existing file on the storage, not only a `FileObject`
  instance.

Also expanded the inline comment on the default storage definition in
`bundles/ApplicationLoggerBundle/config/pimcore/config.yaml` to point out the
shared-storage requirement for multi-server setups.

## Additional info
Documentation-only change (plus a YAML comment); no behavioral changes. All documented
behavior was verified against the current implementation in `ApplicationLoggerBundle`
(`FileObject`, `LogArchiveTask`, `LogMailMaintenanceTask`, `ApplicationLogger`,
`LogController`).