### PR TITLE
Reject unwhitelisted filter properties in NotificationServiceFilterParser

### DIFF
--- a/models/Notification/Service/NotificationServiceFilterParser.php
+++ b/models/Notification/Service/NotificationServiceFilterParser.php
@@ -176,10 +176,10 @@ class NotificationServiceFilterParser
 
     private function getDbProperty(array $item): string
     {
-        $property = $item[self::KEY_PROPERTY];
+        $property = $item[self::KEY_PROPERTY] ?? null;
 
-        if (!isset($this->properties[$property])) {
-            throw new InvalidArgumentException('Unknown filter property: ' . $property);
+        if (!is_string($property) || !isset($this->properties[$property])) {
+            throw new InvalidArgumentException('Unknown filter property: ' . (is_scalar($property) ? (string) $property : gettype($property)));
         }
 
         return $this->properties[$property];

--- a/models/Notification/Service/NotificationServiceFilterParser.php
+++ b/models/Notification/Service/NotificationServiceFilterParser.php
@@ -16,6 +16,7 @@ namespace Pimcore\Model\Notification\Service;
 
 use Carbon\Carbon;
 use Exception;
+use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -177,6 +178,10 @@ class NotificationServiceFilterParser
     {
         $property = $item[self::KEY_PROPERTY];
 
-        return isset($this->properties[$property]) ? $this->properties[$property] : $property;
+        if (!isset($this->properties[$property])) {
+            throw new InvalidArgumentException('Unknown filter property: ' . $property);
+        }
+
+        return $this->properties[$property];
     }
 }

--- a/tests/Unit/Notification/Service/NotificationServiceFilterParserTest.php
+++ b/tests/Unit/Notification/Service/NotificationServiceFilterParserTest.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Notification\Service;
+
+use InvalidArgumentException;
+use Pimcore\Model\Notification\Service\NotificationServiceFilterParser;
+use Pimcore\Tests\Support\Test\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class NotificationServiceFilterParserTest extends TestCase
+{
+    private function buildRequest(array $filter): Request
+    {
+        return Request::create('/admin/notifications/find', 'POST', [
+            'filter' => json_encode($filter),
+        ]);
+    }
+
+    public function testWhitelistedStringPropertyIsAccepted(): void
+    {
+        $parser = new NotificationServiceFilterParser($this->buildRequest([
+            ['type' => 'string', 'property' => 'title', 'operator' => 'like', 'value' => 'test'],
+        ]));
+
+        $result = $parser->parse();
+
+        $this->assertArrayHasKey('title_like', $result);
+        $this->assertSame('title LIKE :title_like', $result['title_like']['condition']);
+    }
+
+    public function testWhitelistedDateOperatorIsAccepted(): void
+    {
+        $parser = new NotificationServiceFilterParser($this->buildRequest([
+            ['type' => 'date', 'property' => 'timestamp', 'operator' => 'gt', 'value' => '2026-01-01'],
+        ]));
+
+        $result = $parser->parse();
+
+        $this->assertArrayHasKey('creationDate_gt', $result);
+        $this->assertSame('creationDate > :creationDate_gt', $result['creationDate_gt']['condition']);
+    }
+
+    public function testUnknownStringPropertyIsRejected(): void
+    {
+        // Not a whitelisted property: previously fell through to being used
+        // verbatim as a raw SQL column name with no escaping.
+        $payload = '1 UNION SELECT id,username,password,email,5 FROM users-- -';
+
+        $parser = new NotificationServiceFilterParser($this->buildRequest([
+            ['type' => 'string', 'property' => $payload, 'operator' => 'like', 'value' => ''],
+        ]));
+
+        $this->expectException(InvalidArgumentException::class);
+        $parser->parse();
+    }
+
+    public function testUnknownDatePropertyIsRejected(): void
+    {
+        $payload = '(SELECT 1 FROM (SELECT SLEEP(5))t)-- -';
+
+        $parser = new NotificationServiceFilterParser($this->buildRequest([
+            ['type' => 'date', 'property' => $payload, 'operator' => 'gt', 'value' => '2026-01-01'],
+        ]));
+
+        $this->expectException(InvalidArgumentException::class);
+        $parser->parse();
+    }
+}

--- a/tests/Unit/Notification/Service/NotificationServiceFilterParserTest.php
+++ b/tests/Unit/Notification/Service/NotificationServiceFilterParserTest.php
@@ -65,6 +65,19 @@ final class NotificationServiceFilterParserTest extends TestCase
         $parser->parse();
     }
 
+    public function testArrayValuedPropertyIsRejectedWithoutTypeError(): void
+    {
+        // A JSON filter can supply `property` as an array; must be rejected
+        // cleanly with InvalidArgumentException, not a raw TypeError from
+        // using an array as an array offset.
+        $parser = new NotificationServiceFilterParser($this->buildRequest([
+            ['type' => 'string', 'property' => ['title'], 'operator' => 'like', 'value' => ''],
+        ]));
+
+        $this->expectException(InvalidArgumentException::class);
+        $parser->parse();
+    }
+
     public function testUnknownDatePropertyIsRejected(): void
     {
         $payload = '(SELECT 1 FROM (SELECT SLEEP(5))t)-- -';


### PR DESCRIPTION
## Summary

`getDbProperty()` in `models/Notification/Service/NotificationServiceFilterParser.php` fell back to returning the raw, user-supplied filter `property` value whenever it didn't match one of the two whitelisted keys (`title` → `title`, `timestamp` → `creationDate`). That raw value was then interpolated directly into the SQL condition string in **column-name position** in `parseString()`/`parseDate()` (e.g. `"{$property} LIKE :{$key}"`), with no escaping or quoting. Parameter binding on the value side (`:key`) never protects a column name used this way.

**Fix:** `getDbProperty()` now throws `InvalidArgumentException` when the property isn't one of the whitelisted keys, instead of falling back to the raw value. Only the two known-safe column names can ever reach the SQL condition string.

## Test plan
- [x] `php -l` on the modified file — no syntax errors
- [x] Added `tests/Unit/Notification/Service/NotificationServiceFilterParserTest.php`: whitelisted `title`/`timestamp` properties (both `string` and `date` filter types) still parse correctly; injection-shaped property values are rejected with `InvalidArgumentException` for both filter types
- [ ] CI (requires the full Codeception/container bootstrap, not run locally)

Co-Authored-By: Claude <noreply@anthropic.com>