### PR TITLE
[Improvement, EC] PEES-1253: Increase size of ownername column in object_relations

### DIFF
--- a/bundles/CoreBundle/src/Migrations/Version20260721000000.php
+++ b/bundles/CoreBundle/src/Migrations/Version20260721000000.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Widen the `ownername` column from VARCHAR(70) to VARCHAR(190) in all relation-like
+ * tables. The generated ownername for a localized field nested inside an object brick
+ * or field collection (e.g. `/objectbrick~<field>/<brickKey>/localizedfield~localizedfield`)
+ * can exceed 70 characters, causing "Data too long for column 'ownername'" on save
+ * under strict SQL mode (see PEES-1253).
+ */
+final class Version20260721000000 extends AbstractMigration
+{
+    private const NEW_LENGTH = 190;
+
+    private const OLD_LENGTH = 70;
+
+    public function getDescription(): string
+    {
+        return sprintf(
+            'Increase `ownername` length from %d to %d in object_relations_*, object_metadata_* and object_url_slugs tables.',
+            self::OLD_LENGTH,
+            self::NEW_LENGTH
+        );
+    }
+
+    public function up(Schema $schema): void
+    {
+        foreach ($this->getPerClassTables() as $tableName) {
+            $this->addSql(sprintf(
+                "ALTER TABLE `%s` MODIFY `ownername` VARCHAR(%d) NOT NULL DEFAULT '';",
+                $tableName,
+                self::NEW_LENGTH
+            ));
+        }
+
+        $this->addSql(sprintf(
+            "ALTER TABLE `object_url_slugs` MODIFY `ownername` VARCHAR(%d) NOT NULL DEFAULT '';",
+            self::NEW_LENGTH
+        ));
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Note: reverting to the shorter length can fail under strict SQL mode if any
+        // ownername value longer than the old length has been persisted in the meantime.
+        foreach ($this->getPerClassTables() as $tableName) {
+            $this->addSql(sprintf(
+                "ALTER TABLE `%s` MODIFY `ownername` VARCHAR(%d) NOT NULL DEFAULT '';",
+                $tableName,
+                self::OLD_LENGTH
+            ));
+        }
+
+        $this->addSql(sprintf(
+            "ALTER TABLE `object_url_slugs` MODIFY `ownername` VARCHAR(%d) NOT NULL DEFAULT '';",
+            self::OLD_LENGTH
+        ));
+    }
+
+    /**
+     * @return string[] names of all per-class object_relations_* and object_metadata_* tables
+     */
+    private function getPerClassTables(): array
+    {
+        return array_merge(
+            $this->connection->fetchFirstColumn("SHOW TABLES LIKE 'object_relations_%'"),
+            $this->connection->fetchFirstColumn("SHOW TABLES LIKE 'object_metadata_%'")
+        );
+    }
+}

--- a/bundles/CoreBundle/src/Migrations/Version20260721000000.php
+++ b/bundles/CoreBundle/src/Migrations/Version20260721000000.php
@@ -81,6 +81,6 @@ final class Version20260721000000 extends AbstractMigration
         return array_values(array_filter(array_merge(
             $this->connection->fetchFirstColumn("SHOW TABLES LIKE 'object_relations_%'"),
             $this->connection->fetchFirstColumn("SHOW TABLES LIKE 'object_metadata_%'")
-        ), static fn (string $tableName): bool => preg_match('/^object_(?:relations|metadata)_\d+$/D', $tableName) === 1));
+        ), static fn (string $tableName): bool => preg_match('/^object_(?:relations|metadata)_[a-zA-Z0-9][a-zA-Z0-9_]*$/D', $tableName) === 1);
     }
 }

--- a/bundles/CoreBundle/src/Migrations/Version20260721000000.php
+++ b/bundles/CoreBundle/src/Migrations/Version20260721000000.php
@@ -78,9 +78,9 @@ final class Version20260721000000 extends AbstractMigration
      */
     private function getPerClassTables(): array
     {
-        return array_merge(
+        return array_values(array_filter(array_merge(
             $this->connection->fetchFirstColumn("SHOW TABLES LIKE 'object_relations_%'"),
             $this->connection->fetchFirstColumn("SHOW TABLES LIKE 'object_metadata_%'")
-        );
+        ), static fn (string $tableName): bool => preg_match('/^object_(?:relations|metadata)_\d+$/D', $tableName) === 1));
     }
 }

--- a/bundles/CoreBundle/src/Migrations/Version20260721000000.php
+++ b/bundles/CoreBundle/src/Migrations/Version20260721000000.php
@@ -78,9 +78,20 @@ final class Version20260721000000 extends AbstractMigration
      */
     private function getPerClassTables(): array
     {
-        return array_values(array_filter(array_merge(
+        $candidates = array_merge(
             $this->connection->fetchFirstColumn("SHOW TABLES LIKE 'object_relations_%'"),
             $this->connection->fetchFirstColumn("SHOW TABLES LIKE 'object_metadata_%'")
-        ), static fn (string $tableName): bool => preg_match('/^object_(?:relations|metadata)_[a-zA-Z0-9][a-zA-Z0-9_]*$/D', $tableName) === 1);
+        );
+
+        $tables = [];
+        foreach ($candidates as $tableName) {
+            if (is_string($tableName)
+                && preg_match('/^object_(?:relations|metadata)_[a-zA-Z0-9][a-zA-Z0-9_]*$/D', $tableName) === 1
+            ) {
+                $tables[] = $tableName;
+            }
+        }
+
+        return $tables;
     }
 }

