### PR TITLE
[Improvement] Cache element permission checks per request

### DIFF
--- a/bundles/CoreBundle/config/event_listeners.yaml
+++ b/bundles/CoreBundle/config/event_listeners.yaml
@@ -43,6 +43,9 @@ services:
 
     Pimcore\Bundle\CoreBundle\EventListener\Frontend\GlobalTemplateVariablesListener: ~
 
+    # invalidates the request-scoped element permission cache on user/role/workspace changes
+    Pimcore\Bundle\CoreBundle\EventListener\PermissionCacheInvalidationListener: ~
+
     Pimcore\Bundle\CoreBundle\EventListener\Frontend\HardlinkCanonicalListener:
         tags:
             - { name: kernel.event_subscriber }

--- a/bundles/CoreBundle/config/services.yaml
+++ b/bundles/CoreBundle/config/services.yaml
@@ -171,7 +171,10 @@ services:
     Pimcore\Model\Version\CoauthorContext: ~
 
     # request-scoped memoization of element permission lookups (DAO result only), cleared per
-    # request and per messenger message via the kernel.reset tag
+    # request and per messenger message via the kernel.reset tag.
+    # public, because it is consumed from the AbstractElement model via the container — like the
+    # workflow Manager and the event dispatcher already are — and models are not container-managed
+    # so they cannot receive it through constructor injection.
     Pimcore\Model\Element\PermissionCache:
         public: true
         tags:

--- a/bundles/CoreBundle/config/services.yaml
+++ b/bundles/CoreBundle/config/services.yaml
@@ -169,6 +169,13 @@ services:
         alias: Pimcore\Model\Version\CoauthorContext
 
     Pimcore\Model\Version\CoauthorContext: ~
+
+    # request-scoped memoization of element permission lookups (DAO result only), cleared per
+    # request and per messenger message via the kernel.reset tag
+    Pimcore\Model\Element\PermissionCache:
+        public: true
+        tags:
+            - { name: kernel.reset, method: reset }
     #
     # SECURITY
     #

--- a/bundles/CoreBundle/src/EventListener/PermissionCacheInvalidationListener.php
+++ b/bundles/CoreBundle/src/EventListener/PermissionCacheInvalidationListener.php
@@ -14,15 +14,25 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\CoreBundle\EventListener;
 
+use Pimcore\Event\AssetEvents;
+use Pimcore\Event\DataObjectEvents;
+use Pimcore\Event\DocumentEvents;
 use Pimcore\Event\UserRoleEvents;
 use Pimcore\Model\Element\PermissionCache;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * Invalidates the request-scoped element permission cache when a user or role is added, updated or
- * deleted. Because element workspaces are persisted together with their user/role, this also covers
- * users_workspaces_* writes. The per-request/per-message boundary is handled separately by the
- * kernel.reset tag on {@see PermissionCache}.
+ * Invalidates the request-scoped element permission cache whenever the underlying workspace data can
+ * change within the same request/message:
+ *
+ * - user/role add/update/delete, because element workspaces are persisted together with their
+ *   user/role, so this also covers users_workspaces_* writes;
+ * - element add/update/delete, because moving or renaming an element rewrites the workspace cpaths
+ *   of the element and its children (see Dao::updateWorkspaces()/updateChildPaths()), which would
+ *   otherwise leave an allow/deny cached before the move stale for the rest of the request.
+ *
+ * The per-request/per-message boundary is handled separately by the kernel.reset tag on
+ * {@see PermissionCache}.
  *
  * @internal
  */
@@ -35,13 +45,22 @@ final class PermissionCacheInvalidationListener implements EventSubscriberInterf
     public static function getSubscribedEvents(): array
     {
         return [
-            UserRoleEvents::POST_ADD => 'onUserRoleChange',
-            UserRoleEvents::POST_UPDATE => 'onUserRoleChange',
-            UserRoleEvents::POST_DELETE => 'onUserRoleChange',
+            UserRoleEvents::POST_ADD => 'onPermissionDataChange',
+            UserRoleEvents::POST_UPDATE => 'onPermissionDataChange',
+            UserRoleEvents::POST_DELETE => 'onPermissionDataChange',
+            AssetEvents::POST_ADD => 'onPermissionDataChange',
+            AssetEvents::POST_UPDATE => 'onPermissionDataChange',
+            AssetEvents::POST_DELETE => 'onPermissionDataChange',
+            DocumentEvents::POST_ADD => 'onPermissionDataChange',
+            DocumentEvents::POST_UPDATE => 'onPermissionDataChange',
+            DocumentEvents::POST_DELETE => 'onPermissionDataChange',
+            DataObjectEvents::POST_ADD => 'onPermissionDataChange',
+            DataObjectEvents::POST_UPDATE => 'onPermissionDataChange',
+            DataObjectEvents::POST_DELETE => 'onPermissionDataChange',
         ];
     }
 
-    public function onUserRoleChange(): void
+    public function onPermissionDataChange(): void
     {
         $this->permissionCache->reset();
     }

