### PR TITLE
Add explicit ORDER BY column allowlist to Redirect\Listing

### DIFF
--- a/bundles/SeoBundle/src/Model/Redirect/Listing.php
+++ b/bundles/SeoBundle/src/Model/Redirect/Listing.php
@@ -24,6 +24,28 @@ use Pimcore\Model;
  */
 class Listing extends Model\Listing\AbstractListing
 {
+    public function isValidOrderKey(string $key): bool
+    {
+        return in_array($key, [
+            'id',
+            'type',
+            'source',
+            'sourceSite',
+            'target',
+            'targetSite',
+            'statusCode',
+            'priority',
+            'regex',
+            'passThroughParameters',
+            'active',
+            'expiry',
+            'creationDate',
+            'modificationDate',
+            'userOwner',
+            'userModification',
+        ], true);
+    }
+
     /**
      * @return Redirect[]
      */

--- a/tests/Model/SeoBundle/Redirect/ListingTest.php
+++ b/tests/Model/SeoBundle/Redirect/ListingTest.php
@@ -66,7 +66,6 @@ final class ListingTest extends TestCase
 
         $this->assertFalse($listing->isValidOrderKey($payload));
 
-        
         $this->expectException(InvalidArgumentException::class);
         $listing->setOrderKey($payload);
     }

--- a/tests/Model/SeoBundle/Redirect/ListingTest.php
+++ b/tests/Model/SeoBundle/Redirect/ListingTest.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\SeoBundle\Redirect;
+
+use InvalidArgumentException;
+use Pimcore\Bundle\SeoBundle\Model\Redirect\Listing;
+use Pimcore\Tests\Support\Test\TestCase;
+
+class ListingTest extends TestCase
+{
+    /**
+     * @dataProvider validOrderKeyProvider
+     */
+    public function testValidOrderKeysAreAccepted(string $key): void
+    {
+        $listing = new Listing();
+        $this->assertTrue($listing->isValidOrderKey($key));
+    }
+
+    public function validOrderKeyProvider(): array
+    {
+        return array_map(static fn (string $key) => [$key], [
+            'id',
+            'type',
+            'source',
+            'sourceSite',
+            'target',
+            'targetSite',
+            'statusCode',
+            'priority',
+            'regex',
+            'passThroughParameters',
+            'active',
+            'expiry',
+            'creationDate',
+            'modificationDate',
+            'userOwner',
+            'userModification',
+        ]);
+    }
+
+    public function testArbitraryColumnNameIsRejected(): void
+    {
+        $listing = new Listing();
+        $this->assertFalse($listing->isValidOrderKey('some_unknown_column'));
+    }
+
+    public function testOrderKeyWithInjectedSqlIsRejected(): void
+    {
+        $listing = new Listing();
+
+        // Under MySQL's ANSI_QUOTES sql_mode, quoteIdentifier() wraps identifiers in
+        // double quotes instead of backticks, so an unvalidated order key containing
+        // a double quote could break out of the identifier and inject SQL.
+        $payload = 'id" ASC,(SELECT SLEEP(5))-- -';
+
+        $this->assertFalse($listing->isValidOrderKey($payload));
+
+        $this->expectException(InvalidArgumentException::class);
+        $listing->setOrderKey($payload);
+    }
+}

--- a/tests/Model/SeoBundle/Redirect/ListingTest.php
+++ b/tests/Model/SeoBundle/Redirect/ListingTest.php
@@ -66,6 +66,7 @@ final class ListingTest extends TestCase
 
         $this->assertFalse($listing->isValidOrderKey($payload));
 
+        
         $this->expectException(InvalidArgumentException::class);
         $listing->setOrderKey($payload);
     }

--- a/tests/Model/SeoBundle/Redirect/ListingTest.php
+++ b/tests/Model/SeoBundle/Redirect/ListingTest.php
@@ -17,7 +17,7 @@ use InvalidArgumentException;
 use Pimcore\Bundle\SeoBundle\Model\Redirect\Listing;
 use Pimcore\Tests\Support\Test\TestCase;
 
