### PR TITLE
Fix workspace permission path-boundary matching (and make it index-usable)

### DIFF
--- a/models/Asset/Dao.php
+++ b/models/Asset/Dao.php
@@ -332,7 +332,7 @@ class Dao extends Model\Element\Dao
 
             $inheritedPermission = $this->isInheritingPermission('list', $userIds);
 
-            $anyAllowedRowOrChildren = 'EXISTS(SELECT list FROM users_workspaces_asset uwa WHERE userId IN (' . implode(',', $userIds) . ') AND list=1 AND LOCATE(CONCAT(`path`,filename),cpath)=1 AND
+            $anyAllowedRowOrChildren = 'EXISTS(SELECT list FROM users_workspaces_asset uwa WHERE userId IN (' . implode(',', $userIds) . ') AND list=1 AND (cpath=CONCAT(`path`,filename) OR LOCATE(CONCAT(`path`,filename,\'/\'),cpath)=1) AND
                 NOT EXISTS(SELECT list FROM users_workspaces_asset WHERE userId =' . $currentUserId . '  AND list=0 AND cpath = uwa.cpath))';
             $isDisallowedCurrentRow = 'EXISTS(SELECT list FROM users_workspaces_asset WHERE userId IN (' . implode(',', $userIds) . ')  AND cid = id AND list=0)';
 
@@ -387,7 +387,7 @@ class Dao extends Model\Element\Dao
 
             $inheritedPermission = $this->isInheritingPermission('list', $userIds);
 
-            $anyAllowedRowOrChildren = 'EXISTS(SELECT list FROM users_workspaces_asset uwa WHERE userId IN (' . implode(',', $userIds) . ') AND list=1 AND LOCATE(CONCAT(`path`,filename),cpath)=1 AND
+            $anyAllowedRowOrChildren = 'EXISTS(SELECT list FROM users_workspaces_asset uwa WHERE userId IN (' . implode(',', $userIds) . ') AND list=1 AND (cpath=CONCAT(`path`,filename) OR LOCATE(CONCAT(`path`,filename,\'/\'),cpath)=1) AND
                 NOT EXISTS(SELECT list FROM users_workspaces_asset WHERE userId =' . $currentUserId . '  AND list=0 AND cpath = uwa.cpath))';
             $isDisallowedCurrentRow = 'EXISTS(SELECT list FROM users_workspaces_asset WHERE userId IN (' . implode(',', $userIds) . ')  AND cid = id AND list=0)';
 

--- a/models/Asset/Listing.php
+++ b/models/Asset/Listing.php
@@ -73,7 +73,7 @@ class Listing extends Model\Listing\AbstractListing implements PaginateListingIn
 
             $inheritedPermission = $asset->getDao()->isInheritingPermission('list', $userIds);
 
-            $anyAllowedRowOrChildren = 'EXISTS(SELECT list FROM users_workspaces_asset uwa WHERE userId IN (' . implode(',', $userIds) . ') AND list=1 AND LOCATE(CONCAT(`path`,filename),cpath)=1 AND
+            $anyAllowedRowOrChildren = 'EXISTS(SELECT list FROM users_workspaces_asset uwa WHERE userId IN (' . implode(',', $userIds) . ') AND list=1 AND (cpath=CONCAT(`path`,filename) OR LOCATE(CONCAT(`path`,filename,\'/\'),cpath)=1) AND
             NOT EXISTS(SELECT list FROM users_workspaces_asset WHERE userId =' . $currentUserId . '  AND list=0 AND cpath = uwa.cpath))';
             $isDisallowedCurrentRow = 'EXISTS(SELECT list FROM users_workspaces_asset WHERE userId IN (' . implode(',', $userIds) . ')  AND cid = id AND list=0)';
 

--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -297,7 +297,7 @@ class Dao extends Model\Element\Dao
 
             // $anyAllowedRowOrChildren checks for nested elements that are `list`=1. This is to allow the folders in between from current parent to any nested elements and due the "additive" permission on the element itself, we can simply ignore list=0 children
             // unless for the same rule found is list=0 on user specific level, in that case it nullifies that entry.
-            $anyAllowedRowOrChildren = 'EXISTS(SELECT list FROM users_workspaces_object uwo WHERE userId IN (' . implode(',', $permissionIds) . ') AND list=1 AND LOCATE(CONCAT(o.path,o.key),cpath)=1 AND
+            $anyAllowedRowOrChildren = 'EXISTS(SELECT list FROM users_workspaces_object uwo WHERE userId IN (' . implode(',', $permissionIds) . ') AND list=1 AND (cpath=CONCAT(o.path,o.key) OR LOCATE(CONCAT(o.path,o.key,\'/\'),cpath)=1) AND
             NOT EXISTS(SELECT list FROM users_workspaces_object WHERE userId =' . $currentUserId . '  AND list=0 AND cpath = uwo.cpath))';
 
             // $allowedCurrentRow checks if the current row is blocked, if found a match it "removes/ignores" the entry from object table, doesn't need to check if is list=1 on user level, since it is done in $anyAllowedRowOrChildren (NB: equal or longer cpath) so we are safe to deduce that there are no valid list=1 rules
