### PR TITLE
[Security] Do not return raw DB exception messages from Custom Report column-config

### DIFF
--- a/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
+++ b/bundles/CustomReportsBundle/src/Controller/Reports/CustomReportController.php
@@ -19,6 +19,7 @@ use Pimcore\Controller\Traits\JsonHelperTrait;
 use Pimcore\Controller\UserAwareController;
 use Pimcore\Extension\Bundle\Exception\AdminClassicBundleNotFoundException;
 use Pimcore\Helper\ParameterBagHelper;
+use Pimcore\Logger;
 use Pimcore\Model\Element\Service;
 use Pimcore\Model\Exception\ConfigWriteException;
 use stdClass;
@@ -278,7 +279,7 @@ class CustomReportController extends UserAwareController
 
             $success = true;
         } catch (Exception $e) {
-            $errorMessage = $e->getMessage();
+            $errorMessage = $this->getColumnConfigurationErrorMessage($e);
         }
 
         return $this->jsonResponse([
@@ -286,6 +287,18 @@ class CustomReportController extends UserAwareController
             'columns' => $result,
             'errorMessage' => $errorMessage,
         ]);
+    }
+
+    /**
+     * Returns a client-safe message for a failed column-configuration lookup. The underlying
+     * exception is logged server-side; its raw message must never be returned to the client, as
+     * it can disclose database schema, table names and system paths.
+     */
+    protected function getColumnConfigurationErrorMessage(Exception $e): string
+    {
+        Logger::error('Custom report column configuration failed: ' . $e->getMessage(), ['exception' => $e]);
+
+        return 'An error occurred while loading the column configuration.';
     }
 
     #[Route('/get-report-config', name: 'pimcore_bundle_customreports_customreport_getreportconfig', methods: ['GET'])]

--- a/tests/Unit/CustomReportsBundle/Controller/Reports/CustomReportControllerTest.php
+++ b/tests/Unit/CustomReportsBundle/Controller/Reports/CustomReportControllerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Unit\CustomReportsBundle\Controller\Reports;
 
+use Exception;
 use Pimcore\Bundle\CustomReportsBundle\Controller\Reports\CustomReportController;
 use Pimcore\Bundle\CustomReportsBundle\Tool\Config;
 use Pimcore\Model\User;
@@ -54,6 +55,11 @@ final class CustomReportControllerTest extends TestCase
             public function applyConfiguration(Config $report, array $data): void
             {
                 $this->applyReportConfiguration($report, $data);
+            }
+
+            public function columnConfigurationErrorMessage(Exception $e): string
+            {
+                return $this->getColumnConfigurationErrorMessage($e);
             }
         };
     }
@@ -126,5 +132,20 @@ final class CustomReportControllerTest extends TestCase
         $this->assertSame(1000, $report->getCreationDate());
         $this->assertSame(1000, $report->getModificationDate());
         $this->assertSame('legit change', $report->getNiceName());
+    }
+
+    public function testColumnConfigurationErrorMessageDoesNotLeakExceptionDetails(): void
+    {
+        // Before this fix, columnConfigAction() returned the raw exception message to the
+        // client, leaking DB error output (schema name, table names, MySQL version, paths).
+        $controller = $this->controllerAsUser(1);
+        $sensitive = "SQLSTATE[42S02]: Base table or view not found: 1146 "
+            . "Table 'pimcore.secret_probe_xyz' doesn't exist";
+
+        $message = $controller->columnConfigurationErrorMessage(new Exception($sensitive));
+
+        $this->assertSame('An error occurred while loading the column configuration.', $message);
+        $this->assertStringNotContainsString('SQLSTATE', $message);
+        $this->assertStringNotContainsString('pimcore.secret_probe_xyz', $message);
     }
 }


### PR DESCRIPTION
## What

`CustomReportController::columnConfigAction()` returned the raw exception message directly to the client:

```php
} catch (Exception $e) {
    $errorMessage = $e->getMessage();
}
return $this->jsonResponse([
    'success' => $success,
    'columns' => $result,
    'errorMessage' => $errorMessage,   // raw DBAL/MySQL error text
]);
```

When a column lookup fails (e.g. an invalid SQL fragment), the underlying DBAL/MySQL error was sent verbatim in the JSON response, disclosing the database schema name, whether a table exists (blind enumeration), the MySQL version, and potentially system paths. Information disclosure (CWE-209), reachable by a user with the `reports_config` permission.

## Fix

Log the exception server-side (via `Pimcore\Logger`) and return a generic message to the client. The handling is extracted into a small `getColumnConfigurationErrorMessage()` helper so it can be unit-tested.

- Only one leak site exists in this controller (`columnConfigAction`); no siblings return exception text.
- Behaviour otherwise unchanged: `success`/`columns` are the same, only the `errorMessage` content is now generic.

## Testing

Adds `testColumnConfigurationErrorMessageDoesNotLeakExceptionDetails` — feeds a realistic `SQLSTATE …` message and asserts the returned string is the generic message and contains neither `SQLSTATE` nor the schema/table name.

## Notes

- Targets `12.3` (oldest maintained line) for forward-merge to `2026.2` → `2026.x`. The classic UI is gone on 2026.* but the route remains registered (`expose: true`), so the endpoint is still reachable and the fix still applies.
- Low severity; no LTS (11.5) backport planned per policy (≥ high only), though 11.5 is affected.

Co-Authored-By: Claude <noreply@anthropic.com>