### PR TITLE
Bug: Check supports inheritance prior to setting its parent data.

### DIFF
--- a/models/DataObject/Concrete/Dao.php
+++ b/models/DataObject/Concrete/Dao.php
@@ -294,7 +294,7 @@ class Dao extends Model\DataObject\AbstractObject\Dao
                         }
 
                         // if the current value is empty and we have data from the parent, we just use it
-                        if ($isEmpty && $parentData) {
+                        if ($isEmpty && $parentData && $fd->supportsInheritance()) {
                             foreach ($columnNames as $columnName) {
                                 if (array_key_exists($columnName, $parentData)) {
                                     $data[$columnName] = $parentData[$columnName];

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -326,7 +326,7 @@ class Dao extends Model\Dao\AbstractDao
                                 }
 
                                 // if the current value is empty and we have data from the parent, we just use it
-                                if ($isEmpty && $parentData) {
+                                if ($isEmpty && $parentData && $fd->supportsInheritance()) {
                                     foreach ($columnNames as $columnName) {
                                         if (array_key_exists($columnName, $parentData)) {
                                             $data[$columnName] = $parentData[$columnName];
@@ -339,7 +339,7 @@ class Dao extends Model\Dao\AbstractDao
                                     }
                                 }
 
-                                if ($inheritanceEnabled && !$fd instanceof CalculatedValue) {
+                                if ($inheritanceEnabled && $fd->supportsInheritance()) {
                                     //get changed fields for inheritance
                                     if ($fd->isRelationType()) {
                                         if (is_array($insertData)) {


### PR DESCRIPTION
closes https://github.com/pimcore/platform-version/issues/275

## Description:

In DataObject\Concrete\Dao::save(), when building the query table row for a child object, the Dao checks whether a field's computed value is empty and, if so, falls back to the parent's stored value:

```
// Concrete/Dao.php ~line 296
if ($isEmpty && $parentData) {
    $data[$columnName] = $parentData[$columnName];
}
```

This does not check `$fd->supportsInheritance()`. As a result, field types that explicitly opt out of inheritance still have their child values silently overwritten with parent data whenever the child's own value is empty.

Affected field types (return false from supportsInheritance() and implement QueryResourcePersistenceAwareInterface):
- CalculatedValue
- Consent

## How to replicate

1. Create a DataObject class with inheritance enabled.
2. Add a calculatedValue field (e.g. isActive, elementType: checkbox) whose calculator returns '' when the object has no relevant data set.
3. Save a parent object such that its calculator returns '1' — the parent's query table row stores isActive = 1.
4. Create a child object under that parent. Set all the fields the calculator reads to non-active values (or leave them empty). The calculator should return '' for the child.
5. Save the child. Expected: isActive = '' (or null) in object_query_* for the child. Actual: isActive = 1 — the parent's stale value is copied in.