@@ -394,7 +394,7 @@ class Dao extends Model\Element\Dao
 
             $inheritedPermission = $this->isInheritingPermission('list', $permissionIds);
 
-            $anyAllowedRowOrChildren = 'EXISTS(SELECT list FROM users_workspaces_object uwo WHERE userId IN (' . implode(',', $permissionIds) . ') AND list=1 AND LOCATE(CONCAT(o.path,o.key),cpath)=1 AND
+            $anyAllowedRowOrChildren = 'EXISTS(SELECT list FROM users_workspaces_object uwo WHERE userId IN (' . implode(',', $permissionIds) . ') AND list=1 AND (cpath=CONCAT(o.path,o.key) OR LOCATE(CONCAT(o.path,o.key,\'/\'),cpath)=1) AND
             NOT EXISTS(SELECT list FROM users_workspaces_object WHERE userId ='.$currentUserId.'  AND list=0 AND cpath = uwo.cpath))';
             $isDisallowedCurrentRow = 'EXISTS(SELECT list FROM users_workspaces_object uworow WHERE userId IN (' . implode(',', $permissionIds) . ')  AND cid = id AND list=0)';
 

--- a/models/Document/Dao.php
+++ b/models/Document/Dao.php
@@ -335,7 +335,7 @@ class Dao extends Model\Element\Dao
 
             $inheritedPermission = $this->isInheritingPermission('list', $userIds);
 
-            $anyAllowedRowOrChildren = 'EXISTS(SELECT list FROM users_workspaces_document uwd WHERE userId IN (' . implode(',', $userIds) . ') AND list=1 AND LOCATE(CONCAT(d.path,d.`key`),cpath)=1 AND
+            $anyAllowedRowOrChildren = 'EXISTS(SELECT list FROM users_workspaces_document uwd WHERE userId IN (' . implode(',', $userIds) . ') AND list=1 AND (cpath=CONCAT(d.path,d.`key`) OR LOCATE(CONCAT(d.path,d.`key`,\'/\'),cpath)=1) AND
                 NOT EXISTS(SELECT list FROM users_workspaces_document WHERE userId =' . $currentUserId . '  AND list=0 AND cpath = uwd.cpath))';
             $isDisallowedCurrentRow = 'EXISTS(SELECT list FROM users_workspaces_document WHERE userId IN (' . implode(',', $userIds) . ')  AND cid = id AND list=0)';
 
@@ -372,7 +372,7 @@ class Dao extends Model\Element\Dao
 
             $inheritedPermission = $this->isInheritingPermission('list', $userIds);
 
-            $anyAllowedRowOrChildren = 'EXISTS(SELECT list FROM users_workspaces_document uwd WHERE userId IN (' . implode(',', $userIds) . ') AND list=1 AND LOCATE(CONCAT(d.path,d.`key`),cpath)=1 AND
+            $anyAllowedRowOrChildren = 'EXISTS(SELECT list FROM users_workspaces_document uwd WHERE userId IN (' . implode(',', $userIds) . ') AND list=1 AND (cpath=CONCAT(d.path,d.`key`) OR LOCATE(CONCAT(d.path,d.`key`,\'/\'),cpath)=1) AND
                 NOT EXISTS(SELECT list FROM users_workspaces_document WHERE userId =' . $currentUserId . '  AND list=0 AND cpath = uwd.cpath))';
             $isDisallowedCurrentRow = 'EXISTS(SELECT list FROM users_workspaces_document WHERE userId IN (' . implode(',', $userIds) . ')  AND cid = id AND list=0)';
 

--- a/models/Element/Dao.php
+++ b/models/Element/Dao.php
@@ -12,6 +12,7 @@
 
 namespace Pimcore\Model\Element;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Exception;
 use Pimcore\Db\Helper;
 use Pimcore\Model;
@@ -90,13 +91,23 @@ abstract class Dao extends Model\Dao\AbstractDao
         // path prefix, e.g. "/foo/Car" matching "/foo/Carpets/...") is both boundary-correct and
         // index-usable on users_workspaces_*.cpath.
         $paths = $this->getAncestorPaths($fullPath);
-        $placeholders = implode(',', array_fill(0, count($paths), '?'));
 
