### PR TITLE
[Improvement] NormalizerInterface: JSON round-trip fidelity fixes + conformance tests

### DIFF
--- a/models/DataObject/ClassDefinition/Data/DateRange.php
+++ b/models/DataObject/ClassDefinition/Data/DateRange.php
@@ -210,7 +210,13 @@ class DateRange extends Data implements
     public function normalize(mixed $value, array $params = []): ?array
     {
         if ($value instanceof CarbonPeriod) {
-            return $value->toArray();
+            // only the boundaries, not CarbonPeriod::toArray(): expanding the period
+            // enumerates EVERY date it contains (unbounded for years-long ranges) while
+            // denormalize() only ever consumed the first and last entry anyway
+            return [
+                $value->getStartDate()->toIso8601String(),
+                $value->getEndDate()?->toIso8601String(),
+            ];
         }
 
         return null;

--- a/models/DataObject/ClassDefinition/Data/EncryptedField.php
+++ b/models/DataObject/ClassDefinition/Data/EncryptedField.php
@@ -43,6 +43,11 @@ class EncryptedField extends Data implements ResourcePersistenceAwareInterface, 
      */
     const STRICT_ENABLED = 1;
 
+    /**
+     * envelope key marking a normalize() value produced with ['preserveEncryption' => true]
+     */
+    public const ENCRYPTED_NORMALIZED_KEY = 'pimcore_encrypted_value';
+
     private static int $strictMode = self::STRICT_ENABLED;
 
     /**
@@ -391,6 +396,21 @@ class EncryptedField extends Data implements ResourcePersistenceAwareInterface, 
                 $plainValue = $this->delegate->normalize($plainValue, $params);
             }
 
+            // normalize() output is used as a storage/wire format (e.g.
+            // Classificationstore\Dao persists it) — persisting the decrypted value
+            // would silently defeat encryption at rest. Opt-in keeps the value
+            // encrypted; the default stays plain for consumers that NEED the data
+            // (e.g. GDPR data-subject export).
+            if ($params['preserveEncryption'] ?? false) {
+                return [
+                    self::ENCRYPTED_NORMALIZED_KEY => $this->encrypt(
+                        json_encode($plainValue, JSON_THROW_ON_ERROR),
+                        null,
+                        ['asString' => true] + $params
+                    ),
+                ];
+            }
+
             return $plainValue;
         }
 
@@ -399,6 +419,15 @@ class EncryptedField extends Data implements ResourcePersistenceAwareInterface, 
 
     public function denormalize(mixed $value, array $params = []): Model\DataObject\Data\EncryptedField
     {
+        // shape-detecting counterpart of normalize(['preserveEncryption' => true])
+        if (is_array($value) && array_key_exists(self::ENCRYPTED_NORMALIZED_KEY, $value)) {
+            $value = json_decode(
+                (string) $this->decrypt($value[self::ENCRYPTED_NORMALIZED_KEY], null, ['asString' => true] + $params),
+                true,
+                512,
+                JSON_THROW_ON_ERROR
+            );
+        }
         if ($this->delegate instanceof NormalizerInterface) {
             $value = $this->delegate->denormalize($value, $params);
         }

--- a/models/DataObject/ClassDefinition/Data/EncryptedField.php
+++ b/models/DataObject/ClassDefinition/Data/EncryptedField.php
@@ -45,6 +45,9 @@ class EncryptedField extends Data implements ResourcePersistenceAwareInterface, 
 
     /**
      * envelope key marking a normalize() value produced with ['preserveEncryption' => true]
+     *
+     * The envelope is NOT deterministic: encrypting the same value twice produces
+     * different output, so it must not be used for equality comparison.
      */
     public const ENCRYPTED_NORMALIZED_KEY = 'pimcore_encrypted_value';
 
@@ -396,11 +399,8 @@ class EncryptedField extends Data implements ResourcePersistenceAwareInterface, 
                 $plainValue = $this->delegate->normalize($plainValue, $params);
             }
 
