### PR TITLE
[Bug, EC] PEES-1176: Cache permission-filtered Required By total count

### DIFF
--- a/models/Dependency/Dao.php
+++ b/models/Dependency/Dao.php
@@ -100,7 +100,13 @@ class Dao extends Model\Dao\AbstractDao
             INNER JOIN assets a ON a.id = d.targetid AND d.targettype = 'asset'
             WHERE d.sourcetype = :sourceType AND d.sourceid = :sourceId AND LOWER(CONCAT(a.path, a.filename)) RLIKE :value
         ) dep
-        ORDER BY " . $orderBy . ' ' . $orderDirection;
+        ORDER BY " . $orderBy . ' ' . $orderDirection . ', type, id';
+        // `type, id` is always appended as a final tiebreaker: `id` alone is not unique across
+        // element types (an asset, a document, and an object can share the same numeric id), so
+        // ties on the requested $orderBy column would otherwise leave row order among them
+        // unspecified - and a caller paginating this query across repeated LIMIT/OFFSET calls
+        // (as the admin dependency grid does) needs a fully deterministic order or rows can be
+        // duplicated or skipped between calls. `(type, id)` is always unique per row here.
 
         $params = [
             'sourceType' => $sourceType,
@@ -164,7 +170,13 @@ class Dao extends Model\Dao\AbstractDao
             INNER JOIN assets a ON a.id = d.sourceid AND d.targettype = 'asset'
             WHERE d.targettype = :targetType AND d.targetid = :targetId AND LOWER(CONCAT(a.path, a.filename)) RLIKE :value
         ) dep
-        ORDER BY " . $orderBy . ' ' . $orderDirection;
+        ORDER BY " . $orderBy . ' ' . $orderDirection . ', type, id';
+        // `type, id` is always appended as a final tiebreaker: `id` alone is not unique across
+        // element types (an asset, a document, and an object can share the same numeric id), so
+        // ties on the requested $orderBy column would otherwise leave row order among them
+        // unspecified - and a caller paginating this query across repeated LIMIT/OFFSET calls
+        // (as the admin dependency grid does) needs a fully deterministic order or rows can be
+        // duplicated or skipped between calls. `(type, id)` is always unique per row here.
 
         $params = [
             'targetType' => $targetType,

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -296,9 +296,16 @@ class Service extends Model\AbstractModel
         // a truncated (too-small) total, which hides real pages, fall back to the raw
         // (never-too-small) total in that case; the common case where the raw set fits within
         // the cap is unaffected and still gets the exact, immediate total.
+        $scanTruncated = $rawOffset < $rawTotal;
+
+        // A truncated scan means the unexamined tail is genuinely unknown - it may or may not
+        // contain hidden rows. Defaulting hasHidden to false there would be a false negative
+        // (silently hiding the warning even though hidden content could exist beyond the cap),
+        // which is worse than an occasional false positive, so treat "we didn't check" as "hidden
+        // dependencies might exist" rather than "there are none".
         $result = [
-            'total' => $rawOffset >= $rawTotal ? $visibleTotal : $rawTotal,
-            'hasHidden' => $hasHidden,
+            'total' => $scanTruncated ? $rawTotal : $visibleTotal,
+            'hasHidden' => $hasHidden || $scanTruncated,
         ];
 
         self::$requiredByVisibilityRequestCache[$cacheKey] = $result;

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -29,6 +29,7 @@ use Exception;
 use InvalidArgumentException;
 use League\Csv\EscapeFormula;
 use Pimcore;
+use Pimcore\Cache;
 use Pimcore\Db;
 use Pimcore\Event\SystemEvents;
 use Pimcore\Logger;
@@ -48,6 +49,7 @@ use Pimcore\Model\Element\DeepCopy\PimcoreClassDefinitionReplaceFilter;
 use Pimcore\Model\Element\DeepCopy\UnmarshalMatcher;
 use Pimcore\Model\Paginator\PaginateListingInterface;
 use Pimcore\Model\Tool\TmpStore;
+use Pimcore\Tool\Admin;
 use Pimcore\Tool\Serialize;
 use ReflectionProperty;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -177,6 +179,68 @@ class Service extends Model\AbstractModel
         }
 
         return $dependencies;