-        $sql = 'SELECT ' . $this->db->quoteIdentifier($type) . ' FROM users_workspaces_' . $tableSuffix . ' WHERE cpath IN (' . $placeholders . ') AND
-        userId IN (' . implode(',', $userIds) . ')
-        ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . end($userIds) . ') DESC, ' . $this->db->quoteIdentifier($type) . ' DESC LIMIT 1';
+        $sql = 'SELECT ' . $this->db->quoteIdentifier($type) . ' FROM users_workspaces_' . $tableSuffix . ' WHERE cpath IN (:paths) AND
+        userId IN (:userIds)
+        ORDER BY LENGTH(cpath) DESC, FIELD(userId, :lastUserId) DESC, ' . $this->db->quoteIdentifier($type) . ' DESC LIMIT 1';
 
-        return (int)$this->db->fetchOne($sql, $paths);
+        return (int)$this->db->fetchOne(
+            $sql,
+            [
+                'paths' => $paths,
+                'userIds' => $userIds,
+                'lastUserId' => end($userIds),
+            ],
+            [
+                'paths' => ArrayParameterType::STRING,
+                'userIds' => ArrayParameterType::INTEGER,
+            ]
+        );
     }
 
     /**

--- a/models/Element/Dao.php
+++ b/models/Element/Dao.php
@@ -84,11 +84,40 @@ abstract class Dao extends Model\Dao\AbstractDao
         }
         $fullPath = $current->getPath() . $current->getKey();
 
-        $sql = 'SELECT ' . $this->db->quoteIdentifier($type) . ' FROM users_workspaces_' . $tableSuffix . ' WHERE LOCATE(cpath, ?)=1 AND
+        // A workspace applies to this element when its cpath is the element itself or one of its
+        // ancestors. Matching the exact set of ancestor paths (instead of LOCATE(cpath, fullPath),
+        // which matches on a raw substring and therefore also matched unrelated siblings sharing a
+        // path prefix, e.g. "/foo/Car" matching "/foo/Carpets/...") is both boundary-correct and
+        // index-usable on users_workspaces_*.cpath.
+        $paths = $this->getAncestorPaths($fullPath);
+        $placeholders = implode(',', array_fill(0, count($paths), '?'));
+
+        $sql = 'SELECT ' . $this->db->quoteIdentifier($type) . ' FROM users_workspaces_' . $tableSuffix . ' WHERE cpath IN (' . $placeholders . ') AND
         userId IN (' . implode(',', $userIds) . ')
         ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . end($userIds) . ') DESC, ' . $this->db->quoteIdentifier($type) . ' DESC LIMIT 1';
 
-        return (int)$this->db->fetchOne($sql, [$fullPath]);
+        return (int)$this->db->fetchOne($sql, $paths);
+    }
+
+    /**
+     * Returns the element's own full path and the full paths of all its ancestors, including the
+     * root path "/". Used for exact, boundary-correct workspace matching against cpath.
+     *
+     * @return string[]
+     */
+    protected function getAncestorPaths(string $fullPath): array
+    {
+        $paths = ['/'];
+        $current = '';
+        foreach (explode('/', trim($fullPath, '/')) as $segment) {
+            if ($segment === '') {
+                continue;
+            }
+            $current .= '/' . $segment;
+            $paths[] = $current;
+        }
+
+        return array_values(array_unique($paths));
     }
 
     /**

--- a/tests/Model/Element/WorkspacePermissionPathBoundaryTest.php
+++ b/tests/Model/Element/WorkspacePermissionPathBoundaryTest.php
@@ -20,17 +20,20 @@ use Pimcore\Tests\Support\Util\TestHelper;
 
 /**
  * Workspace permissions are matched against the element path. A workspace configured on
- * "/perm-test/Car" must NOT apply to the sibling subtree "/perm-test/Carpets", even though
- * the string "/perm-test/Car" is a raw prefix of "/perm-test/Carpets". This guards against a
- * regression where LOCATE()-based matching ignored the path boundary.
+ * "/perm-test/Car" and one configured on the string-prefix sibling "/perm-test/Carpets" must
+ * stay isolated from each other, even though "/perm-test/Car" is a raw prefix of
+ * "/perm-test/Carpets". This guards against a regression where LOCATE()-based matching ignored
+ * the path boundary in either direction.
  *
  * @group model.element.permission
  */
 class WorkspacePermissionPathBoundaryTest extends ModelTestCase
 {
-    private ?User $user = null;
+    /** @var User[] */
+    private array $createdUsers = [];
 
-    private ?User\Role $role = null;
+    /** @var User\Role[] */
+    private array $createdRoles = [];
 
     public function setUp(): void
     {
@@ -40,23 +43,29 @@ class WorkspacePermissionPathBoundaryTest extends ModelTestCase
 
     public function tearDown(): void
     {
-        $this->user?->delete();
-        $this->role?->delete();
+        foreach ($this->createdUsers as $user) {
+            $user->delete();
+        }
+        foreach ($this->createdRoles as $role) {
+            $role->delete();
+        }
+        $this->createdUsers = [];
+        $this->createdRoles = [];
         TestHelper::cleanUp();
         parent::tearDown();
     }
 
-    public function testWorkspaceDoesNotLeakToPrefixSiblingSubtree(): void
+    /**
+     * Ancestor direction (Element\Dao::InheritingPermission via isInheritingPermission):
+     * a workspace on "/perm-test/Car" must not inherit down onto the sibling "/perm-test/Carpets",
+     * whose path shares the "/perm-test/Car" prefix.
+     */
+    public function testAncestorMatchDoesNotLeakToPrefixSibling(): void
     {
-        $root = $this->createFolder('perm-test', 1);
-        $car = $this->createFolder('Car', $root->getId());          // workspace target
-        $carpets = $this->createFolder('Carpets', $root->getId());  // string-prefix sibling
-        $rug = $this->createFolder('rug', $carpets->getId());       // nested under the sibling
-
+        [$root, $car, $carpets, $rug] = $this->createTree();
         $user = $this->createUserWithObjectWorkspace($car);
         $userIds = array_map(intval(...), array_merge($user->getRoles(), [$user->getId()]));
 
-        // --- ancestor direction (Element\Dao::InheritingPermission via isInheritingPermission) ---
         $this->assertSame(
             1,
             $car->getDao()->isInheritingPermission('list', $userIds),
@@ -72,19 +81,39 @@ class WorkspacePermissionPathBoundaryTest extends ModelTestCase
             $rug->getDao()->isInheritingPermission('list', $userIds),
             'workspace on /perm-test/Car must NOT grant list on /perm-test/Carpets/rug'
         );
+    }
 
-        // --- traversal direction (AbstractObject\Dao::getChildAmount EXISTS subquery) ---
-        // As the workspace user, expanding /perm-test must list "Car" (own workspace) but NOT the
-        // sibling "Carpets" (no workspace at or below it).
-        $listableChildren = $root->getDao()->getChildAmount(
-            [DataObject::OBJECT_TYPE_FOLDER],
-            $user
-        );
+    /**
+     * Traversal / descendant direction (AbstractObject\Dao::getChildAmount EXISTS subquery):
+     * a workspace on the longer sibling "/perm-test/Carpets" must not make the shorter
+     * prefix-sibling "/perm-test/Car" appear as a listable child of "/perm-test". This is the
+     * reverse of the ancestor case: "/perm-test/Car" is a raw prefix of "/perm-test/Carpets".
+     */
+    public function testTraversalMatchDoesNotLeakToPrefixSibling(): void
+    {
+        [$root, $car, $carpets] = $this->createTree();
+        $user = $this->createUserWithObjectWorkspace($carpets);
+
+        $listableChildren = $root->getDao()->getChildAmount([DataObject::OBJECT_TYPE_FOLDER], $user);
+
         $this->assertSame(
             1,
             $listableChildren,
-            'tree expand must count only "Car", not the prefix-sibling "Carpets"'
+            'workspace on /perm-test/Carpets must count only "Carpets", not the prefix-sibling "Car"'
         );
+    }
+
+    /**
+     * @return array{0: DataObject\Folder, 1: DataObject\Folder, 2: DataObject\Folder, 3: DataObject\Folder}
+     */
+    private function createTree(): array
+    {
+        $root = $this->createFolder('perm-test', 1);
+        $car = $this->createFolder('Car', $root->getId());
+        $carpets = $this->createFolder('Carpets', $root->getId());
+        $rug = $this->createFolder('rug', $carpets->getId());
+
+        return [$root, $car, $carpets, $rug];
     }
 
     private function createFolder(string $key, int $parentId): DataObject\Folder
@@ -111,7 +140,7 @@ class WorkspacePermissionPathBoundaryTest extends ModelTestCase
         $workspace->setView(true);
         $role->setWorkspacesObject([$workspace]);
         $role->save();
-        $this->role = $role;
+        $this->createdRoles[] = $role;
 
         $user = new User();
         $user->setParentId(0);
@@ -121,7 +150,7 @@ class WorkspacePermissionPathBoundaryTest extends ModelTestCase
         $user->setPermissions(['objects']);
         $user->setRoles([$role->getId()]);
         $user->save();
-        $this->user = $user;
+        $this->createdUsers[] = $user;
 
         return $user;
     }

--- a/tests/Model/Element/WorkspacePermissionPathBoundaryTest.php
+++ b/tests/Model/Element/WorkspacePermissionPathBoundaryTest.php
@@ -13,17 +13,21 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Model\Element;
 
+use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
+use Pimcore\Model\Document;
+use Pimcore\Model\Element\AbstractElement;
 use Pimcore\Model\User;
 use Pimcore\Tests\Support\Test\ModelTestCase;
 use Pimcore\Tests\Support\Util\TestHelper;
 
 /**
- * Workspace permissions are matched against the element path. A workspace configured on
- * "/perm-test/Car" and one configured on the string-prefix sibling "/perm-test/Carpets" must
- * stay isolated from each other, even though "/perm-test/Car" is a raw prefix of
- * "/perm-test/Carpets". This guards against a regression where LOCATE()-based matching ignored
- * the path boundary in either direction.
+ * Workspace permissions are matched against the element path. A workspace on "/root/Car" and one
+ * on the string-prefix sibling "/root/Carpets" must stay isolated, even though "/root/Car" is a
+ * raw prefix of "/root/Carpets". This guards against a regression where LOCATE()-based matching
+ * ignored the "/" path boundary — in both the ancestor direction (Element\Dao::InheritingPermission)
+ * and the descendant/traversal direction (getChildAmount / accessible-listing subqueries for
+ * objects, assets and documents).
  *
  * @group model.element.permission
  */
@@ -56,67 +60,128 @@ class WorkspacePermissionPathBoundaryTest extends ModelTestCase
     }
 
     /**
-     * Ancestor direction (Element\Dao::InheritingPermission via isInheritingPermission):
-     * a workspace on "/perm-test/Car" must not inherit down onto the sibling "/perm-test/Carpets",
-     * whose path shares the "/perm-test/Car" prefix.
+     * Ancestor direction (Element\Dao::InheritingPermission, shared by all element types).
+     * Verifies both the boundary exclusion and — importantly — that the ancestor-path expansion
+     * still grants permission to a genuine descendant (so an implementation that matched only the
+     * element itself would fail).
      */