-            // normalize() output is used as a storage/wire format (e.g.
-            // Classificationstore\Dao persists it) — persisting the decrypted value
-            // would silently defeat encryption at rest. Opt-in keeps the value
-            // encrypted; the default stays plain for consumers that NEED the data
-            // (e.g. GDPR data-subject export).
+            // opt-in for consumers that persist normalize() output; the default stays
+            // plain for consumers that need the value itself
             if ($params['preserveEncryption'] ?? false) {
                 return [
                     self::ENCRYPTED_NORMALIZED_KEY => $this->encrypt(
@@ -421,12 +421,12 @@ class EncryptedField extends Data implements ResourcePersistenceAwareInterface, 
     {
         // shape-detecting counterpart of normalize(['preserveEncryption' => true])
         if (is_array($value) && array_key_exists(self::ENCRYPTED_NORMALIZED_KEY, $value)) {
-            $value = json_decode(
-                (string) $this->decrypt($value[self::ENCRYPTED_NORMALIZED_KEY], null, ['asString' => true] + $params),
-                true,
-                512,
-                JSON_THROW_ON_ERROR
-            );
+            $decrypted = $this->decrypt($value[self::ENCRYPTED_NORMALIZED_KEY], null, ['asString' => true] + $params);
+            // decrypt() returns null when the value cannot be decoded and strict mode is
+            // off — keep that soft failure rather than turning it into a JsonException
+            $value = $decrypted === null
+                ? null
+                : json_decode((string) $decrypted, true, 512, JSON_THROW_ON_ERROR);
         }
         if ($this->delegate instanceof NormalizerInterface) {
             $value = $this->delegate->denormalize($value, $params);

--- a/models/DataObject/ClassDefinition/Data/Hotspotimage.php
+++ b/models/DataObject/ClassDefinition/Data/Hotspotimage.php
@@ -544,9 +544,9 @@ class Hotspotimage extends Data implements ResourcePersistenceAwareInterface, Qu
     {
         if (is_array($value)) {
             $image = new DataObject\Data\Hotspotimage();
-            $image->setHotspots($value['hotspots']);
-            $image->setMarker($value['marker']);
-            $image->setCrop($value['crop']);
+            $image->setHotspots($this->rewrapMarkerHotspotItems($value['hotspots'] ?? null));
+            $image->setMarker($this->rewrapMarkerHotspotItems($value['marker'] ?? null));
+            $image->setCrop($value['crop'] ?? null);
             if ($value['image'] ?? false) {
                 $type = $value['image']['type'];
                 $id = $value['image']['id'];
@@ -560,6 +560,35 @@ class Hotspotimage extends Data implements ResourcePersistenceAwareInterface, Qu
         }
 
         return null;
+    }
+
+    /**
+     * Re-wraps hotspot/marker metadata entries into MarkerHotspotItem instances after the
+     * value passed an array-only boundary (json_encode/decode of normalize() output) —
+     * the same backward-compatibility wrapping getDataFromResource() applies.
+     *
+     * @param array<int, mixed>|null $data
+     *
+     * @return array<int, mixed>|null
+     */
+    private function rewrapMarkerHotspotItems(?array $data): ?array
+    {
+        if ($data === null) {
+            return null;
+        }
+
+        foreach ($data as &$element) {
+            if (is_array($element) && array_key_exists('data', $element) && is_array($element['data']) && count($element['data']) > 0) {
+                foreach ($element['data'] as &$metaData) {
+                    // this is for backward compatibility (Array vs. MarkerHotspotItem)
+                    if (is_array($metaData)) {
+                        $metaData = new Element\Data\MarkerHotspotItem($metaData);
+                    }
+                }
+            }
+        }
+
+        return $data;
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/ImageGallery.php
+++ b/models/DataObject/ClassDefinition/Data/ImageGallery.php
@@ -418,7 +418,10 @@ class ImageGallery extends Data implements ResourcePersistenceAwareInterface, Qu
             $items = [];
             $def = new Hotspotimage();
             foreach ($value as $rawValue) {
-                $items[] = $def->denormalize($rawValue, $params);
+                $item = $def->denormalize($rawValue, $params);
+                if ($item !== null) {
+                    $items[] = $item;
+                }
             }
 
             return new DataObject\Data\ImageGallery($items);

--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -999,7 +999,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
     {
         if (is_array($value)) {
             $lf = new Localizedfield();
-            $lf->setObject($params['object']);
+            $lf->setObject($params['object'] ?? null);
 
             $items = [];
 

--- a/models/DataObject/ClassDefinition/Data/Objectbricks.php
+++ b/models/DataObject/ClassDefinition/Data/Objectbricks.php
@@ -850,7 +850,13 @@ class Objectbricks extends Data implements CustomResourcePersistingInterface, Ty
                 $result[$key] = [];
 
                 foreach ($v as $fieldKey => $fieldValue) {
-                    $fd = $fds[$fieldKey];
+                    $fd = $fds[$fieldKey] ?? null;
+                    if ($fd === null) {
+                        // brick definition seems to have changed
+                        Logger::warn('brick definition seems to have changed, field name: ' . $fieldKey);
+
+                        continue;
+                    }
                     if ($fd instanceof NormalizerInterface) {
                         $fieldValue = $fd->denormalize($fieldValue, $params);
                     }

--- a/tests/Model/DataType/NormalizerTest.php
+++ b/tests/Model/DataType/NormalizerTest.php
@@ -205,7 +205,10 @@ class NormalizerTest extends ModelTestCase
     public function testExternalImage(): void
     {
         $originalValue = new DataObject\Data\ExternalImage('http://someurl.com');
-        $fd = new DataObject\ClassDefinition\Data\Email();
+        // was Data\Email() — the passthrough normalize returned the ExternalImage object
+        // unchanged, so the pre-JSON-boundary assertion compared the object to itself
+        // and the type was never actually tested
+        $fd = new DataObject\ClassDefinition\Data\ExternalImage();
         $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
         $normalizedValue = $fd->normalize($originalValue);
         $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));

--- a/tests/Model/DataType/NormalizerTest.php
+++ b/tests/Model/DataType/NormalizerTest.php
@@ -14,11 +14,13 @@ declare(strict_types=1);
 namespace Pimcore\Tests\Model\DataType;
 
 use Carbon\Carbon;
+use Carbon\CarbonPeriod;
 use Exception;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\Data\Hotspotimage;
 use Pimcore\Model\DataObject\Data\Link;
 use Pimcore\Model\DataObject\Unittest;
+use Pimcore\Model\Element\Data\MarkerHotspotItem;
 use Pimcore\Model\User;
 use Pimcore\Normalizer\NormalizerInterface;
 use Pimcore\Tests\Support\Test\ModelTestCase;
@@ -51,13 +53,31 @@ class NormalizerTest extends ModelTestCase
         parent::tearDown();
     }
 
+    /**
+     * The NormalizerInterface contract this suite enforces: normalize() output must
+     * survive a JSON encode/decode boundary (that is what makes the format portable —
+     * it is persisted e.g. by Classificationstore\Dao and shipped over APIs) and
+     * denormalize() must restore an equal value from the decoded representation.
+     * Without this boundary, object instances leaking through normalize() go
+     * undetected because denormalize() receives them back unchanged.
+     */
+    private function jsonRoundTrip(mixed $normalizedValue): mixed
+    {
+        return json_decode(
+            json_encode($normalizedValue, JSON_THROW_ON_ERROR),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+    }
+
     public function testBooleanSelect(): void
     {
         $originalValue = true;
         $fd = new DataObject\ClassDefinition\Data\BooleanSelect();
         $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
         $normalizedValue = $fd->normalize($originalValue);
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -67,7 +87,7 @@ class NormalizerTest extends ModelTestCase
         $fd = new DataObject\ClassDefinition\Data\Checkbox();
         $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
         $normalizedValue = $fd->normalize($originalValue);
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -78,7 +98,7 @@ class NormalizerTest extends ModelTestCase
         $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
         $normalizedValue = $fd->normalize($originalValue);
         $this->assertTrue(is_array($normalizedValue));
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -88,7 +108,7 @@ class NormalizerTest extends ModelTestCase
         $fd = new DataObject\ClassDefinition\Data\Country();
         $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
         $normalizedValue = $fd->normalize($originalValue);
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -98,7 +118,7 @@ class NormalizerTest extends ModelTestCase
         $fd = new DataObject\ClassDefinition\Data\Countrymultiselect();
         $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
         $normalizedValue = $fd->normalize($originalValue);
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -111,7 +131,7 @@ class NormalizerTest extends ModelTestCase
         $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
         $normalizedValue = $fd->normalize($originalValue);
         $this->assertEquals($ts, $normalizedValue);
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -124,7 +144,7 @@ class NormalizerTest extends ModelTestCase
         $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
         $normalizedValue = $fd->normalize($originalValue);
         $this->assertEquals($ts, $normalizedValue);
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -134,13 +154,52 @@ class NormalizerTest extends ModelTestCase
         $fd = new DataObject\ClassDefinition\Data\Email();
         $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
         $normalizedValue = $fd->normalize($originalValue);
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
     public function testEncryptedField(): void
     {
-        $this->markTestSkipped('implement this as soon as marshal() is gone');
+        $container = \Pimcore::getContainer();
+        if (!$container->hasParameter('pimcore.encryption.secret') || !$container->getParameter('pimcore.encryption.secret')) {
+            $this->markTestSkipped('no pimcore.encryption.secret configured for the test environment');
+        }
+
+        $delegate = new DataObject\ClassDefinition\Data\Input();
+        $fd = new DataObject\ClassDefinition\Data\EncryptedField();
+        $fd->setDelegate($delegate);
+        $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
+
+        $originalValue = new DataObject\Data\EncryptedField($delegate, 'top secret value');
+
+        // default: plain representation (consumers like a GDPR data-subject export need the data)
+        $normalizedValue = $fd->normalize($originalValue);
+        $this->assertSame('top secret value', $normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
+        $this->assertEquals($originalValue, $denormalizedValue);
+
+        // opt-in: value stays encrypted — normalize() output is used as a storage/wire
+        // format, persisting it must not silently defeat encryption at rest
+        $normalizedValue = $fd->normalize($originalValue, ['preserveEncryption' => true]);
+        $this->assertIsArray($normalizedValue);
+        $this->assertArrayHasKey(DataObject\ClassDefinition\Data\EncryptedField::ENCRYPTED_NORMALIZED_KEY, $normalizedValue);
+        $this->assertStringNotContainsString('top secret value', json_encode($normalizedValue, JSON_THROW_ON_ERROR));
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
+        $this->assertEquals($originalValue, $denormalizedValue);
+    }
+
+    public function testDateRange(): void
+    {
+        $originalValue = CarbonPeriod::create('2023-01-01', '2025-12-31');
+
+        $fd = new DataObject\ClassDefinition\Data\DateRange();
+        $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
+        $normalizedValue = $fd->normalize($originalValue);
+        $this->assertIsArray($normalizedValue);
+        $this->assertCount(2, $normalizedValue, 'expected the period boundaries only, not every date the period contains');
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
+        $this->assertEquals($originalValue->getStartDate(), $denormalizedValue->getStartDate());
+        $this->assertEquals($originalValue->getEndDate(), $denormalizedValue->getEndDate());
     }
 
     public function testExternalImage(): void
@@ -149,7 +208,7 @@ class NormalizerTest extends ModelTestCase
         $fd = new DataObject\ClassDefinition\Data\Email();
         $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
         $normalizedValue = $fd->normalize($originalValue);
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -159,7 +218,7 @@ class NormalizerTest extends ModelTestCase
         $fd = new DataObject\ClassDefinition\Data\Firstname();
         $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
         $normalizedValue = $fd->normalize($originalValue);
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -169,7 +228,7 @@ class NormalizerTest extends ModelTestCase
         $fd = new DataObject\ClassDefinition\Data\Gender();
         $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
         $normalizedValue = $fd->normalize($originalValue);
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -185,7 +244,7 @@ class NormalizerTest extends ModelTestCase
         $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
         $normalizedValue = $fd->normalize($originalValue);
         $this->assertTrue(is_array($normalizedValue));
-        $denormalizedValue = $fd->denormalize($normalizedValue, $ownerInfo);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue), $ownerInfo);
 
         $this->assertEquals($originalValue, $denormalizedValue);
     }
@@ -202,7 +261,7 @@ class NormalizerTest extends ModelTestCase
         $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
         $normalizedValue = $fd->normalize($originalValue);
         $this->assertTrue(is_array($normalizedValue));
-        $denormalizedValue = $fd->denormalize($normalizedValue, $ownerInfo);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue), $ownerInfo);
 
         $this->assertEquals($originalValue, $denormalizedValue);
     }
@@ -230,7 +289,7 @@ class NormalizerTest extends ModelTestCase
         $this->assertNotEquals($normalizedValue, $originalValue);
 
         $this->assertTrue(is_array($normalizedValue));
-        $denormalizedValue = $fd->denormalize($normalizedValue, $ownerInfo);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue), $ownerInfo);
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -257,7 +316,7 @@ class NormalizerTest extends ModelTestCase
         $this->assertNotEquals($normalizedValue, $originalValue);
 
         $this->assertTrue(is_array($normalizedValue));
-        $denormalizedValue = $fd->denormalize($normalizedValue, $ownerInfo);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue), $ownerInfo);
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -288,6 +347,15 @@ class NormalizerTest extends ModelTestCase
             [
                 'top' => 56,
                 'left' => 62,
+                // metadata entries are MarkerHotspotItem instances on a loaded value and
+                // must be re-wrapped by denormalize() after the JSON boundary
+                'data' => [
+                    new MarkerHotspotItem([
+                        'name' => 'campaign',
+                        'type' => 'textfield',
+                        'value' => 'summer',
+                    ]),
+                ],
             ],
         ]);
 