--- a/bundles/CoreBundle/src/EventListener/PermissionCacheInvalidationListener.php
+++ b/bundles/CoreBundle/src/EventListener/PermissionCacheInvalidationListener.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\CoreBundle\EventListener;
+
+use Pimcore\Event\UserRoleEvents;
+use Pimcore\Model\Element\PermissionCache;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Invalidates the request-scoped element permission cache when a user or role is added, updated or
+ * deleted. Because element workspaces are persisted together with their user/role, this also covers
+ * users_workspaces_* writes. The per-request/per-message boundary is handled separately by the
+ * kernel.reset tag on {@see PermissionCache}.
+ *
+ * @internal
+ */
+final class PermissionCacheInvalidationListener implements EventSubscriberInterface
+{
+    public function __construct(private readonly PermissionCache $permissionCache)
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            UserRoleEvents::POST_ADD => 'onUserRoleChange',
+            UserRoleEvents::POST_UPDATE => 'onUserRoleChange',
+            UserRoleEvents::POST_DELETE => 'onUserRoleChange',
+        ];
+    }
+
+    public function onUserRoleChange(): void
+    {
+        $this->permissionCache->reset();
+    }
+}

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -480,7 +480,27 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
             return $permissions;
         }
 
-        $permissions = $this->getDao()->areAllowed($columns, $user);
+        // cache only the DAO result per request; the ELEMENT_PERMISSION_IS_ALLOWED event below
+        // stays outside the cache. All requested columns are resolved together (all-or-nothing),
+        // because the DAO derives the "list" permission from the full column set.
+        $permissionCache = Pimcore::getContainer()->get(PermissionCache::class);
+        $permissions = [];
+        foreach ($columns as $column) {
+            $cached = $permissionCache->get($user, $this, $column);
+            if (null === $cached) {
+                $permissions = [];
+
+                break;
+            }
+            $permissions[$column] = (int) $cached;
+        }
+
+        if ($permissions === []) {
+            $permissions = $this->getDao()->areAllowed($columns, $user);
+            foreach ($permissions as $column => $isAllowed) {
+                $permissionCache->set($user, $this, (string) $column, (bool) $isAllowed);
+            }
+        }
 
         foreach ($permissions as $type => $isAllowed) {
             $event = new ElementEvent($this, ['isAllowed' => $isAllowed, 'permissionType' => $type, 'user' => $user]);
@@ -517,7 +537,15 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
         if (!$user->isAllowed(Service::getElementType($this) . 's')) {
             return false;
         }
-        $isAllowed = $this->getDao()->isAllowed($type, $user);
+
+        // cache only the DAO result per request; the workflow-deny check and the
+        // ELEMENT_PERMISSION_IS_ALLOWED event below stay outside the cache
+        $permissionCache = Pimcore::getContainer()->get(PermissionCache::class);
+        $isAllowed = $permissionCache->get($user, $this, $type);
+        if (null === $isAllowed) {
+            $isAllowed = $this->getDao()->isAllowed($type, $user);
+            $permissionCache->set($user, $this, $type, $isAllowed);
+        }
 
         if ($isDeniedInWorkflow) {
             $isAllowed = false;

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -486,7 +486,7 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
         $permissionCache = Pimcore::getContainer()->get(PermissionCache::class);
         $permissions = [];
         foreach ($columns as $column) {
-            $cached = $permissionCache->get($user, $this, $column);
+            $cached = $permissionCache->get($user, $this, $column, PermissionCacheScope::Batch);
             if (null === $cached) {
                 $permissions = [];
 
@@ -498,7 +498,7 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
         if ($permissions === []) {
             $permissions = $this->getDao()->areAllowed($columns, $user);
             foreach ($permissions as $column => $isAllowed) {
-                $permissionCache->set($user, $this, (string) $column, (bool) $isAllowed);
+                $permissionCache->set($user, $this, (string) $column, PermissionCacheScope::Batch, (bool) $isAllowed);
             }
         }
 
@@ -541,10 +541,10 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
         // cache only the DAO result per request; the workflow-deny check and the
         // ELEMENT_PERMISSION_IS_ALLOWED event below stay outside the cache
         $permissionCache = Pimcore::getContainer()->get(PermissionCache::class);
-        $isAllowed = $permissionCache->get($user, $this, $type);
+        $isAllowed = $permissionCache->get($user, $this, $type, PermissionCacheScope::Single);
         if (null === $isAllowed) {
             $isAllowed = $this->getDao()->isAllowed($type, $user);
-            $permissionCache->set($user, $this, $type, $isAllowed);
+            $permissionCache->set($user, $this, $type, PermissionCacheScope::Single, $isAllowed);
         }
 
         if ($isDeniedInWorkflow) {

--- a/models/Element/PermissionCache.php
+++ b/models/Element/PermissionCache.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Model\Element;
+
+use Pimcore\Model\User;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * Request-scoped memoization of element permission lookups. It caches only the raw DAO result of
+ * AbstractElement::isAllowed()/getUserPermissions() so that repeated permission checks on the same
+ * element within a single request do not re-query the users_workspaces_* tables.
+ *
+ * The cache is cleared automatically at the request and messenger-message boundary via the
+ * kernel.reset tag (ResetInterface). Workflow-deny handling and the ELEMENT_PERMISSION_IS_ALLOWED
+ * event are intentionally kept outside this cache by the caller, because listeners may decide
+ * dynamically on every call.
+ *
+ * @internal
+ */
+final class PermissionCache implements ResetInterface
+{
+    /**
+     * @var array<string, bool>
+     */
+    private array $cache = [];
+
+    public function get(User $user, ElementInterface $element, string $type): ?bool
+    {
+        return $this->cache[$this->buildKey($user, $element, $type)] ?? null;
+    }
+
+    public function set(User $user, ElementInterface $element, string $type, bool $allowed): void
+    {
+        $this->cache[$this->buildKey($user, $element, $type)] = $allowed;
+    }
+
+    public function reset(): void
+    {
+        $this->cache = [];
+    }
+
+    private function buildKey(User $user, ElementInterface $element, string $type): string
+    {
+        return implode('-', [
+            $user->getId(),
+            Service::getElementType($element),
+            $element->getId(),
+            $type,
+        ]);
+    }
+}

--- a/models/Element/PermissionCache.php
+++ b/models/Element/PermissionCache.php
@@ -22,9 +22,15 @@ use Symfony\Contracts\Service\ResetInterface;
  * element within a single request do not re-query the users_workspaces_* tables.
  *
  * The cache is cleared automatically at the request and messenger-message boundary via the
- * kernel.reset tag (ResetInterface). Workflow-deny handling and the ELEMENT_PERMISSION_IS_ALLOWED
- * event are intentionally kept outside this cache by the caller, because listeners may decide
- * dynamically on every call.
+ * kernel.reset tag (ResetInterface), and on any permission-affecting mutation (user/role or element
+ * add/update/move/delete) by {@see \Pimcore\Bundle\CoreBundle\EventListener\PermissionCacheInvalidationListener}.
+ * Workflow-deny handling and the ELEMENT_PERMISSION_IS_ALLOWED event are intentionally kept outside
+ * this cache by the caller, because listeners may decide dynamically on every call.
+ *
+ * The key is scoped by {@see PermissionCacheScope} because the single- and batch-permission DAO
+ * paths are not interchangeable, and includes the user's role set so a role change that is applied
+ * in-memory before it is persisted cannot serve a stale result. Elements without an id (not yet
+ * saved) are not cached, because they share no stable identity.
  *
  * @internal
  */
@@ -35,14 +41,22 @@ final class PermissionCache implements ResetInterface
      */
     private array $cache = [];
 
-    public function get(User $user, ElementInterface $element, string $type): ?bool
+    public function get(User $user, ElementInterface $element, string $type, PermissionCacheScope $scope): ?bool
     {
-        return $this->cache[$this->buildKey($user, $element, $type)] ?? null;
+        if (null === $element->getId()) {
+            return null;
+        }
+
+        return $this->cache[$this->buildKey($user, $element, $type, $scope)] ?? null;
     }
 
-    public function set(User $user, ElementInterface $element, string $type, bool $allowed): void
+    public function set(User $user, ElementInterface $element, string $type, PermissionCacheScope $scope, bool $allowed): void
     {
-        $this->cache[$this->buildKey($user, $element, $type)] = $allowed;
+        if (null === $element->getId()) {
+            return;
+        }
+
+        $this->cache[$this->buildKey($user, $element, $type, $scope)] = $allowed;
     }
 
     public function reset(): void
@@ -50,10 +64,15 @@ final class PermissionCache implements ResetInterface
         $this->cache = [];
     }
 
-    private function buildKey(User $user, ElementInterface $element, string $type): string
+    private function buildKey(User $user, ElementInterface $element, string $type, PermissionCacheScope $scope): string
     {
+        $roles = $user->getRoles();
+        sort($roles);
+
         return implode('-', [
+            $scope->value,
             $user->getId(),
+            implode(',', $roles),
             Service::getElementType($element),
             $element->getId(),
             $type,

--- a/models/Element/PermissionCacheScope.php
+++ b/models/Element/PermissionCacheScope.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Model\Element;
+
+/**
+ * Distinguishes the two element permission DAO code paths that must not share a cache entry.
+ *
+ * The single-permission path ({@see AbstractElement::isAllowed()}, DAO isAllowed()) and the batch
+ * path ({@see AbstractElement::getUserPermissions()}, DAO areAllowed()/permissionByTypes()) are not
+ * interchangeable: for the "list" type the batch path excludes an allowed child that also carries a
+ * direct-user deny, while the single path accepts any allowed child. Caching them under the same key
+ * would let whichever runs first return the wrong result for the other.
+ *
+ * @internal
+ */
+enum PermissionCacheScope: string
+{
+    case Single = 'single';
+    case Batch = 'batch';
+}

--- a/tests/Model/Element/PermissionCacheTest.php
+++ b/tests/Model/Element/PermissionCacheTest.php
@@ -13,16 +13,18 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Model\Element;
 
+use Pimcore\Db;
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\Element\PermissionCache;
+use Pimcore\Model\Element\PermissionCacheScope;
 use Pimcore\Model\User;
 use Pimcore\Tests\Support\Test\ModelTestCase;
 use Pimcore\Tests\Support\Util\TestHelper;
 
 /**
- * Unit coverage for the request-scoped element permission memoization service, plus an
- * integration assertion that AbstractElement::isAllowed() populates the cache.
+ * Unit coverage for the request-scoped element permission memoization service, plus an integration
+ * assertion that AbstractElement::isAllowed() is actually served from the cache without re-querying.
  *
  * @group model.element.permission
  */
@@ -60,7 +62,7 @@ class PermissionCacheTest extends ModelTestCase
         $user = $this->inMemoryUser(1);
         $element = $this->inMemoryObject(10);
 
-        $this->assertNull($cache->get($user, $element, 'view'));
+        $this->assertNull($cache->get($user, $element, 'view', PermissionCacheScope::Single));
     }
 
     public function testGetReturnsPreviouslySetValue(): void
@@ -69,11 +71,11 @@ class PermissionCacheTest extends ModelTestCase
         $user = $this->inMemoryUser(1);
         $element = $this->inMemoryObject(10);
 
-        $cache->set($user, $element, 'view', true);
-        $cache->set($user, $element, 'publish', false);
+        $cache->set($user, $element, 'view', PermissionCacheScope::Single, true);
+        $cache->set($user, $element, 'publish', PermissionCacheScope::Single, false);
 
-        $this->assertTrue($cache->get($user, $element, 'view'));
-        $this->assertFalse($cache->get($user, $element, 'publish'));
+        $this->assertTrue($cache->get($user, $element, 'view', PermissionCacheScope::Single));
+        $this->assertFalse($cache->get($user, $element, 'publish', PermissionCacheScope::Single));
     }
 
     public function testResetClearsAllEntries(): void
@@ -82,10 +84,10 @@ class PermissionCacheTest extends ModelTestCase
         $user = $this->inMemoryUser(1);
         $element = $this->inMemoryObject(10);
 
-        $cache->set($user, $element, 'view', true);
+        $cache->set($user, $element, 'view', PermissionCacheScope::Single, true);
         $cache->reset();
 
-        $this->assertNull($cache->get($user, $element, 'view'));
+        $this->assertNull($cache->get($user, $element, 'view', PermissionCacheScope::Single));
     }
 
     public function testKeyIsolationBetweenUsers(): void
@@ -95,10 +97,13 @@ class PermissionCacheTest extends ModelTestCase
         $userB = $this->inMemoryUser(2);
         $element = $this->inMemoryObject(10);
 
-        $cache->set($userA, $element, 'view', true);
+        $cache->set($userA, $element, 'view', PermissionCacheScope::Single, true);
 
-        $this->assertTrue($cache->get($userA, $element, 'view'));
-        $this->assertNull($cache->get($userB, $element, 'view'), 'a value cached for one user must not leak to another');
+        $this->assertTrue($cache->get($userA, $element, 'view', PermissionCacheScope::Single));
+        $this->assertNull(
+            $cache->get($userB, $element, 'view', PermissionCacheScope::Single),
+            'a value cached for one user must not leak to another'
+        );
     }
 
     public function testKeyIsolationBetweenPermissionTypes(): void
@@ -107,9 +112,12 @@ class PermissionCacheTest extends ModelTestCase
         $user = $this->inMemoryUser(1);
         $element = $this->inMemoryObject(10);
 
-        $cache->set($user, $element, 'view', true);
+        $cache->set($user, $element, 'view', PermissionCacheScope::Single, true);
 
-        $this->assertNull($cache->get($user, $element, 'publish'), 'permission types must be cached independently');
+        $this->assertNull(
+            $cache->get($user, $element, 'publish', PermissionCacheScope::Single),
+            'permission types must be cached independently'
+        );
     }
 
     public function testKeyIsolationBetweenElementIds(): void
@@ -119,9 +127,12 @@ class PermissionCacheTest extends ModelTestCase
         $elementA = $this->inMemoryObject(10);
         $elementB = $this->inMemoryObject(11);
 
-        $cache->set($user, $elementA, 'view', true);
+        $cache->set($user, $elementA, 'view', PermissionCacheScope::Single, true);
 
-        $this->assertNull($cache->get($user, $elementB, 'view'), 'different element ids must be cached independently');
+        $this->assertNull(
+            $cache->get($user, $elementB, 'view', PermissionCacheScope::Single),
+            'different element ids must be cached independently'
+        );
     }
 
     public function testKeyIsolationBetweenElementTypes(): void
@@ -132,16 +143,74 @@ class PermissionCacheTest extends ModelTestCase
         $asset = new Asset\Folder();
         $asset->setId(10);
 
-        $cache->set($user, $object, 'view', true);
+        $cache->set($user, $object, 'view', PermissionCacheScope::Single, true);
 
-        $this->assertNull($cache->get($user, $asset, 'view'), 'same id on different element types must not collide');
+        $this->assertNull(
+            $cache->get($user, $asset, 'view', PermissionCacheScope::Single),
+            'same id on different element types must not collide'
+        );
+    }
+
+    public function testKeyIsolationBetweenScopes(): void
+    {
+        $cache = new PermissionCache();
+        $user = $this->inMemoryUser(1);
+        $element = $this->inMemoryObject(10);
+
+        // the single- and batch-permission DAO paths compute "list" differently, so a value cached
+        // for one scope must never be served for the other
+        $cache->set($user, $element, 'list', PermissionCacheScope::Single, true);
+
+        $this->assertTrue($cache->get($user, $element, 'list', PermissionCacheScope::Single));
+        $this->assertNull(
+            $cache->get($user, $element, 'list', PermissionCacheScope::Batch),
+            'single and batch permission results must not share a cache entry'
+        );
+    }
+
+    public function testKeyIsolationBetweenRoleSets(): void
+    {
+        $cache = new PermissionCache();
+        $element = $this->inMemoryObject(10);
+
+        // same user id, different role set (e.g. changed in-memory before being persisted)
+        $userWithRoleA = $this->inMemoryUser(1);
+        $userWithRoleA->setRoles([5]);
+        $userWithRoleB = $this->inMemoryUser(1);
+        $userWithRoleB->setRoles([6]);
+
+        $cache->set($userWithRoleA, $element, 'view', PermissionCacheScope::Single, true);
+
+        $this->assertNull(
+            $cache->get($userWithRoleB, $element, 'view', PermissionCacheScope::Single),
+            'a different role set must not reuse a result cached for another role set'
+        );
+    }
+
+    public function testUnsavedElementsAreNotCached(): void
+    {
+        $cache = new PermissionCache();
+        $user = $this->inMemoryUser(1);
+
+        // an element without an id has no stable identity; caching it would collapse every unsaved
+        // element of the same type onto one key
+        $unsaved = new DataObject\Folder();
+
+        $cache->set($user, $unsaved, 'view', PermissionCacheScope::Single, true);
+
+        $this->assertNull(
+            $cache->get($user, $unsaved, 'view', PermissionCacheScope::Single),
+            'elements without an id must not be cached'
+        );
     }
 
     /**
-     * Integration: a permission check on a real element populates the shared cache instance, so a
-     * repeated check is served from memory instead of re-querying users_workspaces_*.
+     * Integration: a permission check on a real element is served from the shared cache on the
+     * second call, so it must not re-query users_workspaces_*. Proven by mutating the workspace row
+     * directly (which fires no Pimcore event and therefore does not invalidate the cache): the
+     * cached call keeps returning the pre-mutation result, and only a reset() picks up the change.
      */
