### PR TITLE
Escape FieldCollection fieldname in DataObject Listing JOIN condition

### DIFF
--- a/models/DataObject/Listing/Concrete/Dao.php
+++ b/models/DataObject/Listing/Concrete/Dao.php
@@ -173,9 +173,7 @@ class Dao extends Model\DataObject\Listing\Dao
 CONDITION;
 
                 if (!empty($fc['fieldname'])) {
-                    $condition .= <<<CONDITION
- AND {$this->db->quoteIdentifier($name)}.fieldname = "{$fc['fieldname']}"
-CONDITION;
+                    $condition .= ' AND ' . $this->db->quoteIdentifier($name) . '.fieldname = ' . $this->db->quote((string) $fc['fieldname']);
                 }
 
                 // add join

--- a/tests/Model/DataObject/Listing/Concrete/DaoTest.php
+++ b/tests/Model/DataObject/Listing/Concrete/DaoTest.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\DataObject\Listing\Concrete;
+
+use Pimcore\Model\DataObject\Fieldcollection;
+use Pimcore\Model\DataObject\Unittest;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+use Pimcore\Tests\Support\Util\TestHelper;
+
+final class DaoTest extends ModelTestCase
+{
+    protected function setUpTestClasses(): void
+    {
+        $this->tester->setupFieldcollection_Unittestfieldcollection();
+    }
+
+    public function tearDown(): void
+    {
+        TestHelper::cleanUp();
+        parent::tearDown();
+    }
+
+    public function testAddFieldCollectionEscapesFieldnameAgainstSqlInjection(): void
+    {
+        $object = TestHelper::createEmptyObject();
+
+        $items = new Fieldcollection();
+        $items->add(new FieldCollection\Data\Unittestfieldcollection());
+        $object->setFieldcollection($items);
+        $object->save();
+
+        // If this fieldname were interpolated raw into the JOIN condition's SQL
+        // string literal, as it was before this fix (see applyJoins() in
+        // Concrete/Dao.php), the embedded double quote would terminate the
+        // literal and the injected fragment would reference a table that
+        // doesn't exist, causing the query to fail.
+        $maliciousFieldname = '" AND 1=(SELECT 1 FROM this_table_does_not_exist_regression_test)-- -';
+
+        $listing = new Unittest\Listing();
+        $listing->addFieldCollection('unittestfieldcollection', $maliciousFieldname);
+
+        // Must execute as a normal, safely-escaped query instead of throwing a
+        // "table doesn't exist" error from injected SQL.
+        $totalCount = $listing->getTotalCount();
+        $this->assertGreaterThanOrEqual(1, $totalCount);
+    }
+}


### PR DESCRIPTION
## Summary

`applyJoins()` in `models/DataObject/Listing/Concrete/Dao.php` built the FieldCollection JOIN condition using a PHP heredoc that interpolated the FieldCollection's `fieldname` value directly into a double-quoted SQL string literal (`.fieldname = "{$fc['fieldname']}"`), with no escaping. A double-quote character in the fieldname value terminates the string literal early, allowing arbitrary SQL to be injected into the JOIN's ON condition. `addFieldCollection()` (the public entry point on `DataObject\Listing\Concrete`) never validated or escaped this value before storing it.

**Fix:** replaced the raw interpolation with `$this->db->quote((string) $fc['fieldname'])` — Doctrine's standard value-escaping method (the same one already used elsewhere in the codebase, e.g. `AbstractListing::quote()`) — instead of adding redundant input validation upstream. Escaping at the point of SQL construction closes the issue regardless of what the value contains.

Checked for the same interpolation pattern elsewhere in the file (the neighboring Objectbrick JOIN logic) — no other instance found.

## Test plan
- [x] `php -l` on the modified files — no syntax errors
- [x] Added `tests/Model/DataObject/Listing/Concrete/DaoTest.php`: saves an object with a FieldCollection item, then queries via `Listing::addFieldCollection()` using a fieldname payload that would break out of the JOIN condition and reference a nonexistent table if interpolated unescaped; asserts the query executes normally instead of throwing a DB error from injected SQL
- [ ] CI (Codeception suite requires Docker/DB, not run locally)

Co-Authored-By: Claude <noreply@anthropic.com>