+    }
+
+    private const REQUIRED_BY_VISIBLE_TOTAL_SCAN_CHUNK = 200;
+
+    private const REQUIRED_BY_VISIBLE_TOTAL_SCAN_CAP = 5000;
+
+    private const REQUIRED_BY_VISIBLE_TOTAL_CACHE_LIFETIME = 60;
+
+    /**
+     * Permission-filtered "Required By" count for the current admin user, i.e. how many of the
+     * raw dependency rows the user actually has `list` permission to see. Unlike
+     * `Dependency::getRequiredByTotalCount()` (a cheap raw `COUNT(*)`), this requires hydrating
+     * and permission-checking every row up to a safety cap, so the result is cached briefly per
+     * element+user to avoid repeating that scan on every paging request.
+     *
+     * @internal
+     */
+    public static function getRequiredByVisibleTotalCount(Dependency $d): int
+    {
+        $userId = Admin::getCurrentUser()?->getId() ?? 0;
+        $cacheKey = sprintf(
+            'requiredby_visible_total_%s_%d_%d',
+            $d->getSourceType(),
+            $d->getSourceId(),
+            $userId
+        );
+
+        $cached = Cache::load($cacheKey);
+        if ($cached !== false) {
+            return (int) $cached;
+        }
+
+        $rawTotal = $d->getRequiredByTotalCount();
+        $visibleTotal = 0;
+        $rawOffset = 0;
+        $scannedRows = 0;
+
+        while ($rawOffset < $rawTotal && $scannedRows < self::REQUIRED_BY_VISIBLE_TOTAL_SCAN_CAP) {
+            $rows = $d->getRequiredBy($rawOffset, self::REQUIRED_BY_VISIBLE_TOTAL_SCAN_CHUNK);
+            if (empty($rows)) {
+                break;
+            }
+
+            foreach ($rows as $row) {
+                $e = self::getDependedElement($row);
+                if ($e && $e->isAllowed('list')) {
+                    $visibleTotal++;
+                }
+            }
+
+            $rawOffset += count($rows);
+            $scannedRows += count($rows);
+        }
+
+        Cache::save(
+            $visibleTotal,
+            $cacheKey,
+            ['dependency_requiredby_' . $d->getSourceType() . '_' . $d->getSourceId()],
+            self::REQUIRED_BY_VISIBLE_TOTAL_CACHE_LIFETIME
+        );
+
+        return $visibleTotal;
     }
 
     /**

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -262,7 +262,14 @@ class Service extends Model\AbstractModel
         $scannedRows = 0;
 
         while ($rawOffset < $rawTotal && $scannedRows < self::REQUIRED_BY_VISIBLE_TOTAL_SCAN_CAP) {
-            $rows = $d->getRequiredBy($rawOffset, self::REQUIRED_BY_VISIBLE_TOTAL_SCAN_CHUNK);
+            // Clamp to the remaining budget so the cap is a strict upper bound on rows
+            // scanned - without this, a chunk fetched right before the cap (e.g.
+            // scannedRows=4900) could still pull a full chunk and overshoot it.
+            $chunkSize = min(
+                self::REQUIRED_BY_VISIBLE_TOTAL_SCAN_CHUNK,
+                self::REQUIRED_BY_VISIBLE_TOTAL_SCAN_CAP - $scannedRows
+            );
+            $rows = $d->getRequiredBy($rawOffset, $chunkSize);
             if (empty($rows)) {
                 break;
             }

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -188,6 +188,17 @@ class Service extends Model\AbstractModel
     private const REQUIRED_BY_VISIBLE_TOTAL_CACHE_LIFETIME = 60;
 
     /**
+     * In-process memo of scanRequiredByVisibility() results, keyed by cache key - avoids
+     * re-scanning within a single request when both getRequiredByVisibleTotalCount() and
+     * getRequiredByHasHiddenDependencies() are called for the same element+user, since
+     * Cache::save() defers its actual write to shutdown and wouldn't be visible to a second
+     * call yet.
+     *
+     * @var array<string, array{total: int, hasHidden: bool}>
+     */
+    private static array $requiredByVisibilityRequestCache = [];
+
+    /**
      * Permission-filtered "Required By" count for the current admin user, i.e. how many of the
      * raw dependency rows the user actually has `list` permission to see. Unlike
      * `Dependency::getRequiredByTotalCount()` (a cheap raw `COUNT(*)`), this requires hydrating
@@ -198,6 +209,29 @@ class Service extends Model\AbstractModel
      */
     public static function getRequiredByVisibleTotalCount(Dependency $d): int
     {
+        return self::scanRequiredByVisibility($d)['total'];
+    }
+
+    /**
+     * Whether any "Required By" row was found (within the same scan/cache as
+     * getRequiredByVisibleTotalCount()) that the current admin user does not have `list`
+     * permission to see - i.e. whether the dependencies grid should show its hidden-items
+     * notice. Sourced from the same bounded scan as the total so it is stable across every
+     * page, rather than only reflecting whatever one page's own (much shorter) scan happened
+     * to encounter.
+     *
+     * @internal
+     */
+    public static function getRequiredByHasHiddenDependencies(Dependency $d): bool
+    {
+        return self::scanRequiredByVisibility($d)['hasHidden'];
+    }
+
+    /**
+     * @return array{total: int, hasHidden: bool}
+     */
+    private static function scanRequiredByVisibility(Dependency $d): array
+    {
         $userId = Admin::getCurrentUser()?->getId() ?? 0;
         $cacheKey = sprintf(
             'requiredby_visible_total_%s_%d_%d',
@@ -206,17 +240,24 @@ class Service extends Model\AbstractModel
             $userId
         );
 
+        if (isset(self::$requiredByVisibilityRequestCache[$cacheKey])) {
+            return self::$requiredByVisibilityRequestCache[$cacheKey];
+        }
+
         // Cache::save() silently drops falsy payloads on the default (deferred, non-forced)
         // write path - CoreCacheHandler::addToSaveQueue() only queues data that passes a
         // truthy check, so a legitimate count of 0 would never actually get persisted. Wrap
-        // the count in an array so it survives that check, and unwrap it on read.
+        // the result in an array (always truthy) so it survives that check.
         $cached = Cache::load($cacheKey);
-        if (is_array($cached) && array_key_exists('total', $cached)) {
-            return (int) $cached['total'];
+        if (is_array($cached) && array_key_exists('total', $cached) && array_key_exists('hasHidden', $cached)) {
+            self::$requiredByVisibilityRequestCache[$cacheKey] = $cached;
+
+            return $cached;
         }
 
         $rawTotal = $d->getRequiredByTotalCount();
         $visibleTotal = 0;
+        $hasHidden = false;
         $rawOffset = 0;
         $scannedRows = 0;
 
@@ -228,8 +269,13 @@ class Service extends Model\AbstractModel
 
             foreach ($rows as $row) {
                 $e = self::getDependedElement($row);
-                if ($e && $e->isAllowed('list')) {
+                if (!$e) {
+                    continue;
+                }
+                if ($e->isAllowed('list')) {
                     $visibleTotal++;
+                } else {
+                    $hasHidden = true;
                 }
             }
 
@@ -243,16 +289,21 @@ class Service extends Model\AbstractModel
         // a truncated (too-small) total, which hides real pages, fall back to the raw
         // (never-too-small) total in that case; the common case where the raw set fits within
         // the cap is unaffected and still gets the exact, immediate total.
-        $total = $rawOffset >= $rawTotal ? $visibleTotal : $rawTotal;
+        $result = [
+            'total' => $rawOffset >= $rawTotal ? $visibleTotal : $rawTotal,
+            'hasHidden' => $hasHidden,
+        ];
+
+        self::$requiredByVisibilityRequestCache[$cacheKey] = $result;
 
         Cache::save(
-            ['total' => $total],
+            $result,
             $cacheKey,
             ['dependency_requiredby_' . $d->getSourceType() . '_' . $d->getSourceId()],
             self::REQUIRED_BY_VISIBLE_TOTAL_CACHE_LIFETIME
         );
 
-        return $total;
+        return $result;
     }
 
     /**

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -206,9 +206,13 @@ class Service extends Model\AbstractModel
             $userId
         );
 
+        // Cache::save() silently drops falsy payloads on the default (deferred, non-forced)
+        // write path - CoreCacheHandler::addToSaveQueue() only queues data that passes a
+        // truthy check, so a legitimate count of 0 would never actually get persisted. Wrap
+        // the count in an array so it survives that check, and unwrap it on read.
         $cached = Cache::load($cacheKey);
-        if ($cached !== false) {
-            return (int) $cached;
+        if (is_array($cached) && array_key_exists('total', $cached)) {
+            return (int) $cached['total'];
         }
 
         $rawTotal = $d->getRequiredByTotalCount();
@@ -233,14 +237,22 @@ class Service extends Model\AbstractModel
             $scannedRows += count($rows);
         }
 
+        // If the scan cap was hit before the raw table was fully examined, $visibleTotal only
+        // reflects what was seen so far and may under-count - e.g. 6000 fully visible rows
+        // would report 5000 and strand the grid at page 200 of a true 240. Rather than expose
+        // a truncated (too-small) total, which hides real pages, fall back to the raw
+        // (never-too-small) total in that case; the common case where the raw set fits within
+        // the cap is unaffected and still gets the exact, immediate total.
+        $total = $rawOffset >= $rawTotal ? $visibleTotal : $rawTotal;
+
         Cache::save(
-            $visibleTotal,
+            ['total' => $total],
             $cacheKey,
             ['dependency_requiredby_' . $d->getSourceType() . '_' . $d->getSourceId()],
             self::REQUIRED_BY_VISIBLE_TOTAL_CACHE_LIFETIME
         );
 
-        return $visibleTotal;
+        return $total;
     }
 
     /**


### PR DESCRIPTION
Adds Service::getRequiredByVisibleTotalCount(), which scans (bounded, cached 60s per element+user) the raw dependency rows a user can actually list, so admin-ui-classic-bundle's dependency grid can show an accurate page count immediately instead of only self-correcting once a restricted user pages to the end.


## Changes in this pull request  
Resolves https://github.com/pimcore/service-operations/issues/851

## Additional info
