### PR TITLE
Omit file system metadata from embedded meta info extraction

### DIFF
--- a/models/Asset/MetaData/EmbeddedMetaDataTrait.php
+++ b/models/Asset/MetaData/EmbeddedMetaDataTrait.php
@@ -66,7 +66,20 @@ trait EmbeddedMetaDataTrait
                 if ($outputArray) {
                     $embeddedMetaData = $this->flattenArray($outputArray[0]);
 
-                    foreach (['Directory', 'FileName', 'SourceFile', 'ExifToolVersion'] as $removeKey) {
+                    // strip tags describing the local (temporary) file itself, as they carry no
+                    // information about the asset: location, tool version and file system attributes
+                    foreach ([
+                        'Directory',
+                        'FileName',
+                        'SourceFile',
+                        'ExifToolVersion',
+                        'FileAccessDate',
+                        'FileAttributes',
+                        'FileCreateDate',
+                        'FileInodeChangeDate',
+                        'FileModifyDate',
+                        'FilePermissions',
+                    ] as $removeKey) {
                         if (isset($embeddedMetaData[$removeKey])) {
                             unset($embeddedMetaData[$removeKey]);
                         }


### PR DESCRIPTION
When extracting embedded metadata with exiftool, the output includes file system attributes of the local (temporary) file - permissions, access/modify/inode-change timestamps etc. These describe the local copy of the file rather than the asset itself, so they are now removed alongside the already excluded Directory, FileName, SourceFile and ExifToolVersion keys.

Fixes pimcore/pimcore#18497

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `12.3`
- Feature/Improvement: choose `2026.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`2026.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `12.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #18497

## Additional info
