### PR TITLE
Bind CSV export files to the requesting user in CustomReportController

### DIFF
--- a/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
+++ b/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
@@ -364,6 +364,11 @@ class CustomReportController extends UserAwareController
             throw new InvalidArgumentException($exportFileName . ' is not a valid csv file.');
         }
 
+        $currentUserId = $this->getPimcoreUser()?->getId();
+        if (!preg_match('/^report-export-(\d+)-/', $exportFileName, $matches) || (int) $matches[1] !== $currentUserId) {
+            throw new AccessDeniedHttpException('You are not allowed to access this export file.');
+        }
+
         return PIMCORE_SYSTEM_TEMP_DIRECTORY . '/' . $exportFileName;
     }
 
@@ -409,7 +414,7 @@ class CustomReportController extends UserAwareController
         ++$offset;
 
         if (!($exportFile = $request->query->getString('exportFile'))) {
-            $exportFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/report-export-' . uniqid() . '.csv';
+            $exportFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/report-export-' . $this->getPimcoreUser()?->getId() . '-' . uniqid() . '.csv';
             @unlink($exportFile);
         } else {
             $exportFile = $this->getTemporaryFileFromFileName($exportFile);

--- a/tests/Unit/CustomReportsBundle/Controller/Reports/CustomReportControllerTest.php
+++ b/tests/Unit/CustomReportsBundle/Controller/Reports/CustomReportControllerTest.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\CustomReportsBundle\Controller\Reports;
+
+use Pimcore\Bundle\CustomReportsBundle\Controller\Reports\CustomReportController;
+use Pimcore\Model\User;
+use Pimcore\Security\User\User as UserProxy;
+use Pimcore\Tests\Support\Test\TestCase;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+final class CustomReportControllerTest extends TestCase
+{
+    /**
+     * Builds a controller instance whose getPimcoreUser() is stubbed to
+     * return a fake user with the given id, without needing a real
+     * authenticated security context.
+     */
+    private function controllerAsUser(int $userId): CustomReportController
+    {
+        $user = new User();
+        $user->setId($userId);
+        $userProxy = new UserProxy($user);
+
+        return new class($userProxy) extends CustomReportController {
+            public function __construct(private readonly UserProxy $fakeUser)
+            {
+            }
+
+            protected function getPimcoreUser(bool $proxyUser = false): UserProxy|User|null
+            {
+                return $this->fakeUser;
+            }
+
+            public function resolveExportFile(string $exportFileName): string
+            {
+                return $this->getTemporaryFileFromFileName($exportFileName);
+            }
+        };
+    }
+
+    public function testOwnerCanResolveTheirOwnExportFile(): void
+    {
+        $controller = $this->controllerAsUser(42);
+
+        $resolved = $controller->resolveExportFile('report-export-42-abc123.csv');
+
+        $this->assertStringEndsWith('/report-export-42-abc123.csv', $resolved);
+    }
+
+    public function testOtherUserCannotResolveSomeoneElsesExportFile(): void
+    {
+        // Before this fix, any user with the generic 'reports' permission could
+        // resolve (and, via downloadCsvAction(), read and delete) an export file
+        // created by a different user purely by knowing its filename.
+        $controller = $this->controllerAsUser(99);
+
+        $this->expectException(AccessDeniedHttpException::class);
+        $controller->resolveExportFile('report-export-42-abc123.csv');
+    }
+
+    public function testFilenameNotMatchingTheExportPatternIsRejected(): void
+    {
+        $controller = $this->controllerAsUser(42);
+
+        $this->expectException(AccessDeniedHttpException::class);
+        $controller->resolveExportFile('not-an-export-file.csv');
+    }
+}


### PR DESCRIPTION
## Summary

`createCsvAction()` in `bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php` generates export files as `report-export-<uniqid>.csv` and returns the bare filename to the client. Both `downloadCsvAction()` and the paginated-continuation branch of `createCsvAction()` itself accept that filename back from any user holding the generic `reports` permission, with no check that the requester is the one who created the export. Since `downloadCsvAction()` also deletes the file after serving it, any user with `reports` access could read (and destroy) another user's in-progress export purely by learning its filename.

**Fix:** embed the creating user's ID into the generated filename (`report-export-<userId>-<uniqid>.csv`) and verify it against the current user in `getTemporaryFileFromFileName()` — the single shared resolution point both vulnerable call sites already route through — throwing `AccessDeniedHttpException` on a mismatch.

## Test plan
- [x] `php -l` on the modified files — no syntax errors
- [x] Added `tests/Unit/CustomReportsBundle/Controller/Reports/CustomReportControllerTest.php`: stubs the controller's user resolution to avoid needing a full security context, then verifies the owning user can resolve their own export file, a different user cannot (`AccessDeniedHttpException`), and a filename not matching the expected pattern is also rejected
- [ ] CI (requires the full Codeception/container bootstrap, not run locally)

Co-Authored-By: Claude <noreply@anthropic.com>