### PR TITLE
[Improvement]: Allow opting out of FOR UPDATE lock on hydration

### DIFF
--- a/doc/03_Objects/02_Working_with_Objects_via_PHP_API.md
+++ b/doc/03_Objects/02_Working_with_Objects_via_PHP_API.md
@@ -333,6 +333,44 @@ You can switch globally the behaviour (it will bypass `setUnpublished` setting),
 \Pimcore\Model\DataObject::setHideUnpublished(false);
 ```
 
+### Disable Row Locking on Load
+
+Since Pimcore 11.5.2, loading a data object acquires an exclusive row lock (`FOR UPDATE`) to prevent race conditions
+during concurrent read-then-write operations. In read-only scenarios (batch exports, reporting, version snapshots,
+parallel imports loading related objects), this lock is unnecessary and can cause deadlocks or lock wait timeouts.
+
+You can disable the lock globally for a block of operations:
+
+```php
+<?php
+
+use Pimcore\Model\DataObject;
+
+$wasDisabled = DataObject\AbstractObject::isLockingDisabled();
+DataObject\AbstractObject::disableLocking();
+try {
+    // all getById() calls within this block will skip FOR UPDATE
+    $objects = $listing->load();
+} finally {
+    DataObject\AbstractObject::setDisableLocking($wasDisabled);
+}
+```
+
+Or per call using the `lock` parameter on `getById()`:
+
+```php
+<?php
+
+use Pimcore\Model\DataObject;
+
+// load a single object without acquiring a row lock
+$object = DataObject\Myclassname::getById(167, ['lock' => false]);
+```
+
+> **Note:** The lock only applies within database transactions. In regular reads without an active transaction, the
+> `FOR UPDATE` clause has no effect. Only disable locking when you are certain the loaded objects will not be modified
+> in the same transaction.
+
 ### Filter Objects by attributes from Field Collections
 To filter objects by attributes from field collections, you can use following syntax
 (Both code snippets result in the same object listing).

--- a/doc/03_Objects/02_Working_with_Objects_via_PHP_API.md
+++ b/doc/03_Objects/02_Working_with_Objects_via_PHP_API.md
@@ -356,7 +356,7 @@ try {
 }
 ```
 
-Or per call using the `lock` parameter on `getById()`:
+Or per call using the `lock` parameter on `getById()` or `getByPath()`:
 
 ```php
 <?php
@@ -365,6 +365,9 @@ use Pimcore\Model\DataObject;
 
 // load a single object without acquiring a row lock
 $object = DataObject\Myclassname::getById(167, ['lock' => false]);
+
+// also works with getByPath()
+$object = DataObject::getByPath("/path/to/object", ['lock' => false]);
 ```
 
 > **Note:** The lock only applies within database transactions. In regular reads without an active transaction, the

