### PR TITLE
Un-deprecate `Kernel::configureContainer()` and `Kernel::configureRoutes()`

### DIFF
--- a/doc/13_Upgrade_Notes/README.md
+++ b/doc/13_Upgrade_Notes/README.md
@@ -297,23 +297,3 @@ Update your code to use `Twig\Environment` directly instead of `EngineInterface`
 ### QuantityValue Formatting Changes
 
 -   The space between QuantityValue value and unit is going to be removed. Please make sure any custom code that relies on the space is updated accordingly.
-
-### Deprecated Kernel Extension Hooks
-
-Overriding `Pimcore\Kernel::configureContainer()` and `Pimcore\Kernel::configureRoutes()` is now deprecated and will be removed in **Pimcore 2027.1**.
-
-These methods were exposed as `protected` on `Pimcore\Kernel` via trait aliases of `Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait`'s **private** methods. Symfony does not consider them part of its public API and has changed their signatures between minor versions, which can break Pimcore subclasses on Symfony upgrades.
-
-**Migration:**
-
-Replace overrides of `configureContainer()` with one of the following stable, public extension points:
-
--   Move container configuration to `config/packages/*.yaml` (or `config/packages/<env>/*.yaml`).
--   Add a [compiler pass](https://symfony.com/doc/current/service_container/compiler_passes.html) for programmatic container manipulation.
--   Override the public `Pimcore\Kernel::registerContainerConfiguration(LoaderInterface $loader)` method directly. Call `parent::registerContainerConfiguration($loader)` first, then load additional configuration via `$loader->load(...)`.
-
-Replace overrides of `configureRoutes()` with one of the following:
-
--   Move routes to `config/routes/*.yaml`.
--   Register a custom routing loader as a service tagged `routing.loader`.
-

--- a/lib/Kernel.php
+++ b/lib/Kernel.php
@@ -90,6 +90,7 @@ abstract class Kernel extends SymfonyKernel
      */
     protected function configureContainer(ContainerConfigurator $container, LoaderInterface $loader, ContainerBuilder $builder): void
     {
+        // @phpstan-ignore arguments.count (this is necessary to support Symfony pre and post v7.4.9)
         $this->microKernelConfigureContainer($container, $loader, $builder);
     }
 

--- a/lib/Kernel.php
+++ b/lib/Kernel.php
@@ -27,8 +27,6 @@ use Pimcore\Config\BundleConfigLocator;
 use Pimcore\Config\LocationAwareConfigRepository;
 use Pimcore\Event\SystemEvents;
 use Pimcore\HttpKernel\BundleCollection\BundleCollection;
-use ReflectionException;
-use ReflectionMethod;
 use Scheb\TwoFactorBundle\SchebTwoFactorBundle;
 use Symfony\Bundle\DebugBundle\DebugBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
@@ -40,9 +38,11 @@ use Symfony\Bundle\WebProfilerBundle\WebProfilerBundle;
 use Symfony\Cmf\Bundle\RoutingBundle\CmfRoutingBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Kernel as SymfonyKernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use Twig\Extra\TwigExtraBundle\TwigExtraBundle;
 
 abstract class Kernel extends SymfonyKernel
@@ -50,8 +50,8 @@ abstract class Kernel extends SymfonyKernel
     use MicroKernelTrait {
         registerContainerConfiguration as microKernelRegisterContainerConfiguration;
         registerBundles as microKernelRegisterBundles;
-        configureContainer as protected;
-        configureRoutes as protected;
+        configureContainer as microKernelConfigureContainer;
+        configureRoutes as microKernelConfigureRoutes;
     }
 
     private BundleCollection $bundleCollection;
@@ -71,10 +71,44 @@ abstract class Kernel extends SymfonyKernel
         return PIMCORE_LOG_DIRECTORY;
     }
 
+    /**
+     * Configures the container.
+     *
+     * You can register extensions:
+     *
+     *     $container->extension('framework', [
+     *         'secret' => '%secret%'
+     *     ]);
+     *
+     * Or services:
+     *
+     *     $container->services()->set('halloween', 'FooBundle\HalloweenProvider');
+     *
+     * Or parameters:
+     *
+     *     $container->parameters()->set('halloween', 'lot of fun');
+     */
+    protected function configureContainer(ContainerConfigurator $container, LoaderInterface $loader, ContainerBuilder $builder): void
+    {
+        $this->microKernelConfigureContainer($container, $loader, $builder);
+    }
+
+    /**
+     * Adds or imports routes into your application.
+     *
+     *     $routes->import($this->getConfigDir().'/*.{yaml,php}');
+     *     $routes
+     *         ->add('admin_dashboard', '/admin')
+     *         ->controller('App\Controller\AdminController::dashboard')
+     *     ;
+     */
+    protected function configureRoutes(RoutingConfigurator $routes): void
+    {
+        $this->microKernelConfigureRoutes($routes);
+    }
+
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
-        $this->triggerKernelHookDeprecations();
-
         $bundleConfigLocator = new BundleConfigLocator($this);
         foreach ($bundleConfigLocator->locate('config') as $bundleConfig) {
             $loader->load($bundleConfig);
@@ -125,46 +159,6 @@ abstract class Kernel extends SymfonyKernel
                 }
             }
         });
