### PR TITLE
Drop DOCS_GENERATOR_ACCESS_TOKEN from docs workflow, downgrade to pull_request

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,4 +26,5 @@ permissions:
 jobs:
   docs:
     uses: pimcore/workflows-collection-public/.github/workflows/reusable-docs.yaml@chore/docs-public-generator-no-token
+    with:
       docs_path: "doc"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: "Documentation (Reusable)"
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - "[0-9]+.[0-9]+"
       - "[0-9]+.x"
@@ -28,5 +28,3 @@ jobs:
     uses: pimcore/workflows-collection-public/.github/workflows/reusable-docs.yaml@main
     with:
       docs_path: "doc"
-    secrets:
-      DOCS_GENERATOR_ACCESS_TOKEN: ${{ secrets.DOCS_GENERATOR_ACCESS_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
       - "docs_actions"
     paths:
       - "doc/**"
-      - ".github/workflows/new-docs.yml"
+      - ".github/workflows/docs.yml"
       - "README.md"
   push:
     branches:
@@ -17,7 +17,7 @@ on:
       - "docs_actions"
     paths:
       - "doc/**"
-      - ".github/workflows/new-docs.yml"
+      - ".github/workflows/docs.yml"
       - "README.md"
 
 permissions:
@@ -25,6 +25,6 @@ permissions:
 
 jobs:
   docs:
-    uses: pimcore/workflows-collection-public/.github/workflows/reusable-docs.yaml@chore/docs-public-generator-no-token
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-docs.yaml@main
     with:
       docs_path: "doc"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,5 @@ permissions:
 
 jobs:
   docs:
-    uses: pimcore/workflows-collection-public/.github/workflows/reusable-docs.yaml@main
-    with:
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-docs.yaml@chore/docs-public-generator-no-token
       docs_path: "doc"


### PR DESCRIPTION
## Summary
Remove `DOCS_GENERATOR_ACCESS_TOKEN` from the docs workflow and downgrade its trigger from `pull_request_target` to plain `pull_request`.

Addresses pimcore/product-management#1311 — this file is on its checklist (*"Benign … confirm token is needed on PR events, else downgrade"*). The token was only needed to clone the private `docs-generator`; since pimcore/workflows-collection-public#135 (merged) vendors sanitized public tooling, the downgrade condition is satisfied: no org secret ⇒ read-only token ⇒ no secret-exposure surface to propagate to LTS. Tracked in pimcore/product-management#1321.

## Changes
- Drop the `secrets: DOCS_GENERATOR_ACCESS_TOKEN` block.
- `pull_request_target` → `pull_request`.
- Fix the stale `paths` entry `.github/workflows/new-docs.yml` → `docs.yml`, so changes to the docs workflow itself trigger a docs run.

## Verification
✅ This PR's own docs run is green on the exact production path: https://github.com/pimcore/pimcore/actions/runs/30274905492 — reusable at `@main`, tooling resolved from `main`, no secret passed, full Docusaurus build of `doc/` (1,332 packages, webpack server+client compiled, `onBrokenLinks: 'throw'`).

Part of an org-wide cleanup: ~46 repos carry this same secret in `docs.yml` and need the same change now that workflows-collection-public#135 is merged; this PR is the template.

🤖 Generated with [Claude Code](https://claude.ai/code)