@@ -296,7 +364,7 @@ class NormalizerTest extends ModelTestCase
         $normalizedValue = $fd->normalize($originalValue);
         $this->assertNotEquals($normalizedValue, $originalValue);
         $this->assertTrue(is_array($normalizedValue));
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -310,7 +378,7 @@ class NormalizerTest extends ModelTestCase
         $this->assertNotEquals($normalizedValue, $originalValue);
         $this->assertTrue(is_array($normalizedValue));
 
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -334,6 +402,13 @@ class NormalizerTest extends ModelTestCase
                 [
                     'top' => 56 + $i,
                     'left' => 62 + $i,
+                    'data' => [
+                        new MarkerHotspotItem([
+                            'name' => 'campaign',
+                            'type' => 'textfield',
+                            'value' => 'summer-' . $i,
+                        ]),
+                    ],
                 ],
             ]);
             $originalValue[] = $item;
@@ -345,7 +420,7 @@ class NormalizerTest extends ModelTestCase
         $normalizedValue = $fd->normalize($originalValue);
         $this->assertNotEquals($normalizedValue, $originalValue);
         $this->assertTrue(is_array($normalizedValue));
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -356,7 +431,7 @@ class NormalizerTest extends ModelTestCase
         $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
         $normalizedValue = $fd->normalize($originalValue);
         $this->assertEquals($normalizedValue, $originalValue);
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -373,7 +448,7 @@ class NormalizerTest extends ModelTestCase
         $this->assertNotEquals($normalizedValue, $originalValue);
         $this->assertTrue(is_array($normalizedValue));
 
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
 
         $this->assertTrue($denormalizedValue instanceof DataObject\Data\InputQuantityValue);
         $this->assertEquals($originalValue->getValue(), $denormalizedValue->getValue());