-    public function testAncestorMatchDoesNotLeakToPrefixSibling(): void
+    public function testAncestorMatchIsBoundaryCorrect(): void
     {
-        [$root, $car, $carpets, $rug] = $this->createTree();
-        $user = $this->createUserWithObjectWorkspace($car);
-        $userIds = array_map(intval(...), array_merge($user->getRoles(), [$user->getId()]));
+        [$root, $car, $carpets, $rug] = $this->createObjectTree();
+
+        // Workspace on "/root/Car": must not leak onto the prefix-sibling "/root/Carpets" subtree.
+        $carUser = $this->objectUser($car);
+        $carIds = $this->userIds($carUser);
+        $this->assertSame(1, $car->getDao()->isInheritingPermission('list', $carIds), 'control: workspace element itself resolves list=1');
+        $this->assertSame(0, $carpets->getDao()->isInheritingPermission('list', $carIds), 'must not grant list on the prefix-sibling /root/Carpets');
+        $this->assertSame(0, $rug->getDao()->isInheritingPermission('list', $carIds), 'must not grant list on /root/Carpets/rug');
+
+        // Workspace on "/root/Carpets": must grant list on the genuine descendant "rug"
+        // (ancestor-path expansion), while still not reaching the prefix-sibling "/root/Car".
+        $carpetsUser = $this->objectUser($carpets);
+        $carpetsIds = $this->userIds($carpetsUser);
+        $this->assertSame(1, $rug->getDao()->isInheritingPermission('list', $carpetsIds), 'must grant list on the genuine descendant /root/Carpets/rug');
+        $this->assertSame(0, $car->getDao()->isInheritingPermission('list', $carpetsIds), 'must not grant list on the prefix-sibling /root/Car');
+    }
+
+    /**
+     * Traversal direction for DataObjects (AbstractObject\Dao::getChildAmount).
+     * The workspace is placed on the *nested* "rug" so the match on "Carpets" goes through the
+     * slash-bounded LOCATE arm (not the equality arm), proving that legitimate descendant
+     * traversal is preserved while the prefix-sibling "Car" is excluded.
+     */
+    public function testObjectChildAmountIsBoundaryCorrect(): void
+    {
+        [$root, $car, $carpets, $rug] = $this->createObjectTree();
+        $user = $this->objectUser($rug);
 
         $this->assertSame(
             1,
-            $car->getDao()->isInheritingPermission('list', $userIds),
-            'control: the workspace element itself must resolve list=1'
-        );
-        $this->assertSame(
-            0,
-            $carpets->getDao()->isInheritingPermission('list', $userIds),
-            'workspace on /perm-test/Car must NOT grant list on the sibling /perm-test/Carpets'
-        );
-        $this->assertSame(
-            0,
-            $rug->getDao()->isInheritingPermission('list', $userIds),
-            'workspace on /perm-test/Car must NOT grant list on /perm-test/Carpets/rug'
+            $root->getDao()->getChildAmount([DataObject::OBJECT_TYPE_FOLDER], $user),
+            'only "Carpets" (ancestor of the workspace) is listable, not the prefix-sibling "Car"'
         );
     }
 
     /**
-     * Traversal / descendant direction (AbstractObject\Dao::getChildAmount EXISTS subquery):
-     * a workspace on the longer sibling "/perm-test/Carpets" must not make the shorter
-     * prefix-sibling "/perm-test/Car" appear as a listable child of "/perm-test". This is the
-     * reverse of the ancestor case: "/perm-test/Car" is a raw prefix of "/perm-test/Carpets".
+     * Traversal direction for Assets (Asset\Dao::getChildAmount).
      */
