### PR TITLE
Fix: getByPath() falls back to NFC-normalized path candidates to resolve elements with accented names

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -219,7 +219,19 @@ class Asset extends Element\AbstractElement
 
         try {
             $asset = new static();
-            $asset->getDao()->getByPath($path);
+
+            try {
+                $asset->getDao()->getByPath($path);
+            } catch (NotFoundException $e) {
+                // fall back to the NFC-normalized path so a decomposed (NFD) lookup path can
+                // still resolve an element whose key is stored precomposed, without breaking
+                // the exact-path lookup for legacy elements still stored in NFD form
+                $nfcPath = Element\Service::normalizePathToNfc($path);
+                if ($nfcPath === $path) {
+                    throw $e;
+                }
+                $asset->getDao()->getByPath($nfcPath);
+            }
 
             return static::getById(
                 $asset->getId(),

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -220,18 +220,10 @@ class Asset extends Element\AbstractElement
         try {
             $asset = new static();
 
-            try {
-                $asset->getDao()->getByPath($path);
-            } catch (NotFoundException $e) {
-                // fall back to the NFC-normalized path so a decomposed (NFD) lookup path can
-                // still resolve an element whose key is stored precomposed, without breaking
-                // the exact-path lookup for legacy elements still stored in NFD form
-                $nfcPath = Element\Service::normalizePathToNfc($path);
-                if ($nfcPath === $path) {
-                    throw $e;
-                }
-                $asset->getDao()->getByPath($nfcPath);
-            }
+            Element\Service::getByPathWithNfcFallback(
+                fn (string $candidate) => $asset->getDao()->getByPath($candidate),
+                $path
+            );
 
             return static::getById(
                 $asset->getId(),

--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -209,7 +209,10 @@ class Service extends Model\Element\Service
             $asset = new Asset();
 
             if (self::isValidPath($path, 'asset')) {
-                $asset->getDao()->getByPath($path);
+                Element\Service::getByPathWithNfcFallback(
+                    fn (string $candidate) => $asset->getDao()->getByPath($candidate),
+                    $path
+                );
 
                 return true;
             }

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -269,7 +269,19 @@ abstract class AbstractObject extends Model\Element\AbstractElement
 
         try {
             $object = new static();
-            $object->getDao()->getByPath($path);
+
+            try {
+                $object->getDao()->getByPath($path);
+            } catch (Model\Exception\NotFoundException $e) {
+                // fall back to the NFC-normalized path so a decomposed (NFD) lookup path can
+                // still resolve an element whose key is stored precomposed, without breaking
+                // the exact-path lookup for legacy elements still stored in NFD form
+                $nfcPath = Model\Element\Service::normalizePathToNfc($path);
+                if ($nfcPath === $path) {
+                    throw $e;
+                }
+                $object->getDao()->getByPath($nfcPath);
+            }
 
             return static::getById($object->getId(), Model\Element\Service::prepareGetByIdParams($params));
         } catch (Model\Exception\NotFoundException $e) {

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -270,18 +270,10 @@ abstract class AbstractObject extends Model\Element\AbstractElement
         try {
             $object = new static();
 
-            try {
-                $object->getDao()->getByPath($path);
-            } catch (Model\Exception\NotFoundException $e) {
-                // fall back to the NFC-normalized path so a decomposed (NFD) lookup path can
-                // still resolve an element whose key is stored precomposed, without breaking
-                // the exact-path lookup for legacy elements still stored in NFD form
-                $nfcPath = Model\Element\Service::normalizePathToNfc($path);
-                if ($nfcPath === $path) {
-                    throw $e;
-                }
-                $object->getDao()->getByPath($nfcPath);
-            }
+            Model\Element\Service::getByPathWithNfcFallback(
+                fn (string $candidate) => $object->getDao()->getByPath($candidate),
+                $path
+            );
 
             return static::getById($object->getId(), Model\Element\Service::prepareGetByIdParams($params));
         } catch (Model\Exception\NotFoundException $e) {

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -550,16 +550,11 @@ class Service extends Model\Element\Service
         try {
             $object = new DataObject();
 
-            $pathElements = explode('/', $path);
-            $keyIdx = count($pathElements) - 1;
-            $key = $pathElements[$keyIdx];
-            $validKey = Element\Service::getValidKey($key, 'object');
-
-            unset($pathElements[$keyIdx]);
-            $pathOnly = implode('/', $pathElements);
-
-            if ($validKey == $key && self::isValidPath($pathOnly, 'object')) {
-                $object->getDao()->getByPath($path);
+            if (self::isValidPath($path, 'object')) {
+                Element\Service::getByPathWithNfcFallback(
+                    fn (string $candidate) => $object->getDao()->getByPath($candidate),
+                    $path
+                );
 
                 return true;
             }

--- a/models/Document.php
+++ b/models/Document.php
@@ -156,7 +156,15 @@ class Document extends Element\AbstractElement
             );
 
             $doc = static::getById($helperDoc->getId(), $params);
-            RuntimeCache::set($cacheKey, $doc);
+
+            // cache under the resolved document's own real path, not the raw lookup path - an
+            // NFC fallback candidate may have matched instead of $path, and caching under an
+            // alias that move/delete never invalidates (they only clear
+            // getPathCacheKey($this->getRealFullPath()), see delete()) would keep returning a
+            // moved or deleted document to a later lookup by that same alias
+            if ($doc) {
+                RuntimeCache::set(self::getPathCacheKey($doc->getRealFullPath()), $doc);
+            }
         } catch (NotFoundException $e) {
             $doc = null;
         }

--- a/models/Document.php
+++ b/models/Document.php
@@ -150,10 +150,19 @@ class Document extends Element\AbstractElement
         try {
             $helperDoc = new Document();
 
-            Element\Service::getByPathWithNfcFallback(
-                fn (string $candidate) => $helperDoc->getDao()->getByPath($candidate),
-                $path
-            );
+            try {
+                Element\Service::getByPathWithNfcFallback(
+                    fn (string $candidate) => $helperDoc->getDao()->getByExactPath($candidate),
+                    $path
+                );
+            } catch (NotFoundException $e) {
+                // none of the exact-path candidates matched - fall back to a pretty URL match
+                // against the original requested path only, same as before this fallback
+                // existed. A pretty URL is a literal string a content editor configured, not
+                // something that should ever be matched against a synthetic, NFC-normalized
+                // candidate path, so this must run once, after the candidates, not per candidate.
+                $helperDoc->getDao()->getByPrettyUrl($path);
+            }
 
             $doc = static::getById($helperDoc->getId(), $params);
 

--- a/models/Document.php
+++ b/models/Document.php
@@ -150,18 +150,10 @@ class Document extends Element\AbstractElement
         try {
             $helperDoc = new Document();
 
-            try {
-                $helperDoc->getDao()->getByPath($path);
-            } catch (NotFoundException $e) {
-                // fall back to the NFC-normalized path so a decomposed (NFD) lookup path can
-                // still resolve an element whose key is stored precomposed, without breaking
-                // the exact-path lookup for legacy elements still stored in NFD form
-                $nfcPath = Element\Service::normalizePathToNfc($path);
-                if ($nfcPath === $path) {
-                    throw $e;
-                }
-                $helperDoc->getDao()->getByPath($nfcPath);
-            }
+            Element\Service::getByPathWithNfcFallback(
+                fn (string $candidate) => $helperDoc->getDao()->getByPath($candidate),
+                $path
+            );
 
             $doc = static::getById($helperDoc->getId(), $params);
             RuntimeCache::set($cacheKey, $doc);

--- a/models/Document.php
+++ b/models/Document.php
@@ -149,7 +149,20 @@ class Document extends Element\AbstractElement
 
         try {
             $helperDoc = new Document();
-            $helperDoc->getDao()->getByPath($path);
+
+            try {
+                $helperDoc->getDao()->getByPath($path);
+            } catch (NotFoundException $e) {
+                // fall back to the NFC-normalized path so a decomposed (NFD) lookup path can
+                // still resolve an element whose key is stored precomposed, without breaking
+                // the exact-path lookup for legacy elements still stored in NFD form
+                $nfcPath = Element\Service::normalizePathToNfc($path);
+                if ($nfcPath === $path) {
+                    throw $e;
+                }
+                $helperDoc->getDao()->getByPath($nfcPath);
+            }
+
             $doc = static::getById($helperDoc->getId(), $params);
             RuntimeCache::set($cacheKey, $doc);
         } catch (NotFoundException $e) {

--- a/models/Document/Dao.php
+++ b/models/Document/Dao.php
@@ -54,22 +54,56 @@ class Dao extends Model\Element\Dao
      */
     public function getByPath(string $path): void
     {
+        try {
+            $this->getByExactPath($path);
+        } catch (Model\Exception\NotFoundException $e) {
+            try {
+                $this->getByPrettyUrl($path);
+            } catch (Model\Exception\NotFoundException) {
+                throw $e;
+            }
+        }
+    }
+
+    /**
+     * Fetch a row by an exact path/key match only, without falling back to a pretty URL match.
+     * Used for the Unicode-normalization fallback candidates in
+     * Element\Service::getByPathWithNfcFallback(): a candidate is a synthetic, NFC-normalized
+     * variant of the caller's path, not a literal pretty URL a content editor configured, so
+     * matching it against documents_page.prettyUrl could return an unrelated page instead of
+     * correctly falling through to the next candidate.
+     *
+     * @internal
+     *
+     * @throws Model\Exception\NotFoundException
+     */
+    public function getByExactPath(string $path): void
+    {
         $params = $this->extractKeyAndPath($path);
         $data = $this->db->fetchAssociative('SELECT id FROM documents WHERE `path` = BINARY :path AND `key` = BINARY :key', $params);
 
         if ($data) {
             $this->assignVariablesToModel($data);
         } else {
-            // try to find a page with a pretty URL (use the original $path)
-            $data = $this->db->fetchAssociative('SELECT id FROM documents_page WHERE prettyUrl = :prettyUrl', [
-                'prettyUrl' => $path,
-            ]);
+            throw new Model\Exception\NotFoundException("document with path $path doesn't exist");
+        }
+    }
 
-            if ($data) {
-                $this->assignVariablesToModel($data);
-            } else {
-                throw new Model\Exception\NotFoundException("document with path $path doesn't exist");
-            }
+    /**
+     * @internal
+     *
+     * @throws Model\Exception\NotFoundException
+     */
+    public function getByPrettyUrl(string $path): void
+    {
+        $data = $this->db->fetchAssociative('SELECT id FROM documents_page WHERE prettyUrl = :prettyUrl', [
+            'prettyUrl' => $path,
+        ]);
+
+        if ($data) {
+            $this->assignVariablesToModel($data);
+        } else {
+            throw new Model\Exception\NotFoundException("document with path $path doesn't exist");
         }
     }
 

--- a/models/Document/Service.php
+++ b/models/Document/Service.php
@@ -307,7 +307,16 @@ class Service extends Model\Element\Service
             $document = new Document();
             // validate path
             if (self::isValidPath($path, 'document')) {
-                $document->getDao()->getByPath($path);
+                try {
+                    Element\Service::getByPathWithNfcFallback(
+                        fn (string $candidate) => $document->getDao()->getByExactPath($candidate),
+                        $path
+                    );
+                } catch (Model\Exception\NotFoundException) {
+                    // none of the exact-path candidates matched - fall back to a pretty URL
+                    // match against the original requested path only, same as getByPath()
+                    $document->getDao()->getByPrettyUrl($path);
+                }
 
                 return true;
             }

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -41,13 +41,6 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
     use RecursionBlockingEventDispatchHelperTrait;
 
     /**
-     * The maximum length, in characters, of an element's full path. No element can ever be
-     * saved with a longer path (see validatePathLength()), so this also bounds how much work a
-     * getByPath() lookup needs to do for a path that cannot possibly match anything.
-     */
-    final public const MAX_FULL_PATH_LENGTH = 765;
-
-    /**
      * @internal
      */
     protected ?Model\Dependency $dependencies = null;

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -41,6 +41,13 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
     use RecursionBlockingEventDispatchHelperTrait;
 
     /**
+     * The maximum length, in characters, of an element's full path. No element can ever be
+     * saved with a longer path (see validatePathLength()), so this also bounds how much work a
+     * getByPath() lookup needs to do for a path that cannot possibly match anything.
+     */
+    final public const MAX_FULL_PATH_LENGTH = 765;
+
+    /**
      * @internal
      */
     protected ?Model\Dependency $dependencies = null;
@@ -561,8 +568,8 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
      */
     protected function validatePathLength(): void
     {
-        if (mb_strlen($this->getRealFullPath()) > 765) {
-            throw new Exception("Full path is limited to 765 characters, reduce the length of your parent's path");
+        if (mb_strlen($this->getRealFullPath()) > self::MAX_FULL_PATH_LENGTH) {
+            throw new Exception('Full path is limited to ' . self::MAX_FULL_PATH_LENGTH . " characters, reduce the length of your parent's path");
         }
     }
 

--- a/models/Element/ElementInterface.php
+++ b/models/Element/ElementInterface.php
@@ -22,6 +22,14 @@ use Pimcore\Model\Version;
 
 interface ElementInterface extends ModelInterface
 {
+    /**
+     * The maximum length, in characters, of an element's full path. No element can ever be
+     * saved with a longer path (see AbstractElement::validatePathLength()), so this also bounds
+     * how much work a getByPath() lookup needs to do for a path that cannot possibly match
+     * anything (see Service::getByPathWithNfcFallback()).
+     */
+    public const MAX_FULL_PATH_LENGTH = 765;
+
     public function getId(): ?int;
 
     public function getKey(): ?string;

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -876,6 +876,14 @@ class Service extends Model\AbstractModel
      * getNfcFallbackPathCandidates() if the exact path misses. Centralizes the retry policy so
      * Asset, Document and DataObject don't each reimplement it.
      *
+     * getByPath() is a public API that accepts arbitrary caller-supplied strings, unconstrained
+     * by AbstractElement::MAX_FULL_PATH_LENGTH (that limit is only enforced at save time, see
+     * validatePathLength()). Without a bound here, an overlength path with many segments would
+     * turn one miss into a quadratic amount of candidate-building work and a DAO query per
+     * candidate. No real element can ever be stored with a path over that length, so no
+     * candidate could possibly match one either - skip fallback entirely once the path is
+     * already too long to be real.
+     *
      * @internal
      *
      * @throws Model\Exception\NotFoundException
@@ -887,6 +895,10 @@ class Service extends Model\AbstractModel
 
             return;
         } catch (Model\Exception\NotFoundException $e) {
+            if (mb_strlen($path) > AbstractElement::MAX_FULL_PATH_LENGTH) {
+                throw $e;
+            }
+
             foreach (self::getNfcFallbackPathCandidates($path) as $candidate) {
                 try {
                     $attempt($candidate);

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -829,30 +829,34 @@ class Service extends Model\AbstractModel
      * browser's webkitdirectory/File System Access API on macOS) has no way to know where that
      * boundary is, so every accented segment arrives in NFD form regardless.
      *
-     * Candidates therefore normalize progressively longer *trailing* suffixes of the path to
-     * NFC, from "just the final segment" up to "the entire path", leaving the remaining prefix
-     * byte-for-byte untouched in each candidate:
+     * Candidates therefore normalize progressively shorter *trailing* suffixes of the path to
+     * NFC, from "the entire path" down to "just the final segment", leaving the remaining
+     * prefix byte-for-byte untouched in each candidate. The entire-path candidate is tried
+     * first because the common case - and the one motivating this fix - is an entire subtree
+     * freshly created in the same operation (e.g. a Studio folder upload), where every segment
+     * is NFC-stored; trying the narrowest candidates first would cost one DAO query per path
+     * depth for that common case before ever reaching the one that matches. A legacy ancestor
+     * mixed with freshly created descendants is the rarer case and can afford the extra
+     * queries down to the shorter suffixes:
      *
+     * - a lookup path where every segment was freshly created in the same operation is
+     *   resolved by the "entire path normalized" candidate (the first one tried).
      * - path `/Legacy café/New café/Child café` stored as NFD/NFC/NFC (the middle and last
      *   segment freshly created under a legacy first segment) is resolved by the
      *   "last 2 segments normalized" candidate, without touching the still-NFD first segment.
-     * - a lookup path where every segment was freshly created in the same operation is
-     *   resolved by the "entire path normalized" candidate (the last one tried).
      *
      * This is intentionally not applied unconditionally in correctPath(), since that would
      * break the exact-path lookup for elements whose key is still stored in NFD form.
      *
-     * @internal
-     *
      * @return string[]
      */
-    public static function getNfcFallbackPathCandidates(string $path): array
+    private static function getNfcFallbackPathCandidates(string $path): array
     {
         $segments = explode('/', $path);
         $segmentCount = count($segments);
 
         $candidates = [];
-        for ($suffixLength = 1; $suffixLength <= $segmentCount; $suffixLength++) {
+        for ($suffixLength = $segmentCount; $suffixLength >= 1; $suffixLength--) {
             $candidateSegments = $segments;
             for ($i = $segmentCount - $suffixLength; $i < $segmentCount; $i++) {
                 $candidateSegments[$i] = self::normalizeToNfc($candidateSegments[$i]);

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -808,15 +808,27 @@ class Service extends Model\AbstractModel
             $path = rawurldecode($path);
         }
 
-        // normalize to NFC to match the form keys are stored in (see getValidKey()), otherwise a
-        // path built from a decomposed (NFD) source - e.g. macOS filesystems, or a browser's
-        // webkitdirectory/File System Access API on macOS - would fail to resolve an element whose
-        // key was stored precomposed, even right after that element was just created
-        if (Normalizer::isNormalized($path, Normalizer::FORM_C) === false) {
-            $path = Normalizer::normalize($path, Normalizer::FORM_C) ?: $path;
+        return $path;
+    }
+
+    /**
+     * Normalizes a path to precomposed (NFC) Unicode form, matching the form element keys are
+     * stored in (see getValidKey()). Used as a fallback by getByPath() lookups: a path built from
+     * a decomposed (NFD) source - e.g. macOS filesystems, or a browser's webkitdirectory/File
+     * System Access API on macOS - would otherwise fail to resolve an element whose key was
+     * stored precomposed. It is intentionally not applied unconditionally in correctPath(), since
+     * that would break the exact-path lookup for elements whose key is still stored in NFD form
+     * (created before keys were normalized to NFC on write).
+     *
+     * @internal
+     */
+    public static function normalizePathToNfc(string $path): string
+    {
+        if (Normalizer::isNormalized($path, Normalizer::FORM_C)) {
+            return $path;
         }
 
-        return $path;
+        return Normalizer::normalize($path, Normalizer::FORM_C) ?: $path;
     }
 
     /**

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -894,15 +894,14 @@ class Service extends Model\AbstractModel
      *
      * getByPath() is a public API that accepts arbitrary caller-supplied strings, unconstrained
      * by ElementInterface::MAX_FULL_PATH_LENGTH (that limit is only enforced at save time, see
-     * AbstractElement::validatePathLength()). Without a bound here, an overlength path with many
-     * segments would turn one miss into a quadratic amount of candidate-building work and a DAO
-     * query per candidate (further capped at MAX_FALLBACK_CANDIDATES regardless, see
-     * getNfcFallbackPathCandidates()). The bound is checked against the *fully NFC-normalized*
-     * length, not the raw input length: NFC composition never lengthens a string (it can only
-     * combine a base character with a combining mark into one precomposed character), so the
-     * normalized form is the shortest any candidate can be - a decomposed (NFD) path can
-     * legitimately be much longer than MAX_FULL_PATH_LENGTH while still normalizing to a real,
-     * storable path, and checking the raw length would incorrectly reject that case.
+     * AbstractElement::validatePathLength()). The number of candidates - and therefore DAO
+     * queries and candidate-building work - a caller-controlled miss can trigger is bounded by
+     * MAX_FALLBACK_CANDIDATES alone (see getNfcFallbackPathCandidates()), regardless of the raw
+     * path's length. A length-based short-circuit was deliberately not used here: composition
+     * exclusions in Unicode (e.g. U+0344, which NFC always decomposes to U+0308 U+0301) mean NFC
+     * normalization does not strictly guarantee a shorter or equal-length string in every case,
+     * so a fully-normalized path's length is not a reliable lower bound for what a legitimate
+     * preserved-prefix candidate could be.
      *
      * @internal
      *
@@ -915,10 +914,6 @@ class Service extends Model\AbstractModel
 
             return;
         } catch (Model\Exception\NotFoundException $e) {
-            if (mb_strlen(self::normalizeToNfc($path)) > ElementInterface::MAX_FULL_PATH_LENGTH) {
-                throw $e;
-            }
-
             foreach (self::getNfcFallbackPathCandidates($path) as $candidate) {
                 try {
                     $attempt($candidate);
@@ -1134,11 +1129,21 @@ class Service extends Model\AbstractModel
         return self::getValidKey($key, $type) == $key;
     }
 
+    /**
+     * A segment that is not a valid key purely because it is still in decomposed (NFD) Unicode
+     * form is nonetheless accepted here - isValidKey()/getValidKey() always normalize to NFC
+     * (see getValidKey()), so a segment created before that normalization existed would
+     * otherwise never pass. This method's only callers are the *\Service::pathExists()
+     * existence checks (see getByPathWithNfcFallback()), where that must be consistent with
+     * getByPath() resolving the very same path; it is intentionally not applied to
+     * isValidKey() itself, which is also used to validate a *new* key at save time and must
+     * keep rejecting anything not already precomposed.
+     */
     public static function isValidPath(string $path, string $type): bool
     {
         $parts = explode('/', $path);
         foreach ($parts as $part) {
-            if (!self::isValidKey($part, $type)) {
+            if (!self::isValidKey($part, $type) && !self::isValidKey(self::normalizeToNfc($part), $type)) {
                 return false;
             }
         }

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -848,6 +848,14 @@ class Service extends Model\AbstractModel
      * This is intentionally not applied unconditionally in correctPath(), since that would
      * break the exact-path lookup for elements whose key is still stored in NFD form.
      *
+     * Capped at MAX_FALLBACK_CANDIDATES: getByPath() is a public API that accepts arbitrary
+     * caller-supplied strings, and a path within the maximum real path length (see
+     * getByPathWithNfcFallback()) can still be split into many short segments, each one a
+     * distinct candidate and a DAO query. The cap bounds both the candidate-building work here
+     * and the number of queries the caller triggers to a small, fixed number, at the cost of
+     * only the narrowest (least likely to be needed) suffix candidates in a pathologically
+     * deep, all-legacy-until-the-last-few-levels hierarchy.
+     *
      * @return string[]
      */
     private static function getNfcFallbackPathCandidates(string $path): array
@@ -856,7 +864,7 @@ class Service extends Model\AbstractModel
         $segmentCount = count($segments);
 
         $candidates = [];
-        for ($suffixLength = $segmentCount; $suffixLength >= 1; $suffixLength--) {
+        for ($suffixLength = $segmentCount; $suffixLength >= 1 && count($candidates) < self::MAX_FALLBACK_CANDIDATES; $suffixLength--) {
             $candidateSegments = $segments;
             for ($i = $segmentCount - $suffixLength; $i < $segmentCount; $i++) {
                 $candidateSegments[$i] = self::normalizeToNfc($candidateSegments[$i]);
@@ -872,17 +880,29 @@ class Service extends Model\AbstractModel
     }
 
     /**
+     * The maximum number of fallback candidates getNfcFallbackPathCandidates() will build and
+     * getByPathWithNfcFallback() will query for. A realistic element hierarchy is rarely more
+     * than a handful of levels deep; this is generous headroom over that while still bounding
+     * the number of DAO queries one caller-controlled miss can trigger to a small, fixed number.
+     */
+    private const MAX_FALLBACK_CANDIDATES = 32;
+
+    /**
      * Runs a getByPath() DAO lookup, retrying with the Unicode-normalized path candidates from
      * getNfcFallbackPathCandidates() if the exact path misses. Centralizes the retry policy so
      * Asset, Document and DataObject don't each reimplement it.
      *
      * getByPath() is a public API that accepts arbitrary caller-supplied strings, unconstrained
-     * by AbstractElement::MAX_FULL_PATH_LENGTH (that limit is only enforced at save time, see
-     * validatePathLength()). Without a bound here, an overlength path with many segments would
-     * turn one miss into a quadratic amount of candidate-building work and a DAO query per
-     * candidate. No real element can ever be stored with a path over that length, so no
-     * candidate could possibly match one either - skip fallback entirely once the path is
-     * already too long to be real.
+     * by ElementInterface::MAX_FULL_PATH_LENGTH (that limit is only enforced at save time, see
+     * AbstractElement::validatePathLength()). Without a bound here, an overlength path with many
+     * segments would turn one miss into a quadratic amount of candidate-building work and a DAO
+     * query per candidate (further capped at MAX_FALLBACK_CANDIDATES regardless, see
+     * getNfcFallbackPathCandidates()). The bound is checked against the *fully NFC-normalized*
+     * length, not the raw input length: NFC composition never lengthens a string (it can only
+     * combine a base character with a combining mark into one precomposed character), so the
+     * normalized form is the shortest any candidate can be - a decomposed (NFD) path can
+     * legitimately be much longer than MAX_FULL_PATH_LENGTH while still normalizing to a real,
+     * storable path, and checking the raw length would incorrectly reject that case.
      *
      * @internal
      *
@@ -895,7 +915,7 @@ class Service extends Model\AbstractModel
 
             return;
         } catch (Model\Exception\NotFoundException $e) {
-            if (mb_strlen($path) > AbstractElement::MAX_FULL_PATH_LENGTH) {
+            if (mb_strlen(self::normalizeToNfc($path)) > ElementInterface::MAX_FULL_PATH_LENGTH) {
                 throw $e;
             }
 

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -808,6 +808,14 @@ class Service extends Model\AbstractModel
             $path = rawurldecode($path);
         }
 
+        // normalize to NFC to match the form keys are stored in (see getValidKey()), otherwise a
+        // path built from a decomposed (NFD) source - e.g. macOS filesystems, or a browser's
+        // webkitdirectory/File System Access API on macOS - would fail to resolve an element whose
+        // key was stored precomposed, even right after that element was just created
+        if (Normalizer::isNormalized($path, Normalizer::FORM_C) === false) {
+            $path = Normalizer::normalize($path, Normalizer::FORM_C) ?: $path;
+        }
+
         return $path;
     }
 

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -823,19 +823,24 @@ class Service extends Model\AbstractModel
     /**
      * Builds fallback path candidates for getByPath() lookups, tried in order once the exact
      * path misses. Only newly created element keys are normalized to NFC on write (see
-     * getValidKey()), so an element's ancestors may still be stored in decomposed (NFD) form
-     * from before that normalization existed - the two forms of mismatch are independent and
-     * both need a candidate:
+     * getValidKey()), so an arbitrary number of trailing path segments may be freshly created
+     * (NFC-stored) while an arbitrary-depth ancestor prefix is still stored in legacy
+     * decomposed (NFD) form from before that normalization existed - and the caller (e.g. a
+     * browser's webkitdirectory/File System Access API on macOS) has no way to know where that
+     * boundary is, so every accented segment arrives in NFD form regardless.
      *
-     * - dirname unchanged, final key normalized to NFC: resolves a freshly created element
-     *   whose parent path is still stored in legacy NFD form.
-     * - the full path normalized to NFC: resolves a lookup path where every segment - parent
-     *   and key alike - was freshly created (and is thus NFC-stored) in the same operation,
-     *   but the incoming request path still arrives in decomposed (NFD) form, e.g. a browser's
-     *   webkitdirectory/File System Access API on macOS.
+     * Candidates therefore normalize progressively longer *trailing* suffixes of the path to
+     * NFC, from "just the final segment" up to "the entire path", leaving the remaining prefix
+     * byte-for-byte untouched in each candidate:
      *
-     * It is intentionally not applied unconditionally in correctPath(), since that would break
-     * the exact-path lookup for elements whose key is still stored in NFD form.
+     * - path `/Legacy café/New café/Child café` stored as NFD/NFC/NFC (the middle and last
+     *   segment freshly created under a legacy first segment) is resolved by the
+     *   "last 2 segments normalized" candidate, without touching the still-NFD first segment.
+     * - a lookup path where every segment was freshly created in the same operation is
+     *   resolved by the "entire path normalized" candidate (the last one tried).
+     *
+     * This is intentionally not applied unconditionally in correctPath(), since that would
+     * break the exact-path lookup for elements whose key is still stored in NFD form.
      *
      * @internal
      *
@@ -843,21 +848,20 @@ class Service extends Model\AbstractModel
      */
     public static function getNfcFallbackPathCandidates(string $path): array
     {
-        $candidates = [];
+        $segments = explode('/', $path);
+        $segmentCount = count($segments);
 
-        $lastSlash = strrpos($path, '/');
-        if ($lastSlash !== false) {
-            $dirname = substr($path, 0, $lastSlash + 1);
-            $key = substr($path, $lastSlash + 1);
-            $candidate = $dirname . self::normalizeToNfc($key);
-            if ($candidate !== $path) {
+        $candidates = [];
+        for ($suffixLength = 1; $suffixLength <= $segmentCount; $suffixLength++) {
+            $candidateSegments = $segments;
+            for ($i = $segmentCount - $suffixLength; $i < $segmentCount; $i++) {
+                $candidateSegments[$i] = self::normalizeToNfc($candidateSegments[$i]);
+            }
+
+            $candidate = implode('/', $candidateSegments);
+            if ($candidate !== $path && !in_array($candidate, $candidates, true)) {
                 $candidates[] = $candidate;
             }
-        }
-
-        $fullyNormalized = self::normalizeToNfc($path);
-        if ($fullyNormalized !== $path && !in_array($fullyNormalized, $candidates, true)) {
-            $candidates[] = $fullyNormalized;
         }
 
         return $candidates;

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -811,24 +811,86 @@ class Service extends Model\AbstractModel
         return $path;
     }
 
-    /**
-     * Normalizes a path to precomposed (NFC) Unicode form, matching the form element keys are
-     * stored in (see getValidKey()). Used as a fallback by getByPath() lookups: a path built from
-     * a decomposed (NFD) source - e.g. macOS filesystems, or a browser's webkitdirectory/File
-     * System Access API on macOS - would otherwise fail to resolve an element whose key was
-     * stored precomposed. It is intentionally not applied unconditionally in correctPath(), since
-     * that would break the exact-path lookup for elements whose key is still stored in NFD form
-     * (created before keys were normalized to NFC on write).
-     *
-     * @internal
-     */
-    public static function normalizePathToNfc(string $path): string
+    private static function normalizeToNfc(string $value): string
     {
-        if (Normalizer::isNormalized($path, Normalizer::FORM_C)) {
-            return $path;
+        if (Normalizer::isNormalized($value, Normalizer::FORM_C)) {
+            return $value;
         }
 
-        return Normalizer::normalize($path, Normalizer::FORM_C) ?: $path;
+        return Normalizer::normalize($value, Normalizer::FORM_C) ?: $value;
+    }
+
+    /**
+     * Builds fallback path candidates for getByPath() lookups, tried in order once the exact
+     * path misses. Only newly created element keys are normalized to NFC on write (see
+     * getValidKey()), so an element's ancestors may still be stored in decomposed (NFD) form
+     * from before that normalization existed - the two forms of mismatch are independent and
+     * both need a candidate:
+     *
+     * - dirname unchanged, final key normalized to NFC: resolves a freshly created element
+     *   whose parent path is still stored in legacy NFD form.
+     * - the full path normalized to NFC: resolves a lookup path where every segment - parent
+     *   and key alike - was freshly created (and is thus NFC-stored) in the same operation,
+     *   but the incoming request path still arrives in decomposed (NFD) form, e.g. a browser's
+     *   webkitdirectory/File System Access API on macOS.
+     *
+     * It is intentionally not applied unconditionally in correctPath(), since that would break
+     * the exact-path lookup for elements whose key is still stored in NFD form.
+     *
+     * @internal
+     *
+     * @return string[]
+     */
+    public static function getNfcFallbackPathCandidates(string $path): array
+    {
+        $candidates = [];
+
+        $lastSlash = strrpos($path, '/');
+        if ($lastSlash !== false) {
+            $dirname = substr($path, 0, $lastSlash + 1);
+            $key = substr($path, $lastSlash + 1);
+            $candidate = $dirname . self::normalizeToNfc($key);
+            if ($candidate !== $path) {
+                $candidates[] = $candidate;
+            }
+        }
+
+        $fullyNormalized = self::normalizeToNfc($path);
+        if ($fullyNormalized !== $path && !in_array($fullyNormalized, $candidates, true)) {
+            $candidates[] = $fullyNormalized;
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * Runs a getByPath() DAO lookup, retrying with the Unicode-normalized path candidates from
+     * getNfcFallbackPathCandidates() if the exact path misses. Centralizes the retry policy so
+     * Asset, Document and DataObject don't each reimplement it.
+     *
+     * @internal
+     *
+     * @throws Model\Exception\NotFoundException
+     */
+    public static function getByPathWithNfcFallback(callable $attempt, string $path): void
+    {
+        try {
+            $attempt($path);
+
+            return;
+        } catch (Model\Exception\NotFoundException $e) {
+            foreach (self::getNfcFallbackPathCandidates($path) as $candidate) {
+                try {
+                    $attempt($candidate);
+
+                    return;
+                } catch (Model\Exception\NotFoundException) {
+                    continue;
+                }
+            }
+
+            throw $e;
+        }
     }
 
     /**

--- a/tests/Model/Asset/AssetTest.php
+++ b/tests/Model/Asset/AssetTest.php
@@ -467,7 +467,7 @@ class AssetTest extends ModelTestCase
      * webkitdirectory/File System Access API on macOS - by falling back to the NFC-normalized
      * path once the exact-path lookup misses.
      *
-     * @see \Pimcore\Model\Element\Service::normalizePathToNfc()
+     * @see \Pimcore\Model\Element\Service::getByPathWithNfcFallback()
      */
     public function testGetByPathFallsBackToNfcForNfdLookupPath(): void
     {

--- a/tests/Model/Asset/AssetTest.php
+++ b/tests/Model/Asset/AssetTest.php
@@ -15,6 +15,7 @@ namespace Pimcore\Tests\Model\Asset;
 
 use Exception;
 use Normalizer;
+use Pimcore\Db;
 use Pimcore\Model\Asset;
 use Pimcore\Tests\Support\Test\ModelTestCase;
 use Pimcore\Tests\Support\Util\TestHelper;
@@ -427,23 +428,34 @@ class AssetTest extends ModelTestCase
      * decomposed (NFD) Unicode form - e.g. created before element keys were normalized to NFC
      * on write - via an exact-path lookup using that very same NFD path.
      *
+     * The model API can no longer persist such a key directly: Asset::save() -> correctPath()
+     * rejects it via Service::isValidKey(), which itself always normalizes to NFC before
+     * comparing (see #19242). So the legacy row is created via a valid NFC key first, then
+     * rewritten to NFD directly in the database - bypassing model validation - to simulate a
+     * pre-#19242 row.
+     *
      * @see \Pimcore\Model\Element\Service::correctPath()
      */
     public function testGetByPathResolvesLegacyNfdStoredKeyByExactMatch(): void
     {
-        $nfdKey = Normalizer::normalize('nfd-café-' . uniqid(), Normalizer::FORM_D);
+        $nfcKey = Normalizer::normalize('nfd-café-' . uniqid(), Normalizer::FORM_C);
+        $nfdKey = Normalizer::normalize($nfcKey, Normalizer::FORM_D);
         $this->assertNotSame(
+            $nfcKey,
             $nfdKey,
-            Normalizer::normalize($nfdKey, Normalizer::FORM_C),
             'Test fixture setup issue: NFD and NFC forms should differ in bytes.'
         );
 
         $folder = new Asset\Folder();
         $folder->setParentId(1);
-        $folder->setFilename($nfdKey);
+        $folder->setFilename($nfcKey);
         $folder->save();
 
-        $found = Asset::getByPath($folder->getFullPath());
+        $lookupPath = $folder->getRealPath() . $nfdKey;
+
+        Db::get()->update('assets', ['filename' => $nfdKey], ['id' => $folder->getId()]);
+
+        $found = Asset::getByPath($lookupPath, ['force' => true]);
 
         $this->assertInstanceOf(Asset::class, $found);
         $this->assertSame($folder->getId(), $found->getId());

--- a/tests/Model/Asset/AssetTest.php
+++ b/tests/Model/Asset/AssetTest.php
@@ -421,4 +421,61 @@ class AssetTest extends ModelTestCase
 
         $this->assertEquals('image/jpeg', $asset->getMimeType());
     }
+
+    /**
+     * Regression test: getByPath() must still resolve an element whose key is stored in
+     * decomposed (NFD) Unicode form - e.g. created before element keys were normalized to NFC
+     * on write - via an exact-path lookup using that very same NFD path.
+     *
+     * @see \Pimcore\Model\Element\Service::correctPath()
+     */
+    public function testGetByPathResolvesLegacyNfdStoredKeyByExactMatch(): void
+    {
+        $nfdKey = Normalizer::normalize('nfd-café-' . uniqid(), Normalizer::FORM_D);
+        $this->assertNotSame(
+            $nfdKey,
+            Normalizer::normalize($nfdKey, Normalizer::FORM_C),
+            'Test fixture setup issue: NFD and NFC forms should differ in bytes.'
+        );
+
+        $folder = new Asset\Folder();
+        $folder->setParentId(1);
+        $folder->setFilename($nfdKey);
+        $folder->save();
+
+        $found = Asset::getByPath($folder->getFullPath());
+
+        $this->assertInstanceOf(Asset::class, $found);
+        $this->assertSame($folder->getId(), $found->getId());
+    }
+
+    /**
+     * Regression test: getByPath() must resolve an element whose key is stored precomposed
+     * (NFC) when the caller supplies a decomposed (NFD) lookup path - e.g. a browser's
+     * webkitdirectory/File System Access API on macOS - by falling back to the NFC-normalized
+     * path once the exact-path lookup misses.
+     *
+     * @see \Pimcore\Model\Element\Service::normalizePathToNfc()
+     */
+    public function testGetByPathFallsBackToNfcForNfdLookupPath(): void
+    {
+        $nfcKey = Normalizer::normalize('nfc-café-' . uniqid(), Normalizer::FORM_C);
+
+        $folder = new Asset\Folder();
+        $folder->setParentId(1);
+        $folder->setFilename($nfcKey);
+        $folder->save();
+
+        $nfdLookupPath = Normalizer::normalize($folder->getFullPath(), Normalizer::FORM_D);
+        $this->assertNotSame(
+            $folder->getFullPath(),
+            $nfdLookupPath,
+            'Test fixture setup issue: NFD and NFC forms should differ in bytes.'
+        );
+
+        $found = Asset::getByPath($nfdLookupPath);
+
+        $this->assertInstanceOf(Asset::class, $found);
+        $this->assertSame($folder->getId(), $found->getId());
+    }
 }

--- a/tests/Model/Asset/AssetTest.php
+++ b/tests/Model/Asset/AssetTest.php
@@ -499,7 +499,7 @@ class AssetTest extends ModelTestCase
      * at normalizing only the final segment; it needs to try normalizing progressively longer
      * trailing suffixes of the path.
      *
-     * @see \Pimcore\Model\Element\Service::getNfcFallbackPathCandidates()
+     * @see \Pimcore\Model\Element\Service::getByPathWithNfcFallback()
      */
     public function testGetByPathResolvesNestedMixedHierarchy(): void
     {

--- a/tests/Model/Asset/AssetTest.php
+++ b/tests/Model/Asset/AssetTest.php
@@ -490,4 +490,58 @@ class AssetTest extends ModelTestCase
         $this->assertInstanceOf(Asset::class, $found);
         $this->assertSame($folder->getId(), $found->getId());
     }
+
+    /**
+     * Regression test: a nested hierarchy where a legacy NFD-stored ancestor has one or more
+     * freshly created (NFC-stored) descendants below it must still resolve when every accented
+     * segment of the lookup path arrives in decomposed (NFD) form - the caller has no way to
+     * know which segments are legacy and which are freshly created. getByPath() must not stop
+     * at normalizing only the final segment; it needs to try normalizing progressively longer
+     * trailing suffixes of the path.
+     *
+     * @see \Pimcore\Model\Element\Service::getNfcFallbackPathCandidates()
+     */
+    public function testGetByPathResolvesNestedMixedHierarchy(): void
+    {
+        $legacyNfcKey = Normalizer::normalize('legacy-café-' . uniqid(), Normalizer::FORM_C);
+        $legacyNfdKey = Normalizer::normalize($legacyNfcKey, Normalizer::FORM_D);
+        $this->assertNotSame(
+            $legacyNfcKey,
+            $legacyNfdKey,
+            'Test fixture setup issue: NFD and NFC forms should differ in bytes.'
+        );
+
+        // simulate a legacy pre-#19242 ancestor whose key is stored in decomposed (NFD) form
+        $legacyFolder = new Asset\Folder();
+        $legacyFolder->setParentId(1);
+        $legacyFolder->setFilename($legacyNfcKey);
+        $legacyFolder->save();
+        Db::get()->update('assets', ['filename' => $legacyNfdKey], ['id' => $legacyFolder->getId()]);
+
+        // freshly created descendants below the legacy ancestor - their keys are stored NFC,
+        // and their own 'path' column is derived from the parent's *current* (NFD) path
+        $middleFolder = new Asset\Folder();
+        $middleFolder->setParentId($legacyFolder->getId());
+        $middleFolder->setFilename(Normalizer::normalize('new café middle', Normalizer::FORM_C));
+        $middleFolder->save();
+
+        $leafFolder = new Asset\Folder();
+        $leafFolder->setParentId($middleFolder->getId());
+        $leafFolder->setFilename(Normalizer::normalize('new café leaf', Normalizer::FORM_C));
+        $leafFolder->save();
+
+        // what a browser submits: every accented segment in NFD, regardless of which segments
+        // are legacy and which are freshly created
+        $nfdLookupPath = Normalizer::normalize($leafFolder->getRealFullPath(), Normalizer::FORM_D);
+        $this->assertNotSame(
+            $leafFolder->getRealFullPath(),
+            $nfdLookupPath,
+            'Test fixture setup issue: NFD and NFC forms should differ in bytes.'
+        );
+
+        $found = Asset::getByPath($nfdLookupPath, ['force' => true]);
+
+        $this->assertInstanceOf(Asset::class, $found);
+        $this->assertSame($leafFolder->getId(), $found->getId());
+    }
 }

--- a/tests/Model/Asset/AssetTest.php
+++ b/tests/Model/Asset/AssetTest.php
@@ -17,6 +17,7 @@ use Exception;
 use Normalizer;
 use Pimcore\Db;
 use Pimcore\Model\Asset;
+use Pimcore\Model\Asset\Service as AssetService;
 use Pimcore\Tests\Support\Test\ModelTestCase;
 use Pimcore\Tests\Support\Util\TestHelper;
 use Pimcore\Tool\Storage;
@@ -543,5 +544,35 @@ class AssetTest extends ModelTestCase
 
         $this->assertInstanceOf(Asset::class, $found);
         $this->assertSame($leafFolder->getId(), $found->getId());
+    }
+
+    /**
+     * Regression test: Asset\Service::pathExists() must agree with Asset::getByPath() on
+     * whether a path resolves. Without routing pathExists() through the same NFC fallback,
+     * a caller could see pathExists() return false for the very same NFD lookup path that
+     * getByPath() successfully resolves, and incorrectly treat an existing asset as absent.
+     *
+     * @see \Pimcore\Model\Element\Service::getByPathWithNfcFallback()
+     */
+    public function testPathExistsAgreesWithGetByPathForNfdLookupPath(): void
+    {
+        $nfcKey = Normalizer::normalize('nfc-café-' . uniqid(), Normalizer::FORM_C);
+
+        $folder = new Asset\Folder();
+        $folder->setParentId(1);
+        $folder->setFilename($nfcKey);
+        $folder->save();
+
+        $nfdLookupPath = Normalizer::normalize($folder->getFullPath(), Normalizer::FORM_D);
+        $this->assertNotSame(
+            $folder->getFullPath(),
+            $nfdLookupPath,
+            'Test fixture setup issue: NFD and NFC forms should differ in bytes.'
+        );
+
+        $this->assertTrue(
+            AssetService::pathExists($nfdLookupPath),
+            'pathExists() must return true for the same NFD path that getByPath() resolves.'
+        );
     }
 }

--- a/tests/Model/DataObject/ObjectTest.php
+++ b/tests/Model/DataObject/ObjectTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Tests\Model\DataObject;
 
 use Exception;
+use Normalizer;
 use Pimcore\Db;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\QuantityValue\Unit;
@@ -400,5 +401,75 @@ class ObjectTest extends ModelTestCase
 
         $targetObject->setInput($randomText);
         $targetObject->save();
+    }
+
+    /**
+     * Regression test: DataObject\AbstractObject::getByPath() must resolve an object whose key
+     * is stored precomposed (NFC) when the caller supplies a decomposed (NFD) lookup path -
+     * e.g. a browser's webkitdirectory/File System Access API on macOS - by falling back to
+     * the NFC-normalized path once the exact-path lookup misses. DataObject's getByPath() is
+     * an independently implemented call site of the shared Element\Service fallback, so it
+     * needs its own coverage rather than relying on the Asset regression tests alone.
+     *
+     * @see \Pimcore\Model\Element\Service::getByPathWithNfcFallback()
+     */
+    public function testGetByPathFallsBackToNfcForNfdLookupPath(): void
+    {
+        $nfcKey = Normalizer::normalize('nfc-café-' . uniqid(), Normalizer::FORM_C);
+
+        $folder = new DataObject\Folder();
+        $folder->setParentId(1);
+        $folder->setKey($nfcKey);
+        $folder->save();
+
+        $nfdLookupPath = Normalizer::normalize($folder->getFullPath(), Normalizer::FORM_D);
+        $this->assertNotSame(
+            $folder->getFullPath(),
+            $nfdLookupPath,
+            'Test fixture setup issue: NFD and NFC forms should differ in bytes.'
+        );
+
+        $found = DataObject::getByPath($nfdLookupPath, ['force' => true]);
+
+        $this->assertInstanceOf(DataObject::class, $found);
+        $this->assertSame($folder->getId(), $found->getId());
+    }
+
+    /**
+     * Regression test: DataObject\AbstractObject::getByPath() must still resolve an object
+     * whose key is stored in decomposed (NFD) Unicode form - e.g. created before object keys
+     * were normalized to NFC on write - via an exact-path lookup using that very same NFD
+     * path.
+     *
+     * The model API can no longer persist such a key directly: AbstractObject::save() rejects
+     * it via Service::isValidKey(), which always normalizes to NFC before comparing (#19242).
+     * So the legacy row is created via a valid NFC key first, then rewritten to NFD directly
+     * in the database - bypassing model validation - to simulate a pre-#19242 row.
+     *
+     * @see \Pimcore\Model\Element\Service::correctPath()
+     */
+    public function testGetByPathResolvesLegacyNfdStoredKeyByExactMatch(): void
+    {
+        $nfcKey = Normalizer::normalize('nfd-café-' . uniqid(), Normalizer::FORM_C);
+        $nfdKey = Normalizer::normalize($nfcKey, Normalizer::FORM_D);
+        $this->assertNotSame(
+            $nfcKey,
+            $nfdKey,
+            'Test fixture setup issue: NFD and NFC forms should differ in bytes.'
+        );
+
+        $folder = new DataObject\Folder();
+        $folder->setParentId(1);
+        $folder->setKey($nfcKey);
+        $folder->save();
+
+        $lookupPath = $folder->getRealPath() . $nfdKey;
+
+        Db::get()->update('objects', ['key' => $nfdKey], ['id' => $folder->getId()]);
+
+        $found = DataObject::getByPath($lookupPath, ['force' => true]);
+
+        $this->assertInstanceOf(DataObject::class, $found);
+        $this->assertSame($folder->getId(), $found->getId());
     }
 }

--- a/tests/Model/DataObject/ObjectTest.php
+++ b/tests/Model/DataObject/ObjectTest.php
@@ -16,6 +16,7 @@ namespace Pimcore\Tests\Model\DataObject;
 use Exception;
 use Normalizer;
 use Pimcore\Db;
+use Pimcore\Db\Helper as DbHelper;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\QuantityValue\Unit;
 use Pimcore\Model\Element\Service;
@@ -465,7 +466,8 @@ class ObjectTest extends ModelTestCase
 
         $lookupPath = $folder->getRealPath() . $nfdKey;
 
-        Db::get()->update('objects', ['key' => $nfdKey], ['id' => $folder->getId()]);
+        $db = Db::get();
+        $db->update('objects', DbHelper::quoteDataIdentifiers($db, ['key' => $nfdKey]), ['id' => $folder->getId()]);
 
         $found = DataObject::getByPath($lookupPath, ['force' => true]);
 

--- a/tests/Model/DataObject/ObjectTest.php
+++ b/tests/Model/DataObject/ObjectTest.php
@@ -19,6 +19,7 @@ use Pimcore\Db;
 use Pimcore\Db\Helper as DbHelper;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\QuantityValue\Unit;
+use Pimcore\Model\DataObject\Service as DataObjectService;
 use Pimcore\Model\Element\Service;
 use Pimcore\Model\Element\ValidationException;
 use Pimcore\Tests\Support\Test\ModelTestCase;
@@ -473,5 +474,36 @@ class ObjectTest extends ModelTestCase
 
         $this->assertInstanceOf(DataObject::class, $found);
         $this->assertSame($folder->getId(), $found->getId());
+    }
+
+    /**
+     * Regression test: DataObject\Service::pathExists() must agree with
+     * DataObject\AbstractObject::getByPath() on whether a path resolves. Without routing
+     * pathExists() through the same NFC fallback, a caller could see pathExists() return false
+     * for the very same NFD lookup path that getByPath() successfully resolves, and
+     * incorrectly treat an existing object as absent.
+     *
+     * @see \Pimcore\Model\Element\Service::getByPathWithNfcFallback()
+     */
+    public function testPathExistsAgreesWithGetByPathForNfdLookupPath(): void
+    {
+        $nfcKey = Normalizer::normalize('nfc-café-' . uniqid(), Normalizer::FORM_C);
+
+        $folder = new DataObject\Folder();
+        $folder->setParentId(1);
+        $folder->setKey($nfcKey);
+        $folder->save();
+
+        $nfdLookupPath = Normalizer::normalize($folder->getFullPath(), Normalizer::FORM_D);
+        $this->assertNotSame(
+            $folder->getFullPath(),
+            $nfdLookupPath,
+            'Test fixture setup issue: NFD and NFC forms should differ in bytes.'
+        );
+
+        $this->assertTrue(
+            DataObjectService::pathExists($nfdLookupPath),
+            'pathExists() must return true for the same NFD path that getByPath() resolves.'
+        );
     }
 }

--- a/tests/Model/Document/DocumentTest.php
+++ b/tests/Model/Document/DocumentTest.php
@@ -16,6 +16,7 @@ namespace Pimcore\Tests\Model\Document;
 use Exception;
 use Normalizer;
 use Pimcore\Db;
+use Pimcore\Db\Helper as DbHelper;
 use Pimcore\Model\Document;
 use Pimcore\Model\Document\Editable\Input;
 use Pimcore\Model\Document\Email;
@@ -442,7 +443,8 @@ class DocumentTest extends ModelTestCase
 
         $lookupPath = $folder->getRealPath() . $nfdKey;
 
-        Db::get()->update('documents', ['key' => $nfdKey], ['id' => $folder->getId()]);
+        $db = Db::get();
+        $db->update('documents', DbHelper::quoteDataIdentifiers($db, ['key' => $nfdKey]), ['id' => $folder->getId()]);
 
         $found = Document::getByPath($lookupPath, ['force' => true]);
 

--- a/tests/Model/Document/DocumentTest.php
+++ b/tests/Model/Document/DocumentTest.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 namespace Pimcore\Tests\Model\Document;
 
 use Exception;
+use Normalizer;
+use Pimcore\Db;
+use Pimcore\Model\Document;
 use Pimcore\Model\Document\Editable\Input;
 use Pimcore\Model\Document\Email;
 use Pimcore\Model\Document\Link;
@@ -376,5 +379,74 @@ class DocumentTest extends ModelTestCase
         $loadedDocument = Service::getElementFromSession('document', $document->getId(), $session->getId());
 
         $this->assertEquals(count($document->getEditables()), count($loadedDocument->getEditables()));
+    }
+
+    /**
+     * Regression test: Document::getByPath() must resolve a document whose key is stored
+     * precomposed (NFC) when the caller supplies a decomposed (NFD) lookup path - e.g. a
+     * browser's webkitdirectory/File System Access API on macOS - by falling back to the
+     * NFC-normalized path once the exact-path lookup misses. Document's getByPath() has its
+     * own pretty-URL and runtime-cache handling on top of the shared Element\Service fallback,
+     * so it needs its own coverage rather than relying on the Asset regression tests alone.
+     *
+     * @see \Pimcore\Model\Element\Service::getByPathWithNfcFallback()
+     */
+    public function testGetByPathFallsBackToNfcForNfdLookupPath(): void
+    {
+        $nfcKey = Normalizer::normalize('nfc-café-' . uniqid(), Normalizer::FORM_C);
+
+        $folder = new Document\Folder();
+        $folder->setParentId(1);
+        $folder->setKey($nfcKey);
+        $folder->save();
+
+        $nfdLookupPath = Normalizer::normalize($folder->getFullPath(), Normalizer::FORM_D);
+        $this->assertNotSame(
+            $folder->getFullPath(),
+            $nfdLookupPath,
+            'Test fixture setup issue: NFD and NFC forms should differ in bytes.'
+        );
+
+        $found = Document::getByPath($nfdLookupPath, ['force' => true]);
+
+        $this->assertInstanceOf(Document::class, $found);
+        $this->assertSame($folder->getId(), $found->getId());
+    }
+
+    /**
+     * Regression test: Document::getByPath() must still resolve a document whose key is
+     * stored in decomposed (NFD) Unicode form - e.g. created before document keys were
+     * normalized to NFC on write - via an exact-path lookup using that very same NFD path.
+     *
+     * The model API can no longer persist such a key directly: Document::save() rejects it
+     * via Service::isValidKey(), which always normalizes to NFC before comparing (#19242).
+     * So the legacy row is created via a valid NFC key first, then rewritten to NFD directly
+     * in the database - bypassing model validation - to simulate a pre-#19242 row.
+     *
+     * @see \Pimcore\Model\Element\Service::correctPath()
+     */
+    public function testGetByPathResolvesLegacyNfdStoredKeyByExactMatch(): void
+    {
+        $nfcKey = Normalizer::normalize('nfd-café-' . uniqid(), Normalizer::FORM_C);
+        $nfdKey = Normalizer::normalize($nfcKey, Normalizer::FORM_D);
+        $this->assertNotSame(
+            $nfcKey,
+            $nfdKey,
+            'Test fixture setup issue: NFD and NFC forms should differ in bytes.'
+        );
+
+        $folder = new Document\Folder();
+        $folder->setParentId(1);
+        $folder->setKey($nfcKey);
+        $folder->save();
+
+        $lookupPath = $folder->getRealPath() . $nfdKey;
+
+        Db::get()->update('documents', ['key' => $nfdKey], ['id' => $folder->getId()]);
+
+        $found = Document::getByPath($lookupPath, ['force' => true]);
+
+        $this->assertInstanceOf(Document::class, $found);
+        $this->assertSame($folder->getId(), $found->getId());
     }
 }

--- a/tests/Model/Document/DocumentTest.php
+++ b/tests/Model/Document/DocumentTest.php
@@ -415,6 +415,47 @@ class DocumentTest extends ModelTestCase
     }
 
     /**
+     * Regression test: a document resolved via the NFC fallback must be cached (for the
+     * unforced RuntimeCache read path) under its own resolved real path, not under the raw
+     * (NFD) lookup path that was used to find it. Document invalidation (e.g. delete()) only
+     * clears the cache entry for the document's real path - caching an extra entry under the
+     * raw lookup path would create a stale alias that a later unforced lookup by that same
+     * path could return even after the document is deleted.
+     *
+     * @see \Pimcore\Model\Element\Service::getByPathWithNfcFallback()
+     */
+    public function testGetByPathDoesNotCacheStaleAliasForNfcFallbackLookupPath(): void
+    {
+        $nfcKey = Normalizer::normalize('nfc-café-' . uniqid(), Normalizer::FORM_C);
+
+        $folder = new Document\Folder();
+        $folder->setParentId(1);
+        $folder->setKey($nfcKey);
+        $folder->save();
+
+        $nfdLookupPath = Normalizer::normalize($folder->getFullPath(), Normalizer::FORM_D);
+        $this->assertNotSame(
+            $folder->getFullPath(),
+            $nfdLookupPath,
+            'Test fixture setup issue: NFD and NFC forms should differ in bytes.'
+        );
+
+        // unforced, so this populates the RuntimeCache path-cache entry under whatever key
+        // getByPath() decides to use
+        $found = Document::getByPath($nfdLookupPath);
+        $this->assertInstanceOf(Document::class, $found);
+        $this->assertSame($folder->getId(), $found->getId());
+
+        $folder->delete();
+
+        $foundAfterDelete = Document::getByPath($nfdLookupPath);
+        $this->assertNull(
+            $foundAfterDelete,
+            'A deleted document must not still be resolvable through a stale cache entry keyed by the raw NFD lookup path.'
+        );
+    }
+
+    /**
      * Regression test: Document::getByPath() must still resolve a document whose key is
      * stored in decomposed (NFD) Unicode form - e.g. created before document keys were
      * normalized to NFC on write - via an exact-path lookup using that very same NFD path.

--- a/tests/Model/Document/DocumentTest.php
+++ b/tests/Model/Document/DocumentTest.php
@@ -456,6 +456,74 @@ class DocumentTest extends ModelTestCase
     }
 
     /**
+     * Regression test: for a mixed hierarchy (legacy NFD-stored ancestor, freshly created
+     * NFC-stored descendant), the fully-normalized candidate tried first does not match the
+     * real path (it incorrectly also rewrites the still-NFD ancestor segment) - but
+     * Document\Dao::getByPath() would additionally treat a miss as a potential pretty URL, so
+     * if an unrelated page's pretty URL happens to equal that non-matching candidate string,
+     * the fallback must not resolve to that unrelated page instead of continuing to the later
+     * candidate that actually identifies the requested document.
+     *
+     * @see \Pimcore\Model\Document\Dao::getByExactPath()
+     */
+    public function testGetByPathDoesNotResolveToUnrelatedPageViaCandidatePrettyUrlCollision(): void
+    {
+        $legacyNfcKey = Normalizer::normalize('legacy-café-' . uniqid(), Normalizer::FORM_C);
+        $legacyNfdKey = Normalizer::normalize($legacyNfcKey, Normalizer::FORM_D);
+        $this->assertNotSame(
+            $legacyNfcKey,
+            $legacyNfdKey,
+            'Test fixture setup issue: NFD and NFC forms should differ in bytes.'
+        );
+
+        // simulate a legacy pre-#19242 ancestor whose key is stored in decomposed (NFD) form
+        $legacyFolder = new Document\Folder();
+        $legacyFolder->setParentId(1);
+        $legacyFolder->setKey($legacyNfcKey);
+        $legacyFolder->save();
+        $db = Db::get();
+        $db->update('documents', DbHelper::quoteDataIdentifiers($db, ['key' => $legacyNfdKey]), ['id' => $legacyFolder->getId()]);
+
+        // the freshly created target document, stored NFC, below the legacy ancestor
+        $targetDoc = new Page();
+        $targetDoc->setParentId($legacyFolder->getId());
+        $targetDoc->setKey(Normalizer::normalize('target-café-' . uniqid(), Normalizer::FORM_C));
+        $targetDoc->setUserOwner(1);
+        $targetDoc->setUserModification(1);
+        $targetDoc->setCreationDate(time());
+        $targetDoc->save();
+
+        // what a browser submits: every accented segment in NFD, regardless of which segments
+        // are legacy and which are freshly created
+        $nfdLookupPath = Normalizer::normalize($targetDoc->getRealFullPath(), Normalizer::FORM_D);
+        $fullyNormalizedCandidate = Normalizer::normalize($nfdLookupPath, Normalizer::FORM_C);
+        $this->assertNotSame(
+            $targetDoc->getRealFullPath(),
+            $fullyNormalizedCandidate,
+            'Test fixture setup issue: the fully normalized candidate must differ from the real stored path (it must also rewrite the legacy segment).'
+        );
+
+        // an unrelated page whose pretty URL happens to collide with that non-matching candidate
+        $decoyDoc = new Page();
+        $decoyDoc->setParentId(1);
+        $decoyDoc->setKey('decoy-' . uniqid());
+        $decoyDoc->setUserOwner(1);
+        $decoyDoc->setUserModification(1);
+        $decoyDoc->setCreationDate(time());
+        $decoyDoc->setPrettyUrl($fullyNormalizedCandidate);
+        $decoyDoc->save();
+
+        $found = Document::getByPath($nfdLookupPath, ['force' => true]);
+
+        $this->assertInstanceOf(Document::class, $found);
+        $this->assertSame(
+            $targetDoc->getId(),
+            $found->getId(),
+            'The requested document must be resolved via the exact-path candidate, not an unrelated page whose pretty URL coincidentally matches a non-matching candidate.'
+        );
+    }
+
+    /**
      * Regression test: Document::getByPath() must still resolve a document whose key is
      * stored in decomposed (NFD) Unicode form - e.g. created before document keys were
      * normalized to NFC on write - via an exact-path lookup using that very same NFD path.
@@ -491,5 +559,35 @@ class DocumentTest extends ModelTestCase
 
         $this->assertInstanceOf(Document::class, $found);
         $this->assertSame($folder->getId(), $found->getId());
+    }
+
+    /**
+     * Regression test: Document\Service::pathExists() must agree with Document::getByPath() on
+     * whether a path resolves. Without routing pathExists() through the same NFC fallback,
+     * a caller could see pathExists() return false for the very same NFD lookup path that
+     * getByPath() successfully resolves, and incorrectly treat an existing document as absent.
+     *
+     * @see \Pimcore\Model\Element\Service::getByPathWithNfcFallback()
+     */
+    public function testPathExistsAgreesWithGetByPathForNfdLookupPath(): void
+    {
+        $nfcKey = Normalizer::normalize('nfc-café-' . uniqid(), Normalizer::FORM_C);
+
+        $folder = new Document\Folder();
+        $folder->setParentId(1);
+        $folder->setKey($nfcKey);
+        $folder->save();
+
+        $nfdLookupPath = Normalizer::normalize($folder->getFullPath(), Normalizer::FORM_D);
+        $this->assertNotSame(
+            $folder->getFullPath(),
+            $nfdLookupPath,
+            'Test fixture setup issue: NFD and NFC forms should differ in bytes.'
+        );
+
+        $this->assertTrue(
+            Service::pathExists($nfdLookupPath),
+            'pathExists() must return true for the same NFD path that getByPath() resolves.'
+        );
     }
 }

--- a/tests/Service/Element/ServiceTest.php
+++ b/tests/Service/Element/ServiceTest.php
@@ -121,6 +121,29 @@ class ServiceTest extends TestCase
     }
 
     /**
+     * Regression test: isValidPath() must accept a segment that is in decomposed (NFD) Unicode
+     * form - e.g. created before keys were normalized to NFC on write (#19242) - since
+     * *\Service::pathExists() relies on it and must agree with getByPath(), which resolves the
+     * very same path via the NFC fallback. A segment with genuinely invalid characters (not
+     * just a different Unicode form) must still be rejected.
+     *
+     * @see \Pimcore\Model\Element\Service::isValidPath()
+     */
+    public function testIsValidPathAcceptsDecomposedUnicodeFormButRejectsInvalidCharacters(): void
+    {
+        $nfd = Normalizer::normalize('café', Normalizer::FORM_D);
+        $nfc = Normalizer::normalize('café', Normalizer::FORM_C);
+        $this->assertNotSame($nfd, $nfc, 'Test fixture setup issue: NFD and NFC forms should differ in bytes.');
+
+        $this->assertTrue(Service::isValidPath("/Upload Folder/$nfd", 'asset'));
+        $this->assertTrue(Service::isValidPath("/Upload Folder/$nfc", 'asset'));
+        $this->assertFalse(
+            Service::isValidPath('/Upload Folder/invalid<>name', 'asset'),
+            'A segment with genuinely invalid characters must still be rejected, not just a different Unicode form.'
+        );
+    }
+
+    /**
      * correctPath() must leave the Unicode form of the path untouched. Unconditionally
      * rewriting it to NFC here (as opposed to as a getByPath() lookup fallback, see
      * getByPathWithNfcFallback()) would break the exact-path lookup for elements whose
@@ -258,75 +281,35 @@ class ServiceTest extends TestCase
     }
 
     /**
-     * Regression test: getByPath() is a public API that accepts arbitrary caller-supplied
-     * strings, but ElementInterface::MAX_FULL_PATH_LENGTH is only enforced at save time - no
-     * real element can ever be stored with a longer path. Without a bound here, an overlength,
-     * heavily decomposed (NFD) path would still generate and attempt one fallback candidate per
-     * path segment. getByPathWithNfcFallback() must skip fallback entirely once even the
-     * shortest possible candidate - the fully NFC-normalized path - is already too long to
-     * belong to any real element, rather than doing that work only to miss every candidate
-     * anyway.
+     * Regression test: getByPathWithNfcFallback() must not skip fallback based on the raw input
+     * path's length, even when that length is far beyond ElementInterface::MAX_FULL_PATH_LENGTH.
+     * A length-based short-circuit was deliberately not used: composition exclusions in Unicode
+     * (e.g. U+0344, which NFC always decomposes to two code points) mean the fully-normalized
+     * form of a path is not a universally reliable lower bound on how short a legitimate
+     * candidate could be, so treating it as one can incorrectly skip a fallback that would
+     * otherwise have resolved. Candidate volume is instead bounded solely by
+     * MAX_FALLBACK_CANDIDATES (see the cap test below), independent of path length.
      *
      * @see \Pimcore\Model\Element\Service::getByPathWithNfcFallback()
      */
-    public function testGetByPathWithNfcFallbackSkipsFallbackForOverlengthPath(): void
+    public function testGetByPathWithNfcFallbackAttemptsFallbackRegardlessOfRawPathLength(): void
     {
-        // a run of the same precomposed accented character so that NFD-normalizing it doubles
-        // its length (base + combining mark each), while keeping the NFC form compact
         $nfcSegment = str_repeat(Normalizer::normalize('é', Normalizer::FORM_C), 260);
-        $nfdSegment = Normalizer::normalize($nfcSegment, Normalizer::FORM_D);
-        $this->assertNotSame($nfcSegment, $nfdSegment, 'Test fixture setup issue.');
-
-        $overlengthPath = "/$nfdSegment/$nfdSegment/$nfdSegment";
-        $fullyNormalizedLength = mb_strlen(Normalizer::normalize($overlengthPath, Normalizer::FORM_C));
-        $this->assertGreaterThan(
-            ElementInterface::MAX_FULL_PATH_LENGTH,
-            $fullyNormalizedLength,
-            'Test fixture setup issue: even the fully NFC-normalized form must exceed the maximum length no real element could have.'
-        );
-
-        $this->assertSame(
-            [$overlengthPath],
-            $this->recordAttemptedPaths($overlengthPath),
-            'No fallback candidates should be attempted when even the fully NFC-normalized path is longer than any real element could have.'
-        );
-    }
-
-    /**
-     * Regression test: NFD-decomposing a path can noticeably lengthen it (a single precomposed
-     * character can become a base character plus a combining mark), so a path whose fully
-     * NFC-normalized form fits within ElementInterface::MAX_FULL_PATH_LENGTH - and could
-     * therefore be a real, storable element - may still exceed that length in its raw,
-     * decomposed form. getByPathWithNfcFallback() must judge the length bound by the shortest
-     * possible candidate (the fully normalized path), not the raw input, or it would incorrectly
-     * refuse to even attempt a fallback that could otherwise resolve.
-     *
-     * @see \Pimcore\Model\Element\Service::getByPathWithNfcFallback()
-     */
-    public function testGetByPathWithNfcFallbackStillAttemptsFallbackWhenOnlyDecomposedFormIsOverlength(): void
-    {
-        $nfcSegment = str_repeat(Normalizer::normalize('é', Normalizer::FORM_C), 250);
         $nfdSegment = Normalizer::normalize($nfcSegment, Normalizer::FORM_D);
         $this->assertNotSame($nfcSegment, $nfdSegment, 'Test fixture setup issue.');
 
         $lookupPath = "/$nfdSegment/$nfdSegment/$nfdSegment";
         $fullyNormalizedPath = Normalizer::normalize($lookupPath, Normalizer::FORM_C);
-
         $this->assertGreaterThan(
             ElementInterface::MAX_FULL_PATH_LENGTH,
             mb_strlen($lookupPath),
-            'Test fixture setup issue: the raw decomposed path must exceed the maximum length.'
-        );
-        $this->assertLessThanOrEqual(
-            ElementInterface::MAX_FULL_PATH_LENGTH,
-            mb_strlen($fullyNormalizedPath),
-            'Test fixture setup issue: the fully NFC-normalized form must still fit within the maximum length any real element could have.'
+            'Test fixture setup issue: the raw path must exceed the maximum length any real element could have.'
         );
 
         $this->assertContains(
             $fullyNormalizedPath,
             $this->recordAttemptedPaths($lookupPath),
-            'A path whose decomposed form exceeds the limit but whose NFC-normalized form does not must still be attempted as a fallback candidate.'
+            'A fallback candidate must still be attempted even for a path far longer than any real element could have.'
         );
     }
 

--- a/tests/Service/Element/ServiceTest.php
+++ b/tests/Service/Element/ServiceTest.php
@@ -16,6 +16,7 @@ namespace Pimcore\Tests\Service\Element;
 use Normalizer;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\Element\Service;
+use Pimcore\Model\Exception\NotFoundException;
 use Pimcore\Tests\Support\Test\TestCase;
 use Pimcore\Tests\Support\Util\TestHelper;
 
@@ -121,12 +122,12 @@ class ServiceTest extends TestCase
     /**
      * correctPath() must leave the Unicode form of the path untouched. Unconditionally
      * rewriting it to NFC here (as opposed to as a getByPath() lookup fallback, see
-     * normalizePathToNfc()) would break the exact-path lookup for elements whose key is
-     * still stored in decomposed (NFD) form, e.g. created before keys were normalized to
-     * NFC on write.
+     * getNfcFallbackPathCandidates()) would break the exact-path lookup for elements whose
+     * key is still stored in decomposed (NFD) form, e.g. created before keys were normalized
+     * to NFC on write.
      *
      * @see \Pimcore\Model\Element\Service::correctPath()
-     * @see \Pimcore\Model\Element\Service::normalizePathToNfc()
+     * @see \Pimcore\Model\Element\Service::getNfcFallbackPathCandidates()
      */
     public function testCorrectPathDoesNotChangeUnicodeForm(): void
     {
@@ -136,21 +137,99 @@ class ServiceTest extends TestCase
     }
 
     /**
-     * Regression test: getValidKey() stores element keys precomposed (NFC). normalizePathToNfc()
-     * is the fallback getByPath() callers use once an exact-path lookup misses, so a path built
-     * from decomposed (NFD) input - e.g. a browser's webkitdirectory/File System Access API on
-     * macOS - can still resolve an element right after it was created.
+     * Regression test: a freshly created child (NFC-stored key, see getValidKey()) under a
+     * legacy parent path still stored in decomposed (NFD) form must be resolvable from an
+     * NFD-form lookup path without also rewriting - and thereby breaking a match against -
+     * the still-NFD parent path. The "preserve dirname, normalize only the key" candidate
+     * must therefore be tried before the "normalize the whole path" candidate.
      *
-     * @see \Pimcore\Model\Element\Service::normalizePathToNfc()
+     * @see \Pimcore\Model\Element\Service::getNfcFallbackPathCandidates()
      */
-    public function testNormalizePathToNfc(): void
+    public function testGetNfcFallbackPathCandidatesPrefersPreservingDirname(): void
+    {
+        $nfdParent = Normalizer::normalize('/Legacy café Parent/', Normalizer::FORM_D);
+        $nfcChildKey = Normalizer::normalize('New café Child', Normalizer::FORM_C);
+        $nfdChildKey = Normalizer::normalize($nfcChildKey, Normalizer::FORM_D);
+        $this->assertNotSame(
+            $nfcChildKey,
+            $nfdChildKey,
+            'Test fixture setup issue: NFD and NFC forms should differ in bytes.'
+        );
+
+        $lookupPath = $nfdParent . $nfdChildKey;
+        $candidates = Service::getNfcFallbackPathCandidates($lookupPath);
+
+        $this->assertSame(
+            $nfdParent . $nfcChildKey,
+            $candidates[0],
+            'The first candidate must preserve the (legacy, still-NFD) dirname and only normalize the final key.'
+        );
+        $this->assertContains(
+            Normalizer::normalize($lookupPath, Normalizer::FORM_C),
+            $candidates,
+            'The fully NFC-normalized path must also be offered, for a hierarchy that is entirely freshly created.'
+        );
+    }
+
+    /**
+     * If the path is already fully NFC-normalized, no fallback candidates are produced -
+     * getByPathWithNfcFallback() must not retry with a path identical to the one that just
+     * missed.
+     *
+     * @see \Pimcore\Model\Element\Service::getNfcFallbackPathCandidates()
+     */
+    public function testGetNfcFallbackPathCandidatesEmptyWhenAlreadyNfc(): void
+    {
+        $nfc = Normalizer::normalize('/Upload Folder/Special café', Normalizer::FORM_C);
+
+        $this->assertSame([], Service::getNfcFallbackPathCandidates($nfc));
+    }
+
+    /**
+     * Regression test: getByPathWithNfcFallback() must fall through the candidates in order
+     * and succeed as soon as one of them resolves - this is what lets a freshly created
+     * element (NFC-stored) still be found from an NFD-form lookup path, e.g. a browser's
+     * webkitdirectory/File System Access API on macOS.
+     *
+     * @see \Pimcore\Model\Element\Service::getByPathWithNfcFallback()
+     */
+    public function testGetByPathWithNfcFallbackTriesCandidatesInOrder(): void
     {
         $nfd = Normalizer::normalize('/Upload Folder/Special café', Normalizer::FORM_D);
         $nfc = Normalizer::normalize('/Upload Folder/Special café', Normalizer::FORM_C);
 
-        $this->assertNotSame($nfd, $nfc, 'Test fixture setup issue: NFD and NFC forms should differ in bytes.');
-        $this->assertSame($nfc, Service::normalizePathToNfc($nfd));
-        $this->assertSame($nfc, Service::normalizePathToNfc($nfc));
+        $attempted = [];
+        $attempt = function (string $candidate) use (&$attempted, $nfc): void {
+            $attempted[] = $candidate;
+            if ($candidate !== $nfc) {
+                throw new NotFoundException('not found: ' . $candidate);
+            }
+        };
+
+        Service::getByPathWithNfcFallback($attempt, $nfd);
+
+        $this->assertSame(
+            $nfc,
+            end($attempted),
+            'The lookup must eventually succeed with the fully NFC-normalized path.'
+        );
+    }
+
+    /**
+     * Regression test: if every candidate misses, getByPathWithNfcFallback() must rethrow the
+     * original exact-path NotFoundException rather than swallowing it.
+     *
+     * @see \Pimcore\Model\Element\Service::getByPathWithNfcFallback()
+     */
+    public function testGetByPathWithNfcFallbackRethrowsWhenNoCandidateMatches(): void
+    {
+        $nfd = Normalizer::normalize('/Upload Folder/Special café', Normalizer::FORM_D);
+
+        $this->expectException(NotFoundException::class);
+
+        Service::getByPathWithNfcFallback(function (string $candidate): void {
+            throw new NotFoundException('not found: ' . $candidate);
+        }, $nfd);
     }
 
     public function testCloneMe(): void

--- a/tests/Service/Element/ServiceTest.php
+++ b/tests/Service/Element/ServiceTest.php
@@ -119,21 +119,38 @@ class ServiceTest extends TestCase
     }
 
     /**
-     * Regression test: getValidKey() stores element keys precomposed (NFC), but correctPath()
-     * previously left the incoming path untouched. A path built from decomposed (NFD) input -
-     * e.g. a browser's webkitdirectory/File System Access API on macOS - would then fail to
-     * resolve an element right after it was created, because the DB lookup compares byte-exact
-     * against the NFC-stored key.
+     * correctPath() must leave the Unicode form of the path untouched. Unconditionally
+     * rewriting it to NFC here (as opposed to as a getByPath() lookup fallback, see
+     * normalizePathToNfc()) would break the exact-path lookup for elements whose key is
+     * still stored in decomposed (NFD) form, e.g. created before keys were normalized to
+     * NFC on write.
      *
      * @see \Pimcore\Model\Element\Service::correctPath()
+     * @see \Pimcore\Model\Element\Service::normalizePathToNfc()
      */
-    public function testCorrectPathNormalizesToNfc(): void
+    public function testCorrectPathDoesNotChangeUnicodeForm(): void
+    {
+        $nfd = Normalizer::normalize('/Upload Folder/Special café', Normalizer::FORM_D);
+
+        $this->assertSame($nfd, Service::correctPath($nfd));
+    }
+
+    /**
+     * Regression test: getValidKey() stores element keys precomposed (NFC). normalizePathToNfc()
+     * is the fallback getByPath() callers use once an exact-path lookup misses, so a path built
+     * from decomposed (NFD) input - e.g. a browser's webkitdirectory/File System Access API on
+     * macOS - can still resolve an element right after it was created.
+     *
+     * @see \Pimcore\Model\Element\Service::normalizePathToNfc()
+     */
+    public function testNormalizePathToNfc(): void
     {
         $nfd = Normalizer::normalize('/Upload Folder/Special café', Normalizer::FORM_D);
         $nfc = Normalizer::normalize('/Upload Folder/Special café', Normalizer::FORM_C);
 
         $this->assertNotSame($nfd, $nfc, 'Test fixture setup issue: NFD and NFC forms should differ in bytes.');
-        $this->assertSame($nfc, Service::correctPath($nfd));
+        $this->assertSame($nfc, Service::normalizePathToNfc($nfd));
+        $this->assertSame($nfc, Service::normalizePathToNfc($nfc));
     }
 
     public function testCloneMe(): void

--- a/tests/Service/Element/ServiceTest.php
+++ b/tests/Service/Element/ServiceTest.php
@@ -118,6 +118,24 @@ class ServiceTest extends TestCase
         $this->assertSame($nfc, Service::getValidKey($nfd, 'asset'));
     }
 
+    /**
+     * Regression test: getValidKey() stores element keys precomposed (NFC), but correctPath()
+     * previously left the incoming path untouched. A path built from decomposed (NFD) input -
+     * e.g. a browser's webkitdirectory/File System Access API on macOS - would then fail to
+     * resolve an element right after it was created, because the DB lookup compares byte-exact
+     * against the NFC-stored key.
+     *
+     * @see \Pimcore\Model\Element\Service::correctPath()
+     */
+    public function testCorrectPathNormalizesToNfc(): void
+    {
+        $nfd = Normalizer::normalize('/Upload Folder/Special café', Normalizer::FORM_D);
+        $nfc = Normalizer::normalize('/Upload Folder/Special café', Normalizer::FORM_C);
+
+        $this->assertNotSame($nfd, $nfc, 'Test fixture setup issue: NFD and NFC forms should differ in bytes.');
+        $this->assertSame($nfc, Service::correctPath($nfd));
+    }
+
     public function testCloneMe(): void
     {
         // create object with property

--- a/tests/Service/Element/ServiceTest.php
+++ b/tests/Service/Element/ServiceTest.php
@@ -172,6 +172,48 @@ class ServiceTest extends TestCase
     }
 
     /**
+     * Regression test: a lookup path may have any number of trailing segments freshly created
+     * (NFC-stored) below an ancestor still stored in legacy decomposed (NFD) form - the caller
+     * (e.g. a browser submitting every accented segment in NFD) has no way to know where that
+     * boundary is, so a mixed hierarchy more than one level deep must still resolve. The
+     * "normalize the last 2 segments, leave the legacy first segment untouched" candidate must
+     * be offered, and before the "normalize the entire path" candidate.
+     *
+     * @see \Pimcore\Model\Element\Service::getNfcFallbackPathCandidates()
+     */
+    public function testGetNfcFallbackPathCandidatesHandlesNestedMixedHierarchy(): void
+    {
+        $nfdLegacySegment = Normalizer::normalize('Legacy café', Normalizer::FORM_D);
+        $nfcMiddleSegment = Normalizer::normalize('New café', Normalizer::FORM_C);
+        $nfdMiddleSegment = Normalizer::normalize($nfcMiddleSegment, Normalizer::FORM_D);
+        $nfcLastSegment = Normalizer::normalize('Child café', Normalizer::FORM_C);
+        $nfdLastSegment = Normalizer::normalize($nfcLastSegment, Normalizer::FORM_D);
+
+        // the actual stored path: legacy first segment still NFD, the two freshly created
+        // segments below it NFC
+        $storedPath = "/$nfdLegacySegment/$nfcMiddleSegment/$nfcLastSegment";
+
+        // what a browser submits: every accented segment in NFD, since it cannot tell which
+        // segments are legacy and which are freshly created
+        $lookupPath = "/$nfdLegacySegment/$nfdMiddleSegment/$nfdLastSegment";
+        $this->assertNotSame($storedPath, $lookupPath, 'Test fixture setup issue.');
+
+        $candidates = Service::getNfcFallbackPathCandidates($lookupPath);
+        $fullyNormalized = Normalizer::normalize($lookupPath, Normalizer::FORM_C);
+
+        $this->assertContains(
+            $storedPath,
+            $candidates,
+            'Normalizing only the trailing 2 segments (leaving the legacy first segment as NFD) must be offered as a candidate.'
+        );
+        $this->assertLessThan(
+            array_search($fullyNormalized, $candidates, true),
+            array_search($storedPath, $candidates, true),
+            'The candidate preserving the legacy segment must be tried before the fully normalized path.'
+        );
+    }
+
+    /**
      * If the path is already fully NFC-normalized, no fallback candidates are produced -
      * getByPathWithNfcFallback() must not retry with a path identical to the one that just
      * missed.

--- a/tests/Service/Element/ServiceTest.php
+++ b/tests/Service/Element/ServiceTest.php
@@ -15,6 +15,7 @@ namespace Pimcore\Tests\Service\Element;
 
 use Normalizer;
 use Pimcore\Model\DataObject;
+use Pimcore\Model\Element\AbstractElement;
 use Pimcore\Model\Element\Service;
 use Pimcore\Model\Exception\NotFoundException;
 use Pimcore\Tests\Support\Test\TestCase;
@@ -253,6 +254,34 @@ class ServiceTest extends TestCase
             [$nfc],
             $this->recordAttemptedPaths($nfc),
             'No fallback candidates should be attempted when the path is already fully NFC.'
+        );
+    }
+
+    /**
+     * Regression test: getByPath() is a public API that accepts arbitrary caller-supplied
+     * strings, but AbstractElement::MAX_FULL_PATH_LENGTH is only enforced at save time - no
+     * real element can ever be stored with a longer path. Without a bound here, an overlength,
+     * heavily decomposed (NFD) path would still generate and attempt one fallback candidate per
+     * path segment. getByPathWithNfcFallback() must skip fallback entirely once the path is
+     * already too long to belong to any real element, rather than doing that work only to miss
+     * every candidate anyway.
+     *
+     * @see \Pimcore\Model\Element\Service::getByPathWithNfcFallback()
+     */
+    public function testGetByPathWithNfcFallbackSkipsFallbackForOverlengthPath(): void
+    {
+        $segment = Normalizer::normalize('café', Normalizer::FORM_D);
+        $overlengthPath = str_repeat('/' . $segment, (int) ceil((AbstractElement::MAX_FULL_PATH_LENGTH + 10) / (mb_strlen($segment) + 1)));
+        $this->assertGreaterThan(
+            AbstractElement::MAX_FULL_PATH_LENGTH,
+            mb_strlen($overlengthPath),
+            'Test fixture setup issue: the path must exceed the maximum length no real element can have.'
+        );
+
+        $this->assertSame(
+            [$overlengthPath],
+            $this->recordAttemptedPaths($overlengthPath),
+            'No fallback candidates should be attempted for a path longer than any real element could have.'
         );
     }
 

--- a/tests/Service/Element/ServiceTest.php
+++ b/tests/Service/Element/ServiceTest.php
@@ -15,7 +15,7 @@ namespace Pimcore\Tests\Service\Element;
 
 use Normalizer;
 use Pimcore\Model\DataObject;
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Element\Service;
 use Pimcore\Model\Exception\NotFoundException;
 use Pimcore\Tests\Support\Test\TestCase;
@@ -259,29 +259,104 @@ class ServiceTest extends TestCase
 
     /**
      * Regression test: getByPath() is a public API that accepts arbitrary caller-supplied
-     * strings, but AbstractElement::MAX_FULL_PATH_LENGTH is only enforced at save time - no
+     * strings, but ElementInterface::MAX_FULL_PATH_LENGTH is only enforced at save time - no
      * real element can ever be stored with a longer path. Without a bound here, an overlength,
      * heavily decomposed (NFD) path would still generate and attempt one fallback candidate per
-     * path segment. getByPathWithNfcFallback() must skip fallback entirely once the path is
-     * already too long to belong to any real element, rather than doing that work only to miss
-     * every candidate anyway.
+     * path segment. getByPathWithNfcFallback() must skip fallback entirely once even the
+     * shortest possible candidate - the fully NFC-normalized path - is already too long to
+     * belong to any real element, rather than doing that work only to miss every candidate
+     * anyway.
      *
      * @see \Pimcore\Model\Element\Service::getByPathWithNfcFallback()
      */
     public function testGetByPathWithNfcFallbackSkipsFallbackForOverlengthPath(): void
     {
-        $segment = Normalizer::normalize('café', Normalizer::FORM_D);
-        $overlengthPath = str_repeat('/' . $segment, (int) ceil((AbstractElement::MAX_FULL_PATH_LENGTH + 10) / (mb_strlen($segment) + 1)));
+        // a run of the same precomposed accented character so that NFD-normalizing it doubles
+        // its length (base + combining mark each), while keeping the NFC form compact
+        $nfcSegment = str_repeat(Normalizer::normalize('é', Normalizer::FORM_C), 260);
+        $nfdSegment = Normalizer::normalize($nfcSegment, Normalizer::FORM_D);
+        $this->assertNotSame($nfcSegment, $nfdSegment, 'Test fixture setup issue.');
+
+        $overlengthPath = "/$nfdSegment/$nfdSegment/$nfdSegment";
+        $fullyNormalizedLength = mb_strlen(Normalizer::normalize($overlengthPath, Normalizer::FORM_C));
         $this->assertGreaterThan(
-            AbstractElement::MAX_FULL_PATH_LENGTH,
-            mb_strlen($overlengthPath),
-            'Test fixture setup issue: the path must exceed the maximum length no real element can have.'
+            ElementInterface::MAX_FULL_PATH_LENGTH,
+            $fullyNormalizedLength,
+            'Test fixture setup issue: even the fully NFC-normalized form must exceed the maximum length no real element could have.'
         );
 
         $this->assertSame(
             [$overlengthPath],
             $this->recordAttemptedPaths($overlengthPath),
-            'No fallback candidates should be attempted for a path longer than any real element could have.'
+            'No fallback candidates should be attempted when even the fully NFC-normalized path is longer than any real element could have.'
+        );
+    }
+
+    /**
+     * Regression test: NFD-decomposing a path can noticeably lengthen it (a single precomposed
+     * character can become a base character plus a combining mark), so a path whose fully
+     * NFC-normalized form fits within ElementInterface::MAX_FULL_PATH_LENGTH - and could
+     * therefore be a real, storable element - may still exceed that length in its raw,
+     * decomposed form. getByPathWithNfcFallback() must judge the length bound by the shortest
+     * possible candidate (the fully normalized path), not the raw input, or it would incorrectly
+     * refuse to even attempt a fallback that could otherwise resolve.
+     *
+     * @see \Pimcore\Model\Element\Service::getByPathWithNfcFallback()
+     */
+    public function testGetByPathWithNfcFallbackStillAttemptsFallbackWhenOnlyDecomposedFormIsOverlength(): void
+    {
+        $nfcSegment = str_repeat(Normalizer::normalize('é', Normalizer::FORM_C), 250);
+        $nfdSegment = Normalizer::normalize($nfcSegment, Normalizer::FORM_D);
+        $this->assertNotSame($nfcSegment, $nfdSegment, 'Test fixture setup issue.');
+
+        $lookupPath = "/$nfdSegment/$nfdSegment/$nfdSegment";
+        $fullyNormalizedPath = Normalizer::normalize($lookupPath, Normalizer::FORM_C);
+
+        $this->assertGreaterThan(
+            ElementInterface::MAX_FULL_PATH_LENGTH,
+            mb_strlen($lookupPath),
+            'Test fixture setup issue: the raw decomposed path must exceed the maximum length.'
+        );
+        $this->assertLessThanOrEqual(
+            ElementInterface::MAX_FULL_PATH_LENGTH,
+            mb_strlen($fullyNormalizedPath),
+            'Test fixture setup issue: the fully NFC-normalized form must still fit within the maximum length any real element could have.'
+        );
+
+        $this->assertContains(
+            $fullyNormalizedPath,
+            $this->recordAttemptedPaths($lookupPath),
+            'A path whose decomposed form exceeds the limit but whose NFC-normalized form does not must still be attempted as a fallback candidate.'
+        );
+    }
+
+    /**
+     * Regression test: a path within the maximum real path length can still be split into far
+     * more segments than any realistic element hierarchy would have (e.g. many short accented
+     * segments). Without a cap independent of total path length, a miss on such a path would
+     * generate and attempt one fallback candidate per segment. getByPathWithNfcFallback() must
+     * bound the number of candidates attempted to a small, fixed number regardless of segment
+     * count.
+     *
+     * @see \Pimcore\Model\Element\Service::getByPathWithNfcFallback()
+     */
+    public function testGetByPathWithNfcFallbackCapsNumberOfCandidates(): void
+    {
+        $segment = Normalizer::normalize('é', Normalizer::FORM_D);
+        $segmentCount = 100;
+        $path = str_repeat('/' . $segment, $segmentCount);
+        $this->assertLessThanOrEqual(
+            ElementInterface::MAX_FULL_PATH_LENGTH,
+            mb_strlen(Normalizer::normalize($path, Normalizer::FORM_C)),
+            'Test fixture setup issue: the fully normalized path must still fit within the length limit.'
+        );
+
+        $attempted = $this->recordAttemptedPaths($path);
+
+        $this->assertLessThan(
+            $segmentCount,
+            count($attempted),
+            'The number of fallback candidates attempted must be bounded to a small fixed number, not one per path segment.'
         );
     }
 

--- a/tests/Service/Element/ServiceTest.php
+++ b/tests/Service/Element/ServiceTest.php
@@ -122,12 +122,12 @@ class ServiceTest extends TestCase
     /**
      * correctPath() must leave the Unicode form of the path untouched. Unconditionally
      * rewriting it to NFC here (as opposed to as a getByPath() lookup fallback, see
-     * getNfcFallbackPathCandidates()) would break the exact-path lookup for elements whose
+     * getByPathWithNfcFallback()) would break the exact-path lookup for elements whose
      * key is still stored in decomposed (NFD) form, e.g. created before keys were normalized
      * to NFC on write.
      *
      * @see \Pimcore\Model\Element\Service::correctPath()
-     * @see \Pimcore\Model\Element\Service::getNfcFallbackPathCandidates()
+     * @see \Pimcore\Model\Element\Service::getByPathWithNfcFallback()
      */
     public function testCorrectPathDoesNotChangeUnicodeForm(): void
     {
@@ -137,15 +137,41 @@ class ServiceTest extends TestCase
     }
 
     /**
-     * Regression test: a freshly created child (NFC-stored key, see getValidKey()) under a
-     * legacy parent path still stored in decomposed (NFD) form must be resolvable from an
-     * NFD-form lookup path without also rewriting - and thereby breaking a match against -
-     * the still-NFD parent path. The "preserve dirname, normalize only the key" candidate
-     * must therefore be tried before the "normalize the whole path" candidate.
+     * Records every path getByPathWithNfcFallback() attempts, without ever succeeding, so the
+     * full candidate order can be asserted on.
      *
-     * @see \Pimcore\Model\Element\Service::getNfcFallbackPathCandidates()
+     * @return string[]
      */
-    public function testGetNfcFallbackPathCandidatesPrefersPreservingDirname(): void
+    private function recordAttemptedPaths(string $lookupPath): array
+    {
+        $attempted = [];
+        $attempt = function (string $candidate) use (&$attempted): void {
+            $attempted[] = $candidate;
+
+            throw new NotFoundException('not found: ' . $candidate);
+        };
+
+        try {
+            Service::getByPathWithNfcFallback($attempt, $lookupPath);
+            $this->fail('Expected a NotFoundException.');
+        } catch (NotFoundException) {
+            // expected - $attempt() never succeeds, so every candidate gets tried
+        }
+
+        return $attempted;
+    }
+
+    /**
+     * Regression test: the common case - and the one motivating this fix - is an entire
+     * subtree freshly created in the same operation (e.g. a Studio folder upload), where every
+     * segment is NFC-stored but the lookup path arrives in NFD form. getByPathWithNfcFallback()
+     * must try the fully NFC-normalized path first, so that common case costs one extra query,
+     * not one per path depth. A legacy parent path still stored in decomposed (NFD) form is the
+     * rarer case; its "preserve dirname, normalize only the key" candidate is tried after.
+     *
+     * @see \Pimcore\Model\Element\Service::getByPathWithNfcFallback()
+     */
+    public function testGetByPathWithNfcFallbackTriesFullyNormalizedPathBeforePreservingDirname(): void
     {
         $nfdParent = Normalizer::normalize('/Legacy café Parent/', Normalizer::FORM_D);
         $nfcChildKey = Normalizer::normalize('New café Child', Normalizer::FORM_C);
@@ -157,17 +183,17 @@ class ServiceTest extends TestCase
         );
 
         $lookupPath = $nfdParent . $nfdChildKey;
-        $candidates = Service::getNfcFallbackPathCandidates($lookupPath);
+        $dirnamePreservedCandidate = $nfdParent . $nfcChildKey;
+        $fullyNormalizedCandidate = Normalizer::normalize($lookupPath, Normalizer::FORM_C);
 
-        $this->assertSame(
-            $nfdParent . $nfcChildKey,
-            $candidates[0],
-            'The first candidate must preserve the (legacy, still-NFD) dirname and only normalize the final key.'
-        );
-        $this->assertContains(
-            Normalizer::normalize($lookupPath, Normalizer::FORM_C),
-            $candidates,
-            'The fully NFC-normalized path must also be offered, for a hierarchy that is entirely freshly created.'
+        $attempted = $this->recordAttemptedPaths($lookupPath);
+
+        $this->assertContains($fullyNormalizedCandidate, $attempted);
+        $this->assertContains($dirnamePreservedCandidate, $attempted);
+        $this->assertLessThan(
+            array_search($dirnamePreservedCandidate, $attempted, true),
+            array_search($fullyNormalizedCandidate, $attempted, true),
+            'The fully NFC-normalized path must be tried before the dirname-preserving candidate.'
         );
     }
 
@@ -175,13 +201,12 @@ class ServiceTest extends TestCase
      * Regression test: a lookup path may have any number of trailing segments freshly created
      * (NFC-stored) below an ancestor still stored in legacy decomposed (NFD) form - the caller
      * (e.g. a browser submitting every accented segment in NFD) has no way to know where that
-     * boundary is, so a mixed hierarchy more than one level deep must still resolve. The
-     * "normalize the last 2 segments, leave the legacy first segment untouched" candidate must
-     * be offered, and before the "normalize the entire path" candidate.
+     * boundary is, so a mixed hierarchy more than one level deep must still resolve via one of
+     * the candidates getByPathWithNfcFallback() tries.
      *
-     * @see \Pimcore\Model\Element\Service::getNfcFallbackPathCandidates()
+     * @see \Pimcore\Model\Element\Service::getByPathWithNfcFallback()
      */
-    public function testGetNfcFallbackPathCandidatesHandlesNestedMixedHierarchy(): void
+    public function testGetByPathWithNfcFallbackHandlesNestedMixedHierarchy(): void
     {
         $nfdLegacySegment = Normalizer::normalize('Legacy café', Normalizer::FORM_D);
         $nfcMiddleSegment = Normalizer::normalize('New café', Normalizer::FORM_C);
@@ -198,18 +223,18 @@ class ServiceTest extends TestCase
         $lookupPath = "/$nfdLegacySegment/$nfdMiddleSegment/$nfdLastSegment";
         $this->assertNotSame($storedPath, $lookupPath, 'Test fixture setup issue.');
 
-        $candidates = Service::getNfcFallbackPathCandidates($lookupPath);
+        $attempted = $this->recordAttemptedPaths($lookupPath);
         $fullyNormalized = Normalizer::normalize($lookupPath, Normalizer::FORM_C);
 
         $this->assertContains(
             $storedPath,
-            $candidates,
-            'Normalizing only the trailing 2 segments (leaving the legacy first segment as NFD) must be offered as a candidate.'
+            $attempted,
+            'Normalizing only the trailing 2 segments (leaving the legacy first segment as NFD) must be tried.'
         );
         $this->assertLessThan(
-            array_search($fullyNormalized, $candidates, true),
-            array_search($storedPath, $candidates, true),
-            'The candidate preserving the legacy segment must be tried before the fully normalized path.'
+            array_search($storedPath, $attempted, true),
+            array_search($fullyNormalized, $attempted, true),
+            'The fully normalized path is tried before the candidate preserving the legacy segment.'
         );
     }
 
@@ -218,13 +243,17 @@ class ServiceTest extends TestCase
      * getByPathWithNfcFallback() must not retry with a path identical to the one that just
      * missed.
      *
-     * @see \Pimcore\Model\Element\Service::getNfcFallbackPathCandidates()
+     * @see \Pimcore\Model\Element\Service::getByPathWithNfcFallback()
      */
-    public function testGetNfcFallbackPathCandidatesEmptyWhenAlreadyNfc(): void
+    public function testGetByPathWithNfcFallbackDoesNotRetryWhenPathAlreadyNfc(): void
     {
         $nfc = Normalizer::normalize('/Upload Folder/Special café', Normalizer::FORM_C);
 
-        $this->assertSame([], Service::getNfcFallbackPathCandidates($nfc));
+        $this->assertSame(
+            [$nfc],
+            $this->recordAttemptedPaths($nfc),
+            'No fallback candidates should be attempted when the path is already fully NFC.'
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary

Follow-up to #19242. That PR normalizes newly created element keys to NFC in `Element\Service::getValidKey()`, but `Element\Service::correctPath()` — used by every `getByPath()` lookup (`Asset`, `Document`, `DataObject` all funnel through it) — left the incoming path untouched.

**Symptom:** during Studio's folder-upload tree traversal, resolving a folder's ID by path (`GetIdByPathController` → `ElementService::getAllowedElementIdByPath` → `Asset::getByPath()`) fails with `error_element_not_found` for folder names containing accented characters (e.g. `/Upload Folder/Special àéìòù`), even though the folder was just created successfully moments earlier in the same upload session.

**Root cause:** browsers report accented names in decomposed (NFD) Unicode form on macOS (`webkitdirectory`/File System Access API), e.g. `à` = `a` + combining grave accent. Since #19242, a freshly created folder's key is stored precomposed (NFC). But the immediate follow-up path lookup during tree traversal still sends the original NFD-form path, and `Asset\Dao::getByPath()` (and the Document/DataObject equivalents) compare `WHERE path = BINARY :path AND filename/key = BINARY :key` — a byte-exact match on both the parent path and the final key — so the NFD lookup path never matches the NFC-stored key.

## Fix

`correctPath()` itself is **not** touched — it still returns the path unchanged with respect to Unicode form. Unconditionally rewriting it to NFC there would break the *reverse* case: elements whose key is still stored in decomposed (NFD) form (created before #19242 introduced NFC normalization on write) would no longer be found by the very same exact-match lookup path that used to resolve them — an outright regression for legacy data, not just an unfixed limitation.

Instead, `getByPath()` in `Asset`, `Document`, and `DataObject\AbstractObject` now goes through a single shared retry policy in `Element\Service`:

**`Element\Service::getByPathWithNfcFallback(callable $attempt, string $path)`** attempts the exact path first (this is what keeps legacy NFD-stored elements resolving correctly), and only on a miss retries with a series of fallback candidates, one DAO query per candidate, stopping at the first hit. The candidates (built by a private helper) progressively normalize *trailing suffixes* of the path to NFC, from "the entire path" down to "just the final segment", leaving the remaining prefix untouched in each one — a caller (e.g. a browser submitting every accented segment in NFD) has no way to know which path segments are legacy (still NFD) and which were freshly created (NFC, per #19242), and more than one trailing segment can be freshly created below a legacy ancestor:
- a lookup path where every segment was freshly created in the same operation is resolved by the "entire path normalized" candidate, tried **first** — this is deliberate: it's the common case (an entire subtree created in one Studio upload), and trying the narrowest candidates first would cost one query per path depth before ever reaching the one that matches.
- `/Legacy café/New café/Child café` stored as NFD/NFC/NFC (the last two segments freshly created under a legacy first segment) is resolved by the "last 2 segments normalized" candidate, tried after the full-path one, without touching the still-NFD first segment. A legacy ancestor mixed with fresh descendants is the rarer case and can afford the extra query.

The three model classes each just supply a closure over their own `Dao::getByPath()` call; the exact-then-fallback control flow, exception handling, and candidate generation live in one place (`Element\Service`) instead of being duplicated three times. The candidate-building helper is private — it has no caller outside `Element\Service`, so tests exercise it indirectly through `getByPathWithNfcFallback()` by recording the sequence of paths it attempts.

**Bounding the fallback:** `getByPath()` is a public API that accepts arbitrary caller-supplied strings. The number of candidates — and therefore the DAO queries and candidate-building work a caller-controlled miss can trigger — is bounded solely by a **candidate-count cap** (`MAX_FALLBACK_CANDIDATES = 32`), independent of path length: a path within the maximum real element path length (765 chars, only enforced at save time in `AbstractElement::validatePathLength()`) can still be split into far more segments than any realistic hierarchy would have. A length-based short-circuit was deliberately *not* used instead: Unicode composition exclusions (e.g. U+0344, which NFC always decomposes to two code points) mean NFC normalization doesn't strictly guarantee a shorter-or-equal-length string in every case, so a fully-normalized path's length isn't a universally reliable lower bound on how short a legitimate candidate could be — an earlier version of this fix that used such a length check could incorrectly skip a fallback that would otherwise have resolved.

The shared max-path-length constant lives on `Element\ElementInterface` (`MAX_FULL_PATH_LENGTH`), not on the concrete `AbstractElement` class — per Pimcore's PHP coding guidelines, constants are private by default and public constants belong on interfaces.

**Cache correctness:** `Document::getByPath()` layers its own `RuntimeCache` path-cache on top of the shared fallback. It previously cached the resolved document under the *raw* lookup path's cache key — but when an NFC fallback candidate is what actually matched, that raw-path key is never touched by move/delete invalidation (which only clears the cache entry for the document's real path), so it becomes a stale alias: a later unforced lookup by that same raw path could keep returning a moved or deleted document. Fixed by caching under the resolved document's own real path instead.

**Pretty URL collision:** `Document\Dao::getByPath()` also falls back to matching `documents_page.prettyUrl` on a miss. Retrying each NFC candidate through that same method meant a non-matching candidate (a synthetic, NFC-normalized string, not a literal pretty URL) could coincidentally collide with an unrelated page's configured pretty URL, resolving to the wrong document before ever trying the candidate that actually identifies the requested one. Split `Document\Dao::getByPath()` into `getByExactPath()` (path/key match only) and `getByPrettyUrl()`; the NFC-candidate cascade now uses `getByExactPath()` exclusively, with pretty URL matching applied once, after the cascade, against the original requested path only — matching prior behavior for that case exactly.

**`pathExists()` parity:** the three `*\Service::pathExists()` implementations called their DAOs directly, bypassing the shared fallback entirely — so the same NFD lookup path could make `pathExists()` return `false` while `getByPath()` resolved the element, letting a caller treat an existing path as absent. Also, `isValidPath()` (which all three use as a pre-check before ever reaching the DAO) rejects any segment whose NFC-normalized form differs from the input — which is *every* genuinely NFD-form segment, since `getValidKey()` always normalizes to NFC — so the pre-check would reject a resolvable NFD path outright regardless. Fixed by wiring all three through `getByPathWithNfcFallback()` (`Document\Service::pathExists()` follows the same exact-then-pretty-url split as `Document::getByPath()`), and by making `isValidPath()` also accept a segment when *only* its Unicode form differs from a valid key (not any other invalid character) — this method's only callers are these three `pathExists()` checks, so the relaxation doesn't affect `isValidKey()` itself, which must keep rejecting non-precomposed input when validating a *new* key at save time.

**Affected files:**
- `models/Element/Service.php` — added `getByPathWithNfcFallback()` (public) and a private candidate-building helper, bounded by candidate count only; `isValidPath()` now Unicode-form-tolerant; `correctPath()` unchanged (no Unicode normalization).
- `models/Element/ElementInterface.php` — added the shared `MAX_FULL_PATH_LENGTH` constant.
- `models/Element/AbstractElement.php` — `validatePathLength()` now references the inherited interface constant instead of a magic number.
- `models/Document/Dao.php` — split `getByPath()` into `getByExactPath()` and `getByPrettyUrl()`.
- `models/Asset.php`, `models/Document.php`, `models/DataObject/AbstractObject.php` — `getByPath()` delegates the exact/fallback retry to `Element\Service::getByPathWithNfcFallback()`; `Document::getByPath()` additionally caches under the resolved real path and separates exact-path fallback from the pretty-URL check.
- `models/Asset/Service.php`, `models/Document/Service.php`, `models/DataObject/Service.php` — `pathExists()` now routes through the same shared fallback (`DataObject\Service::pathExists()` also simplified to drop redundant last-segment validation logic equivalent to `isValidPath()` on the whole path).

**Remaining limitation:** a legacy element whose key is stored in NFD form is only resolved if the lookup path itself arrives in NFD form (or otherwise matches one of the candidates above). If such an element is looked up via a path whose relevant segment is already NFC (and thus does not match the stored NFD bytes), it still won't resolve — that asymmetric case is unchanged from current `main` behavior and isn't something this PR regresses or fixes.

## Test plan
- [x] `tests/Service/Element/ServiceTest.php`: unit tests confirming `correctPath()` leaves the Unicode form untouched; `isValidPath()` accepts decomposed Unicode form but rejects genuinely invalid characters; and coverage of `getByPathWithNfcFallback()` via a recording closure — full-path-before-dirname-preserving ordering, the nested mixed hierarchy, no retry when already NFC, fallback attempted regardless of raw path length, the candidate-count cap, and rethrowing the original exception when every candidate misses.
- [x] `tests/Model/Asset/AssetTest.php`, `tests/Model/Document/DocumentTest.php`, `tests/Model/DataObject/ObjectTest.php`: functional regression tests for each of the three independent `getByPath()` call sites, plus a `pathExists()` parity test per type —
  - `testGetByPathResolvesLegacyNfdStoredKeyByExactMatch()`: a legacy row with an NFD-stored key (written directly to the DB, bypassing model validation, to simulate data from before #19242) still resolves via `getByPath()` using that same NFD path.
  - `testGetByPathFallsBackToNfcForNfdLookupPath()`: a freshly-created NFC-stored element resolves via `getByPath()` when the caller supplies an NFD-form lookup path.
  - `AssetTest::testGetByPathResolvesNestedMixedHierarchy()`: a 3-level asset hierarchy (legacy NFD-stored ancestor, two freshly created NFC-stored descendants below it) resolves via `getByPath()` when every accented path segment arrives in NFD form.
  - `DocumentTest::testGetByPathDoesNotCacheStaleAliasForNfcFallbackLookupPath()`: a document resolved via NFC fallback, then deleted, is no longer resolvable through the same (unforced) NFD lookup path — proving no stale cache alias survives the deletion.
  - `DocumentTest::testGetByPathDoesNotResolveToUnrelatedPageViaCandidatePrettyUrlCollision()`: a mixed-hierarchy NFD lookup resolves to the correct document even when an unrelated page's pretty URL collides with a non-matching candidate.
  - `testPathExistsAgreesWithGetByPathForNfdLookupPath()` (Asset/Document/DataObject): `pathExists()` returns `true` for the same NFD path `getByPath()` resolves.
- [x] `php -l` syntax check on all changed files.
- [x] CI (GitHub Actions): fixed two Codeception failures caught in an earlier push — the `key` column on the `documents`/`objects` tables is a reserved SQL word, so the legacy-row test fixtures' raw `Db::get()->update(...)` calls need `Db\Helper::quoteDataIdentifiers()` (the `assets` table's `filename` column isn't reserved, so that fixture was unaffected). All CI checks (Codeception across every DB/PHP matrix combo, Psalm, PHPStan) passed on the prior commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