@@ -393,7 +468,7 @@ class NormalizerTest extends ModelTestCase
         $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
         $normalizedValue = $fd->normalize($originalValue);
         $this->assertTrue(is_array($normalizedValue));
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -413,7 +488,7 @@ class NormalizerTest extends ModelTestCase
         $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
         $normalizedValue = $fd->normalize($originalValue, ['object' => $object]);
         /** @var DataObject\Localizedfield $denormalizedValue */
-        $denormalizedValue = $fd->denormalize($normalizedValue, ['object' => $object]);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue), ['object' => $object]);
         $this->assertEquals('123', $denormalizedValue->getLocalizedValue('linput'));
 
         $objects = $denormalizedValue->getLocalizedValue('lobjects');
@@ -436,7 +511,7 @@ class NormalizerTest extends ModelTestCase
         $this->assertTrue(is_array($normalizedValue[0]));
         $this->assertTrue(is_array($normalizedValue[1]));
 
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($targetObject1->getId(), $denormalizedValue[0]->getId());
         $this->assertEquals($targetObject2->getId(), $denormalizedValue[1]->getId());
     }
@@ -459,7 +534,7 @@ class NormalizerTest extends ModelTestCase
         $this->assertTrue(is_array($normalizedValue[1]));
         $this->assertTrue(is_array($normalizedValue[2]));
 
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($targetObject1->getId(), $denormalizedValue[0]->getId());
         $this->assertEquals($targetObject2->getId(), $denormalizedValue[1]->getId());
         $this->assertEquals($targetAsset1->getId(), $denormalizedValue[2]->getId());
