### PR TITLE
Validate field-collection type in Listing::addFieldCollection()

### DIFF
--- a/models/DataObject/Listing/Concrete.php
+++ b/models/DataObject/Listing/Concrete.php
@@ -134,7 +134,11 @@ abstract class Concrete extends Model\DataObject\Listing
             throw new Exception('No fieldcollectiontype given');
         }
 
-        DataObject\Fieldcollection\Definition::getByKey($type);
+        $definition = DataObject\Fieldcollection\Definition::getByKey($type);
+        if (!$definition instanceof DataObject\Fieldcollection\Definition) {
+            throw new Exception('Unknown fieldcollection type: ' . $type);
+        }
+
         $this->fieldCollectionConfigs[] = ['type' => $type, 'fieldname' => $fieldname];
     }
 

--- a/tests/Model/DataObject/Listing/Concrete/DaoTest.php
+++ b/tests/Model/DataObject/Listing/Concrete/DaoTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Model\DataObject\Listing\Concrete;
 
+use Exception;
 use Pimcore\Model\DataObject\Fieldcollection;
 use Pimcore\Model\DataObject\Unittest;
 use Pimcore\Tests\Support\Test\ModelTestCase;
@@ -54,5 +55,28 @@ final class DaoTest extends ModelTestCase
         // "table doesn't exist" error from injected SQL.
         $totalCount = $listing->getTotalCount();
         $this->assertGreaterThanOrEqual(1, $totalCount);
+    }
+
+    public function testAddFieldCollectionRejectsUnknownType(): void
+    {
+        // Previously accepted verbatim: getByKey()'s return value was discarded,
+        // so any string reached applyJoins() and was concatenated raw into the
+        // JOIN's table name (object_collection_<type>_<classId>), which Doctrine
+        // never quotes. Only a type matching a real, existing field-collection
+        // definition may be used now.
+        $maliciousType = 'nonexistent" ON 1=1 LEFT JOIN users-- -';
+
+        $listing = new Unittest\Listing();
+
+        $this->expectException(Exception::class);
+        $listing->addFieldCollection($maliciousType, 'irrelevant');
+    }
+
+    public function testAddFieldCollectionStillAcceptsARealType(): void
+    {
+        $listing = new Unittest\Listing();
+        $listing->addFieldCollection('unittestfieldcollection', 'fieldinput1');
+
+        $this->assertCount(1, $listing->getFieldCollections());
     }
 }


### PR DESCRIPTION
## Summary

`Concrete\Dao::applyJoins()` concatenates the field-collection `type` value raw into the `LEFT JOIN`'s table name (`object_collection_<type>_<classId>`), which Doctrine's `QueryBuilder` never quotes or escapes for table names/aliases. `Listing\Concrete::addFieldCollection()` called `Fieldcollection\Definition::getByKey($type)` but discarded its return value — `getByKey()` only throws for path-traversal characters (`/`, `\`, `..`) and otherwise silently returns `null` for an unknown key, so it was never an effective validator and any string reached the join unvalidated.

(The `fieldname` value going into the `ON` condition's string literal was already fixed separately, using `Connection::quote()`. This closes a second, distinct gap in the same function: the `type` value reaching the raw table name.)

**Fix:** require `getByKey($type)` to actually return a real `Definition` instance in `addFieldCollection()`, throwing otherwise. Since the backing property is private and only writable through this one method, this closes the gap at its single entry point.

## Test plan
- [x] `php -l` on the modified files — no syntax errors
- [x] Extended `tests/Model/DataObject/Listing/Concrete/DaoTest.php`: a type value that doesn't match a real field-collection definition is rejected; a real, existing type still works correctly
- [ ] CI (requires the full Codeception/container bootstrap, not run locally)

Co-Authored-By: Claude <noreply@anthropic.com>