-    public function testTraversalMatchDoesNotLeakToPrefixSibling(): void
+    public function testAssetChildAmountIsBoundaryCorrect(): void
     {
-        [$root, $car, $carpets] = $this->createTree();
-        $user = $this->createUserWithObjectWorkspace($carpets);
+        [$root, $car, $carpets, $rug] = $this->createAssetTree();
+        $user = $this->assetUser($rug);
 
-        $listableChildren = $root->getDao()->getChildAmount([DataObject::OBJECT_TYPE_FOLDER], $user);
-
-        $this->assertSame(
-            1,
-            $listableChildren,
-            'workspace on /perm-test/Carpets must count only "Carpets", not the prefix-sibling "Car"'
-        );
+        $this->assertSame(1, $root->getDao()->getChildAmount($user), 'only "Carpets" is listable, not the prefix-sibling "Car"');
     }
+
+    /**
+     * Accessible-listing path for Assets (Asset\Listing::filterAccessibleByUser) — a separate
+     * traversal SQL site from the DAO.
+     */
+    public function testAssetAccessibleListingIsBoundaryCorrect(): void
+    {
+        [$root, $car, $carpets, $rug] = $this->createAssetTree();
+        $user = $this->assetUser($rug);
+
+        $listing = new Asset\Listing();
+        $listing->addConditionParam('parentId = ?', [$root->getId()]);
+        $listing->filterAccessibleByUser($user, $root);
+
+        $this->assertSame(1, count($listing->load()), 'accessible listing returns only "Carpets", not the prefix-sibling "Car"');
+    }
+
+    /**
+     * Traversal direction for Documents (Document\Dao::getChildAmount).
+     */
+    public function testDocumentChildAmountIsBoundaryCorrect(): void
+    {
+        [$root, $car, $carpets, $rug] = $this->createDocumentTree();
+        $user = $this->documentUser($rug);
+
+        $this->assertSame(1, $root->getDao()->getChildAmount($user), 'only "Carpets" is listable, not the prefix-sibling "Car"');
+    }
+
+    // ------------------------------------------------------------------ fixtures
 
     /**
      * @return array{0: DataObject\Folder, 1: DataObject\Folder, 2: DataObject\Folder, 3: DataObject\Folder}
      */