@@ -475,7 +550,7 @@ class NormalizerTest extends ModelTestCase
         $normalizedValue = $fd->normalize($originalValue);
         $this->assertTrue(is_array($normalizedValue));
 
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue->getId(), $denormalizedValue->getId());
     }
 
@@ -489,7 +564,7 @@ class NormalizerTest extends ModelTestCase
         $this->assertEquals($originalValue, $normalizedValue);
         $this->assertTrue(is_array($normalizedValue));
 
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -499,7 +574,7 @@ class NormalizerTest extends ModelTestCase
         $fd = new DataObject\ClassDefinition\Data\Numeric();
         $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
         $normalizedValue = $fd->normalize($originalValue);
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -509,7 +584,7 @@ class NormalizerTest extends ModelTestCase
         $fd = new DataObject\ClassDefinition\Data\Password();
         $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
         $normalizedValue = $fd->normalize($originalValue);
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -526,7 +601,7 @@ class NormalizerTest extends ModelTestCase
         $this->assertNotEquals($normalizedValue, $originalValue);
         $this->assertTrue(is_array($normalizedValue));
 
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
 
         $this->assertTrue($denormalizedValue instanceof DataObject\Data\QuantityValue);
         $this->assertEquals($originalValue->getValue(), $denormalizedValue->getValue());
