### PR TITLE
[Security] Restrict Custom Report update to an explicit field allowlist

### DIFF
--- a/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
+++ b/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
@@ -43,6 +43,33 @@ class CustomReportController extends UserAwareController
 {
     use JsonHelperTrait;
 
+    /**
+     * Fields that may be written through updateAction(). Mirrors the writable set of the
+     * Studio API (CustomReportHydrator::dehydrateReportDetails()) and deliberately excludes
+     * identity and audit fields (name, creationDate, modificationDate) that must never be
+     * settable through the update payload.
+     */
+    private const ALLOWED_UPDATE_FIELDS = [
+        'sql',
+        'columnConfiguration',
+        'dataSourceConfig',
+        'niceName',
+        'group',
+        'groupIconClass',
+        'iconClass',
+        'menuShortcut',
+        'reportClass',
+        'chartType',
+        'pieColumn',
+        'pieLabelColumn',
+        'xAxis',
+        'yAxis',
+        'shareGlobally',
+        'sharedUserNames',
+        'sharedRoleNames',
+        'pagination',
+    ];
+
     #[Route('/tree', name: 'pimcore_bundle_customreports_customreport_tree', methods: ['GET', 'POST'])]
     public function treeAction(): JsonResponse
     {
@@ -186,16 +213,31 @@ class CustomReportController extends UserAwareController
         $pagination = $adapter->getPagination();
         $data['pagination'] = $pagination;
 
-        foreach ($data as $key => $value) {
-            $setter = 'set' . ucfirst($key);
-            if (method_exists($report, $setter)) {
-                $report->$setter($value);
-            }
-        }
+        $this->applyReportConfiguration($report, $data);
 
         $report->save();
 
         return $this->jsonResponse(['success' => true]);
+    }
+
+    /**
+     * Applies only whitelisted fields from the decoded update payload to the report,
+     * guarding against mass assignment of arbitrary Config setters.
+     *
+     * @param array<string, mixed> $data
+     */
+    protected function applyReportConfiguration(Tool\Config $report, array $data): void
+    {
+        foreach (self::ALLOWED_UPDATE_FIELDS as $field) {
+            if (!array_key_exists($field, $data)) {
+                continue;
+            }
+
+            $setter = 'set' . ucfirst($field);
+            if (method_exists($report, $setter)) {
+                $report->$setter($data[$field]);
+            }
+        }
     }
 
     #[Route('/column-config', name: 'pimcore_bundle_customreports_customreport_columnconfig', methods: ['POST'])]

--- a/tests/Unit/CustomReportsBundle/Controller/Reports/CustomReportControllerTest.php
+++ b/tests/Unit/CustomReportsBundle/Controller/Reports/CustomReportControllerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Tests\Unit\CustomReportsBundle\Controller\Reports;
 
 use Pimcore\Bundle\CustomReportsBundle\Controller\Reports\CustomReportController;
+use Pimcore\Bundle\CustomReportsBundle\Tool\Config;
 use Pimcore\Model\User;
 use Pimcore\Security\User\User as UserProxy;
 use Pimcore\Tests\Support\Test\TestCase;
@@ -46,6 +47,14 @@ final class CustomReportControllerTest extends TestCase
             {
                 return $this->getTemporaryFileFromFileName($exportFileName);
             }
+
+            /**
+             * @param array<string, mixed> $data
+             */
+            public function applyConfiguration(Config $report, array $data): void
+            {
+                $this->applyReportConfiguration($report, $data);
+            }
         };
     }
 
@@ -75,5 +84,47 @@ final class CustomReportControllerTest extends TestCase
 
         $this->expectException(AccessDeniedHttpException::class);
         $controller->resolveExportFile('not-an-export-file.csv');
+    }
+
+    public function testUpdateAppliesWhitelistedConfigurationFields(): void
+    {
+        $controller = $this->controllerAsUser(1);
+        $report = new Config();
+
+        $controller->applyConfiguration($report, [
+            'sql' => 'SELECT 1',
+            'niceName' => 'Quarterly figures',
+            'shareGlobally' => false,
+            'sharedUserNames' => ['alice'],
+        ]);
+
+        $this->assertSame('SELECT 1', $report->getSql());
+        $this->assertSame('Quarterly figures', $report->getNiceName());
+        $this->assertFalse($report->getShareGlobally());
+        $this->assertSame(['alice'], $report->getSharedUserNames());
+    }
+
+    public function testUpdateIgnoresFieldsOutsideTheWhitelist(): void
+    {
+        // Before this fix, updateAction() applied any setter whose name matched an
+        // attacker-supplied key, letting a reports_config user tamper with a report's
+        // identity (name) and audit timestamps by adding extra keys to the payload.
+        $controller = $this->controllerAsUser(1);
+        $report = new Config();
+        $report->setName('finance_report');
+        $report->setCreationDate(1000);
+        $report->setModificationDate(1000);
+
+        $controller->applyConfiguration($report, [
+            'name' => 'attacker_renamed',
+            'creationDate' => 0,
+            'modificationDate' => 0,
+            'niceName' => 'legit change',
+        ]);
+
+        $this->assertSame('finance_report', $report->getName());
+        $this->assertSame(1000, $report->getCreationDate());
+        $this->assertSame(1000, $report->getModificationDate());
+        $this->assertSame('legit change', $report->getNiceName());
     }
 }


### PR DESCRIPTION
## What

`CustomReportController::updateAction()` mapped the decoded `configuration` payload onto the report model with a dynamic setter loop guarded only by `method_exists()`:

```php
foreach ($data as $key => $value) {
    $setter = 'set' . ucfirst($key);
    if (method_exists($report, $setter)) {
        $report->$setter($value);
    }
}
```

There was no allowlist, so **any** public setter on `Tool\Config` was reachable from the request body. A user with the `reports_config` permission could write fields the report editor never exposes — most importantly the report identity (`name`) and the audit timestamps (`creationDate` / `modificationDate`) — by adding extra keys to the payload (a mass-assignment / CWE-915 issue).

## Fix

Replace the dynamic loop with an explicit allowlist (`ALLOWED_UPDATE_FIELDS`) applied by a small `applyReportConfiguration()` helper. The list mirrors the writable field set of the Studio API's authoritative update path (`CustomReportHydrator::dehydrateReportDetails()`), so it is intentionally **behaviour-preserving for legitimate use**:

- SQL, data-source, column and chart configuration — still writable.
- Sharing configuration (`shareGlobally`, `sharedUserNames`, `sharedRoleNames`) — still writable (this is a legitimate `reports_config` capability, and the classic editor only shows it to users with `share_configurations`).
- `name`, `creationDate`, `modificationDate` — **no longer** settable through the payload. The classic editor's name field is `disabled`, so it never legitimately submits a name; the load key is the separate top-level `name` request parameter.

## Testing

Adds two unit tests to `CustomReportControllerTest`:
- `testUpdateAppliesWhitelistedConfigurationFields` — allowlisted fields (incl. SQL and sharing) are applied.
- `testUpdateIgnoresFieldsOutsideTheWhitelist` — `name` and audit timestamps in the payload are ignored while a legitimate field in the same payload is still applied.

## Notes

- Targets `12.3` (oldest maintained line, where the classic report editor still ships) for forward-merge to `2026.2` → `2026.x`. On `2026.*` the classic UI is gone but the routes remain registered (`expose: true`), so the endpoint is still reachable and the hardening still applies.
- `updateAction` and the `Tool\Config` model are identical across `12.3`/`2026.x`, so the change ports cleanly.

Co-Authored-By: Claude <noreply@anthropic.com>