-    private function createTree(): array
+    private function createObjectTree(): array
     {
-        $root = $this->createFolder('perm-test', 1);
-        $car = $this->createFolder('Car', $root->getId());
-        $carpets = $this->createFolder('Carpets', $root->getId());
-        $rug = $this->createFolder('rug', $carpets->getId());
+        $root = $this->objectFolder('perm-test', 1);
+        $car = $this->objectFolder('Car', $root->getId());
+        $carpets = $this->objectFolder('Carpets', $root->getId());
+        $rug = $this->objectFolder('rug', $carpets->getId());
 
         return [$root, $car, $carpets, $rug];
     }
 
-    private function createFolder(string $key, int $parentId): DataObject\Folder
+    /**
+     * @return array{0: Asset\Folder, 1: Asset\Folder, 2: Asset\Folder, 3: Asset\Folder}
+     */
+    private function createAssetTree(): array
+    {
+        $root = $this->assetFolder('perm-test', 1);
+        $car = $this->assetFolder('Car', $root->getId());
+        $carpets = $this->assetFolder('Carpets', $root->getId());
+        $rug = $this->assetFolder('rug', $carpets->getId());
+
+        return [$root, $car, $carpets, $rug];
+    }
+
+    /**
+     * @return array{0: Document\Folder, 1: Document\Folder, 2: Document\Folder, 3: Document\Folder}
+     */
+    private function createDocumentTree(): array
+    {
+        $root = $this->documentFolder('perm-test', 1);
+        $car = $this->documentFolder('Car', $root->getId());
+        $carpets = $this->documentFolder('Carpets', $root->getId());
+        $rug = $this->documentFolder('rug', $carpets->getId());
+
+        return [$root, $car, $carpets, $rug];
+    }
+
+    private function objectFolder(string $key, int $parentId): DataObject\Folder
     {
         $folder = new DataObject\Folder();
         $folder->setParentId($parentId);
@@ -126,19 +191,64 @@ class WorkspacePermissionPathBoundaryTest extends ModelTestCase
         return $folder;
     }
 
