### PR TITLE
[Improvement] Make child list-permission checks sargable (getChildAmount/hasChildren)

### DIFF
--- a/models/Asset/Dao.php
+++ b/models/Asset/Dao.php
@@ -323,26 +323,20 @@ class Dao extends Model\Element\Dao
             return false;
         }
 
-        $query = 'SELECT `a`.`id` FROM `assets` a  WHERE parentId = ? ';
+        $query = 'SELECT o.id FROM assets o WHERE parentId = :parentId';
+        $params = ['parentId' => $this->model->getId()];
+        $types = [];
 
         if ($user && !$user->isAdmin()) {
-            $userIds = $user->getRoles();
-            $currentUserId = $user->getId();
-            $userIds[] = $currentUserId;
-
-            $inheritedPermission = $this->isInheritingPermission('list', $userIds);
-
-            $anyAllowedRowOrChildren = 'EXISTS(SELECT list FROM users_workspaces_asset uwa WHERE userId IN (' . implode(',', $userIds) . ') AND list=1 AND (cpath=CONCAT(`path`,filename) OR LOCATE(CONCAT(`path`,filename,\'/\'),cpath)=1) AND
-                NOT EXISTS(SELECT list FROM users_workspaces_asset WHERE userId =' . $currentUserId . '  AND list=0 AND cpath = uwa.cpath))';
-            $isDisallowedCurrentRow = 'EXISTS(SELECT list FROM users_workspaces_asset WHERE userId IN (' . implode(',', $userIds) . ')  AND cid = id AND list=0)';
-
-            $query .= ' AND IF(' . $anyAllowedRowOrChildren . ',1,IF(' . $inheritedPermission . ', ' . $isDisallowedCurrentRow . ' = 0, 0)) = 1';
+            [$condition, $permissionParams, $permissionTypes] = $this->buildChildListPermissionCondition($user, 'asset', 'filename');
+            $query .= ' AND ' . $condition;
+            $params += $permissionParams;
+            $types += $permissionTypes;
         }
 
-        $query .= ' LIMIT 1;';
-        $c = $this->db->fetchOne($query, [$this->model->getId()]);
+        $query .= ' LIMIT 1';
 