-    }
-
-    /**
-     * Emits deprecation notices when subclasses override configureContainer() or
-     * configureRoutes(). These methods are exposed via the MicroKernelTrait `as protected`
-     * aliases on this class. They are private in MicroKernelTrait, are not part of
-     * Symfony's public extension API, and their signatures have changed between
-     * Symfony minor versions. Subclasses should override the public
-     * registerContainerConfiguration() (and use a routing loader for routes) instead.
-     */
-    private function triggerKernelHookDeprecations(): void
-    {
-        foreach (['configureContainer', 'configureRoutes'] as $method) {
-            try {
-                $declaringClass = (new ReflectionMethod($this, $method))->getDeclaringClass()->getName();
-            } catch (ReflectionException) {
-                continue;
-            }
-
-            // The method is declared either by this class (via the trait alias) or
-            // by MicroKernelTrait itself. In both cases no subclass is overriding it.
-            if ($declaringClass === self::class || $declaringClass === MicroKernelTrait::class) {
-                continue;
-            }
-
-            $replacement = $method === 'configureContainer'
-                ? 'Override the public registerContainerConfiguration(LoaderInterface $loader) method instead, or move the configuration to config/packages/*.yaml or a compiler pass.'
-                : 'Register a routing loader service tagged "routing.loader" instead, or add the routes to config/routes/*.yaml.';
-
-            trigger_deprecation(
-                'pimcore/pimcore',
-                '2026.1',
-                'Overriding %s::%s() is deprecated since Pimcore 2026.1 and will be removed in 2027.1. ' .
-                'It relies on a private method of Symfony\\Bundle\\FrameworkBundle\\Kernel\\MicroKernelTrait '
-                . 'whose signature is not part of Symfony\'s public API. %s',
-                $declaringClass,
-                $method,
-                $replacement
-            );
-        }
     }
 
     public function boot(): void

--- a/lib/Kernel.php
+++ b/lib/Kernel.php
@@ -27,6 +27,7 @@ use Pimcore\Config\BundleConfigLocator;
 use Pimcore\Config\LocationAwareConfigRepository;
 use Pimcore\Event\SystemEvents;
 use Pimcore\HttpKernel\BundleCollection\BundleCollection;
+use ReflectionMethod;
 use Scheb\TwoFactorBundle\SchebTwoFactorBundle;
 use Symfony\Bundle\DebugBundle\DebugBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
@@ -36,13 +37,12 @@ use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Bundle\WebProfilerBundle\WebProfilerBundle;
 use Symfony\Cmf\Bundle\RoutingBundle\CmfRoutingBundle;
+use Symfony\Component\Config\Loader\Loader;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Kernel as SymfonyKernel;
-use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use Twig\Extra\TwigExtraBundle\TwigExtraBundle;
 
 abstract class Kernel extends SymfonyKernel
@@ -50,8 +50,7 @@ abstract class Kernel extends SymfonyKernel
     use MicroKernelTrait {
         registerContainerConfiguration as microKernelRegisterContainerConfiguration;
         registerBundles as microKernelRegisterBundles;
-        configureContainer as microKernelConfigureContainer;
-        configureRoutes as microKernelConfigureRoutes;
+        configureRoutes as protected;
     }
 
     private BundleCollection $bundleCollection;
@@ -71,48 +70,35 @@ abstract class Kernel extends SymfonyKernel
         return PIMCORE_LOG_DIRECTORY;
     }
 
