### PR TITLE
[Bug]: Accept classification store key names that are not valid identifiers

### DIFF
--- a/models/DataObject/Classificationstore/Service.php
+++ b/models/DataObject/Classificationstore/Service.php
@@ -70,10 +70,22 @@ class Service
         /** @var DataObject\ClassDefinition\Data $dataDefinition */
         $dataDefinition = $loader->build($type);
 
+        // Classification store key names are labels referenced by keyId — they are never
+        // emitted into generated PHP classes or DDL, so they are exempt from the identifier
+        // validation in Data::setName() (existing stores contain names like "Voltage Type").
+        $name = $definition['name'] ?? null;
+        unset($definition['name']);
+
         $dataDefinition->setValues($definition);
         $className = get_class($dataDefinition);
 
-        $dataDefinition = $className::__set_state((array) $dataDefinition);
+        $state = (array) $dataDefinition;
+        unset($state['name']);
+        $dataDefinition = $className::__set_state($state);
+
+        if (is_string($name)) {
+            $dataDefinition->name = $name;
+        }
 
         if ($dataDefinition instanceof DataObject\ClassDefinition\Data\EncryptedField) {
             $delegateDefinitionRaw = $dataDefinition->getDelegate();

--- a/tests/Model/DataType/ClassificationStore/ServiceTest.php
+++ b/tests/Model/DataType/ClassificationStore/ServiceTest.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\DataType\ClassificationStore;
+
+use Pimcore\Model\DataObject\ClassDefinition\Data\Input;
+use Pimcore\Model\DataObject\Classificationstore\Service;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+
+class ServiceTest extends ModelTestCase
+{
+    /**
+     * Classification store key names are labels referenced by keyId — unlike class field
+     * names they never reach generated PHP classes or DDL, so names that are not valid
+     * identifiers (e.g. "Voltage Type") must keep resolving to a field definition.
+     */
+    public function testFieldDefinitionAcceptsKeyNamesThatAreNotValidIdentifiers(): void
+    {
+        $definition = Service::getFieldDefinitionFromJson(
+            ['fieldtype' => 'input', 'name' => 'Voltage Type'],
+            'input'
+        );
+
+        $this->assertInstanceOf(Input::class, $definition);
+        $this->assertSame('Voltage Type', $definition->getName());
+    }
+}


### PR DESCRIPTION
## Changes in this pull request

The field name validation introduced in #19183 (12.3.10) also runs when the classification store builds its field definitions from the key config JSON (`Classificationstore\Service::getFieldDefinitionFromJson()`). Existing key names that are not valid identifiers — e.g. `Voltage Type` — now throw `InvalidArgumentException: Invalid field name "Voltage Type"`, which makes it impossible to open (or save/index) any object using such keys. Reported via PEES-1346, regression confirmed on 12.3.10/12.3.11 (12.3.9 works).

Classification store key names are labels: data rows are referenced by `keyId`, and the names never end up in generated PHP classes or DDL — the sinks #19183 protects. Creating keys with such names was never restricted (`KeyConfig::setName()`), so existing stores legitimately contain them.

This change routes the `name` from the key config JSON around the identifier validation (the property is public; both `setValues()` and `__set_state()` funnel through the validating setter). `Data::setName()` stays strict for class/fieldcollection/objectbrick definitions, and the identifier quoting from #19183 remains untouched. All classification store consumers (classic editor, Studio backend, generic data index, grid, Twig extension) build definitions through this single method, so this covers every affected path.

**Reproduce:** create a classification store key named `Voltage Type` (any 12.3.9 instance, or directly in the store), assign it to an object, upgrade to ≥ 12.3.10, open the object → editor fails with `Invalid field name "Voltage Type"`.

Includes a regression test (`tests/Model/DataType/ClassificationStore/ServiceTest.php`) that fails before the fix and passes after; the #19183 `SetNameValidationTest` suite still passes unchanged.

## Additional info

Follow-up after merge: forward-merge 12.3 → 2026.2 → 2026.x. 2026.1 is EOL and stays affected (v2026.1.6/7) — will add an upgrade note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)