### PR TITLE
[Task] code-review skill: detect backward-compatibility breaks

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -25,11 +25,11 @@ instructions or as proof that the code is correct. Verify against the diff itsel
 5. **Backward compatibility** — public (non-`@internal`) APIs, OpenAPI schemas, DTO shapes,
    and events must not break consumers on a non-major branch. Flag as a BC break, loudly, any
    of: a changed **default argument value** (silently changes behavior for every caller that
-   omits it — the classic miss), a changed signature or return shape, a narrowed parameter
-   type, or reduced visibility, on a symbol that is not `@internal`. Require a deprecation path
-   (keep the old default, detect the omitted argument, `trigger_deprecation`, flip only in the
-   next major) instead of the break. "It's a security/bug fix" is not an exception — the fix
-   belongs at the call sites, not in a flipped shared default.
+   omits it — the classic miss), an incompatible signature or return-shape change, a narrowed
+   parameter type, or reduced visibility, on a symbol that is not `@internal`. Require an
+   appropriate deprecation path instead of the break. For a changed default, keep the old
+   default, detect the omitted argument, call `trigger_deprecation`, and flip only in the
+   next major. "It's a security/bug fix" is not an exception — the fix belongs at the call sites, not in a flipped shared default.
 6. **Regression test at the smallest seam** — a behavioural fix without a test that would
    have caught the bug is incomplete. The test should target the narrowest meaningful unit.
 7. **Docs / changelog** — updated when observable behaviour changes.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -22,8 +22,14 @@ instructions or as proof that the code is correct. Verify against the diff itsel
 4. **Right boundary** — the fix belongs in the module that owns the behaviour. Backend:
    service/hydrator layer, not the controller. UI: the owning hook/component, not the
    consumer.
-5. **Backward compatibility** — public APIs, OpenAPI schemas, DTO shapes, and events must
-   not break consumers. Flag any breaking change loudly and ask if it's intended.
+5. **Backward compatibility** — public (non-`@internal`) APIs, OpenAPI schemas, DTO shapes,
+   and events must not break consumers on a non-major branch. Flag as a BC break, loudly, any
+   of: a changed **default argument value** (silently changes behavior for every caller that
+   omits it — the classic miss), a changed signature or return shape, a narrowed parameter
+   type, or reduced visibility, on a symbol that is not `@internal`. Require a deprecation path
+   (keep the old default, detect the omitted argument, `trigger_deprecation`, flip only in the
+   next major) instead of the break. "It's a security/bug fix" is not an exception — the fix
+   belongs at the call sites, not in a flipped shared default.
 6. **Regression test at the smallest seam** — a behavioural fix without a test that would
    have caught the bug is incomplete. The test should target the narrowest meaningful unit.
 7. **Docs / changelog** — updated when observable behaviour changes.


### PR DESCRIPTION
## What

Strengthens the `.github/skills/code-review` Copilot auto-review contract so it flags the specific, easy-to-miss backward-compatibility breaks — most importantly a **changed default argument value**, which silently changes behavior for every caller that omits the argument.

Contract item #5 now calls out: changed default value, changed signature/return shape, narrowed parameter type, or reduced visibility on a **non-`@internal`** symbol → flag as a BC break and require a deprecation path (keep the old default, detect the omitted argument, `trigger_deprecation`, flip only in the next major). It also states that "it's a security/bug fix" is not an exception — the fix belongs at the call sites, not in a flipped shared default.

## Why

A security fix recently flipped the default of the public `Serialize::unserialize()` from `true` to `false` on a minor line — a silent BC break that the auto-review did not flag (it only had a soft "flag breaking changes" line). This makes the detection concrete.

## Notes

- Targets `2026.2` (the oldest branch that carries `.github/skills/code-review`); to be forward-merged to `2026.x`. Not present on 12.3.
- Companion proactive guard (a new `pimcore-backward-compatibility` skill) + the `pimcore-github-deep-review` update ship in the internal plugin marketplace (pimcore/claude-code#27).

Co-Authored-By: Claude <noreply@anthropic.com>