--- a/bundles/InstallBundle/dump/install.sql
+++ b/bundles/InstallBundle/dump/install.sql
@@ -799,7 +799,7 @@ CREATE TABLE `object_url_slugs` (
       `classId` VARCHAR(50) NOT NULL DEFAULT '0',
       `fieldname` VARCHAR(70) NOT NULL DEFAULT '0',
       `ownertype` ENUM('object','fieldcollection','localizedfield','objectbrick') NOT NULL DEFAULT 'object',
-      `ownername` VARCHAR(70) NOT NULL DEFAULT '',
+      `ownername` VARCHAR(190) NOT NULL DEFAULT '',
       `position` VARCHAR(70) NOT NULL DEFAULT '0',
       `slug` varchar(765) NOT NULL, /* slug in utf8mb4 (4-byte) using the full key length of 3072 bytes */
       `siteId` INT(11) NOT NULL DEFAULT '0',

--- a/doc/13_Upgrade_Notes/README.md
+++ b/doc/13_Upgrade_Notes/README.md
@@ -8,6 +8,9 @@
 ### [Assets]
 - [Thumbnails] The cache lifetime used for the `Cache-Control` and `Expires` HTTP headers when a thumbnail is delivered on-the-fly through the thumbnail service is now configurable via `pimcore.assets.thumbnails.cache_lifetime` (in seconds). It defaults to `604800` (one week), which preserves the previous hard-coded behavior.
 
+### [DataObject]
+- [Relations] The `ownername` column has been widened from `VARCHAR(70)` to `VARCHAR(190)` in the per-class relation tables (`object_relations_*`), the advanced-relation metadata tables (`object_metadata_*`) and `object_url_slugs`. The generated `ownername` for a localized field nested inside an object brick or field collection (e.g. `/objectbrick~<field>/<brickKey>/localizedfield~localizedfield`) can exceed 70 characters, which caused "Data too long for column 'ownername'" on save under strict SQL mode. Existing installations are updated automatically by the migration `Version20260721000000`; no code or configuration changes are required.
+
 
 ## Pimcore 2026.2.0
 

--- a/models/DataObject/ClassDefinition/Dao.php
+++ b/models/DataObject/ClassDefinition/Dao.php
@@ -190,7 +190,7 @@ class Dao extends Model\Dao\AbstractDao
             `fieldname` varchar(70) NOT NULL DEFAULT '0',
             `index` int(11) unsigned NOT NULL DEFAULT '0',
             `ownertype` enum('object','fieldcollection','localizedfield','objectbrick') NOT NULL DEFAULT 'object',
-            `ownername` varchar(70) NOT NULL DEFAULT '',
+            `ownername` varchar(190) NOT NULL DEFAULT '',
             `position` varchar(70) NOT NULL DEFAULT '0',
             INDEX `forward_lookup` (`src_id`, `ownertype`, `ownername`, `position`),
             INDEX `reverse_lookup` (`dest_id`, `type`),

--- a/models/DataObject/Data/AbstractMetadata/Dao.php
+++ b/models/DataObject/Data/AbstractMetadata/Dao.php
@@ -57,7 +57,7 @@ class Dao extends Model\Dao\AbstractDao
               `column` varchar(190) NOT NULL,
               `data` text,
               `ownertype` ENUM('object','fieldcollection','localizedfield','objectbrick') NOT NULL DEFAULT 'object',
-              `ownername` VARCHAR(70) NOT NULL DEFAULT '',
+              `ownername` VARCHAR(190) NOT NULL DEFAULT '',
               `position` VARCHAR(70) NOT NULL DEFAULT '0',
               `index` int(11) unsigned NOT NULL DEFAULT '0',
               PRIMARY KEY (`auto_id`),


### PR DESCRIPTION
The ownername generated for a localized field nested inside an object brick or field collection (e.g.
`/objectbrick~<field>/<brickKey>/localizedfield~localizedfield`) can exceed 70 characters. Under strict SQL mode this aborts the object save with "SQLSTATE[22001] Data too long for column 'ownername'".

Widen `ownername` to VARCHAR(190) in the object_relations_<classId>, object_metadata_<classId> and object_url_slugs table definitions and add a migration that alters existing tables. 190 stays within the utf8mb4 index key-length limits for the affected indexes (forward_lookup / metadata_un).

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `12.3`
- Feature/Improvement: choose `2026.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`2026.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `12.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/service-operations/issues/933

## Additional info
Why 190? 

th object_metadata_* and object_url_slugs define INDEX ownername (ownername) — a full index on the column by itself. InnoDB has two possible per-index byte limits:

767 bytes — the older/conservative limit (COMPACT/REDUNDANT row format, or innodb_large_prefix off).
3072 bytes — the modern limit (DYNAMIC/COMPRESSED row format + large prefix, default since MySQL 5.7.7 / MariaDB 10.2).
utf8mb4 stores up to 4 bytes per character, so a fully-indexed column is capped at 767 / 4 = 191 characters under the conservative limit. Rounded down, that's 190 — the max width you can index without depending on the DB being in the modern configuration.