-    private function createUserWithObjectWorkspace(DataObject\AbstractObject $workspaceTarget): User
+    private function assetFolder(string $key, int $parentId): Asset\Folder
+    {
+        $folder = new Asset\Folder();
+        $folder->setParentId($parentId);
+        $folder->setFilename($key);
+        $folder->save();
+
+        return $folder;
+    }
+
+    private function documentFolder(string $key, int $parentId): Document\Folder
+    {
+        $folder = new Document\Folder();
+        $folder->setParentId($parentId);
+        $folder->setKey($key);
+        $folder->save();
+
+        return $folder;
+    }
+
+    private function objectUser(DataObject\AbstractObject $target): User
+    {
+        return $this->makeUser('objects', function (User\Role $role) use ($target): void {
+            $role->setWorkspacesObject([$this->workspace(new User\Workspace\DataObject(), $target)]);
+        });
+    }
+
+    private function assetUser(Asset $target): User
+    {
+        return $this->makeUser('assets', function (User\Role $role) use ($target): void {
+            $role->setWorkspacesAsset([$this->workspace(new User\Workspace\Asset(), $target)]);
+        });
+    }
+
+    private function documentUser(Document $target): User
+    {
+        return $this->makeUser('documents', function (User\Role $role) use ($target): void {
+            $role->setWorkspacesDocument([$this->workspace(new User\Workspace\Document(), $target)]);
+        });
+    }
+
+    private function workspace(User\Workspace\AbstractWorkspace $workspace, AbstractElement $target): User\Workspace\AbstractWorkspace
+    {
+        $workspace->setCid($target->getId());
+        $workspace->setCpath($target->getRealFullPath());
+        $workspace->setList(true);
+        $workspace->setView(true);
+
+        return $workspace;
+    }
+
+    private function makeUser(string $permission, callable $assignWorkspace): User
     {
         $role = new User\Role();
         $role->setParentId(0);
         $role->setName('perm_boundary_role_' . uniqid());
-        $role->setPermissions(['objects']);
-
-        $workspace = new User\Workspace\DataObject();
-        $workspace->setCid($workspaceTarget->getId());
-        $workspace->setCpath($workspaceTarget->getRealFullPath());
-        $workspace->setList(true);
-        $workspace->setView(true);
-        $role->setWorkspacesObject([$workspace]);
+        $role->setPermissions([$permission]);
+        $assignWorkspace($role);
         $role->save();
         $this->createdRoles[] = $role;
 
@@ -147,11 +257,19 @@ class WorkspacePermissionPathBoundaryTest extends ModelTestCase
         $user->setName('perm_boundary_user_' . uniqid());
         $user->setActive(true);
         $user->setAdmin(false);
-        $user->setPermissions(['objects']);
+        $user->setPermissions([$permission]);
         $user->setRoles([$role->getId()]);
         $user->save();
         $this->createdUsers[] = $user;
 
         return $user;
+    }
+
+    /**
+     * @return int[]
+     */
+    private function userIds(User $user): array
+    {
+        return array_map(intval(...), array_merge($user->getRoles(), [$user->getId()]));
     }
 }