-        return (bool)$c;
+        return (bool) $this->db->fetchOne($query, $params, $types);
     }
 
     /**
@@ -378,23 +372,18 @@ class Dao extends Model\Element\Dao
             return 0;
         }
 
-        $query = 'SELECT COUNT(*) AS count FROM assets WHERE parentId = ?';
+        $query = 'SELECT COUNT(*) AS count FROM assets o WHERE parentId = :parentId';
+        $params = ['parentId' => $this->model->getId()];
+        $types = [];
 
         if ($user && !$user->isAdmin()) {
-            $userIds = $user->getRoles();
-            $currentUserId = $user->getId();
-            $userIds[] = $currentUserId;
-
-            $inheritedPermission = $this->isInheritingPermission('list', $userIds);
-
-            $anyAllowedRowOrChildren = 'EXISTS(SELECT list FROM users_workspaces_asset uwa WHERE userId IN (' . implode(',', $userIds) . ') AND list=1 AND (cpath=CONCAT(`path`,filename) OR LOCATE(CONCAT(`path`,filename,\'/\'),cpath)=1) AND
-                NOT EXISTS(SELECT list FROM users_workspaces_asset WHERE userId =' . $currentUserId . '  AND list=0 AND cpath = uwa.cpath))';
-            $isDisallowedCurrentRow = 'EXISTS(SELECT list FROM users_workspaces_asset WHERE userId IN (' . implode(',', $userIds) . ')  AND cid = id AND list=0)';
-
-            $query .= ' AND IF(' . $anyAllowedRowOrChildren . ',1,IF(' . $inheritedPermission . ', ' . $isDisallowedCurrentRow . ' = 0, 0)) = 1';
+            [$condition, $permissionParams, $permissionTypes] = $this->buildChildListPermissionCondition($user, 'asset', 'filename');
+            $query .= ' AND ' . $condition;
+            $params += $permissionParams;
+            $types += $permissionTypes;
         }
 
-        return (int) $this->db->fetchOne($query, [$this->model->getId()]);
+        return (int) $this->db->fetchOne($query, $params, $types);
     }
 
     public function isLocked(): bool

--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -12,6 +12,7 @@
 
 namespace Pimcore\Model\DataObject\AbstractObject;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Exception;
 use Pimcore\Db\Helper;
 use Pimcore\Logger;
@@ -286,28 +287,15 @@ class Dao extends Model\Element\Dao
             return false;
         }
 
-        $sql = 'SELECT 1 FROM objects o WHERE parentId = ? ';
+        $sql = 'SELECT 1 FROM objects o WHERE parentId = :parentId';
+        $params = ['parentId' => $this->model->getId()];
+        $types = [];
+
         if ($user && !$user->isAdmin()) {
-            $roleIds = $user->getRoles();
-            $currentUserId = $user->getId();
-            $permissionIds = array_merge($roleIds, [$currentUserId]);
-
-            //gets the permission of the ancestors, since it would be the same for each row with same parentId, it is done once outside the query to avoid extra subquery.
-            $inheritedPermission = $this->isInheritingPermission('list', $permissionIds);
-
-            // $anyAllowedRowOrChildren checks for nested elements that are `list`=1. This is to allow the folders in between from current parent to any nested elements and due the "additive" permission on the element itself, we can simply ignore list=0 children
-            // unless for the same rule found is list=0 on user specific level, in that case it nullifies that entry.
-            $anyAllowedRowOrChildren = 'EXISTS(SELECT list FROM users_workspaces_object uwo WHERE userId IN (' . implode(',', $permissionIds) . ') AND list=1 AND (cpath=CONCAT(o.path,o.key) OR LOCATE(CONCAT(o.path,o.key,\'/\'),cpath)=1) AND
-            NOT EXISTS(SELECT list FROM users_workspaces_object WHERE userId =' . $currentUserId . '  AND list=0 AND cpath = uwo.cpath))';
-
-            // $allowedCurrentRow checks if the current row is blocked, if found a match it "removes/ignores" the entry from object table, doesn't need to check if is list=1 on user level, since it is done in $anyAllowedRowOrChildren (NB: equal or longer cpath) so we are safe to deduce that there are no valid list=1 rules
-            $isDisallowedCurrentRow = 'EXISTS(SELECT list FROM users_workspaces_object uworow WHERE userId IN (' . implode(',', $permissionIds) . ')  AND cid = id AND list=0)';
-
-            //If no children with list=1 (with no user-level list=0) is found, we consider the inherited permission rule
-            //if $inheritedPermission=0 then everything is disallowed (or doesn't specify any rule) for that row, we can skip $isDisallowedCurrentRow
-            //if $inheritedPermission=1, then we are allowed unless the current row is specifically disabled, already knowing from $anyAllowedRowOrChildren that there are no list=1(without user permission list=0),so this "blocker" is the highest cpath available for this row if found
-
-            $sql .= ' AND IF(' . $anyAllowedRowOrChildren . ',1,IF(' . $inheritedPermission . ', ' . $isDisallowedCurrentRow . ' = 0, 0)) = 1';
+            [$condition, $permissionParams, $permissionTypes] = $this->buildChildListPermissionCondition($user, 'object', 'key');
+            $sql .= ' AND ' . $condition;
+            $params += $permissionParams;
+            $types += $permissionTypes;
         }
 
         $includingUnpublished ??= !DataObject::doHideUnpublished();
@@ -316,13 +304,14 @@ class Dao extends Model\Element\Dao
         }
 
         if ($objectTypes) {
-            $sql .= " AND `type` IN ('" . implode("','", $objectTypes) . "')";
+            $sql .= ' AND `type` IN (:objectTypes)';
+            $params['objectTypes'] = $objectTypes;
+            $types['objectTypes'] = ArrayParameterType::STRING;
         }
 
         $sql .= ' LIMIT 1';
-        $c = $this->db->fetchOne($sql, [$this->model->getId()]);
 
-        return (bool)$c;
+        return (bool) $this->db->fetchOne($sql, $params, $types);
     }
 
     /**
@@ -381,27 +370,24 @@ class Dao extends Model\Element\Dao
             return 0;
         }
 
-        $query = 'SELECT COUNT(*) AS count FROM objects o WHERE parentId = ?';
+        $query = 'SELECT COUNT(*) AS count FROM objects o WHERE parentId = :parentId';
+        $params = ['parentId' => $this->model->getId()];
+        $types = [];
 
         if ($objectTypes) {
-            $query .= sprintf(' AND `type` IN (\'%s\')', implode("','", $objectTypes));
+            $query .= ' AND `type` IN (:objectTypes)';
+            $params['objectTypes'] = $objectTypes;
+            $types['objectTypes'] = ArrayParameterType::STRING;
         }
 
         if ($user && !$user->isAdmin()) {
-            $roleIds = $user->getRoles();
-            $currentUserId = $user->getId();
-            $permissionIds = array_merge($roleIds, [$currentUserId]);
-
-            $inheritedPermission = $this->isInheritingPermission('list', $permissionIds);
-
-            $anyAllowedRowOrChildren = 'EXISTS(SELECT list FROM users_workspaces_object uwo WHERE userId IN (' . implode(',', $permissionIds) . ') AND list=1 AND (cpath=CONCAT(o.path,o.key) OR LOCATE(CONCAT(o.path,o.key,\'/\'),cpath)=1) AND
-            NOT EXISTS(SELECT list FROM users_workspaces_object WHERE userId ='.$currentUserId.'  AND list=0 AND cpath = uwo.cpath))';
-            $isDisallowedCurrentRow = 'EXISTS(SELECT list FROM users_workspaces_object uworow WHERE userId IN (' . implode(',', $permissionIds) . ')  AND cid = id AND list=0)';
-
-            $query .= ' AND IF(' . $anyAllowedRowOrChildren . ',1,IF(' . $inheritedPermission . ', ' . $isDisallowedCurrentRow . ' = 0, 0)) = 1';
+            [$condition, $permissionParams, $permissionTypes] = $this->buildChildListPermissionCondition($user, 'object', 'key');
+            $query .= ' AND ' . $condition;
+            $params += $permissionParams;
+            $types += $permissionTypes;
         }
 
-        return (int) $this->db->fetchOne($query, [$this->model->getId()]);
+        return (int) $this->db->fetchOne($query, $params, $types);
     }
 
     /**

--- a/models/Document/Dao.php
+++ b/models/Document/Dao.php
@@ -326,20 +326,15 @@ class Dao extends Model\Element\Dao
             return false;
         }
 
-        $sql = 'SELECT id FROM documents d WHERE parentId = ? ';
+        $sql = 'SELECT o.id FROM documents o WHERE parentId = :parentId';
+        $params = ['parentId' => $this->model->getId()];
+        $types = [];
 
         if ($user && !$user->isAdmin()) {
-            $userIds = $user->getRoles();
-            $currentUserId = $user->getId();
-            $userIds[] = $currentUserId;
-
-            $inheritedPermission = $this->isInheritingPermission('list', $userIds);
-
-            $anyAllowedRowOrChildren = 'EXISTS(SELECT list FROM users_workspaces_document uwd WHERE userId IN (' . implode(',', $userIds) . ') AND list=1 AND (cpath=CONCAT(d.path,d.`key`) OR LOCATE(CONCAT(d.path,d.`key`,\'/\'),cpath)=1) AND
-                NOT EXISTS(SELECT list FROM users_workspaces_document WHERE userId =' . $currentUserId . '  AND list=0 AND cpath = uwd.cpath))';
-            $isDisallowedCurrentRow = 'EXISTS(SELECT list FROM users_workspaces_document WHERE userId IN (' . implode(',', $userIds) . ')  AND cid = id AND list=0)';
-
-            $sql .= ' AND IF(' . $anyAllowedRowOrChildren . ',1,IF(' . $inheritedPermission . ', ' . $isDisallowedCurrentRow . ' = 0, 0)) = 1';
+            [$condition, $permissionParams, $permissionTypes] = $this->buildChildListPermissionCondition($user, 'document', 'key');
+            $sql .= ' AND ' . $condition;
+            $params += $permissionParams;
+            $types += $permissionTypes;
         }
 
         $includingUnpublished ??= !Model\Document::doHideUnpublished();
@@ -349,9 +344,7 @@ class Dao extends Model\Element\Dao
 
         $sql .= ' LIMIT 1';
 
-        $c = $this->db->fetchOne($sql, [$this->model->getId()]);
-
-        return (bool)$c;
+        return (bool) $this->db->fetchOne($sql, $params, $types);
     }
 
     /**
@@ -364,22 +357,18 @@ class Dao extends Model\Element\Dao
         if (!$this->model->getId()) {
             return 0;
         }
-        $sql = 'SELECT count(*) FROM documents d WHERE parentId = ? ';
+        $sql = 'SELECT COUNT(*) FROM documents o WHERE parentId = :parentId';
+        $params = ['parentId' => $this->model->getId()];
+        $types = [];
+
         if ($user && !$user->isAdmin()) {
-            $userIds = $user->getRoles();
-            $currentUserId = $user->getId();
-            $userIds[] = $currentUserId;
-
-            $inheritedPermission = $this->isInheritingPermission('list', $userIds);
-
-            $anyAllowedRowOrChildren = 'EXISTS(SELECT list FROM users_workspaces_document uwd WHERE userId IN (' . implode(',', $userIds) . ') AND list=1 AND (cpath=CONCAT(d.path,d.`key`) OR LOCATE(CONCAT(d.path,d.`key`,\'/\'),cpath)=1) AND
-                NOT EXISTS(SELECT list FROM users_workspaces_document WHERE userId =' . $currentUserId . '  AND list=0 AND cpath = uwd.cpath))';
-            $isDisallowedCurrentRow = 'EXISTS(SELECT list FROM users_workspaces_document WHERE userId IN (' . implode(',', $userIds) . ')  AND cid = id AND list=0)';
-
-            $sql .= ' AND IF(' . $anyAllowedRowOrChildren . ',1,IF(' . $inheritedPermission . ', ' . $isDisallowedCurrentRow . ' = 0, 0)) = 1';
+            [$condition, $permissionParams, $permissionTypes] = $this->buildChildListPermissionCondition($user, 'document', 'key');
+            $sql .= ' AND ' . $condition;
+            $params += $permissionParams;
+            $types += $permissionTypes;
         }
 
-        return (int) $this->db->fetchOne($sql, [$this->model->getId()]);
+        return (int) $this->db->fetchOne($sql, $params, $types);
     }
 
     /**

--- a/models/Element/Dao.php
+++ b/models/Element/Dao.php
@@ -224,4 +224,102 @@ abstract class Dao extends Model\Dao\AbstractDao
 
         return (int)$permissionsChildren;
     }
+
+    /**
+     * Builds a boundary-correct, index-usable "listable child" WHERE fragment (against the `o`
+     * alias of the element table) for the children of the current folder, together with its bound
+     * parameters and types.
+     *
+     * A child is listable when the user has an allowed (list=1, not user-denied) workspace on the
+     * child itself or anywhere in its subtree, or when the folder inherits the list permission and
+     * the child is not explicitly denied. The subtree check is resolved with a single folder-scoped
+     * lookup (a constant cpath prefix, so the cpath index range applies) instead of a
+     * LOCATE(cpath) correlated subquery evaluated per child — turning an
+     * O(children * workspace-rows) scan into O(children + workspace-rows).
+     *
+     * @return array{0: string, 1: array<string, mixed>, 2: array<string, ArrayParameterType>}
+     *
+     * @throws \Doctrine\DBAL\Exception
+     */
+    protected function buildChildListPermissionCondition(User $user, string $tableSuffix, string $keyColumn): array
+    {
+        $userIds = $user->getRoles();
+        $userIds[] = $user->getId();
+        $currentUserId = $user->getId();
+        $table = 'users_workspaces_' . $tableSuffix;
+
+        $folderPath = $this->model->getRealFullPath();
+        $childPrefix = $folderPath === '/' ? '/' : $folderPath . '/';
+
+        // the user's allowed (list=1) workspace paths anywhere in this folder's subtree, excluding
+        // paths the current user is explicitly denied on — a single sargable range on cpath
+        $allowedPaths = $this->db->fetchFirstColumn(
+            'SELECT uw.cpath FROM ' . $table . ' uw
+             WHERE uw.userId IN (:userIds) AND uw.list = 1 AND uw.cpath LIKE :childPrefix
+               AND NOT EXISTS(
+                   SELECT 1 FROM ' . $table . ' denied
+                   WHERE denied.userId = :currentUserId AND denied.list = 0 AND denied.cpath = uw.cpath
+               )',
+            [
+                'userIds' => $userIds,
+                'childPrefix' => Helper::escapeLike($childPrefix) . '%',
+                'currentUserId' => $currentUserId,
+            ],
+            ['userIds' => ArrayParameterType::INTEGER]
+        );
+
+        $allowedChildKeys = $this->immediateChildSegments($childPrefix, $allowedPaths);
+
+        $conditions = [];
+        $params = [];
+        $types = [];
+
+        if ($allowedChildKeys !== []) {
+            $conditions[] = 'o.' . $this->db->quoteIdentifier($keyColumn) . ' IN (:allowedChildKeys)';
+            $params['allowedChildKeys'] = $allowedChildKeys;
+            $types['allowedChildKeys'] = ArrayParameterType::STRING;
+        }
+
+        // when the folder inherits list, a child is listable unless it is explicitly denied
+        if ($this->InheritingPermission('list', $userIds, $tableSuffix) !== 0) {
+            $conditions[] = 'NOT EXISTS(
+                SELECT 1 FROM ' . $table . ' deniedChild
+                WHERE deniedChild.userId IN (:deniedUserIds) AND deniedChild.cid = o.id AND deniedChild.list = 0
+            )';
+            $params['deniedUserIds'] = $userIds;
+            $types['deniedUserIds'] = ArrayParameterType::INTEGER;
+        }
+
+        // no allowed subtree and no inherited permission -> no child is listable
+        $condition = $conditions === [] ? '0' : '(' . implode(' OR ', $conditions) . ')';
+
+        return [$condition, $params, $types];
+    }
+
+    /**
+     * Extracts the distinct immediate child segment directly under $childPrefix from a set of
+     * descendant cpaths (e.g. "/a/b/" + "/a/b/c/d" -> "c").
+     *
+     * @param string[] $cpaths
+     *
+     * @return string[]
+     */
+    private function immediateChildSegments(string $childPrefix, array $cpaths): array
+    {
+        $prefixLength = strlen($childPrefix);
+        $segments = [];
+        foreach ($cpaths as $cpath) {
+            if (!str_starts_with($cpath, $childPrefix)) {
+                continue;
+            }
+            $rest = substr($cpath, $prefixLength);
+            $slash = strpos($rest, '/');
+            $segment = $slash === false ? $rest : substr($rest, 0, $slash);
+            if ($segment !== '') {
+                $segments[$segment] = true;
+            }
+        }
+
+        return array_keys($segments);
+    }
 }