@@ -542,7 +617,7 @@ class NormalizerTest extends ModelTestCase
         $this->assertNotEquals($normalizedValue, $originalValue);
         $this->assertTrue(is_array($normalizedValue));
 
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
 
         $this->assertTrue($denormalizedValue instanceof DataObject\Data\RgbaColor);
         $this->assertEquals($originalValue, $denormalizedValue);
@@ -557,7 +632,7 @@ class NormalizerTest extends ModelTestCase
         $normalizedValue = $fd->normalize($originalValue);
         $this->assertEquals($originalValue, $normalizedValue);
 
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -570,7 +645,7 @@ class NormalizerTest extends ModelTestCase
         $normalizedValue = $fd->normalize($originalValue);
         $this->assertEquals($originalValue, $normalizedValue);
 
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -588,7 +663,7 @@ class NormalizerTest extends ModelTestCase
         $normalizedValue = $fd->normalize($originalValue);
         $this->assertTrue(is_array($normalizedValue));
 
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -607,7 +682,7 @@ class NormalizerTest extends ModelTestCase
         $this->assertTrue(is_array($normalizedValue));
         $this->assertEquals($normalizedValue, $originalValue);
 
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -618,7 +693,7 @@ class NormalizerTest extends ModelTestCase
         $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
         $normalizedValue = $fd->normalize($originalValue);
         $this->assertEquals($normalizedValue, $originalValue);
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -629,7 +704,7 @@ class NormalizerTest extends ModelTestCase
         $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
         $normalizedValue = $fd->normalize($originalValue);
         $this->assertEquals($normalizedValue, $originalValue);
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -644,7 +719,7 @@ class NormalizerTest extends ModelTestCase
         $normalizedValue = $fd->normalize($originalValue);
         $this->assertTrue(is_array($normalizedValue));
         $this->assertNotEquals($originalValue, $normalizedValue);
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -658,7 +733,7 @@ class NormalizerTest extends ModelTestCase
         $normalizedValue = $fd->normalize($originalValue);
         $this->assertEquals($originalValue, $normalizedValue);
 
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -680,7 +755,7 @@ class NormalizerTest extends ModelTestCase
         $normalizedValue = $fd->normalize($originalValue);
         $this->assertTrue(is_array($normalizedValue));
         $this->assertNotEquals($originalValue, $normalizedValue);
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 
@@ -691,7 +766,7 @@ class NormalizerTest extends ModelTestCase
         $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
         $normalizedValue = $fd->normalize($originalValue);
         $this->assertEquals($normalizedValue, $originalValue);
-        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
     }
 }

--- a/tests/Model/DataType/NormalizerTest.php
+++ b/tests/Model/DataType/NormalizerTest.php
@@ -186,6 +186,22 @@ class NormalizerTest extends ModelTestCase
         $this->assertStringNotContainsString('top secret value', json_encode($normalizedValue, JSON_THROW_ON_ERROR));
         $denormalizedValue = $fd->denormalize($this->jsonRoundTrip($normalizedValue));
         $this->assertEquals($originalValue, $denormalizedValue);