-    public function testIsAllowedPopulatesCache(): void
+    public function testIsAllowedIsServedFromCacheWithoutRequerying(): void
     {
         $root = new DataObject\Folder();
         $root->setParentId(1);
@@ -153,14 +222,33 @@ class PermissionCacheTest extends ModelTestCase
         $cache = \Pimcore::getContainer()->get(PermissionCache::class);
         $cache->reset();
 
-        $this->assertNull($cache->get($user, $root, 'view'), 'precondition: nothing cached yet');
+        $this->assertNull(
+            $cache->get($user, $root, 'view', PermissionCacheScope::Single),
+            'precondition: nothing cached yet'
+        );
 
-        $first = $root->isAllowed('view', $user);
-        $this->assertNotNull($cache->get($user, $root, 'view'), 'isAllowed() must memoize the DAO result');
-        $this->assertSame($first, $cache->get($user, $root, 'view'));
+        // first call queries the DAO and memoizes the granted permission
+        $this->assertTrue($root->isAllowed('view', $user), 'workspace grants view on the first lookup');
+        $this->assertTrue(
+            $cache->get($user, $root, 'view', PermissionCacheScope::Single),
+            'isAllowed() must memoize the DAO result'
+        );
 
-        // repeated call returns the same result
-        $this->assertSame($first, $root->isAllowed('view', $user));
+        // remove the grant behind the cache's back (raw delete fires no event -> no invalidation)
+        Db::get()->delete('users_workspaces_object', ['cid' => $root->getId()]);
+
+        // if isAllowed() re-queried the DAO here it would now return false; the cache must shield it
+        $this->assertTrue(
+            $root->isAllowed('view', $user),
+            'the second call must be served from the cache without re-querying the workspace table'
+        );
+
+        // only after an explicit reset does the DAO run again and observe the removed grant
+        $cache->reset();
+        $this->assertFalse(
+            $root->isAllowed('view', $user),
+            'after reset the DAO is queried again and sees the removed workspace grant'
+        );
 
         $root->delete();
     }