--- a/models/Element/Dao.php
+++ b/models/Element/Dao.php
@@ -220,7 +220,7 @@ abstract class Dao extends Model\Dao\AbstractDao
             WHERE cpath LIKE ? AND userId IN (' . implode(',', $userIds) . ') AND list = 1
             AND NOT EXISTS( SELECT list FROM users_workspaces_'.$tableSuffix.' WHERE cid = uw.cid AND list = 0 AND userId ='.end($userIds).')
             LIMIT 1',
-            [Helper::escapeLike($path) . '%']);
+            [$this->escapeLikePrefix($path) . '%']);
 
         return (int)$permissionsChildren;
     }
@@ -262,7 +262,7 @@ abstract class Dao extends Model\Dao\AbstractDao
                )',
             [
                 'userIds' => $userIds,
-                'childPrefix' => Helper::escapeLike($childPrefix) . '%',
+                'childPrefix' => $this->escapeLikePrefix($childPrefix) . '%',
                 'currentUserId' => $currentUserId,
             ],
             ['userIds' => ArrayParameterType::INTEGER]
@@ -307,6 +307,8 @@ abstract class Dao extends Model\Dao\AbstractDao
     private function immediateChildSegments(string $childPrefix, array $cpaths): array
     {
         $prefixLength = strlen($childPrefix);
+        // the DB rows were matched with escapeLikePrefix() (backslash-safe), but the raw cpath
+        // values themselves are unescaped, so compare against the unescaped prefix here
         $segments = [];
         foreach ($cpaths as $cpath) {
             if (!str_starts_with($cpath, $childPrefix)) {
@@ -321,5 +323,17 @@ abstract class Dao extends Model\Dao\AbstractDao
         }
 
         return array_keys($segments);
+    }
+
+    /**
+     * Escapes a value for use as a literal prefix in a LIKE pattern. Unlike Helper::escapeLike(),
+     * this also escapes backslashes — they are valid in (object) element keys but are the default
+     * LIKE escape character in MySQL, so leaving them unescaped would corrupt the pattern and drop
+     * legitimate matches. Backslashes are escaped first so the escapes added for "_"/"%" are not
+     * themselves re-escaped.
+     */
+    private function escapeLikePrefix(string $value): string
+    {
+        return Helper::escapeLike(str_replace('\\', '\\\\', $value));
     }
 }