--- a/tests/Model/Element/WorkspacePermissionPathBoundaryTest.php
+++ b/tests/Model/Element/WorkspacePermissionPathBoundaryTest.php
@@ -1,0 +1,128 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\Element;
+
+use Pimcore\Model\DataObject;
+use Pimcore\Model\User;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+use Pimcore\Tests\Support\Util\TestHelper;
+
+/**
+ * Workspace permissions are matched against the element path. A workspace configured on
+ * "/perm-test/Car" must NOT apply to the sibling subtree "/perm-test/Carpets", even though
+ * the string "/perm-test/Car" is a raw prefix of "/perm-test/Carpets". This guards against a
+ * regression where LOCATE()-based matching ignored the path boundary.
+ *
+ * @group model.element.permission
+ */
+class WorkspacePermissionPathBoundaryTest extends ModelTestCase
+{
+    private ?User $user = null;
+
+    private ?User\Role $role = null;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        TestHelper::cleanUp();
+    }
+
+    public function tearDown(): void
+    {
+        $this->user?->delete();
+        $this->role?->delete();
+        TestHelper::cleanUp();
+        parent::tearDown();
+    }
+
+    public function testWorkspaceDoesNotLeakToPrefixSiblingSubtree(): void
+    {
+        $root = $this->createFolder('perm-test', 1);
+        $car = $this->createFolder('Car', $root->getId());          // workspace target
+        $carpets = $this->createFolder('Carpets', $root->getId());  // string-prefix sibling
+        $rug = $this->createFolder('rug', $carpets->getId());       // nested under the sibling
+
+        $user = $this->createUserWithObjectWorkspace($car);
+        $userIds = array_map(intval(...), array_merge($user->getRoles(), [$user->getId()]));
+
+        // --- ancestor direction (Element\Dao::InheritingPermission via isInheritingPermission) ---
+        $this->assertSame(
+            1,
+            $car->getDao()->isInheritingPermission('list', $userIds),
+            'control: the workspace element itself must resolve list=1'
+        );
+        $this->assertSame(
+            0,
+            $carpets->getDao()->isInheritingPermission('list', $userIds),
+            'workspace on /perm-test/Car must NOT grant list on the sibling /perm-test/Carpets'
+        );
+        $this->assertSame(
+            0,
+            $rug->getDao()->isInheritingPermission('list', $userIds),
+            'workspace on /perm-test/Car must NOT grant list on /perm-test/Carpets/rug'
+        );
+
+        // --- traversal direction (AbstractObject\Dao::getChildAmount EXISTS subquery) ---
+        // As the workspace user, expanding /perm-test must list "Car" (own workspace) but NOT the
+        // sibling "Carpets" (no workspace at or below it).
+        $listableChildren = $root->getDao()->getChildAmount(
+            [DataObject::OBJECT_TYPE_FOLDER],
+            $user
+        );
+        $this->assertSame(
+            1,
+            $listableChildren,
+            'tree expand must count only "Car", not the prefix-sibling "Carpets"'
+        );
+    }
+
+    private function createFolder(string $key, int $parentId): DataObject\Folder
+    {
+        $folder = new DataObject\Folder();
+        $folder->setParentId($parentId);
+        $folder->setKey($key);
+        $folder->save();
+
+        return $folder;
+    }
+
+    private function createUserWithObjectWorkspace(DataObject\AbstractObject $workspaceTarget): User
+    {
+        $role = new User\Role();
+        $role->setParentId(0);
+        $role->setName('perm_boundary_role_' . uniqid());
+        $role->setPermissions(['objects']);
+
+        $workspace = new User\Workspace\DataObject();
+        $workspace->setCid($workspaceTarget->getId());
+        $workspace->setCpath($workspaceTarget->getRealFullPath());
+        $workspace->setList(true);
+        $workspace->setView(true);
+        $role->setWorkspacesObject([$workspace]);
+        $role->save();
+        $this->role = $role;
+
+        $user = new User();
+        $user->setParentId(0);
+        $user->setName('perm_boundary_user_' . uniqid());
+        $user->setActive(true);
+        $user->setAdmin(false);
+        $user->setPermissions(['objects']);
+        $user->setRoles([$role->getId()]);
+        $user->save();
+        $this->user = $user;
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## What

Workspace permissions are matched against the element path. The matching used `LOCATE()`, which compares on a **raw substring with no path boundary** — so a workspace configured on `/foo/Car` also matched the unrelated sibling subtree `/foo/Carpets/...` (any element whose path merely starts with the same characters).

This fixes the matching to be boundary-correct, and takes the opportunity to make the ancestor-direction query index-usable.

## Changes

- **Ancestor direction** — `Element\Dao::InheritingPermission()`: replace `LOCATE(cpath, <fullPath>)` with an exact match against the element's ancestor path set, `cpath IN (<ancestor paths>)`. This is both boundary-correct and index-usable on `users_workspaces_*.cpath` (the old predicate is a function of the column and cannot use an index). The "most specific workspace wins" resolution (`ORDER BY LENGTH(cpath) DESC`) is unchanged.
- **Descendant / traversal direction** — the child-permission `EXISTS` subqueries in `DataObject\AbstractObject\Dao`, `Asset\Dao`, `Asset\Listing` and `Document\Dao`: add an explicit `/` boundary so a row only matches workspaces on itself or genuine descendants.

A new helper `Element\Dao::getAncestorPaths()` builds the ancestor list.

## Correctness note

The old behavior could grant access across sibling subtrees whose names share a string prefix. The corrected matching is stricter and consistent with the already boundary-exact `cid IN (...)` resolution in `permissionByTypes()`.

## Test

`tests/Model/Element/WorkspacePermissionPathBoundaryTest.php` covers both directions: a user whose only workspace is on `/perm-test/Car` must **not** receive `list` on the sibling `/perm-test/Carpets` (nor its children), while still resolving correctly on its own workspace. Fails before the fix, passes after.

Relates to pimcore/platform-version#214.