--- a/tests/Model/Element/PermissionCacheTest.php
+++ b/tests/Model/Element/PermissionCacheTest.php
@@ -253,6 +253,91 @@ class PermissionCacheTest extends ModelTestCase
         $root->delete();
     }
 
+    /**
+     * The listener is what keeps same-request authorization correct after a workspace is persisted:
+     * saving a user/role fires UserRoleEvents::POST_UPDATE, which must reset the shared cache.
+     */
+    public function testRoleWorkspaceChangeInvalidatesCacheViaListener(): void
+    {
+        $root = new DataObject\Folder();
+        $root->setParentId(1);
+        $root->setKey('permission-cache-role-inv-' . uniqid());
+        $root->save();
+
+        $role = $this->createObjectRole($root->getId(), $root->getRealFullPath(), true, true);
+        $user = $this->createNonAdminObjectUser([$role->getId()]);
+
+        $cache = \Pimcore::getContainer()->get(PermissionCache::class);
+        $cache->reset();
+
+        $this->assertTrue($root->isAllowed('view', $user));
+        $this->assertTrue(
+            $cache->get($user, $root, 'view', PermissionCacheScope::Single),
+            'precondition: the granted permission is cached'
+        );
+
+        // revoke view on the role's workspace and persist it: POST_UPDATE must reset the shared cache
+        $workspace = new User\Workspace\DataObject();
+        $workspace->setCid($root->getId());
+        $workspace->setCpath($root->getRealFullPath());
+        $workspace->setList(true);
+        $workspace->setView(false);
+        $role->setWorkspacesObject([$workspace]);
+        $role->save();
+
+        $this->assertNull(
+            $cache->get($user, $root, 'view', PermissionCacheScope::Single),
+            'saving a role/workspace must invalidate the cached permission through the listener'
+        );
+        $this->assertFalse(
+            $root->isAllowed('view', $user),
+            're-query after invalidation must reflect the revoked grant'
+        );
+    }
+
+    /**
+     * Moving an element rewrites its (and its children's) workspace cpaths, so the listener must
+     * also reset the shared cache on element POST_UPDATE.
+     */
+    public function testElementMoveInvalidatesCacheViaListener(): void
+    {
+        $source = new DataObject\Folder();
+        $source->setParentId(1);
+        $source->setKey('permission-cache-move-src-' . uniqid());
+        $source->save();
+
+        $destination = new DataObject\Folder();
+        $destination->setParentId(1);
+        $destination->setKey('permission-cache-move-dest-' . uniqid());
+        $destination->save();
+
+        $element = new DataObject\Folder();
+        $element->setParentId($source->getId());
+        $element->setKey('permission-cache-move-element-' . uniqid());
+        $element->save();
+
+        $role = $this->createObjectRole($element->getId(), $element->getRealFullPath(), true, true);
+        $user = $this->createNonAdminObjectUser([$role->getId()]);
+
+        $cache = \Pimcore::getContainer()->get(PermissionCache::class);
+        $cache->reset();
+
+        $this->assertTrue($element->isAllowed('view', $user));
+        $this->assertTrue(
+            $cache->get($user, $element, 'view', PermissionCacheScope::Single),
+            'precondition: the granted permission is cached'
+        );
+
+        // move the element: POST_UPDATE must reset the shared cache through the listener
+        $element->setParentId($destination->getId());
+        $element->save();
+
+        $this->assertNull(
+            $cache->get($user, $element, 'view', PermissionCacheScope::Single),
+            'moving an element must invalidate cached permissions through the listener'
+        );
+    }
+
     private function inMemoryUser(int $id): User
     {
         $user = new User();
@@ -271,11 +356,18 @@ class PermissionCacheTest extends ModelTestCase
 
     private function makeObjectUser(DataObject\AbstractObject $target): User
     {
+        $role = $this->createObjectRole($target->getId(), $target->getRealFullPath(), true, true);
+
+        return $this->createNonAdminObjectUser([$role->getId()]);
+    }
+
+    private function createObjectRole(int $cid, string $cpath, bool $view, bool $list): User\Role
+    {
         $workspace = new User\Workspace\DataObject();
-        $workspace->setCid($target->getId());
-        $workspace->setCpath($target->getRealFullPath());
-        $workspace->setList(true);
-        $workspace->setView(true);
+        $workspace->setCid($cid);
+        $workspace->setCpath($cpath);
+        $workspace->setList($list);
+        $workspace->setView($view);
 
         $role = new User\Role();
         $role->setParentId(0);
@@ -285,13 +377,21 @@ class PermissionCacheTest extends ModelTestCase
         $role->save();
         $this->createdRoles[] = $role;
 
+        return $role;
+    }
+
+    /**
+     * @param int[] $roleIds
+     */
+    private function createNonAdminObjectUser(array $roleIds): User
+    {
         $user = new User();
         $user->setParentId(0);
         $user->setName('permission_cache_user_' . uniqid());
         $user->setActive(true);
         $user->setAdmin(false);
         $user->setPermissions(['objects']);
-        $user->setRoles([$role->getId()]);
+        $user->setRoles($roleIds);
         $user->save();
         $this->createdUsers[] = $user;
 

--- a/tests/Model/Element/PermissionCacheTest.php
+++ b/tests/Model/Element/PermissionCacheTest.php
@@ -1,0 +1,212 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\Element;
+
+use Pimcore\Model\Asset;
+use Pimcore\Model\DataObject;
+use Pimcore\Model\Element\PermissionCache;
+use Pimcore\Model\User;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+use Pimcore\Tests\Support\Util\TestHelper;
+
+/**
+ * Unit coverage for the request-scoped element permission memoization service, plus an
+ * integration assertion that AbstractElement::isAllowed() populates the cache.
+ *
+ * @group model.element.permission
+ */
+class PermissionCacheTest extends ModelTestCase
+{
+    /** @var User[] */
+    private array $createdUsers = [];
+
+    /** @var User\Role[] */
+    private array $createdRoles = [];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        TestHelper::cleanUp();
+    }
+
+    public function tearDown(): void
+    {
+        foreach ($this->createdUsers as $user) {
+            $user->delete();
+        }
+        foreach ($this->createdRoles as $role) {
+            $role->delete();
+        }
+        $this->createdUsers = [];
+        $this->createdRoles = [];
+        TestHelper::cleanUp();
+        parent::tearDown();
+    }
+
+    public function testReturnsNullWhenNotCached(): void
+    {
+        $cache = new PermissionCache();
+        $user = $this->inMemoryUser(1);
+        $element = $this->inMemoryObject(10);
+
+        $this->assertNull($cache->get($user, $element, 'view'));
+    }
+
+    public function testGetReturnsPreviouslySetValue(): void
+    {
+        $cache = new PermissionCache();
+        $user = $this->inMemoryUser(1);
+        $element = $this->inMemoryObject(10);
+
+        $cache->set($user, $element, 'view', true);
+        $cache->set($user, $element, 'publish', false);
+
+        $this->assertTrue($cache->get($user, $element, 'view'));
+        $this->assertFalse($cache->get($user, $element, 'publish'));
+    }
+
+    public function testResetClearsAllEntries(): void
+    {
+        $cache = new PermissionCache();
+        $user = $this->inMemoryUser(1);
+        $element = $this->inMemoryObject(10);
+
+        $cache->set($user, $element, 'view', true);
+        $cache->reset();
+
+        $this->assertNull($cache->get($user, $element, 'view'));
+    }
+
+    public function testKeyIsolationBetweenUsers(): void
+    {
+        $cache = new PermissionCache();
+        $userA = $this->inMemoryUser(1);
+        $userB = $this->inMemoryUser(2);
+        $element = $this->inMemoryObject(10);
+
+        $cache->set($userA, $element, 'view', true);
+
+        $this->assertTrue($cache->get($userA, $element, 'view'));
+        $this->assertNull($cache->get($userB, $element, 'view'), 'a value cached for one user must not leak to another');
+    }
+
+    public function testKeyIsolationBetweenPermissionTypes(): void
+    {
+        $cache = new PermissionCache();
+        $user = $this->inMemoryUser(1);
+        $element = $this->inMemoryObject(10);
+
+        $cache->set($user, $element, 'view', true);
+
+        $this->assertNull($cache->get($user, $element, 'publish'), 'permission types must be cached independently');
+    }
+
+    public function testKeyIsolationBetweenElementIds(): void
+    {
+        $cache = new PermissionCache();
+        $user = $this->inMemoryUser(1);
+        $elementA = $this->inMemoryObject(10);
+        $elementB = $this->inMemoryObject(11);
+
+        $cache->set($user, $elementA, 'view', true);
+
+        $this->assertNull($cache->get($user, $elementB, 'view'), 'different element ids must be cached independently');
+    }
+
+    public function testKeyIsolationBetweenElementTypes(): void
+    {
+        $cache = new PermissionCache();
+        $user = $this->inMemoryUser(1);
+        $object = $this->inMemoryObject(10);
+        $asset = new Asset\Folder();
+        $asset->setId(10);
+
+        $cache->set($user, $object, 'view', true);
+
+        $this->assertNull($cache->get($user, $asset, 'view'), 'same id on different element types must not collide');
+    }
+
+    /**
+     * Integration: a permission check on a real element populates the shared cache instance, so a
+     * repeated check is served from memory instead of re-querying users_workspaces_*.
+     */
+    public function testIsAllowedPopulatesCache(): void
+    {
+        $root = new DataObject\Folder();
+        $root->setParentId(1);
+        $root->setKey('permission-cache-test-' . uniqid());
+        $root->save();
+
+        $user = $this->makeObjectUser($root);
+
+        $cache = \Pimcore::getContainer()->get(PermissionCache::class);
+        $cache->reset();
+
+        $this->assertNull($cache->get($user, $root, 'view'), 'precondition: nothing cached yet');
+
+        $first = $root->isAllowed('view', $user);
+        $this->assertNotNull($cache->get($user, $root, 'view'), 'isAllowed() must memoize the DAO result');
+        $this->assertSame($first, $cache->get($user, $root, 'view'));
+
+        // repeated call returns the same result
+        $this->assertSame($first, $root->isAllowed('view', $user));
+
+        $root->delete();
+    }
+
+    private function inMemoryUser(int $id): User
+    {
+        $user = new User();
+        $user->setId($id);
+
+        return $user;
+    }
+
+    private function inMemoryObject(int $id): DataObject\Folder
+    {
+        $object = new DataObject\Folder();
+        $object->setId($id);
+
+        return $object;
+    }
+
+    private function makeObjectUser(DataObject\AbstractObject $target): User
+    {
+        $workspace = new User\Workspace\DataObject();
+        $workspace->setCid($target->getId());
+        $workspace->setCpath($target->getRealFullPath());
+        $workspace->setList(true);
+        $workspace->setView(true);
+
+        $role = new User\Role();
+        $role->setParentId(0);
+        $role->setName('permission_cache_role_' . uniqid());
+        $role->setPermissions(['objects']);
+        $role->setWorkspacesObject([$workspace]);
+        $role->save();
+        $this->createdRoles[] = $role;
+
+        $user = new User();
+        $user->setParentId(0);
+        $user->setName('permission_cache_user_' . uniqid());
+        $user->setActive(true);
+        $user->setAdmin(false);
+        $user->setPermissions(['objects']);
+        $user->setRoles([$role->getId()]);
+        $user->save();
+        $this->createdUsers[] = $user;
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## Problem

Element permission resolution has **no request-level caching**. Every `isAllowed()` / `getUserPermissions()` call on an element re-queries the `users_workspaces_*` tables through the DAO. Calling `isAllowed('view', $user)` twice on the same element runs the SQL twice, and admin listings that check many elements pay the cost repeatedly within a single request.

## Design

- **New service `Pimcore\Model\Element\PermissionCache`** (`models/Element/PermissionCache.php`) — an in-memory map keyed on `(userId, elementType, elementId, permissionType)`. It implements `Symfony\Contracts\Service\ResetInterface` and exposes `get()`, `set()`, `reset()`. `final`, `@internal`, `strict_types`.
- **Registration** in `bundles/CoreBundle/config/services.yaml` with `public: true` (fetched from a model via `Pimcore::getContainer()->get()`) and the `kernel.reset` tag (`method: reset`), so it is cleared automatically at the **request** and **messenger-message** boundary.
- **Integration** in `models/Element/AbstractElement.php`:
  - `isAllowed()` — memoizes **only** `$this->getDao()->isAllowed()`.
  - `getUserPermissions()` — memoizes **only** `$this->getDao()->areAllowed()`, resolved **all-or-nothing** across the requested columns because the DAO derives the `list` permission from the full column set (a partial column set would break `permissionByTypes()`).
  - The **workflow-deny check** and the **`ELEMENT_PERMISSION_IS_ALLOWED` event stay OUTSIDE the cache** — listeners still run on every call and may decide dynamically. Return-value semantics are preserved (bool for `isAllowed()`, `int` `0/1` for `getUserPermissions()`).

## Invalidation

- **Per request / per worker message:** handled automatically by the `kernel.reset` tag (`ResetInterface`).
- **Within a request:** `Pimcore\Bundle\CoreBundle\EventListener\PermissionCacheInvalidationListener` calls `reset()` on `UserRoleEvents::POST_ADD` / `POST_UPDATE` / `POST_DELETE`. Because element workspaces are persisted together with their user/role, this also covers `users_workspaces_*` writes (workspace saves).
- **TODO (follow-up):** element **move / path change** updates the `cpath` of workspace rows in each DAO's `update()` and can therefore change permission results within the same request. A reset hook for that path is **not** wired in this first cut — documented here as a deliberate follow-up. The per-request `reset()` guarantee is unaffected.

## Backward compatibility

Behavior-preserving: the same permission result is returned within a request. Only the DAO lookup is memoized; the workflow check and the event remain live on every call.

## Tests

`tests/Model/Element/PermissionCacheTest.php` (`@group model.element.permission`, extends `ModelTestCase`):
- unit coverage of the service — get/set/reset and key isolation across users, permission types, element ids and element types;
- an integration assertion that `AbstractElement::isAllowed()` populates the shared cache instance.

> Not run locally (shared test environment / registration-gated). **CI validates.**

## Assumptions / notes

- Service fetched via `Pimcore::getContainer()->get()` to match how core models pull container services; hence `public: true`.
- `getUserPermissions()` caches all-or-nothing to stay correct with the DAO's `list`-column derivation.

Relates to pimcore/platform-version#212