+
+        // an undecodable envelope keeps the documented soft failure when strict mode is
+        // off: decrypt() returns null, and denormalize() must not raise instead
+        $strictMode = DataObject\ClassDefinition\Data\EncryptedField::isStrictMode();
+        DataObject\ClassDefinition\Data\EncryptedField::setStrictMode(
+            DataObject\ClassDefinition\Data\EncryptedField::STRICT_DISABLED
+        );
+
+        try {
+            $denormalizedValue = $fd->denormalize([
+                DataObject\ClassDefinition\Data\EncryptedField::ENCRYPTED_NORMALIZED_KEY => 'not a ciphertext',
+            ]);
+            $this->assertNull($denormalizedValue->getPlain());
+        } finally {
+            DataObject\ClassDefinition\Data\EncryptedField::setStrictMode($strictMode);
+        }
     }
 
     public function testDateRange(): void


### PR DESCRIPTION
## Changes in this pull request

`normalize()` output is a storage/wire format — `Classificationstore\Dao` persists it, APIs ship it — so its contract is: **the output must survive a JSON encode/decode boundary, and `denormalize()` must restore an equal value from the decoded representation.** Several implementations currently violate this, and the test suite couldn't notice because it round-trips PHP values without ever crossing JSON (object instances leak through `normalize()` and come back unchanged).

### Fixes
- **DateRange**: `normalize()` returned `CarbonPeriod::toArray()` — every single date the period contains (a 3-year range ≈ 1,100 entries; unbounded for long ranges). Now returns the two boundaries only. Read-side compatible: `denormalize()` only ever consumed `reset()`/`end()`, so previously stored values keep denormalizing correctly.
- **Hotspotimage**: `denormalize()` did not re-wrap hotspot/marker metadata into `MarkerHotspotItem` instances after a JSON boundary (the same BC wrapping `getDataFromResource()` applies via its `$rewritePath` closure) and emitted undefined-array-key warnings for missing keys.
- **ImageGallery**: `denormalize()` could push `null` items into the gallery; inherits the marker re-wrap via its Hotspotimage delegation.
- **EncryptedField**: `normalize()` returns the **decrypted** value — any consumer persisting normalize output silently defeats encryption at rest. New opt-in `normalize($value, ['preserveEncryption' => true])` returns an encrypted envelope (`pimcore_encrypted_value`), and `denormalize()` detects that shape. **Default behavior unchanged** — consumers like the GDPR data-subject export legitimately need the plain data.
- **Localizedfields**: `denormalize()` accessed `$params['object']` unguarded → warning + `TypeError` when no object context is available.
- **Objectbricks**: `denormalize()` logs + skips fields removed from the brick definition (mirrors the Localizedfields pattern) instead of undefined-array-key warnings.

### Tests
`NormalizerTest` now routes **every** `denormalize()` call through a JSON encode/decode boundary (`jsonRoundTrip()` helper) — the suite now enforces the actual portability contract for all covered types. Additionally:
- new `testDateRange` (asserts boundaries-only + round-trip)
- the skipped `testEncryptedField` (`implement this as soon as marshal() is gone`) is replaced with real coverage of both modes, incl. asserting the plaintext does not appear in the opt-in payload (skips gracefully when no `pimcore.encryption.secret` is configured)
- `testHotspotimage` / `testImageGallery` fixtures now include marker metadata items (`MarkerHotspotItem`) — the exact case the re-wrap fix addresses

## Additional info

- Verified locally: boundaries-only DateRange round-trip, marker re-wrap incl. delegation, missing-key tolerance, and the EncryptedField envelope (plain default intact, no plaintext in the opt-in payload, decrypt restores the value) against a booted kernel with a generated defuse key.
- Known follow-up (out of scope here): `Hotspotimage::normalize()` emits marker item **values** as-is — for element-type metadata items holding a live element instance this is not JSON-portable; normalizing those to `{type, id}` refs changes the output shape and deserves its own discussion.
- `Objectbricks::denormalize()` returning a plain array (not an `Objectbrick` container) is an interface asymmetry, but changing it would break the declared `?array` return type — flagged for a major.
- Happy to split the pure bug fixes out and retarget them to the maintenance branch if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)