-    /**
-     * Configures the container.
-     *
-     * You can register extensions:
-     *
-     *     $container->extension('framework', [
-     *         'secret' => '%secret%'
-     *     ]);
-     *
-     * Or services:
-     *
-     *     $container->services()->set('halloween', 'FooBundle\HalloweenProvider');
-     *
-     * Or parameters:
-     *
-     *     $container->parameters()->set('halloween', 'lot of fun');
-     */
-    protected function configureContainer(ContainerConfigurator $container, LoaderInterface $loader, ContainerBuilder $builder): void
-    {
-        // @phpstan-ignore arguments.count (this is necessary to support Symfony pre and post v7.4.9)
-        $this->microKernelConfigureContainer($container, $loader, $builder);
-    }
-
-    /**
-     * Adds or imports routes into your application.
-     *
-     *     $routes->import($this->getConfigDir().'/*.{yaml,php}');
-     *     $routes
-     *         ->add('admin_dashboard', '/admin')
-     *         ->controller('App\Controller\AdminController::dashboard')
-     *     ;
-     */
-    protected function configureRoutes(RoutingConfigurator $routes): void
-    {
-        $this->microKernelConfigureRoutes($routes);
-    }
-
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
+        if (!$loader instanceof Loader) {
+            throw new \InvalidArgumentException(sprintf('The loader must be an instance of %s.', Loader::class));
+        }
+
         $bundleConfigLocator = new BundleConfigLocator($this);
         foreach ($bundleConfigLocator->locate('config') as $bundleConfig) {
             $loader->load($bundleConfig);
+        }
+
+        /**
+         * Imports configuration files from Symfony's standard locations just as {@see MicroKernelTrait::configureRoutes}
+         * would do. We need to do this here, because users that implement `configureRoutes` inside their kernel have no
+         * possibility to call this method from the trait (and, sadly, neither have we, so we have to replicate it).
+         */
+        if (self::class !== new ReflectionMethod($this, 'configureContainer')->getDeclaringClass()->getName()) {
+            // makes the "config" base folder optional, otherwise `import` would throw if it does not exist
+            $configDir = preg_replace('{/config$}', '/{config}', $this->getConfigDir());
+            $loader->import($configDir.'/{packages}/*.{php,yaml}', 'glob');
+            $loader->import($configDir.'/{packages}/'.$this->getEnvironment().'/*.{php,yaml}', 'glob');
+
+            if (is_file($this->getConfigDir().'/services.yaml')) {
+                $loader->import($this->getConfigDir().'/services.yaml');
+                $loader->import($configDir.'/{services}_'.$this->getEnvironment().'.yaml', 'glob');
+            } else {
+                $loader->import($configDir.'/{services}.php', 'glob');
+                $loader->import($configDir.'/{services}_'.$this->getEnvironment().'.php', 'glob');
+            }
         }
 
         $this->microKernelRegisterContainerConfiguration($loader);


### PR DESCRIPTION
## Changes in this pull request  
The deprecation added in #19114 is reverted and replaced with a BC compatible way.

## Additional info

I don't think the deprecation in PR #19114 is the right approach. @mcop1's argument was that these methods are `private` in Symfony's `MicroKernelTrait` and therefore *not* part of Symfony's public API, which is why no BC promise would apply.

I believe, however, that they *are*, in fact, part of the public API (see: [Building your own Framework with the MicroKernelTrait](https://symfony.com/doc/current/configuration/micro_kernel_trait.html)) and should therefore continue to be provided by Pimcore.

Pimcore simply hasn’t used them as intended so far. These methods are in a trait meant to be used *directly* in projects. Whether they are `private` is therefore irrelevant, because private methods in a library’s trait are still directly visible to the user—traits essentially *copy* the code into the class (and therefore *are* part of the public API of a library).

So, typically, projects use this trait directly. In that case, the two private methods are essentially the default—as long as they aren’t overridden. However, *no* LSP applies to traits in this regard! This means that the user *can* override these methods in their class with a *different* signature (see: https://3v4l.org/lkgir).

For this reason, the change in Symfony was *not* a BC break, because only a few parameters at the *end* of `configureContainer()` were removed—which means it can still be *called* the same way. 
As long as the method *has not* been overridden, everything is fine. But if it *has been* overridden, then *everything is fine as well*!
And even if the user imports it into their class under a different name and then calls it internally, everything is fine, because PHP allows *more* parameters to be passed than are declared in the method's signature.

However, because the Pimcore kernel imports these methods as `protected` and thus makes them available to its children, it *adopts these methods as its own*, and the LSP *does* apply (see: https://3v4l.org/81ql9)!

If Symfony has now removed parameters from the end of the method in the trait, this has *no effect* on direct users—but for indirect users who inherit from the Pimcore kernel, it *does* have an effect, since the signatures suddenly differ, which they are not allowed to do, according to LSP.

~The correct approach would therefore be to make the methods from the trait available only *indirectly* by defining them within the Pimcore kernel itself, which gives *us* control over the signature and allows *us* to determine when it changes, and to call the methods from the trait within our kernel methods, to still let them act as a default (see: https://3v4l.org/Qo3DN).~

As it turns our, the previously proposed solution is now a BC break in the other direction (for all that have already upgraded).

---

My new solution is:

**`configureRoutes()`**:

Symfony didn't touch the `configureRoutes()` method, so we can leave it as it was (we can handle it *if* Symfony one day changes its signature).

**`configureContainer()`**:

The `protected` import of `configureContainer()` from `MicroKernelTrait` is removed. So this method is now `private` to Pimcore's kernel. This allows the user to override it with any signature. 
The problem here is, that it's not possible to call `parent::configureContainer()` anymore in the user's method, so Symfony's default import of config files from `{project-root}/config` won't happen. 
To fix this, we replicate the code (because we have no way of calling this method from the trait inside Pimcore's kernel), so it still works. 
The only caveat is that it's now not possible anymore for the user to *skip* the default import (by *not* calling `parent::configureContainer()`). But if there's no `{project-root}/config`, nothing won't be imported, so everything should be fine.