--- a/tests/Model/Element/WorkspacePermissionPathBoundaryTest.php
+++ b/tests/Model/Element/WorkspacePermissionPathBoundaryTest.php
@@ -205,6 +205,28 @@ class WorkspacePermissionPathBoundaryTest extends ModelTestCase
         );
     }
 
+    /**
+     * A backslash is valid in an object key but is MySQL's default LIKE escape character. Expanding
+     * a folder whose path contains a backslash must still find the allowed workspaces in its
+     * subtree (guards the escapeLikePrefix() handling in buildChildListPermissionCondition()).
+     */
+    public function testObjectChildAmountHandlesBackslashInFolderPath(): void
+    {
+        $root = $this->objectFolder('perm-bslash-' . uniqid(), 1);
+        $backslashFolder = $this->objectFolder('a\\b', $root->getId());
+        $leaf = $this->objectFolder('leaf', $backslashFolder->getId());
+
+        // the grant sits on the descendant "leaf"; listing the backslash folder's children relies
+        // on a LIKE over its backslash-containing path
+        $user = $this->objectUserWithGrants([[$leaf, true]]);
+
+        $this->assertSame(
+            1,
+            $backslashFolder->getDao()->getChildAmount([DataObject::OBJECT_TYPE_FOLDER], $user),
+            'the allowed descendant must be found despite the backslash in the folder path'
+        );
+    }
+
     // ------------------------------------------------------------------ fixtures
 
     /**

--- a/tests/Model/Element/WorkspacePermissionPathBoundaryTest.php
+++ b/tests/Model/Element/WorkspacePermissionPathBoundaryTest.php
@@ -140,6 +140,71 @@ class WorkspacePermissionPathBoundaryTest extends ModelTestCase
         $this->assertSame(1, $root->getDao()->getChildAmount($user), 'only "Carpets" is listable, not the prefix-sibling "Car"');
     }
 
+    /**
+     * getChildAmount counts a child with an allowed workspace directly on it together with a child
+     * that only has an allowed workspace deeper in its subtree, and ignores children with no grant.
+     * Exercises the de-correlated subtree lookup resolving several distinct child keys.
+     */
+    public function testObjectChildAmountCountsDirectAndDescendantGrants(): void
+    {
+        $root = $this->objectFolder('perm-grants-' . uniqid(), 1);
+        $direct = $this->objectFolder('direct', $root->getId());
+        $viaChild = $this->objectFolder('viaChild', $root->getId());
+        $deep = $this->objectFolder('deep', $viaChild->getId());
+        $this->objectFolder('none', $root->getId());
+
+        $user = $this->objectUserWithGrants([[$direct, true], [$deep, true]]);
+
+        $this->assertSame(
+            2,
+            $root->getDao()->getChildAmount([DataObject::OBJECT_TYPE_FOLDER], $user),
+            'the directly-granted child and the child with a granted descendant are both listable'
+        );
+        $this->assertTrue($root->getDao()->hasChildren([DataObject::OBJECT_TYPE_FOLDER], true, $user));
+    }
+
+    /**
+     * With an inherited list grant on the folder, every child is listable except one carrying an
+     * explicit list=0 for the user. Exercises the inherited-permission arm and the deny-on-child
+     * exclusion (empty allowed-subtree set).
+     */
+    public function testObjectChildAmountExcludesDeniedChild(): void
+    {
+        $root = $this->objectFolder('perm-deny-' . uniqid(), 1);
+        $this->objectFolder('a', $root->getId());
+        $denied = $this->objectFolder('b', $root->getId());
+        $this->objectFolder('c', $root->getId());
+
+        // list granted on the folder itself (inherited by its children), denied on "b"
+        $user = $this->objectUserWithGrants([[$root, true], [$denied, false]]);
+
+        $this->assertSame(
+            2,
+            $root->getDao()->getChildAmount([DataObject::OBJECT_TYPE_FOLDER], $user),
+            'the inherited grant lists every child except the explicitly denied one'
+        );
+    }
+
+    /**
+     * hasChildren mirrors getChildAmount > 0: true when a listable child exists, false when the
+     * user has no grant reaching this folder's subtree.
+     */
+    public function testObjectHasChildrenReflectsListPermission(): void
+    {
+        $root = $this->objectFolder('perm-has-' . uniqid(), 1);
+        $child = $this->objectFolder('child', $root->getId());
+
+        $granted = $this->objectUserWithGrants([[$child, true]]);
+        $this->assertTrue($root->getDao()->hasChildren([DataObject::OBJECT_TYPE_FOLDER], true, $granted));
+
+        $sibling = $this->objectFolder('sibling-' . uniqid(), 1);
+        $strangerGrant = $this->objectUserWithGrants([[$sibling, true]]);
+        $this->assertFalse(
+            $root->getDao()->hasChildren([DataObject::OBJECT_TYPE_FOLDER], true, $strangerGrant),
+            'a grant outside this folder must not make it report children'
+        );
+    }
+
     // ------------------------------------------------------------------ fixtures
 
     /**
@@ -215,6 +280,25 @@ class WorkspacePermissionPathBoundaryTest extends ModelTestCase
     {
         return $this->makeUser('objects', function (User\Role $role) use ($target): void {
             $role->setWorkspacesObject([$this->workspace(new User\Workspace\DataObject(), $target)]);
+        });
+    }
+
+    /**
+     * @param array<int, array{0: AbstractElement, 1: bool}> $grants  [target element, listAllowed]
+     */
+    private function objectUserWithGrants(array $grants): User
+    {
+        return $this->makeUser('objects', function (User\Role $role) use ($grants): void {
+            $workspaces = [];
+            foreach ($grants as [$target, $listAllowed]) {
+                $workspace = new User\Workspace\DataObject();
+                $workspace->setCid($target->getId());
+                $workspace->setCpath($target->getRealFullPath());
+                $workspace->setList($listAllowed);
+                $workspace->setView(true);
+                $workspaces[] = $workspace;
+            }
+            $role->setWorkspacesObject($workspaces);
         });
     }
 