-class ListingTest extends TestCase
+final class ListingTest extends TestCase
 {
     /**
      * @dataProvider validOrderKeyProvider
@@ -28,7 +28,7 @@ class ListingTest extends TestCase
         $this->assertTrue($listing->isValidOrderKey($key));
     }
 
-    public function validOrderKeyProvider(): array
+    public static function validOrderKeyProvider(): array
     {
         return array_map(static fn (string $key) => [$key], [
             'id',
@@ -56,13 +56,12 @@ class ListingTest extends TestCase
         $this->assertFalse($listing->isValidOrderKey('some_unknown_column'));
     }
 
-    public function testOrderKeyWithInjectedSqlIsRejected(): void
+    public function testOrderKeyOutsideTheAllowlistIsRejected(): void
     {
         $listing = new Listing();
 
-        // Under MySQL's ANSI_QUOTES sql_mode, quoteIdentifier() wraps identifiers in
-        // double quotes instead of backticks, so an unvalidated order key containing
-        // a double quote could break out of the identifier and inject SQL.
+        // Not a real column: previously accepted unconditionally since
+        // isValidOrderKey() returned true for any input.
         $payload = 'id" ASC,(SELECT SLEEP(5))-- -';
 
         $this->assertFalse($listing->isValidOrderKey($payload));


### PR DESCRIPTION
## Summary

`AbstractListing::isValidOrderKey()` unconditionally returns `true`, so `Redirect\Listing` (used by `RedirectsController`) never validated the user-supplied `orderKey` against the real set of `redirects` columns before passing it to `quoteIdentifier()`.

**Correction:** an earlier version of this PR description claimed this was exploitable as SQL injection under MySQL's `ANSI_QUOTES` sql_mode, on the assumption that `quoteIdentifier()` would switch to double-quote wrapping in that mode. That's incorrect for Pimcore's current stack — `Doctrine\DBAL\Platforms\AbstractMySQLPlatform::quoteSingleIdentifier()` (doctrine/dbal `^4.4`, as required here) always wraps identifiers in backticks and doubles any embedded backtick, regardless of sql_mode, so the double-quote breakout described does not apply. Thanks to Copilot's review for catching this.

This PR still closes a real gap: `isValidOrderKey()` performed no actual validation, so any string was silently accepted as an `ORDER BY` column name. That's fixed here with an explicit allowlist of the real `redirects` table columns (`id`, `type`, `source`, `sourceSite`, `target`, `targetSite`, `statusCode`, `priority`, `regex`, `passThroughParameters`, `active`, `expiry`, `creationDate`, `modificationDate`, `userOwner`, `userModification`), matching the existing allowlist pattern already used in `Translation\Listing` and `DataObject\QuantityValue\Unit\Listing` — a defense-in-depth / correctness fix rather than a fix for an active SQL injection.

The base `AbstractListing::isValidOrderKey()` default (`true`) is intentionally left unchanged in this PR — other listing subclasses rely on that inherited default without their own override, and flipping it globally would need each of those audited and allowlisted individually to avoid breaking sorting across admin grids. That broader audit is out of scope here.

## Test plan
- [x] `php -l` on the modified files — no syntax errors
- [x] Added `tests/Model/SeoBundle/Redirect/ListingTest.php`: valid columns accepted, unknown/out-of-allowlist keys rejected by `isValidOrderKey()` and raise `InvalidArgumentException` from `setOrderKey()`
- [x] Verified no call site in the codebase passes `setOrderKey($orderKey, false)` with user-controlled input (which would bypass the allowlist)
- [x] Verified the allowlist matches the `redirects` table schema (`bundles/SeoBundle/src/Resources/install/install.sql`)
- [x] CI green (Psalm, PHPStan, Codeception across supported PHP/DB matrix)

Co-Authored-By: Claude <noreply@anthropic.com>