--- a/doc/03_Objects/02_Working_with_Objects_via_PHP_API.md
+++ b/doc/03_Objects/02_Working_with_Objects_via_PHP_API.md
@@ -370,9 +370,7 @@ $object = DataObject\Myclassname::getById(167, ['lock' => false]);
 $object = DataObject::getByPath("/path/to/object", ['lock' => false]);
 ```
 
-> **Note:** The lock only applies within database transactions. In regular reads without an active transaction, the
-> `FOR UPDATE` clause has no effect. Only disable locking when you are certain the loaded objects will not be modified
-> in the same transaction.
+> **Note:** `FOR UPDATE` takes effect in transactions. With autocommit enabled, it is held only for the duration of the statement, but it can still block if other transactions hold conflicting locks. Only disable locking when you are certain the loaded objects will not be modified in the same transaction.
 
 ### Filter Objects by attributes from Field Collections
 To filter objects by attributes from field collections, you can use following syntax

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -278,6 +278,8 @@ abstract class AbstractObject extends Model\Element\AbstractElement
 
     /**
      * @param array{force?: bool, lock?: bool, ...} $params
+     *
+     * @throws InvalidArgumentException when the lock option is not boolean
      */
     public static function getByPath(string $path, array $params = []): static|null
     {

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -291,12 +291,13 @@ abstract class AbstractObject extends Model\Element\AbstractElement
 
         $path = Model\Element\Service::correctPath($path);
 
+        $lock = self::getLockParam($params);
+        unset($params['lock']);
+
         try {
             $object = new static();
             $object->getDao()->getByPath($path);
 
-            $lock = self::getLockParam($params);
-            unset($params['lock']);
             $preparedParams = Model\Element\Service::prepareGetByIdParams($params);
             $preparedParams['lock'] = $lock;
 

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -192,7 +192,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
     /**
      * Static helper to get an object by the passed ID
      *
-     * @param array{force?: bool, ...} $params
+     * @param array{force?: bool, lock?: bool, ...} $params
      */
     public static function getById(int $id, array $params = []): ?static
     {
@@ -202,7 +202,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
 
         $cacheKey = self::getCacheKey($id);
 
-        $lock = $params['lock'] ?? true;
+        $lock = self::getLockParam($params);
         unset($params['lock']);
         $params = Model\Element\Service::prepareGetByIdParams($params);
 
@@ -230,16 +230,14 @@ abstract class AbstractObject extends Model\Element\AbstractElement
                     $object = self::getModelFactory()->build($className);
                     RuntimeCache::set($cacheKey, $object);
 
+                    $wasLockingDisabled = self::isLockingDisabled();
                     if (!$lock) {
-                        $wasLockingDisabled = self::isLockingDisabled();
                         self::disableLocking();
                     }
                     try {
                         $object->getDao()->getById($id);
                     } finally {
-                        if (!$lock) {
-                            self::setDisableLocking($wasLockingDisabled);
-                        }
+                        self::setDisableLocking($wasLockingDisabled);
                     }
 
                     if ($object->getModificationDate() !== null) {
@@ -278,6 +276,9 @@ abstract class AbstractObject extends Model\Element\AbstractElement
         return $object;
     }
 
+    /**
+     * @param array{force?: bool, lock?: bool, ...} $params
+     */
     public static function getByPath(string $path, array $params = []): static|null
     {
         if (!$path) {
@@ -290,7 +291,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
             $object = new static();
             $object->getDao()->getByPath($path);
 
-            $lock = $params['lock'] ?? true;
+            $lock = self::getLockParam($params);
             unset($params['lock']);
             $preparedParams = Model\Element\Service::prepareGetByIdParams($params);
             $preparedParams['lock'] = $lock;
@@ -974,6 +975,21 @@ abstract class AbstractObject extends Model\Element\AbstractElement
     public static function enableLocking(): void
     {
         self::setDisableLocking(false);
+    }
+
+    /**
+     * Extracts and validates the 'lock' option from the given params.
+     *
+     * @param array<string, mixed> $params
+     */
+    private static function getLockParam(array $params): bool
+    {
+        $lock = $params['lock'] ?? true;
+        if (!is_bool($lock)) {
+            throw new InvalidArgumentException('The "lock" parameter must be of type boolean');
+        }
+
+        return $lock;
     }
 
     /**

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -290,7 +290,12 @@ abstract class AbstractObject extends Model\Element\AbstractElement
             $object = new static();
             $object->getDao()->getByPath($path);
 
-            return static::getById($object->getId(), Model\Element\Service::prepareGetByIdParams($params));
+            $lock = $params['lock'] ?? true;
+            unset($params['lock']);
+            $preparedParams = Model\Element\Service::prepareGetByIdParams($params);
+            $preparedParams['lock'] = $lock;
+
+            return static::getById($object->getId(), $preparedParams);
         } catch (Model\Exception\NotFoundException $e) {
             return null;
         }

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -70,7 +70,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
     /**
      * @internal
      */
-    protected static bool $disableLocking = false;
+    private static bool $disableLocking = false;
 
     /**
      * @internal
@@ -950,7 +950,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
     }
 
     /**
-     * @internal
+     * Returns whether the FOR UPDATE row lock during object hydration is currently disabled.
      */
     public static function isLockingDisabled(): bool
     {
@@ -958,7 +958,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
     }
 
     /**
-     * @internal
+     * Enables or disables the FOR UPDATE row lock during object hydration.
      */
     public static function setDisableLocking(bool $disableLocking): void
     {
@@ -966,7 +966,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
     }
 
     /**
-     * @internal
+     * Disables the FOR UPDATE row lock during object hydration, e.g. for read-only batch processing.
      */
     public static function disableLocking(): void
     {
@@ -974,7 +974,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
     }
 
     /**
-     * @internal
+     * Re-enables the FOR UPDATE row lock during object hydration.
      */
     public static function enableLocking(): void
     {
@@ -988,12 +988,15 @@ abstract class AbstractObject extends Model\Element\AbstractElement
      */
     private static function getLockParam(array $params): bool
     {
-        $lock = $params['lock'] ?? true;
-        if (!is_bool($lock)) {
+        if (!array_key_exists('lock', $params)) {
+            return true;
+        }
+
+        if (!is_bool($params['lock'])) {
             throw new InvalidArgumentException('The "lock" parameter must be of type boolean');
         }
 
-        return $lock;
+        return $params['lock'];
     }
 
     /**

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -193,6 +193,8 @@ abstract class AbstractObject extends Model\Element\AbstractElement
      * Static helper to get an object by the passed ID
      *
      * @param array{force?: bool, lock?: bool, ...} $params
+     *
+     * @throws InvalidArgumentException when the lock option is not boolean
      */
     public static function getById(int $id, array $params = []): ?static
     {

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -69,6 +69,11 @@ abstract class AbstractObject extends Model\Element\AbstractElement
 
     /**
      * @internal
+     */
+    protected static bool $disableLocking = false;
+
+    /**
+     * @internal
      *
      * @var string[]
      */
@@ -197,6 +202,8 @@ abstract class AbstractObject extends Model\Element\AbstractElement
 
         $cacheKey = self::getCacheKey($id);
 
+        $lock = $params['lock'] ?? true;
+        unset($params['lock']);
         $params = Model\Element\Service::prepareGetByIdParams($params);
 
         if (!$params['force'] && RuntimeCache::isRegistered($cacheKey)) {
@@ -222,7 +229,19 @@ abstract class AbstractObject extends Model\Element\AbstractElement
                     /** @var AbstractObject $object */
                     $object = self::getModelFactory()->build($className);
                     RuntimeCache::set($cacheKey, $object);
-                    $object->getDao()->getById($id);
+
+                    if (!$lock) {
+                        $wasLockingDisabled = self::isLockingDisabled();
+                        self::disableLocking();
+                    }
+                    try {
+                        $object->getDao()->getById($id);
+                    } finally {
+                        if (!$lock) {
+                            self::setDisableLocking($wasLockingDisabled);
+                        }
+                    }
+
                     if ($object->getModificationDate() !== null) {
                         $object->__setDataVersionTimestamp($object->getModificationDate());
                     }
@@ -918,6 +937,38 @@ abstract class AbstractObject extends Model\Element\AbstractElement
     public static function enableDirtyDetection(): void
     {
         self::setDisableDirtyDetection(false);
+    }
+
+    /**
+     * @internal
+     */
+    public static function isLockingDisabled(): bool
+    {
+        return self::$disableLocking;
+    }
+
+    /**
+     * @internal
+     */
+    public static function setDisableLocking(bool $disableLocking): void
+    {
+        self::$disableLocking = $disableLocking;
+    }
+
+    /**
+     * @internal
+     */
+    public static function disableLocking(): void
+    {
+        self::setDisableLocking(true);
+    }
+
+    /**
+     * @internal
+     */
+    public static function enableLocking(): void
+    {
+        self::setDisableLocking(false);
     }
 
     /**

--- a/models/DataObject/Concrete/Dao.php
+++ b/models/DataObject/Concrete/Dao.php
@@ -129,7 +129,12 @@ class Dao extends Model\DataObject\AbstractObject\Dao
      */
     public function getData(): void
     {
-        if (!$data = $this->db->fetchAssociative('SELECT * FROM object_store_' . $this->model->getClassId() . ' WHERE oo_id = ? FOR UPDATE', [$this->model->getId()])) {
+        $sql = 'SELECT * FROM object_store_' . $this->model->getClassId() . ' WHERE oo_id = ?';
+        if (!DataObject\AbstractObject::isLockingDisabled()) {
+            $sql .= ' FOR UPDATE';
+        }
+
+        if (!$data = $this->db->fetchAssociative($sql, [$this->model->getId()])) {
             return;
         }
 

--- a/tests/Model/DataObject/ObjectLockingTest.php
+++ b/tests/Model/DataObject/ObjectLockingTest.php
@@ -126,7 +126,7 @@ final class ObjectLockingTest extends ModelTestCase
         $capturedSql = [];
         $connection = $this->createMock(Connection::class);
         $connection->method('fetchAssociative')->willReturnCallback(
-            function (string $sql) use (&$capturedSql): bool {
+            function (string $sql, array $params = [], array $types = []) use (&$capturedSql): array|false {
                 $capturedSql[] = $sql;
 
                 return false;

--- a/tests/Model/DataObject/ObjectLockingTest.php
+++ b/tests/Model/DataObject/ObjectLockingTest.php
@@ -1,0 +1,107 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\DataObject;
+
+use InvalidArgumentException;
+use Pimcore\Model\DataObject;
+use Pimcore\Model\DataObject\AbstractObject;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+use Pimcore\Tests\Support\Util\TestHelper;
+
+/**
+ * Class ObjectLockingTest
+ *
+ * @package Pimcore\Tests\Model\DataObject
+ *
+ * @group model.dataobject.object
+ */
+class ObjectLockingTest extends ModelTestCase
+{
+    protected function tearDown(): void
+    {
+        AbstractObject::enableLocking();
+        parent::tearDown();
+    }
+
+    public function testLockingIsEnabledByDefault(): void
+    {
+        $this->assertFalse(AbstractObject::isLockingDisabled(), 'Hydration locking must be enabled by default.');
+    }
+
+    public function testDisableLockingAccessors(): void
+    {
+        AbstractObject::disableLocking();
+        $this->assertTrue(AbstractObject::isLockingDisabled());
+
+        AbstractObject::enableLocking();
+        $this->assertFalse(AbstractObject::isLockingDisabled());
+
+        AbstractObject::setDisableLocking(true);
+        $this->assertTrue(AbstractObject::isLockingDisabled());
+
+        AbstractObject::setDisableLocking(false);
+        $this->assertFalse(AbstractObject::isLockingDisabled());
+    }
+
+    public function testGetByIdWithLockParamRestoresLockingState(): void
+    {
+        $object = TestHelper::createEmptyObject();
+
+        $loaded = Concrete::getById($object->getId(), ['force' => true, 'lock' => false]);
+        $this->assertInstanceOf(Concrete::class, $loaded);
+        $this->assertSame($object->getId(), $loaded->getId());
+        $this->assertFalse(
+            AbstractObject::isLockingDisabled(),
+            'Locking state must be restored after getById() with lock param.'
+        );
+
+        AbstractObject::disableLocking();
+        $loaded = Concrete::getById($object->getId(), ['force' => true, 'lock' => false]);
+        $this->assertInstanceOf(Concrete::class, $loaded);
+        $this->assertTrue(
+            AbstractObject::isLockingDisabled(),
+            'Previously disabled locking must stay disabled after getById() with lock param.'
+        );
+    }
+
+    public function testGetByPathSupportsLockParam(): void
+    {
+        $object = TestHelper::createEmptyObject();
+
+        $loaded = DataObject::getByPath($object->getFullPath(), ['force' => true, 'lock' => false]);
+        $this->assertInstanceOf(Concrete::class, $loaded);
+        $this->assertSame($object->getId(), $loaded->getId());
+        $this->assertFalse(
+            AbstractObject::isLockingDisabled(),
+            'Locking state must be restored after getByPath() with lock param.'
+        );
+    }
+
+    public function testGetByIdRejectsNonBooleanLockParam(): void
+    {
+        $object = TestHelper::createEmptyObject();
+
+        $this->expectException(InvalidArgumentException::class);
+        Concrete::getById($object->getId(), ['force' => true, 'lock' => 'false']);
+    }
+
+    public function testGetByPathRejectsNonBooleanLockParam(): void
+    {
+        $object = TestHelper::createEmptyObject();
+
+        $this->expectException(InvalidArgumentException::class);
+        DataObject::getByPath($object->getFullPath(), ['lock' => 1]);
+    }
+}

--- a/tests/Model/DataObject/ObjectLockingTest.php
+++ b/tests/Model/DataObject/ObjectLockingTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Pimcore\Tests\Model\DataObject;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception\LockWaitTimeoutException;
 use Exception;
 use InvalidArgumentException;
 use Pimcore\Cache\RuntimeCache;
@@ -109,6 +111,12 @@ final class ObjectLockingTest extends ModelTestCase
         DataObject::getByPath($object->getFullPath(), ['lock' => 1]);
     }
 
+    public function testGetByPathRejectsNonBooleanLockParamForMissingPath(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        DataObject::getByPath('/some/path/that/does/not/exist', ['lock' => 'false']);
+    }
+
     public function testGetByIdRejectsNullLockParam(): void
     {
         $object = TestHelper::createEmptyObject();
@@ -151,6 +159,48 @@ final class ObjectLockingTest extends ModelTestCase
             $capturedSql[1],
             'Hydration query must not lock while locking is disabled.'
         );
+    }
+
+    public function testLockParamSkipsRowLockEndToEnd(): void
+    {
+        $object = TestHelper::createEmptyObject();
+        $id = $object->getId();
+        $db = Db::get();
+
+        // hold an exclusive lock on the object's data row from a second connection
+        $blocker = DriverManager::getConnection($db->getParams());
+        $blocker->beginTransaction();
+        $blocker->executeQuery(
+            'SELECT oo_id FROM object_store_' . $object->getClassId() . ' WHERE oo_id = ? FOR UPDATE',
+            [$id]
+        );
+
+        $db->executeStatement('SET SESSION innodb_lock_wait_timeout = 1');
+
+        try {
+            // without the row lock, hydration is a plain read and succeeds despite the concurrent lock
+            $loaded = Concrete::getById($id, ['force' => true, 'lock' => false]);
+            $this->assertInstanceOf(Concrete::class, $loaded);
+
+            // with the default locking behavior, the same load has to wait for the lock and times out
+            $lockWaitDetected = false;
+
+            try {
+                Concrete::getById($id, ['force' => true]);
+            } catch (LockWaitTimeoutException) {
+                $lockWaitDetected = true;
+            }
+
+            $this->assertTrue(
+                $lockWaitDetected,
+                'Loading with default locking was expected to wait for the concurrently held row lock.'
+            );
+        } finally {
+            $db->executeStatement('SET SESSION innodb_lock_wait_timeout = DEFAULT');
+            $blocker->rollBack();
+            $blocker->close();
+            RuntimeCache::clear();
+        }
     }
 
     public function testLockingStateIsRestoredWhenHydrationFails(): void

--- a/tests/Model/DataObject/ObjectLockingTest.php
+++ b/tests/Model/DataObject/ObjectLockingTest.php
@@ -13,7 +13,11 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Model\DataObject;
 
+use Doctrine\DBAL\Connection;
+use Exception;
 use InvalidArgumentException;
+use Pimcore\Cache\RuntimeCache;
+use Pimcore\Db;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\Concrete;
@@ -27,7 +31,7 @@ use Pimcore\Tests\Support\Util\TestHelper;
  *
  * @group model.dataobject.object
  */
-class ObjectLockingTest extends ModelTestCase
+final class ObjectLockingTest extends ModelTestCase
 {
     protected function tearDown(): void
     {
@@ -103,5 +107,77 @@ class ObjectLockingTest extends ModelTestCase
 
         $this->expectException(InvalidArgumentException::class);
         DataObject::getByPath($object->getFullPath(), ['lock' => 1]);
+    }
+
+    public function testGetByIdRejectsNullLockParam(): void
+    {
+        $object = TestHelper::createEmptyObject();
+
+        $this->expectException(InvalidArgumentException::class);
+        Concrete::getById($object->getId(), ['force' => true, 'lock' => null]);
+    }
+
+    public function testGetDataAppendsForUpdateOnlyWhenLockingEnabled(): void
+    {
+        $object = TestHelper::createEmptyObject();
+        $dao = $object->getDao();
+        $originalDb = $dao->db;
+
+        $capturedSql = [];
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchAssociative')->willReturnCallback(
+            function (string $sql) use (&$capturedSql): bool {
+                $capturedSql[] = $sql;
+
+                return false;
+            }
+        );
+
+        $dao->db = $connection;
+
+        try {
+            $dao->getData();
+            AbstractObject::disableLocking();
+            $dao->getData();
+        } finally {
+            $dao->db = $originalDb;
+            AbstractObject::enableLocking();
+        }
+
+        $this->assertCount(2, $capturedSql);
+        $this->assertStringContainsString('FOR UPDATE', $capturedSql[0], 'Hydration query must lock by default.');
+        $this->assertStringNotContainsString(
+            'FOR UPDATE',
+            $capturedSql[1],
+            'Hydration query must not lock while locking is disabled.'
+        );
+    }
+
+    public function testLockingStateIsRestoredWhenHydrationFails(): void
+    {
+        $object = TestHelper::createEmptyObject();
+        $id = $object->getId();
+        $originalClassId = $object->getClassId();
+        $db = Db::get();
+
+        // point the object to a non-existing class, so hydration fails while loading the object data
+        $db->executeStatement('UPDATE objects SET classId = ? WHERE id = ?', ['brokenLockingTest', $id]);
+
+        $hydrationFailed = false;
+
+        try {
+            Concrete::getById($id, ['force' => true, 'lock' => false]);
+        } catch (Exception) {
+            $hydrationFailed = true;
+        } finally {
+            $db->executeStatement('UPDATE objects SET classId = ? WHERE id = ?', [$originalClassId, $id]);
+            RuntimeCache::clear();
+        }
+
+        $this->assertTrue($hydrationFailed, 'Hydration was expected to fail with a broken class id.');
+        $this->assertFalse(
+            AbstractObject::isLockingDisabled(),
+            'Locking state must be restored when hydration fails.'
+        );
     }
 }


### PR DESCRIPTION
## Changes in this pull request

Resolves #18984

Recreation of #18985 by @Externaluse (thank you, Stefan!), rebased onto `2026.x`. The original commits are cherry-picked with authorship preserved, so all credit goes to the original contributor.

Allows integrators to opt out of the `FOR UPDATE` row lock during read-only object hydration, preventing deadlocks in batch imports, version snapshots, and other read-only scenarios.

### What changed

- Add static flag `AbstractObject::$disableLocking` (default `false`) with accessors mirroring `$disableDirtyDetection`:
  `isLockingDisabled()` / `setDisableLocking(bool)` / `disableLocking()` / `enableLocking()`
- Guard `FOR UPDATE` in `Concrete\Dao::getData()` with `if (!AbstractObject::isLockingDisabled())`
- Add `['lock' => false]` option on `getById()` — internally toggles the flag for that single call via try/finally
- Pass the `lock` param through `getByPath()` to `getById()` for consistency
- Documentation added in `doc/03_Objects/02_Working_with_Objects_via_PHP_API.md`

### Design notes

The static flag is the primary mechanism, following the established pattern of `$hideUnpublished`, `$getInheritedValues`, and `$disableDirtyDetection`. The `['lock' => false]` param on `getById()` is syntactic sugar — it sets/restores the flag internally. Note that the lock parameter isn't passed to `Model\Element\Service::prepareGetByIdParams` as it doesn't apply universally.

The original PR targeted `11.5` since the deadlocks are a side effect of the `FOR UPDATE` clause introduced in v11.5.2 via #17788; this recreation targets `2026.x` instead.

## Additional info

Context and analysis: https://github.com/pimcore/pimcore/issues/17781#issuecomment-3913281020