### PR DESCRIPTION
## What

`getChildAmount()` and `hasChildren()` filter the listable children of a folder with a correlated subquery that runs `LOCATE(CONCAT(o.path, o.key, '/'), cpath)` **per candidate child**. Because `cpath` is wrapped in `LOCATE`, the predicate is not sargable, so for every child the subquery scans the whole set of workspace rows the user's identity resolves to. The cost is therefore `O(children × workspace-rows)`, which dominates tree expansion for editors who have many workspace rules on large trees.

## How

The expensive part is the "does the user have an allowed workspace on this child **or anywhere in its subtree**" test. Instead of evaluating it per child, it is resolved once per folder:

- All workspace paths under the folder being expanded share a **constant `cpath` prefix**, so a single `cpath LIKE 'folderpath/%'` lookup uses the `cpath` index range (the same pattern already used by `checkChildrenForPathTraversal()`).
- The immediate child segment of each returned path is derived in PHP, giving the set of child keys that are (or contain) an allowed workspace.
- The child count/exists query then matches `o.<key> IN (:allowedChildKeys)` plus the unchanged inherited/deny logic.

This turns the check into `O(children + workspace-rows)`.

The self / inherited / deny semantics are unchanged. The original boolean

```
IF(anyAllowed, 1, IF(inherited, NOT denied, 0)) = 1
```

simplifies exactly to `anyAllowed OR (inherited AND NOT denied)`, and the rewrite produces identical results.

## Scope

- Shared logic lives in `Element\Dao::buildChildListPermissionCondition()`, parameterised by workspace-table suffix and child-key column, and is used by the **DataObject, Asset and Document** DAOs.
- `Asset\Listing::filterAccessibleByUser()` is intentionally **left unchanged**: it filters arbitrary listings, so there is no single folder scope to key the index range on.
- The four modified DAO classes are all `@internal`; no public method signatures change and no methods are removed (only two new methods are added).

## Tests

`WorkspacePermissionPathBoundaryTest` is extended with direct-grant, descendant-only-grant, denied-child and `hasChildren` cases. The existing path-boundary cases already exercise `getChildAmount` for all three element types, guarding against a boundary regression.