### PR TITLE
Added trigger branches

### DIFF
--- a/.github/workflows/sync-changes-scheduled.yml
+++ b/.github/workflows/sync-changes-scheduled.yml
@@ -9,6 +9,10 @@ on:
       - '2026.2'
       - '12.3'
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   sync-branches:
     uses: pimcore/workflows-collection-public/.github/workflows/reusable-sync-changes.yaml@main

--- a/.github/workflows/sync-changes-scheduled.yml
+++ b/.github/workflows/sync-changes-scheduled.yml
@@ -3,6 +3,11 @@ on:
   workflow_dispatch:
   schedule:
     - cron:  '30 21 * * *'
+  push:
+    branches:
+      - '2026.x'
+      - '2026.2'
+      - '12.3'
 
 jobs:
   sync-branches:


### PR DESCRIPTION
This pull request updates the workflow trigger configuration in `.github/workflows/sync-changes-scheduled.yml` to ensure the workflow runs automatically when changes are pushed to specific branches. This improves automation and keeps the workflow in sync with important release branches.

Workflow trigger updates:

* Added a `push` event trigger for the `2026.x`, `2026.2`, and `12.3` branches to the workflow configuration, so the workflow will run on pushes to these branches.