### PR TITLE
Make Twig sandbox object/function access policy configurable (blocklist + allowlist)

### DIFF
--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -338,6 +338,8 @@ pimcore:
                 functions: ['path', 'asset']
                 blocked_classes: []
                 allowed_classes: []
+                blocked_functions: []
+                allowed_functions: []
 
     gotenberg:
         base_url: 'http://gotenberg:3000'

--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -336,9 +336,40 @@ pimcore:
                 tags: ['set']
                 filters: ['escape', 'trans', 'default']
                 functions: ['path', 'asset']
-                blocked_classes: []
+                blocked_classes:
+                    - Pimcore\Model\Dao\AbstractDao
+                    - Doctrine\DBAL\Connection
+                    - PDO
+                    - PDOStatement
+                    - Symfony\Component\DependencyInjection\ContainerInterface
+                    - Symfony\Component\Process\Process
+                    - Pimcore\Model\User
                 allowed_classes: []
-                blocked_functions: []
+                blocked_functions:
+                    - pimcore_asset
+                    - pimcore_asset_by_path
+                    - pimcore_document
+                    - pimcore_document_by_path
+                    - pimcore_document_wrap_hardlink
+                    - pimcore_object
+                    - pimcore_object_by_path
+                    - pimcore_object_classificationstore_group
+                    - pimcore_object_brick_definition_key
+                    - pimcore_site
+                    - pimcore_site_by_root_id
+                    - pimcore_site_by_domain
+                    - pimcore_site_current
+                    - pimcore_user
+                hard_blocked_methods:
+                    Pimcore\Model\User:
+                        - getPassword
+                        - getPasswordRecoveryToken
+                        - getTwoFactorAuthentication
+                    Pimcore\Model\Asset:
+                        - getData
+                        - getStream
+                        - getLocalFile
+                        - getTemporaryFile
 
     gotenberg:
         base_url: 'http://gotenberg:3000'

--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -336,6 +336,8 @@ pimcore:
                 tags: ['set']
                 filters: ['escape', 'trans', 'default']
                 functions: ['path', 'asset']
+                blocked_classes: []
+                allowed_classes: []
 
     gotenberg:
         base_url: 'http://gotenberg:3000'

--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -346,19 +346,19 @@ pimcore:
                     - Pimcore\Model\User
                 allowed_classes: []
                 blocked_functions:
-                    - pimcore_asset
-                    - pimcore_asset_by_path
-                    - pimcore_document
-                    - pimcore_document_by_path
-                    - pimcore_document_wrap_hardlink
-                    - pimcore_object
-                    - pimcore_object_by_path
-                    - pimcore_object_classificationstore_group
-                    - pimcore_object_brick_definition_key
-                    - pimcore_site
-                    - pimcore_site_by_root_id
-                    - pimcore_site_by_domain
-                    - pimcore_site_current
+                    # - pimcore_asset
+                    # - pimcore_asset_by_path
+                    # - pimcore_document
+                    # - pimcore_document_by_path
+                    # - pimcore_document_wrap_hardlink
+                    # - pimcore_object
+                    # - pimcore_object_by_path
+                    # - pimcore_object_classificationstore_group
+                    # - pimcore_object_brick_definition_key
+                    # - pimcore_site
+                    # - pimcore_site_by_root_id
+                    # - pimcore_site_by_domain
+                    # - pimcore_site_current
                     - pimcore_user
                 hard_blocked_methods:
                     Pimcore\Model\User:

--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -339,7 +339,6 @@ pimcore:
                 blocked_classes: []
                 allowed_classes: []
                 blocked_functions: []
-                allowed_functions: []
 
     gotenberg:
         base_url: 'http://gotenberg:3000'

--- a/bundles/CoreBundle/config/templating_twig.yaml
+++ b/bundles/CoreBundle/config/templating_twig.yaml
@@ -77,6 +77,8 @@ services:
             $allowedTags: '%pimcore.templating.twig.sandbox_security_policy.tags%'
             $allowedFilters: '%pimcore.templating.twig.sandbox_security_policy.filters%'
             $allowedFunctions: '%pimcore.templating.twig.sandbox_security_policy.functions%'
+            $blockedClasses: '%pimcore.templating.twig.sandbox_security_policy.blocked_classes%'
+            $allowedClasses: '%pimcore.templating.twig.sandbox_security_policy.allowed_classes%'
 
     Twig\Extension\SandboxExtension:
         arguments:

--- a/bundles/CoreBundle/config/templating_twig.yaml
+++ b/bundles/CoreBundle/config/templating_twig.yaml
@@ -79,6 +79,8 @@ services:
             $allowedFunctions: '%pimcore.templating.twig.sandbox_security_policy.functions%'
             $blockedClasses: '%pimcore.templating.twig.sandbox_security_policy.blocked_classes%'
             $allowedClasses: '%pimcore.templating.twig.sandbox_security_policy.allowed_classes%'
+            $blockedFunctions: '%pimcore.templating.twig.sandbox_security_policy.blocked_functions%'
+            $allowedPimcoreFunctions: '%pimcore.templating.twig.sandbox_security_policy.allowed_functions%'
 
     Twig\Extension\SandboxExtension:
         arguments:

--- a/bundles/CoreBundle/config/templating_twig.yaml
+++ b/bundles/CoreBundle/config/templating_twig.yaml
@@ -80,6 +80,7 @@ services:
             $blockedClasses: '%pimcore.templating.twig.sandbox_security_policy.blocked_classes%'
             $allowedClasses: '%pimcore.templating.twig.sandbox_security_policy.allowed_classes%'
             $blockedFunctions: '%pimcore.templating.twig.sandbox_security_policy.blocked_functions%'
+            $hardBlockedMethods: '%pimcore.templating.twig.sandbox_security_policy.hard_blocked_methods%'
 
     Twig\Extension\SandboxExtension:
         arguments:

--- a/bundles/CoreBundle/config/templating_twig.yaml
+++ b/bundles/CoreBundle/config/templating_twig.yaml
@@ -80,7 +80,6 @@ services:
             $blockedClasses: '%pimcore.templating.twig.sandbox_security_policy.blocked_classes%'
             $allowedClasses: '%pimcore.templating.twig.sandbox_security_policy.allowed_classes%'
             $blockedFunctions: '%pimcore.templating.twig.sandbox_security_policy.blocked_functions%'
-            $allowedPimcoreFunctions: '%pimcore.templating.twig.sandbox_security_policy.allowed_functions%'
 
     Twig\Extension\SandboxExtension:
         arguments:

--- a/bundles/CoreBundle/src/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Configuration.php
@@ -2091,6 +2091,20 @@ final class Configuration implements ConfigurationInterface
                                 classes listed here (and their subclasses) remain reachable.')
                                 ->scalarPrototype()->end()
                             ->end()
+                            ->arrayNode('blocked_functions')
+                                ->info('Additional `pimcore_*` function names that must not be covered by the
+                                blanket `pimcore_*` prefix auto-allow, on top of the built-in denylist. Ignored
+                                when `allowed_functions` is non-empty.')
+                                ->scalarPrototype()->end()
+                            ->end()
+                            ->arrayNode('allowed_functions')
+                                ->info('`pimcore_*` function names that remain callable from sandboxed twig
+                                templates. As soon as this list contains at least one entry, the `pimcore_*`
+                                prefix rule switches from denylist mode to allowlist mode: the built-in and
+                                configured `blocked_functions` denylist is deactivated, and only the `pimcore_*`
+                                functions listed here (plus whatever is in `functions`) remain callable.')
+                                ->scalarPrototype()->end()
+                            ->end()
                         ->end()
                     ->end()
                 ->end()

--- a/bundles/CoreBundle/src/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Configuration.php
@@ -2077,6 +2077,20 @@ final class Configuration implements ConfigurationInterface
                             ->arrayNode('functions')
                                 ->scalarPrototype()->end()
                             ->end()
+                            ->arrayNode('blocked_classes')
+                                ->info('Additional FQCNs that must not be traversable (method calls or property
+                                access) from sandboxed twig templates, on top of the built-in denylist. Ignored
+                                when `allowed_classes` is non-empty.')
+                                ->scalarPrototype()->end()
+                            ->end()
+                            ->arrayNode('allowed_classes')
+                                ->info('FQCNs that are traversable (method calls or property access) from
+                                sandboxed twig templates. As soon as this list contains at least one entry, the
+                                security policy switches from denylist mode to allowlist mode: the built-in and
+                                configured `blocked_classes` denylist is deactivated, and only instances of the
+                                classes listed here (and their subclasses) remain reachable.')
+                                ->scalarPrototype()->end()
+                            ->end()
                         ->end()
                     ->end()
                 ->end()

--- a/bundles/CoreBundle/src/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Configuration.php
@@ -2093,16 +2093,7 @@ final class Configuration implements ConfigurationInterface
                             ->end()
                             ->arrayNode('blocked_functions')
                                 ->info('Additional `pimcore_*` function names that must not be covered by the
-                                blanket `pimcore_*` prefix auto-allow, on top of the built-in denylist. Ignored
-                                when `allowed_functions` is non-empty.')
-                                ->scalarPrototype()->end()
-                            ->end()
-                            ->arrayNode('allowed_functions')
-                                ->info('`pimcore_*` function names that remain callable from sandboxed twig
-                                templates. As soon as this list contains at least one entry, the `pimcore_*`
-                                prefix rule switches from denylist mode to allowlist mode: the built-in and
-                                configured `blocked_functions` denylist is deactivated, and only the `pimcore_*`
-                                functions listed here (plus whatever is in `functions`) remain callable.')
+                                blanket `pimcore_*` prefix auto-allow, on top of the built-in denylist.')
                                 ->scalarPrototype()->end()
                             ->end()
                         ->end()

--- a/bundles/CoreBundle/src/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Configuration.php
@@ -2078,23 +2078,37 @@ final class Configuration implements ConfigurationInterface
                                 ->scalarPrototype()->end()
                             ->end()
                             ->arrayNode('blocked_classes')
-                                ->info('Additional FQCNs that must not be traversable (method calls or property
-                                access) from sandboxed twig templates, on top of the built-in denylist. Ignored
-                                when `allowed_classes` is non-empty.')
+                                ->info('FQCNs that must not be traversable (method calls or property access) from
+                                sandboxed twig templates. Defaults to Pimcore\'s built-in denylist (database/
+                                infrastructure layer, `Pimcore\Model\User`) - a site can append further FQCNs on
+                                top of that default. Ignored when `allowed_classes` is non-empty.')
                                 ->scalarPrototype()->end()
                             ->end()
                             ->arrayNode('allowed_classes')
                                 ->info('FQCNs that are traversable (method calls or property access) from
                                 sandboxed twig templates. As soon as this list contains at least one entry, the
-                                security policy switches from denylist mode to allowlist mode: the built-in and
-                                configured `blocked_classes` denylist is deactivated, and only instances of the
-                                classes listed here (and their subclasses) remain reachable.')
+                                security policy switches from denylist mode to allowlist mode: the
+                                `blocked_classes` denylist is deactivated, and only instances of the classes
+                                listed here (and their subclasses) remain reachable.')
                                 ->scalarPrototype()->end()
                             ->end()
                             ->arrayNode('blocked_functions')
-                                ->info('Additional `pimcore_*` function names that must not be covered by the
-                                blanket `pimcore_*` prefix auto-allow, on top of the built-in denylist.')
+                                ->info('`pimcore_*` function names that must not be covered by the blanket
+                                `pimcore_*` prefix auto-allow. Defaults to Pimcore\'s built-in denylist of
+                                functions that look up and return a live model instance by id/path - a site can
+                                append further function names on top of that default.')
                                 ->scalarPrototype()->end()
+                            ->end()
+                            ->arrayNode('hard_blocked_methods')
+                                ->info('FQCN => list-of-method-names map. Methods listed here can never be called
+                                on a matching instance from a sandboxed twig template, regardless of the
+                                blocked_classes/allowed_classes configuration. Defaults to a small set of
+                                secret/content-returning getters (e.g. `User::getPassword`, `Asset::getData`) -
+                                a site can extend the map with further classes/methods on top of that default.')
+                                ->useAttributeAsKey('class')
+                                ->arrayPrototype()
+                                    ->scalarPrototype()->end()
+                                ->end()
                             ->end()
                         ->end()
                     ->end()

--- a/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php
+++ b/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php
@@ -82,6 +82,8 @@ final class PimcoreCoreExtension extends ConfigurableExtension implements Prepen
         $container->setParameter('pimcore.templating.twig.sandbox_security_policy.functions', $config['templating_engine']['twig']['sandbox_security_policy']['functions']);
         $container->setParameter('pimcore.templating.twig.sandbox_security_policy.blocked_classes', $config['templating_engine']['twig']['sandbox_security_policy']['blocked_classes']);
         $container->setParameter('pimcore.templating.twig.sandbox_security_policy.allowed_classes', $config['templating_engine']['twig']['sandbox_security_policy']['allowed_classes']);
+        $container->setParameter('pimcore.templating.twig.sandbox_security_policy.blocked_functions', $config['templating_engine']['twig']['sandbox_security_policy']['blocked_functions']);
+        $container->setParameter('pimcore.templating.twig.sandbox_security_policy.allowed_functions', $config['templating_engine']['twig']['sandbox_security_policy']['allowed_functions']);
 
         // register pimcore config on container
         // TODO is this bad practice?

--- a/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php
+++ b/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php
@@ -80,6 +80,8 @@ final class PimcoreCoreExtension extends ConfigurableExtension implements Prepen
         $container->setParameter('pimcore.templating.twig.sandbox_security_policy.tags', $config['templating_engine']['twig']['sandbox_security_policy']['tags']);
         $container->setParameter('pimcore.templating.twig.sandbox_security_policy.filters', $config['templating_engine']['twig']['sandbox_security_policy']['filters']);
         $container->setParameter('pimcore.templating.twig.sandbox_security_policy.functions', $config['templating_engine']['twig']['sandbox_security_policy']['functions']);
+        $container->setParameter('pimcore.templating.twig.sandbox_security_policy.blocked_classes', $config['templating_engine']['twig']['sandbox_security_policy']['blocked_classes']);
+        $container->setParameter('pimcore.templating.twig.sandbox_security_policy.allowed_classes', $config['templating_engine']['twig']['sandbox_security_policy']['allowed_classes']);
 
         // register pimcore config on container
         // TODO is this bad practice?

--- a/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php
+++ b/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php
@@ -83,7 +83,6 @@ final class PimcoreCoreExtension extends ConfigurableExtension implements Prepen
         $container->setParameter('pimcore.templating.twig.sandbox_security_policy.blocked_classes', $config['templating_engine']['twig']['sandbox_security_policy']['blocked_classes']);
         $container->setParameter('pimcore.templating.twig.sandbox_security_policy.allowed_classes', $config['templating_engine']['twig']['sandbox_security_policy']['allowed_classes']);
         $container->setParameter('pimcore.templating.twig.sandbox_security_policy.blocked_functions', $config['templating_engine']['twig']['sandbox_security_policy']['blocked_functions']);
-        $container->setParameter('pimcore.templating.twig.sandbox_security_policy.allowed_functions', $config['templating_engine']['twig']['sandbox_security_policy']['allowed_functions']);
 
         // register pimcore config on container
         // TODO is this bad practice?

--- a/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php
+++ b/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php
@@ -83,6 +83,7 @@ final class PimcoreCoreExtension extends ConfigurableExtension implements Prepen
         $container->setParameter('pimcore.templating.twig.sandbox_security_policy.blocked_classes', $config['templating_engine']['twig']['sandbox_security_policy']['blocked_classes']);
         $container->setParameter('pimcore.templating.twig.sandbox_security_policy.allowed_classes', $config['templating_engine']['twig']['sandbox_security_policy']['allowed_classes']);
         $container->setParameter('pimcore.templating.twig.sandbox_security_policy.blocked_functions', $config['templating_engine']['twig']['sandbox_security_policy']['blocked_functions']);
+        $container->setParameter('pimcore.templating.twig.sandbox_security_policy.hard_blocked_methods', $config['templating_engine']['twig']['sandbox_security_policy']['hard_blocked_methods']);
 
         // register pimcore config on container
         // TODO is this bad practice?

--- a/doc/05_Objects/01_Object_Classes/03_Layout_Elements/01_Dynamic_Text_Labels.md
+++ b/doc/05_Objects/01_Object_Classes/03_Layout_Elements/01_Dynamic_Text_Labels.md
@@ -78,3 +78,7 @@ security policies for tags, filters & functions. Please use following configurat
                   filters: ['upper']
                   functions: ['include', 'path']
 ```
+
+The sandbox also restricts which objects a template may call methods or access properties
+on. See [Twig Sandbox Object Access](../../../26_Best_Practice/80_Twig_Sandbox_Object_Access.md)
+for the `blocked_classes` / `allowed_classes` options.

--- a/doc/19_Development_Tools_and_Details/25_Email_Framework/README.md
+++ b/doc/19_Development_Tools_and_Details/25_Email_Framework/README.md
@@ -112,3 +112,8 @@ security policies for tags, filters & functions. Please use following configurat
                   filters: ['upper']
                   functions: ['include', 'path']
 ```
+
+The same sandbox is also used to evaluate `Dynamic Text` layout components in DataObject
+classes. See [Twig Sandbox Object Access](../../26_Best_Practice/80_Twig_Sandbox_Object_Access.md)
+for how to control which PHP objects a sandboxed template is allowed to reach (via a
+`blocked_classes` denylist or an `allowed_classes` allowlist).

--- a/doc/19_Development_Tools_and_Details/25_Email_Framework/README.md
+++ b/doc/19_Development_Tools_and_Details/25_Email_Framework/README.md
@@ -117,5 +117,4 @@ The same sandbox is also used to evaluate `Dynamic Text` layout components in Da
 classes. See [Twig Sandbox Object & Function Access](../../26_Best_Practice/80_Twig_Sandbox_Object_Access.md)
 for how to control which PHP objects a sandboxed template is allowed to reach (via a
 `blocked_classes` denylist or an `allowed_classes` allowlist), and which `pimcore_*`
-functions are auto-allowed (via a `blocked_functions` denylist or an `allowed_functions`
-allowlist).
+functions are auto-allowed (via a `blocked_functions` denylist).

--- a/doc/19_Development_Tools_and_Details/25_Email_Framework/README.md
+++ b/doc/19_Development_Tools_and_Details/25_Email_Framework/README.md
@@ -114,6 +114,8 @@ security policies for tags, filters & functions. Please use following configurat
 ```
 
 The same sandbox is also used to evaluate `Dynamic Text` layout components in DataObject
-classes. See [Twig Sandbox Object Access](../../26_Best_Practice/80_Twig_Sandbox_Object_Access.md)
+classes. See [Twig Sandbox Object & Function Access](../../26_Best_Practice/80_Twig_Sandbox_Object_Access.md)
 for how to control which PHP objects a sandboxed template is allowed to reach (via a
-`blocked_classes` denylist or an `allowed_classes` allowlist).
+`blocked_classes` denylist or an `allowed_classes` allowlist), and which `pimcore_*`
+functions are auto-allowed (via a `blocked_functions` denylist or an `allowed_functions`
+allowlist).

--- a/doc/26_Best_Practice/80_Twig_Sandbox_Object_Access.md
+++ b/doc/26_Best_Practice/80_Twig_Sandbox_Object_Access.md
@@ -11,22 +11,28 @@ read properties on, and which `pimcore_*` **functions** are callable.
 Both are enforced by `Pimcore\Twig\Sandbox\SecurityPolicy` and are configurable via
 `templating_engine.twig.sandbox_security_policy`. Object access supports both a
 denylist and an allowlist mode, described below; function access is denylist-only.
+Every built-in denylist described in this document (`blocked_classes`,
+`blocked_functions`, `hard_blocked_methods`) is defined as the *default value* of
+its config option in `bundles/CoreBundle/config/pimcore/default.yaml`, not hardcoded
+in `SecurityPolicy` - a site's own config for the same option is merged with (appended
+to) that default, not substituted for it, so extending one of these options cannot
+accidentally drop the shipped defaults.
 
 ## Object access: two modes
 
 The policy supports two mutually exclusive modes:
 
 - **Blocklist mode (default)** - every object is reachable *except* instances of a
-  denylist of classes. Pimcore ships a built-in denylist covering the database/
+  denylist of classes. Pimcore's `blocked_classes` default covers the database/
   infrastructure layer (`Pimcore\Model\Dao\AbstractDao`, `Doctrine\DBAL\Connection`,
   `PDO`, `PDOStatement`, Symfony's `ContainerInterface`, `Process`) and
   `Pimcore\Model\User` (whose getters expose the password hash and password
-  recovery token). Use `blocked_classes` to add more classes to this denylist.
+  recovery token). Set `blocked_classes` to add more classes to this denylist.
 - **Allowlist mode** - as soon as `allowed_classes` contains at least one entry, the
   policy switches to allow only instances of the listed classes (and their
-  subclasses). **The entire denylist (built-in + `blocked_classes`) is deactivated
-  in this mode** - every object that is not an instance of an allowed class is
-  denied, regardless of what `blocked_classes` contains.
+  subclasses). **The entire `blocked_classes` denylist is deactivated in this
+  mode** - every object that is not an instance of an allowed class is denied,
+  regardless of what `blocked_classes` contains.
 
 A blocklist is inherently open-ended: it must enumerate every class whose data must
 stay out of templates, and any class added to the codebase later (or reachable via
@@ -36,18 +42,21 @@ rendering are reachable, so newly introduced classes are denied by default. Pref
 allowlist mode wherever the set of objects passed into a sandboxed template
 (`Mail::setParams()`, `Layout\Text` context) is small and known.
 
-## Always-blocked methods
+## Hard-blocked methods
 
-`Pimcore\Model\Asset` is deliberately **not** on the built-in denylist - templates
-commonly need it for filename/thumbnail access. But its content-returning methods
-(`getData`, `getStream`, `getLocalFile`, `getTemporaryFile`) would let a template
-read the raw bytes of any asset, bypassing that asset's workspace ACL. These
-methods - together with `User::getPassword`, `User::getPasswordRecoveryToken` and
-`User::getTwoFactorAuthentication` (returns the MFA secret alongside the rest of the
-2FA config) - are hard-blocked unconditionally: unlike the denylist, this check is
-**not** bypassed by allowlist mode. Even a site that explicitly allowlists `Asset` or
-`User` cannot make these specific methods template-reachable again. This set is
-not configurable; it exists to keep a small number of secret/content-returning
+`Pimcore\Model\Asset` is deliberately **not** on the `blocked_classes` denylist -
+templates commonly need it for filename/thumbnail access. But its content-returning
+methods (`getData`, `getStream`, `getLocalFile`, `getTemporaryFile`) would let a
+template read the raw bytes of any asset, bypassing that asset's workspace ACL.
+These methods - together with `User::getPassword`, `User::getPasswordRecoveryToken`
+and `User::getTwoFactorAuthentication` (returns the MFA secret alongside the rest of
+the 2FA config) - are hard-blocked via the `hard_blocked_methods` option: unlike
+`blocked_classes`, this check is **not** bypassed by allowlist mode. Even a site
+that explicitly allowlists `Asset` or `User` cannot make these specific methods
+template-reachable again. `hard_blocked_methods` can be extended (a site can add
+further FQCN => methods entries on top of the shipped default), but the shipped
+entries themselves stay in effect - since config for this option is merged with the
+default rather than replacing it - keeping a small number of secret/content-returning
 getters closed off no matter how the rest of the policy is configured.
 
 ## Function access
@@ -55,16 +64,17 @@ getters closed off no matter how the rest of the policy is configured.
 The `functions` option (see [Email Framework](../19_Development_Tools_and_Details/25_Email_Framework/README.md#sandbox-restrictions))
 is an explicit allowlist: a function must be listed there to be callable from a
 sandboxed template. Independently, any Twig function whose name starts with
-`pimcore_` is additionally auto-allowed, except for a built-in denylist of functions
-that look up and return a live model instance by id/path, whose getters can expose
-data outside the sandboxed template's intended scope (e.g. `pimcore_user(1)`,
-`pimcore_asset(id)` - see [Always-blocked methods](#always-blocked-methods) above
-for why those two are additionally hard-blocked at the object layer): `pimcore_asset`,
+`pimcore_` is additionally auto-allowed, except for the `blocked_functions` denylist,
+which by default covers functions that look up and return a live model instance by
+id/path, whose getters can expose data outside the sandboxed template's intended
+scope (e.g. `pimcore_user(1)`, `pimcore_asset(id)` - see
+[Hard-blocked methods](#hard-blocked-methods) above for why those two are
+additionally hard-blocked at the object layer): `pimcore_asset`,
 `pimcore_asset_by_path`, `pimcore_document`, `pimcore_document_by_path`,
 `pimcore_document_wrap_hardlink`, `pimcore_object`, `pimcore_object_by_path`,
 `pimcore_object_classificationstore_group`, `pimcore_object_brick_definition_key`,
 `pimcore_site`, `pimcore_site_by_root_id`, `pimcore_site_by_domain`,
-`pimcore_site_current`, `pimcore_user`. Use `blocked_functions` to add more
+`pimcore_site_current`, `pimcore_user`. Set `blocked_functions` to add more
 functions to this denylist.
 
 All other `pimcore_*` functions (rendering/helper functions such as `pimcore_dump`,
@@ -72,6 +82,11 @@ All other `pimcore_*` functions (rendering/helper functions such as `pimcore_dum
 so existing template rendering is unaffected.
 
 ## Configuration
+
+`blocked_classes`, `blocked_functions` and `hard_blocked_methods` already default to
+Pimcore's built-in denylists in `default.yaml` (shown below, abbreviated) - a site's
+own `config/packages/pimcore.yaml` only needs to list what it wants to *add* on top of
+those defaults:
 
 ```yaml
 pimcore:
@@ -81,13 +96,50 @@ pimcore:
                 tags: ['set']
                 filters: ['escape', 'trans', 'default']
                 functions: ['path', 'asset']
-                # Extend the built-in class denylist (Dao/Connection/PDO/.../User).
-                # Only consulted while allowed_classes is empty.
-                blocked_classes: []
+                # Defaults to the built-in class denylist (Dao/Connection/PDO/.../User) -
+                # a site's own config is appended to it. Only consulted while
+                # allowed_classes is empty.
+                blocked_classes:
+                    - Pimcore\Model\Dao\AbstractDao
+                    - Doctrine\DBAL\Connection
+                    - PDO
+                    - PDOStatement
+                    - Symfony\Component\DependencyInjection\ContainerInterface
+                    - Symfony\Component\Process\Process
+                    - Pimcore\Model\User
                 # Non-empty => object allowlist mode. Deactivates the class denylist entirely.
                 allowed_classes: []
-                # Extend the built-in pimcore_* function denylist.
-                blocked_functions: []
+                # Defaults to the built-in pimcore_* function denylist - a site's own
+                # config is appended to it.
+                blocked_functions:
+                    - pimcore_asset
+                    - pimcore_asset_by_path
+                    - pimcore_document
+                    - pimcore_document_by_path
+                    - pimcore_document_wrap_hardlink
+                    - pimcore_object
+                    - pimcore_object_by_path
+                    - pimcore_object_classificationstore_group
+                    - pimcore_object_brick_definition_key
+                    - pimcore_site
+                    - pimcore_site_by_root_id
+                    - pimcore_site_by_domain
+                    - pimcore_site_current
+                    - pimcore_user
+                # FQCN => method names that are never callable, regardless of
+                # blocked_classes/allowed_classes. Defaults to a small set of
+                # secret/content-returning getters - a site's own config is merged
+                # with (not substituted for) this default.
+                hard_blocked_methods:
+                    Pimcore\Model\User:
+                        - getPassword
+                        - getPasswordRecoveryToken
+                        - getTwoFactorAuthentication
+                    Pimcore\Model\Asset:
+                        - getData
+                        - getStream
+                        - getLocalFile
+                        - getTemporaryFile
 ```
 
 ### Example: allowlist mode
@@ -108,11 +160,10 @@ pimcore:
                     - 'App\Mail\OrderConfirmationData'
 ```
 
-With this configuration, `blocked_classes` (and the built-in denylist) is ignored -
-any object that is not a `Product` or `OrderConfirmationData` (or a subclass)
-raises `Twig\Sandbox\SecurityNotAllowedMethodError` /
-`SecurityNotAllowedPropertyError` when a template tries to call a method or read a
-property on it.
+With this configuration, `blocked_classes` is ignored entirely - any object that is
+not a `Product` or `OrderConfirmationData` (or a subclass) raises
+`Twig\Sandbox\SecurityNotAllowedMethodError` / `SecurityNotAllowedPropertyError` when
+a template tries to call a method or read a property on it.
 
 ### Example: extending the denylist
 
@@ -129,6 +180,10 @@ pimcore:
                 blocked_classes:
                     - 'App\Service\SecretsProvider'
 ```
+
+A site's own config for `blocked_classes` is merged with Pimcore's shipped default,
+not substituted for it, so this results in the built-in denylist *plus*
+`App\Service\SecretsProvider` - not just the single entry shown above.
 
 ### Example: extending the function denylist
 
@@ -149,6 +204,12 @@ pimcore:
   that isn't installed) is skipped silently.
 - `blocked_functions` accepts exact Twig function names (as used in a template,
   e.g. `pimcore_user`) and is matched by string comparison.
+- `hard_blocked_methods` keys are FQCNs, matched the same way as `blocked_classes`;
+  each value is a list of method names, matched by string comparison.
+- `blocked_classes`, `blocked_functions` and `hard_blocked_methods` are Symfony
+  config array nodes, so a site's own value for any of them is merged with (appended
+  to) Pimcore's default rather than replacing it - there is no config-only way to
+  remove an entry from the shipped defaults.
 - The object and function mechanisms are independent of each other, and both are
   independent from the `tags` / `filters` allowlists, which still apply as before.
 - Changing these settings requires clearing the Symfony container cache

--- a/doc/26_Best_Practice/80_Twig_Sandbox_Object_Access.md
+++ b/doc/26_Best_Practice/80_Twig_Sandbox_Object_Access.md
@@ -18,8 +18,9 @@ The policy supports two mutually exclusive modes:
 - **Blocklist mode (default)** - every object is reachable *except* instances of a
   denylist of classes. Pimcore ships a built-in denylist covering the database/
   infrastructure layer (`Pimcore\Model\Dao\AbstractDao`, `Doctrine\DBAL\Connection`,
-  `PDO`, `PDOStatement`, Symfony's `ContainerInterface`, `Process`). Use
-  `blocked_classes` to add more classes to this denylist.
+  `PDO`, `PDOStatement`, Symfony's `ContainerInterface`, `Process`) and
+  `Pimcore\Model\User` (whose getters expose the password hash and password
+  recovery token). Use `blocked_classes` to add more classes to this denylist.
 - **Allowlist mode** - as soon as `allowed_classes` contains at least one entry, the
   policy switches to allow only instances of the listed classes (and their
   subclasses). **The entire denylist (built-in + `blocked_classes`) is deactivated
@@ -34,6 +35,19 @@ rendering are reachable, so newly introduced classes are denied by default. Pref
 allowlist mode wherever the set of objects passed into a sandboxed template
 (`Mail::setParams()`, `Layout\Text` context) is small and known.
 
+## Always-blocked methods
+
+`Pimcore\Model\Asset` is deliberately **not** on the built-in denylist - templates
+commonly need it for filename/thumbnail access. But its content-returning methods
+(`getData`, `getStream`, `getLocalFile`, `getTemporaryFile`) would let a template
+read the raw bytes of any asset, bypassing that asset's workspace ACL. These
+methods - together with `User::getPassword` / `User::getPasswordRecoveryToken` -
+are hard-blocked unconditionally: unlike the denylist, this check is **not**
+bypassed by allowlist mode. Even a site that explicitly allowlists `Asset` or
+`User` cannot make these specific methods template-reachable again. This set is
+not configurable; it exists to keep a small number of secret/content-returning
+getters closed off no matter how the rest of the policy is configured.
+
 ## Configuration
 
 ```yaml
@@ -44,10 +58,9 @@ pimcore:
                 tags: ['set']
                 filters: ['escape', 'trans', 'default']
                 functions: ['path', 'asset']
-                # Extend the built-in denylist. Only consulted while allowed_classes is empty.
-                blocked_classes:
-                    - 'Pimcore\Model\User'
-                    - 'Pimcore\Model\Asset'
+                # Extend the built-in denylist (Dao/Connection/PDO/.../User). Only
+                # consulted while allowed_classes is empty.
+                blocked_classes: []
                 # Non-empty => allowlist mode. Deactivates the denylist entirely.
                 allowed_classes: []
 ```
@@ -80,9 +93,8 @@ property on it.
 
 If switching to a full allowlist is not feasible (e.g. many different DataObject
 classes are legitimately passed into templates), extend the denylist instead to
-explicitly deny classes whose getters return sensitive data, such as
-`Pimcore\Model\User` (password hash, password recovery token) or the
-content-returning methods on `Pimcore\Model\Asset`:
+explicitly deny further classes whose getters return sensitive data - e.g. a
+custom service locator or a DTO wrapping credentials:
 
 ```yaml
 pimcore:
@@ -90,8 +102,7 @@ pimcore:
         twig:
             sandbox_security_policy:
                 blocked_classes:
-                    - 'Pimcore\Model\User'
-                    - 'Pimcore\Model\Asset'
+                    - 'App\Service\SecretsProvider'
 ```
 
 ## Notes

--- a/doc/26_Best_Practice/80_Twig_Sandbox_Object_Access.md
+++ b/doc/26_Best_Practice/80_Twig_Sandbox_Object_Access.md
@@ -9,9 +9,8 @@ and, independently, which **PHP objects** a template is allowed to call methods 
 read properties on, and which `pimcore_*` **functions** are callable.
 
 Both are enforced by `Pimcore\Twig\Sandbox\SecurityPolicy` and are configurable via
-`templating_engine.twig.sandbox_security_policy`. They follow the same blocklist/
-allowlist shape, described once below and then applied to objects and functions
-separately.
+`templating_engine.twig.sandbox_security_policy`. Object access supports both a
+denylist and an allowlist mode, described below; function access is denylist-only.
 
 ## Object access: two modes
 
@@ -51,36 +50,26 @@ methods - together with `User::getPassword`, `User::getPasswordRecoveryToken` an
 not configurable; it exists to keep a small number of secret/content-returning
 getters closed off no matter how the rest of the policy is configured.
 
-## Function access: two modes
+## Function access
 
 The `functions` option (see [Email Framework](../19_Development_Tools_and_Details/25_Email_Framework/README.md#sandbox-restrictions))
 is an explicit allowlist: a function must be listed there to be callable from a
-sandboxed template - this always applies, in either mode below, and is unaffected by
-them. Independently, any Twig function whose name starts with `pimcore_` is
-additionally auto-allowed, following the exact same two-mode shape as object access:
-
-- **Blocklist mode (default)** - every `pimcore_*` function is auto-allowed *except*
-  a denylist of functions. Pimcore ships a built-in denylist of functions that look
-  up and return a live model instance by id/path, whose getters can expose data
-  outside the sandboxed template's intended scope (e.g. `pimcore_user(1)`,
-  `pimcore_asset(id)` - see [Always-blocked methods](#always-blocked-methods) above
-  for why those two are additionally hard-blocked at the object layer): `pimcore_asset`,
-  `pimcore_asset_by_path`, `pimcore_document`, `pimcore_document_by_path`,
-  `pimcore_document_wrap_hardlink`, `pimcore_object`, `pimcore_object_by_path`,
-  `pimcore_object_classificationstore_group`, `pimcore_object_brick_definition_key`,
-  `pimcore_site`, `pimcore_site_by_root_id`, `pimcore_site_by_domain`,
-  `pimcore_site_current`, `pimcore_user`. Use `blocked_functions` to add more
-  functions to this denylist.
-- **Allowlist mode** - as soon as `allowed_functions` contains at least one entry,
-  the `pimcore_*` prefix rule switches to allow only the listed functions.
-  **The entire denylist (built-in + `blocked_functions`) is deactivated in this
-  mode** - every `pimcore_*` function not in `allowed_functions` (and not in the
-  general `functions` allowlist) is denied.
+sandboxed template. Independently, any Twig function whose name starts with
+`pimcore_` is additionally auto-allowed, except for a built-in denylist of functions
+that look up and return a live model instance by id/path, whose getters can expose
+data outside the sandboxed template's intended scope (e.g. `pimcore_user(1)`,
+`pimcore_asset(id)` - see [Always-blocked methods](#always-blocked-methods) above
+for why those two are additionally hard-blocked at the object layer): `pimcore_asset`,
+`pimcore_asset_by_path`, `pimcore_document`, `pimcore_document_by_path`,
+`pimcore_document_wrap_hardlink`, `pimcore_object`, `pimcore_object_by_path`,
+`pimcore_object_classificationstore_group`, `pimcore_object_brick_definition_key`,
+`pimcore_site`, `pimcore_site_by_root_id`, `pimcore_site_by_domain`,
+`pimcore_site_current`, `pimcore_user`. Use `blocked_functions` to add more
+functions to this denylist.
 
 All other `pimcore_*` functions (rendering/helper functions such as `pimcore_dump`,
-`pimcore_url`, `pimcore_head_link`, the editable functions, ...) remain auto-allowed
-in blocklist mode, so existing template rendering is unaffected unless a site
-switches to allowlist mode.
+`pimcore_url`, `pimcore_head_link`, the editable functions, ...) remain auto-allowed,
+so existing template rendering is unaffected.
 
 ## Configuration
 
@@ -97,11 +86,8 @@ pimcore:
                 blocked_classes: []
                 # Non-empty => object allowlist mode. Deactivates the class denylist entirely.
                 allowed_classes: []
-                # Extend the built-in pimcore_* function denylist. Only consulted
-                # while allowed_functions is empty.
+                # Extend the built-in pimcore_* function denylist.
                 blocked_functions: []
-                # Non-empty => pimcore_* function allowlist mode. Deactivates that denylist entirely.
-                allowed_functions: []
 ```
 
 ### Example: allowlist mode
@@ -144,26 +130,6 @@ pimcore:
                     - 'App\Service\SecretsProvider'
 ```
 
-### Example: pimcore_* function allowlist mode
-
-If a site's sandboxed templates only ever need one or two of the id/path-lookup
-functions, lock the `pimcore_*` prefix rule down to exactly those instead of relying
-on the (larger) built-in denylist:
-
-```yaml
-pimcore:
-    templating_engine:
-        twig:
-            sandbox_security_policy:
-                allowed_functions:
-                    - 'pimcore_user'
-```
-
-With this configuration, `blocked_functions` (and the built-in function denylist) is
-ignored - every `pimcore_*` function other than `pimcore_user` now raises
-`Twig\Sandbox\SecurityNotAllowedFunctionError`, including ones that were previously
-auto-allowed (e.g. `pimcore_dump`). Add them to `functions` if still needed.
-
 ### Example: extending the function denylist
 
 ```yaml
@@ -181,11 +147,10 @@ pimcore:
   name; matching uses `instanceof`, so subclasses/implementations are covered
   automatically, and a configured class that doesn't exist (e.g. an optional bundle
   that isn't installed) is skipped silently.
-- `blocked_functions`/`allowed_functions` accept exact Twig function names (as used
-  in a template, e.g. `pimcore_user`) and are matched by string comparison.
-- The object and function mechanisms are independent - switching one to allowlist
-  mode does not affect the other. Both are independent from the `tags` / `filters`
-  allowlists, which still apply as before.
+- `blocked_functions` accepts exact Twig function names (as used in a template,
+  e.g. `pimcore_user`) and is matched by string comparison.
+- The object and function mechanisms are independent of each other, and both are
+  independent from the `tags` / `filters` allowlists, which still apply as before.
 - Changing these settings requires clearing the Symfony container cache
   (`bin/console cache:clear`) since the security policy is wired as a container
   parameter.

--- a/doc/26_Best_Practice/80_Twig_Sandbox_Object_Access.md
+++ b/doc/26_Best_Practice/80_Twig_Sandbox_Object_Access.md
@@ -43,9 +43,10 @@ allowlist mode wherever the set of objects passed into a sandboxed template
 commonly need it for filename/thumbnail access. But its content-returning methods
 (`getData`, `getStream`, `getLocalFile`, `getTemporaryFile`) would let a template
 read the raw bytes of any asset, bypassing that asset's workspace ACL. These
-methods - together with `User::getPassword` / `User::getPasswordRecoveryToken` -
-are hard-blocked unconditionally: unlike the denylist, this check is **not**
-bypassed by allowlist mode. Even a site that explicitly allowlists `Asset` or
+methods - together with `User::getPassword`, `User::getPasswordRecoveryToken` and
+`User::getTwoFactorAuthentication` (returns the MFA secret alongside the rest of the
+2FA config) - are hard-blocked unconditionally: unlike the denylist, this check is
+**not** bypassed by allowlist mode. Even a site that explicitly allowlists `Asset` or
 `User` cannot make these specific methods template-reachable again. This set is
 not configurable; it exists to keep a small number of secret/content-returning
 getters closed off no matter how the rest of the policy is configured.

--- a/doc/26_Best_Practice/80_Twig_Sandbox_Object_Access.md
+++ b/doc/26_Best_Practice/80_Twig_Sandbox_Object_Access.md
@@ -64,22 +64,44 @@ getters closed off no matter how the rest of the policy is configured.
 The `functions` option (see [Email Framework](../19_Development_Tools_and_Details/25_Email_Framework/README.md#sandbox-restrictions))
 is an explicit allowlist: a function must be listed there to be callable from a
 sandboxed template. Independently, any Twig function whose name starts with
-`pimcore_` is additionally auto-allowed, except for the `blocked_functions` denylist,
-which by default covers functions that look up and return a live model instance by
-id/path, whose getters can expose data outside the sandboxed template's intended
-scope (e.g. `pimcore_user(1)`, `pimcore_asset(id)` - see
-[Hard-blocked methods](#hard-blocked-methods) above for why those two are
-additionally hard-blocked at the object layer): `pimcore_asset`,
-`pimcore_asset_by_path`, `pimcore_document`, `pimcore_document_by_path`,
-`pimcore_document_wrap_hardlink`, `pimcore_object`, `pimcore_object_by_path`,
-`pimcore_object_classificationstore_group`, `pimcore_object_brick_definition_key`,
-`pimcore_site`, `pimcore_site_by_root_id`, `pimcore_site_by_domain`,
-`pimcore_site_current`, `pimcore_user`. Set `blocked_functions` to add more
-functions to this denylist.
+`pimcore_` is additionally auto-allowed, except for the `blocked_functions` denylist.
+By default, that denylist only contains `pimcore_user` (see
+[Hard-blocked methods](#hard-blocked-methods) above for why `User` getters are
+additionally hard-blocked at the object layer regardless).
 
-All other `pimcore_*` functions (rendering/helper functions such as `pimcore_dump`,
-`pimcore_url`, `pimcore_head_link`, the editable functions, ...) remain auto-allowed,
-so existing template rendering is unaffected.
+All other `pimcore_*` functions - including the other id/path lookup functions,
+`pimcore_asset`, `pimcore_asset_by_path`, `pimcore_document`,
+`pimcore_document_by_path`, `pimcore_document_wrap_hardlink`, `pimcore_object`,
+`pimcore_object_by_path`, `pimcore_object_classificationstore_group`,
+`pimcore_object_brick_definition_key`, `pimcore_site`, `pimcore_site_by_root_id`,
+`pimcore_site_by_domain`, `pimcore_site_current` - are auto-allowed by default, so
+existing template rendering is unaffected. Each of these hands back a live model
+instance looked up by an arbitrary id/path, which a sandboxed template can then call
+further getters on to reach data outside its intended scope. **For a high-security
+setup, add these to `blocked_functions`** (they're listed, commented out, in
+`default.yaml` - uncomment or copy them into a site's own config) to restore the
+stricter posture:
+
+```yaml
+pimcore:
+    templating_engine:
+        twig:
+            sandbox_security_policy:
+                blocked_functions:
+                    - pimcore_asset
+                    - pimcore_asset_by_path
+                    - pimcore_document
+                    - pimcore_document_by_path
+                    - pimcore_document_wrap_hardlink
+                    - pimcore_object
+                    - pimcore_object_by_path
+                    - pimcore_object_classificationstore_group
+                    - pimcore_object_brick_definition_key
+                    - pimcore_site
+                    - pimcore_site_by_root_id
+                    - pimcore_site_by_domain
+                    - pimcore_site_current
+```
 
 ## Configuration
 
@@ -110,21 +132,24 @@ pimcore:
                 # Non-empty => object allowlist mode. Deactivates the class denylist entirely.
                 allowed_classes: []
                 # Defaults to the built-in pimcore_* function denylist - a site's own
-                # config is appended to it.
+                # config is appended to it. Only pimcore_user is blocked out of the
+                # box; the id/path lookup functions below are shipped commented out -
+                # uncomment them (or add the equivalent to a site's own config) for a
+                # high-security setup.
                 blocked_functions:
-                    - pimcore_asset
-                    - pimcore_asset_by_path
-                    - pimcore_document
-                    - pimcore_document_by_path
-                    - pimcore_document_wrap_hardlink
-                    - pimcore_object
-                    - pimcore_object_by_path
-                    - pimcore_object_classificationstore_group
-                    - pimcore_object_brick_definition_key
-                    - pimcore_site
-                    - pimcore_site_by_root_id
-                    - pimcore_site_by_domain
-                    - pimcore_site_current
+                    # - pimcore_asset
+                    # - pimcore_asset_by_path
+                    # - pimcore_document
+                    # - pimcore_document_by_path
+                    # - pimcore_document_wrap_hardlink
+                    # - pimcore_object
+                    # - pimcore_object_by_path
+                    # - pimcore_object_classificationstore_group
+                    # - pimcore_object_brick_definition_key
+                    # - pimcore_site
+                    # - pimcore_site_by_root_id
+                    # - pimcore_site_by_domain
+                    # - pimcore_site_current
                     - pimcore_user
                 # FQCN => method names that are never callable, regardless of
                 # blocked_classes/allowed_classes. Defaults to a small set of

--- a/doc/26_Best_Practice/80_Twig_Sandbox_Object_Access.md
+++ b/doc/26_Best_Practice/80_Twig_Sandbox_Object_Access.md
@@ -1,0 +1,109 @@
+# Twig Sandbox Object Access (Blocklist / Allowlist)
+
+Pimcore renders certain user-authored Twig templates - Email documents (subject &
+body), and DataObject `Layout\Text` (Dynamic Text) components - inside a Twig
+[sandbox](https://twig.symfony.com/doc/3.x/api.html#sandbox-extension). The sandbox
+restricts which tags, filters and functions a template may use (see
+[Email Framework](../19_Development_Tools_and_Details/25_Email_Framework/README.md#sandbox-restrictions))
+and, independently, which **PHP objects** a template is allowed to call methods or
+read properties on.
+
+Object access is enforced by `Pimcore\Twig\Sandbox\SecurityPolicy` and is
+configurable via `templating_engine.twig.sandbox_security_policy`.
+
+## Two modes
+
+The policy supports two mutually exclusive modes:
+
+- **Blocklist mode (default)** - every object is reachable *except* instances of a
+  denylist of classes. Pimcore ships a built-in denylist covering the database/
+  infrastructure layer (`Pimcore\Model\Dao\AbstractDao`, `Doctrine\DBAL\Connection`,
+  `PDO`, `PDOStatement`, Symfony's `ContainerInterface`, `Process`). Use
+  `blocked_classes` to add more classes to this denylist.
+- **Allowlist mode** - as soon as `allowed_classes` contains at least one entry, the
+  policy switches to allow only instances of the listed classes (and their
+  subclasses). **The entire denylist (built-in + `blocked_classes`) is deactivated
+  in this mode** - every object that is not an instance of an allowed class is
+  denied, regardless of what `blocked_classes` contains.
+
+A blocklist is inherently open-ended: it must enumerate every class whose data must
+stay out of templates, and any class added to the codebase later (or reachable via
+a getter that returns a different object) can accidentally slip through. An
+allowlist inverts this: only the classes a site explicitly trusts for template
+rendering are reachable, so newly introduced classes are denied by default. Prefer
+allowlist mode wherever the set of objects passed into a sandboxed template
+(`Mail::setParams()`, `Layout\Text` context) is small and known.
+
+## Configuration
+
+```yaml
+pimcore:
+    templating_engine:
+        twig:
+            sandbox_security_policy:
+                tags: ['set']
+                filters: ['escape', 'trans', 'default']
+                functions: ['path', 'asset']
+                # Extend the built-in denylist. Only consulted while allowed_classes is empty.
+                blocked_classes:
+                    - 'Pimcore\Model\User'
+                    - 'Pimcore\Model\Asset'
+                # Non-empty => allowlist mode. Deactivates the denylist entirely.
+                allowed_classes: []
+```
+
+### Example: allowlist mode
+
+If a site only ever passes a handful of DTOs/value objects into sandboxed
+templates (e.g. an order confirmation email that only needs `firstName`,
+`lastName` and a `product` DataObject), lock the sandbox down to exactly those
+classes:
+
+```yaml
+pimcore:
+    templating_engine:
+        twig:
+            sandbox_security_policy:
+                functions: ['path', 'asset']
+                allowed_classes:
+                    - 'Pimcore\Model\DataObject\Product'
+                    - 'App\Mail\OrderConfirmationData'
+```
+
+With this configuration, `blocked_classes` (and the built-in denylist) is ignored -
+any object that is not a `Product` or `OrderConfirmationData` (or a subclass)
+raises `Twig\Sandbox\SecurityNotAllowedMethodError` /
+`SecurityNotAllowedPropertyError` when a template tries to call a method or read a
+property on it.
+
+### Example: extending the denylist
+
+If switching to a full allowlist is not feasible (e.g. many different DataObject
+classes are legitimately passed into templates), extend the denylist instead to
+explicitly deny classes whose getters return sensitive data, such as
+`Pimcore\Model\User` (password hash, password recovery token) or the
+content-returning methods on `Pimcore\Model\Asset`:
+
+```yaml
+pimcore:
+    templating_engine:
+        twig:
+            sandbox_security_policy:
+                blocked_classes:
+                    - 'Pimcore\Model\User'
+                    - 'Pimcore\Model\Asset'
+```
+
+## Notes
+
+- `blocked_classes` and `allowed_classes` both accept any fully qualified class or
+  interface name; matching uses `instanceof`, so subclasses/implementations are
+  covered automatically.
+- Classes that don't exist (e.g. an optional bundle that isn't installed) are
+  skipped silently, matching the existing behavior of the built-in denylist.
+- This only governs **object** access from within the sandbox. It is independent
+  from the `tags` / `filters` / `functions` allowlists, which still apply as
+  before.
+- Changing these settings requires clearing the Symfony container cache
+  (`bin/console cache:clear`) since the security policy is wired as a container
+  parameter.

--- a/doc/26_Best_Practice/80_Twig_Sandbox_Object_Access.md
+++ b/doc/26_Best_Practice/80_Twig_Sandbox_Object_Access.md
@@ -1,4 +1,4 @@
-# Twig Sandbox Object Access (Blocklist / Allowlist)
+# Twig Sandbox Object & Function Access (Blocklist / Allowlist)
 
 Pimcore renders certain user-authored Twig templates - Email documents (subject &
 body), and DataObject `Layout\Text` (Dynamic Text) components - inside a Twig
@@ -6,12 +6,14 @@ body), and DataObject `Layout\Text` (Dynamic Text) components - inside a Twig
 restricts which tags, filters and functions a template may use (see
 [Email Framework](../19_Development_Tools_and_Details/25_Email_Framework/README.md#sandbox-restrictions))
 and, independently, which **PHP objects** a template is allowed to call methods or
-read properties on.
+read properties on, and which `pimcore_*` **functions** are callable.
 
-Object access is enforced by `Pimcore\Twig\Sandbox\SecurityPolicy` and is
-configurable via `templating_engine.twig.sandbox_security_policy`.
+Both are enforced by `Pimcore\Twig\Sandbox\SecurityPolicy` and are configurable via
+`templating_engine.twig.sandbox_security_policy`. They follow the same blocklist/
+allowlist shape, described once below and then applied to objects and functions
+separately.
 
-## Two modes
+## Object access: two modes
 
 The policy supports two mutually exclusive modes:
 
@@ -48,6 +50,37 @@ bypassed by allowlist mode. Even a site that explicitly allowlists `Asset` or
 not configurable; it exists to keep a small number of secret/content-returning
 getters closed off no matter how the rest of the policy is configured.
 
+## Function access: two modes
+
+The `functions` option (see [Email Framework](../19_Development_Tools_and_Details/25_Email_Framework/README.md#sandbox-restrictions))
+is an explicit allowlist: a function must be listed there to be callable from a
+sandboxed template - this always applies, in either mode below, and is unaffected by
+them. Independently, any Twig function whose name starts with `pimcore_` is
+additionally auto-allowed, following the exact same two-mode shape as object access:
+
+- **Blocklist mode (default)** - every `pimcore_*` function is auto-allowed *except*
+  a denylist of functions. Pimcore ships a built-in denylist of functions that look
+  up and return a live model instance by id/path, whose getters can expose data
+  outside the sandboxed template's intended scope (e.g. `pimcore_user(1)`,
+  `pimcore_asset(id)` - see [Always-blocked methods](#always-blocked-methods) above
+  for why those two are additionally hard-blocked at the object layer): `pimcore_asset`,
+  `pimcore_asset_by_path`, `pimcore_document`, `pimcore_document_by_path`,
+  `pimcore_document_wrap_hardlink`, `pimcore_object`, `pimcore_object_by_path`,
+  `pimcore_object_classificationstore_group`, `pimcore_object_brick_definition_key`,
+  `pimcore_site`, `pimcore_site_by_root_id`, `pimcore_site_by_domain`,
+  `pimcore_site_current`, `pimcore_user`. Use `blocked_functions` to add more
+  functions to this denylist.
+- **Allowlist mode** - as soon as `allowed_functions` contains at least one entry,
+  the `pimcore_*` prefix rule switches to allow only the listed functions.
+  **The entire denylist (built-in + `blocked_functions`) is deactivated in this
+  mode** - every `pimcore_*` function not in `allowed_functions` (and not in the
+  general `functions` allowlist) is denied.
+
+All other `pimcore_*` functions (rendering/helper functions such as `pimcore_dump`,
+`pimcore_url`, `pimcore_head_link`, the editable functions, ...) remain auto-allowed
+in blocklist mode, so existing template rendering is unaffected unless a site
+switches to allowlist mode.
+
 ## Configuration
 
 ```yaml
@@ -58,11 +91,16 @@ pimcore:
                 tags: ['set']
                 filters: ['escape', 'trans', 'default']
                 functions: ['path', 'asset']
-                # Extend the built-in denylist (Dao/Connection/PDO/.../User). Only
-                # consulted while allowed_classes is empty.
+                # Extend the built-in class denylist (Dao/Connection/PDO/.../User).
+                # Only consulted while allowed_classes is empty.
                 blocked_classes: []
-                # Non-empty => allowlist mode. Deactivates the denylist entirely.
+                # Non-empty => object allowlist mode. Deactivates the class denylist entirely.
                 allowed_classes: []
+                # Extend the built-in pimcore_* function denylist. Only consulted
+                # while allowed_functions is empty.
+                blocked_functions: []
+                # Non-empty => pimcore_* function allowlist mode. Deactivates that denylist entirely.
+                allowed_functions: []
 ```
 
 ### Example: allowlist mode
@@ -105,16 +143,48 @@ pimcore:
                     - 'App\Service\SecretsProvider'
 ```
 
+### Example: pimcore_* function allowlist mode
+
+If a site's sandboxed templates only ever need one or two of the id/path-lookup
+functions, lock the `pimcore_*` prefix rule down to exactly those instead of relying
+on the (larger) built-in denylist:
+
+```yaml
+pimcore:
+    templating_engine:
+        twig:
+            sandbox_security_policy:
+                allowed_functions:
+                    - 'pimcore_user'
+```
+
+With this configuration, `blocked_functions` (and the built-in function denylist) is
+ignored - every `pimcore_*` function other than `pimcore_user` now raises
+`Twig\Sandbox\SecurityNotAllowedFunctionError`, including ones that were previously
+auto-allowed (e.g. `pimcore_dump`). Add them to `functions` if still needed.
+
+### Example: extending the function denylist
+
+```yaml
+pimcore:
+    templating_engine:
+        twig:
+            sandbox_security_policy:
+                blocked_functions:
+                    - 'pimcore_element_tags'
+```
+
 ## Notes
 
-- `blocked_classes` and `allowed_classes` both accept any fully qualified class or
-  interface name; matching uses `instanceof`, so subclasses/implementations are
-  covered automatically.
-- Classes that don't exist (e.g. an optional bundle that isn't installed) are
-  skipped silently, matching the existing behavior of the built-in denylist.
-- This only governs **object** access from within the sandbox. It is independent
-  from the `tags` / `filters` / `functions` allowlists, which still apply as
-  before.
+- `blocked_classes`/`allowed_classes` accept any fully qualified class or interface
+  name; matching uses `instanceof`, so subclasses/implementations are covered
+  automatically, and a configured class that doesn't exist (e.g. an optional bundle
+  that isn't installed) is skipped silently.
+- `blocked_functions`/`allowed_functions` accept exact Twig function names (as used
+  in a template, e.g. `pimcore_user`) and are matched by string comparison.
+- The object and function mechanisms are independent - switching one to allowlist
+  mode does not affect the other. Both are independent from the `tags` / `filters`
+  allowlists, which still apply as before.
 - Changing these settings requires clearing the Symfony container cache
   (`bin/console cache:clear`) since the security policy is wired as a container
   parameter.

--- a/lib/Twig/Sandbox/SecurityPolicy.php
+++ b/lib/Twig/Sandbox/SecurityPolicy.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
 
 namespace Pimcore\Twig\Sandbox;
 
-use PDO;
-use PDOStatement;
 use Twig\Sandbox\SecurityNotAllowedFilterError;
 use Twig\Sandbox\SecurityNotAllowedFunctionError;
 use Twig\Sandbox\SecurityNotAllowedMethodError;
@@ -30,65 +28,6 @@ use Twig\Sandbox\SecurityPolicyInterface;
  */
 final class SecurityPolicy implements SecurityPolicyInterface
 {
-    /**
-     * Default classes whose instances must not be traversable from Twig templates.
-     * Method calls and property accesses on objects that are instances of any of these
-     * classes will throw, preventing templates from traversing into
-     * database or infrastructure layers (e.g. object.getDao().db.fetchOne(...)).
-     *
-     * This is the fallback denylist used when no allowed classes are configured. It stays
-     * as a private constant (rather than a configurable default) so that a site cannot
-     * accidentally weaken it via config merging - use the `blocked_classes` config option
-     * to extend it, or `allowed_classes` to replace this denylist model with an allowlist.
-     */
-    private const BLOCKED_CLASSES = [
-        \Pimcore\Model\Dao\AbstractDao::class,
-        \Doctrine\DBAL\Connection::class,
-        PDO::class,
-        PDOStatement::class,
-        \Symfony\Component\DependencyInjection\ContainerInterface::class,
-        \Symfony\Component\Process\Process::class,
-        \Pimcore\Model\User::class,
-    ];
-
-    /**
-     * Methods that must never be callable from a Twig template on an instance of the given
-     * class, no matter the blocklist/allowlist configuration - unlike BLOCKED_CLASSES/
-     * $blockedClasses/$allowedClasses, this check is not bypassed by allowlist mode. Used for
-     * classes that otherwise stay reachable (e.g. Asset is commonly used in templates for
-     * filename/thumbnail access) but expose a handful of methods that return raw secrets or
-     * file contents.
-     */
-    private const ALWAYS_BLOCKED_METHODS = [
-        \Pimcore\Model\User::class => ['getPassword', 'getPasswordRecoveryToken', 'getTwoFactorAuthentication'],
-        \Pimcore\Model\Asset::class => ['getData', 'getStream', 'getLocalFile', 'getTemporaryFile'],
-    ];
-
-    /**
-     * Default `pimcore_*` functions excluded from the blanket prefix auto-allow, because
-     * they look up and return a live model instance by id/path whose getters can expose
-     * data outside the sandboxed template's intended scope (e.g. `pimcore_user(1)`,
-     * `pimcore_asset(id)`).
-     *
-     * Use the `blocked_functions` config option to extend this denylist.
-     */
-    private const BLOCKED_FUNCTIONS = [
-        'pimcore_asset',
-        'pimcore_asset_by_path',
-        'pimcore_document',
-        'pimcore_document_by_path',
-        'pimcore_document_wrap_hardlink',
-        'pimcore_object',
-        'pimcore_object_by_path',
-        'pimcore_object_classificationstore_group',
-        'pimcore_object_brick_definition_key',
-        'pimcore_site',
-        'pimcore_site_by_root_id',
-        'pimcore_site_by_domain',
-        'pimcore_site_current',
-        'pimcore_user',
-    ];
-
     private array $allowedTags;
 
     private array $allowedFilters;
@@ -100,7 +39,9 @@ final class SecurityPolicy implements SecurityPolicyInterface
     private array $allowedFunctions;
 
     /**
-     * Additional classes to deny, on top of the built-in BLOCKED_CLASSES. Ignored
+     * Classes to deny - includes Pimcore's built-in denylist (database/infrastructure
+     * layer, `Pimcore\Model\User`) via the `sandbox_security_policy.blocked_classes`
+     * default in default.yaml, plus whatever a site appends to that same option. Ignored
      * whenever $allowedClasses is non-empty (allowlist mode takes over entirely).
      */
     private array $blockedClasses;
@@ -108,16 +49,29 @@ final class SecurityPolicy implements SecurityPolicyInterface
     /**
      * When non-empty, switches from denylist mode to allowlist mode: only instances of
      * these classes (and their subclasses) may have their methods/properties accessed
-     * from a sandboxed template. Every other object is denied, and the denylist
-     * (BLOCKED_CLASSES + $blockedClasses) is no longer consulted.
+     * from a sandboxed template. Every other object is denied, and $blockedClasses is no
+     * longer consulted.
      */
     private array $allowedClasses;
 
     /**
-     * Additional `pimcore_*` function names to exclude from the prefix auto-allow, on top
-     * of the built-in BLOCKED_FUNCTIONS.
+     * `pimcore_*` function names to exclude from the prefix auto-allow - includes
+     * Pimcore's built-in denylist of id/path lookup functions via the
+     * `sandbox_security_policy.blocked_functions` default in default.yaml, plus whatever
+     * a site appends to that same option.
      */
     private array $blockedFunctions;
+
+    /**
+     * FQCN => method names map. Methods listed here can never be called on a matching
+     * instance from a sandboxed template, no matter the blocklist/allowlist
+     * configuration - unlike $blockedClasses/$allowedClasses, this check is not bypassed
+     * by allowlist mode. Populated via the `sandbox_security_policy.hard_blocked_methods`
+     * default in default.yaml (secret/content-returning getters such as
+     * `User::getPassword`, `Asset::getData`, ...), extendable by a site via that same
+     * option.
+     */
+    private array $hardBlockedMethods;
 
     public function __construct(
         array $allowedTags = [],
@@ -126,6 +80,7 @@ final class SecurityPolicy implements SecurityPolicyInterface
         array $blockedClasses = [],
         array $allowedClasses = [],
         array $blockedFunctions = [],
+        array $hardBlockedMethods = [],
     ) {
         $this->allowedTags = $allowedTags;
         $this->allowedFilters = $allowedFilters;
@@ -133,6 +88,7 @@ final class SecurityPolicy implements SecurityPolicyInterface
         $this->blockedClasses = $blockedClasses;
         $this->allowedClasses = $allowedClasses;
         $this->blockedFunctions = $blockedFunctions;
+        $this->hardBlockedMethods = $hardBlockedMethods;
     }
 
     public function setAllowedTags(array $tags): void
@@ -163,6 +119,11 @@ final class SecurityPolicy implements SecurityPolicyInterface
     public function setBlockedFunctions(array $blockedFunctions): void
     {
         $this->blockedFunctions = $blockedFunctions;
+    }
+
+    public function setHardBlockedMethods(array $hardBlockedMethods): void
+    {
+        $this->hardBlockedMethods = $hardBlockedMethods;
     }
 
     /**
@@ -211,7 +172,7 @@ final class SecurityPolicy implements SecurityPolicyInterface
      */
     public function checkMethodAllowed($obj, $method): void
     {
-        $this->assertNotAlwaysBlockedMethod($obj, $method);
+        $this->assertNotHardBlockedMethod($obj, $method);
 
         if ($this->isAllowlistMode()) {
             if (!$this->matchesAnyClass($obj, $this->allowedClasses)) {
@@ -227,7 +188,7 @@ final class SecurityPolicy implements SecurityPolicyInterface
             return;
         }
 
-        if ($this->matchesAnyClass($obj, [...self::BLOCKED_CLASSES, ...$this->blockedClasses])) {
+        if ($this->matchesAnyClass($obj, $this->blockedClasses)) {
             $class = $obj::class;
 
             throw new SecurityNotAllowedMethodError(
@@ -258,7 +219,7 @@ final class SecurityPolicy implements SecurityPolicyInterface
             return;
         }
 
-        if ($this->matchesAnyClass($obj, [...self::BLOCKED_CLASSES, ...$this->blockedClasses])) {
+        if ($this->matchesAnyClass($obj, $this->blockedClasses)) {
             $class = $obj::class;
 
             throw new SecurityNotAllowedPropertyError(
@@ -274,16 +235,16 @@ final class SecurityPolicy implements SecurityPolicyInterface
      */
     private function isPimcoreFunctionAllowed(string $function): bool
     {
-        return !in_array($function, [...self::BLOCKED_FUNCTIONS, ...$this->blockedFunctions], true);
+        return !in_array($function, $this->blockedFunctions, true);
     }
 
     /**
      * @param object $obj
      * @param string $method
      */
-    private function assertNotAlwaysBlockedMethod($obj, $method): void
+    private function assertNotHardBlockedMethod($obj, $method): void
     {
-        foreach (self::ALWAYS_BLOCKED_METHODS as $class => $methods) {
+        foreach ($this->hardBlockedMethods as $class => $methods) {
             if (!class_exists($class, false) && !interface_exists($class, false)) {
                 continue;
             }

--- a/lib/Twig/Sandbox/SecurityPolicy.php
+++ b/lib/Twig/Sandbox/SecurityPolicy.php
@@ -60,7 +60,7 @@ final class SecurityPolicy implements SecurityPolicyInterface
      * file contents.
      */
     private const ALWAYS_BLOCKED_METHODS = [
-        \Pimcore\Model\User::class => ['getPassword', 'getPasswordRecoveryToken'],
+        \Pimcore\Model\User::class => ['getPassword', 'getPasswordRecoveryToken', 'getTwoFactorAuthentication'],
         \Pimcore\Model\Asset::class => ['getData', 'getStream', 'getLocalFile', 'getTemporaryFile'],
     ];
 

--- a/lib/Twig/Sandbox/SecurityPolicy.php
+++ b/lib/Twig/Sandbox/SecurityPolicy.php
@@ -70,10 +70,7 @@ final class SecurityPolicy implements SecurityPolicyInterface
      * data outside the sandboxed template's intended scope (e.g. `pimcore_user(1)`,
      * `pimcore_asset(id)`).
      *
-     * This is the fallback denylist consulted while $allowedPimcoreFunctions is empty - use
-     * the `blocked_functions` config option to extend it, or `allowed_functions` to replace
-     * the prefix auto-allow with an explicit allowlist instead. Mirrors BLOCKED_CLASSES /
-     * `blocked_classes` / `allowed_classes` for object access.
+     * Use the `blocked_functions` config option to extend this denylist.
      */
     private const BLOCKED_FUNCTIONS = [
         'pimcore_asset',
@@ -97,8 +94,8 @@ final class SecurityPolicy implements SecurityPolicyInterface
     private array $allowedFilters;
 
     /**
-     * Explicitly allowed functions - always allowed, regardless of blocked/allowed_functions
-     * mode, in addition to whatever the `pimcore_*` prefix rule permits.
+     * Explicitly allowed functions - always allowed, in addition to whatever the
+     * `pimcore_*` prefix rule permits.
      */
     private array $allowedFunctions;
 
@@ -118,18 +115,9 @@ final class SecurityPolicy implements SecurityPolicyInterface
 
     /**
      * Additional `pimcore_*` function names to exclude from the prefix auto-allow, on top
-     * of the built-in BLOCKED_FUNCTIONS. Ignored whenever $allowedPimcoreFunctions is
-     * non-empty (allowlist mode takes over entirely).
+     * of the built-in BLOCKED_FUNCTIONS.
      */
     private array $blockedFunctions;
-
-    /**
-     * When non-empty, switches the `pimcore_*` prefix rule from denylist mode to allowlist
-     * mode: only the listed `pimcore_*` functions (plus whatever is in $allowedFunctions)
-     * are callable from a sandboxed template. Every other `pimcore_*` function is denied,
-     * and the denylist (BLOCKED_FUNCTIONS + $blockedFunctions) is no longer consulted.
-     */
-    private array $allowedPimcoreFunctions;
 
     public function __construct(
         array $allowedTags = [],
@@ -138,7 +126,6 @@ final class SecurityPolicy implements SecurityPolicyInterface
         array $blockedClasses = [],
         array $allowedClasses = [],
         array $blockedFunctions = [],
-        array $allowedPimcoreFunctions = [],
     ) {
         $this->allowedTags = $allowedTags;
         $this->allowedFilters = $allowedFilters;
@@ -146,7 +133,6 @@ final class SecurityPolicy implements SecurityPolicyInterface
         $this->blockedClasses = $blockedClasses;
         $this->allowedClasses = $allowedClasses;
         $this->blockedFunctions = $blockedFunctions;
-        $this->allowedPimcoreFunctions = $allowedPimcoreFunctions;
     }
 
     public function setAllowedTags(array $tags): void
@@ -179,11 +165,6 @@ final class SecurityPolicy implements SecurityPolicyInterface
         $this->blockedFunctions = $blockedFunctions;
     }
 
-    public function setAllowedPimcoreFunctions(array $allowedPimcoreFunctions): void
-    {
-        $this->allowedPimcoreFunctions = $allowedPimcoreFunctions;
-    }
-
     /**
      * True once at least one class has been configured in the allowlist. In that mode
      * the denylist (built-in + configured) is bypassed entirely: only allowlisted
@@ -192,17 +173,6 @@ final class SecurityPolicy implements SecurityPolicyInterface
     private function isAllowlistMode(): bool
     {
         return [] !== $this->allowedClasses;
-    }
-
-    /**
-     * True once at least one `pimcore_*` function has been configured in
-     * $allowedPimcoreFunctions. In that mode the `pimcore_*` prefix denylist (built-in +
-     * configured) is bypassed entirely: only allowlisted `pimcore_*` functions remain
-     * callable from sandboxed templates.
-     */
-    private function isPimcoreFunctionAllowlistMode(): bool
-    {
-        return [] !== $this->allowedPimcoreFunctions;
     }
 
     /**
@@ -304,10 +274,6 @@ final class SecurityPolicy implements SecurityPolicyInterface
      */
     private function isPimcoreFunctionAllowed(string $function): bool
     {
-        if ($this->isPimcoreFunctionAllowlistMode()) {
-            return in_array($function, $this->allowedPimcoreFunctions, true);
-        }
-
         return !in_array($function, [...self::BLOCKED_FUNCTIONS, ...$this->blockedFunctions], true);
     }
 

--- a/lib/Twig/Sandbox/SecurityPolicy.php
+++ b/lib/Twig/Sandbox/SecurityPolicy.php
@@ -31,10 +31,15 @@ use Twig\Sandbox\SecurityPolicyInterface;
 final class SecurityPolicy implements SecurityPolicyInterface
 {
     /**
-     * Classes whose instances must not be traversable from Twig templates.
+     * Default classes whose instances must not be traversable from Twig templates.
      * Method calls and property accesses on objects that are instances of any of these
      * classes will throw, preventing templates from traversing into
      * database or infrastructure layers (e.g. object.getDao().db.fetchOne(...)).
+     *
+     * This is the fallback denylist used when no allowed classes are configured. It stays
+     * as a private constant (rather than a configurable default) so that a site cannot
+     * accidentally weaken it via config merging - use the `blocked_classes` config option
+     * to extend it, or `allowed_classes` to replace this denylist model with an allowlist.
      */
     private const BLOCKED_CLASSES = [
         \Pimcore\Model\Dao\AbstractDao::class,
@@ -51,11 +56,32 @@ final class SecurityPolicy implements SecurityPolicyInterface
 
     private array $allowedFunctions;
 
-    public function __construct(array $allowedTags = [], array $allowedFilters = [], array $allowedFunctions = [])
-    {
+    /**
+     * Additional classes to deny, on top of the built-in BLOCKED_CLASSES. Ignored
+     * whenever $allowedClasses is non-empty (allowlist mode takes over entirely).
+     */
+    private array $blockedClasses;
+
+    /**
+     * When non-empty, switches from denylist mode to allowlist mode: only instances of
+     * these classes (and their subclasses) may have their methods/properties accessed
+     * from a sandboxed template. Every other object is denied, and the denylist
+     * (BLOCKED_CLASSES + $blockedClasses) is no longer consulted.
+     */
+    private array $allowedClasses;
+
+    public function __construct(
+        array $allowedTags = [],
+        array $allowedFilters = [],
+        array $allowedFunctions = [],
+        array $blockedClasses = [],
+        array $allowedClasses = [],
+    ) {
         $this->allowedTags = $allowedTags;
         $this->allowedFilters = $allowedFilters;
         $this->allowedFunctions = $allowedFunctions;
+        $this->blockedClasses = $blockedClasses;
+        $this->allowedClasses = $allowedClasses;
     }
 
     public function setAllowedTags(array $tags): void
@@ -71,6 +97,26 @@ final class SecurityPolicy implements SecurityPolicyInterface
     public function setAllowedFunctions(array $functions): void
     {
         $this->allowedFunctions = $functions;
+    }
+
+    public function setBlockedClasses(array $blockedClasses): void
+    {
+        $this->blockedClasses = $blockedClasses;
+    }
+
+    public function setAllowedClasses(array $allowedClasses): void
+    {
+        $this->allowedClasses = $allowedClasses;
+    }
+
+    /**
+     * True once at least one class has been configured in the allowlist. In that mode
+     * the denylist (built-in + configured) is bypassed entirely: only allowlisted
+     * classes are reachable from sandboxed templates.
+     */
+    private function isAllowlistMode(): bool
+    {
+        return [] !== $this->allowedClasses;
     }
 
     /**
@@ -106,12 +152,8 @@ final class SecurityPolicy implements SecurityPolicyInterface
      */
     public function checkMethodAllowed($obj, $method): void
     {
-        foreach (self::BLOCKED_CLASSES as $blocked) {
-            if (!class_exists($blocked, false) && !interface_exists($blocked, false)) {
-                continue;
-            }
-
-            if ($obj instanceof $blocked) {
+        if ($this->isAllowlistMode()) {
+            if (!$this->matchesAnyClass($obj, $this->allowedClasses)) {
                 $class = $obj::class;
 
                 throw new SecurityNotAllowedMethodError(
@@ -120,6 +162,18 @@ final class SecurityPolicy implements SecurityPolicyInterface
                     $method,
                 );
             }
+
+            return;
+        }
+
+        if ($this->matchesAnyClass($obj, [...self::BLOCKED_CLASSES, ...$this->blockedClasses])) {
+            $class = $obj::class;
+
+            throw new SecurityNotAllowedMethodError(
+                sprintf('Calling method "%s" on "%s" is not allowed in templates.', $method, $class),
+                $class,
+                $method,
+            );
         }
     }
 
@@ -129,12 +183,8 @@ final class SecurityPolicy implements SecurityPolicyInterface
      */
     public function checkPropertyAllowed($obj, $property): void
     {
-        foreach (self::BLOCKED_CLASSES as $blocked) {
-            if (!class_exists($blocked, false) && !interface_exists($blocked, false)) {
-                continue;
-            }
-
-            if ($obj instanceof $blocked) {
+        if ($this->isAllowlistMode()) {
+            if (!$this->matchesAnyClass($obj, $this->allowedClasses)) {
                 $class = $obj::class;
 
                 throw new SecurityNotAllowedPropertyError(
@@ -143,6 +193,37 @@ final class SecurityPolicy implements SecurityPolicyInterface
                     $property,
                 );
             }
+
+            return;
         }
+
+        if ($this->matchesAnyClass($obj, [...self::BLOCKED_CLASSES, ...$this->blockedClasses])) {
+            $class = $obj::class;
+
+            throw new SecurityNotAllowedPropertyError(
+                sprintf('Accessing property "%s" on "%s" is not allowed in templates.', $property, $class),
+                $class,
+                $property,
+            );
+        }
+    }
+
+    /**
+     * @param object $obj
+     * @param string[] $classes
+     */
+    private function matchesAnyClass($obj, array $classes): bool
+    {
+        foreach ($classes as $candidate) {
+            if (!class_exists($candidate, false) && !interface_exists($candidate, false)) {
+                continue;
+            }
+
+            if ($obj instanceof $candidate) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/lib/Twig/Sandbox/SecurityPolicy.php
+++ b/lib/Twig/Sandbox/SecurityPolicy.php
@@ -64,10 +64,42 @@ final class SecurityPolicy implements SecurityPolicyInterface
         \Pimcore\Model\Asset::class => ['getData', 'getStream', 'getLocalFile', 'getTemporaryFile'],
     ];
 
+    /**
+     * Default `pimcore_*` functions excluded from the blanket prefix auto-allow, because
+     * they look up and return a live model instance by id/path whose getters can expose
+     * data outside the sandboxed template's intended scope (e.g. `pimcore_user(1)`,
+     * `pimcore_asset(id)`).
+     *
+     * This is the fallback denylist consulted while $allowedPimcoreFunctions is empty - use
+     * the `blocked_functions` config option to extend it, or `allowed_functions` to replace
+     * the prefix auto-allow with an explicit allowlist instead. Mirrors BLOCKED_CLASSES /
+     * `blocked_classes` / `allowed_classes` for object access.
+     */
+    private const BLOCKED_FUNCTIONS = [
+        'pimcore_asset',
+        'pimcore_asset_by_path',
+        'pimcore_document',
+        'pimcore_document_by_path',
+        'pimcore_document_wrap_hardlink',
+        'pimcore_object',
+        'pimcore_object_by_path',
+        'pimcore_object_classificationstore_group',
+        'pimcore_object_brick_definition_key',
+        'pimcore_site',
+        'pimcore_site_by_root_id',
+        'pimcore_site_by_domain',
+        'pimcore_site_current',
+        'pimcore_user',
+    ];
+
     private array $allowedTags;
 
     private array $allowedFilters;
 
+    /**
+     * Explicitly allowed functions - always allowed, regardless of blocked/allowed_functions
+     * mode, in addition to whatever the `pimcore_*` prefix rule permits.
+     */
     private array $allowedFunctions;
 
     /**
@@ -84,18 +116,37 @@ final class SecurityPolicy implements SecurityPolicyInterface
      */
     private array $allowedClasses;
 
+    /**
+     * Additional `pimcore_*` function names to exclude from the prefix auto-allow, on top
+     * of the built-in BLOCKED_FUNCTIONS. Ignored whenever $allowedPimcoreFunctions is
+     * non-empty (allowlist mode takes over entirely).
+     */
+    private array $blockedFunctions;
+
+    /**
+     * When non-empty, switches the `pimcore_*` prefix rule from denylist mode to allowlist
+     * mode: only the listed `pimcore_*` functions (plus whatever is in $allowedFunctions)
+     * are callable from a sandboxed template. Every other `pimcore_*` function is denied,
+     * and the denylist (BLOCKED_FUNCTIONS + $blockedFunctions) is no longer consulted.
+     */
+    private array $allowedPimcoreFunctions;
+
     public function __construct(
         array $allowedTags = [],
         array $allowedFilters = [],
         array $allowedFunctions = [],
         array $blockedClasses = [],
         array $allowedClasses = [],
+        array $blockedFunctions = [],
+        array $allowedPimcoreFunctions = [],
     ) {
         $this->allowedTags = $allowedTags;
         $this->allowedFilters = $allowedFilters;
         $this->allowedFunctions = $allowedFunctions;
         $this->blockedClasses = $blockedClasses;
         $this->allowedClasses = $allowedClasses;
+        $this->blockedFunctions = $blockedFunctions;
+        $this->allowedPimcoreFunctions = $allowedPimcoreFunctions;
     }
 
     public function setAllowedTags(array $tags): void
@@ -123,6 +174,16 @@ final class SecurityPolicy implements SecurityPolicyInterface
         $this->allowedClasses = $allowedClasses;
     }
 
+    public function setBlockedFunctions(array $blockedFunctions): void
+    {
+        $this->blockedFunctions = $blockedFunctions;
+    }
+
+    public function setAllowedPimcoreFunctions(array $allowedPimcoreFunctions): void
+    {
+        $this->allowedPimcoreFunctions = $allowedPimcoreFunctions;
+    }
+
     /**
      * True once at least one class has been configured in the allowlist. In that mode
      * the denylist (built-in + configured) is bypassed entirely: only allowlisted
@@ -131,6 +192,17 @@ final class SecurityPolicy implements SecurityPolicyInterface
     private function isAllowlistMode(): bool
     {
         return [] !== $this->allowedClasses;
+    }
+
+    /**
+     * True once at least one `pimcore_*` function has been configured in
+     * $allowedPimcoreFunctions. In that mode the `pimcore_*` prefix denylist (built-in +
+     * configured) is bypassed entirely: only allowlisted `pimcore_*` functions remain
+     * callable from sandboxed templates.
+     */
+    private function isPimcoreFunctionAllowlistMode(): bool
+    {
+        return [] !== $this->allowedPimcoreFunctions;
     }
 
     /**
@@ -153,8 +225,11 @@ final class SecurityPolicy implements SecurityPolicyInterface
         }
 
         foreach ($functions as $function) {
-            // check if a function is allowed or a Pimcore Twig function
-            if (!in_array($function, $this->allowedFunctions) && !str_starts_with($function, 'pimcore_')) {
+            if (in_array($function, $this->allowedFunctions, true)) {
+                continue;
+            }
+
+            if (!str_starts_with($function, 'pimcore_') || !$this->isPimcoreFunctionAllowed($function)) {
                 throw new SecurityNotAllowedFunctionError(sprintf('Function "%s" is not allowed.', $function), $function);
             }
         }
@@ -222,6 +297,18 @@ final class SecurityPolicy implements SecurityPolicyInterface
                 $property,
             );
         }
+    }
+
+    /**
+     * @param string $function a function name already known to start with `pimcore_`
+     */
+    private function isPimcoreFunctionAllowed(string $function): bool
+    {
+        if ($this->isPimcoreFunctionAllowlistMode()) {
+            return in_array($function, $this->allowedPimcoreFunctions, true);
+        }
+
+        return !in_array($function, [...self::BLOCKED_FUNCTIONS, ...$this->blockedFunctions], true);
     }
 
     /**

--- a/lib/Twig/Sandbox/SecurityPolicy.php
+++ b/lib/Twig/Sandbox/SecurityPolicy.php
@@ -48,6 +48,20 @@ final class SecurityPolicy implements SecurityPolicyInterface
         PDOStatement::class,
         \Symfony\Component\DependencyInjection\ContainerInterface::class,
         \Symfony\Component\Process\Process::class,
+        \Pimcore\Model\User::class,
+    ];
+
+    /**
+     * Methods that must never be callable from a Twig template on an instance of the given
+     * class, no matter the blocklist/allowlist configuration - unlike BLOCKED_CLASSES/
+     * $blockedClasses/$allowedClasses, this check is not bypassed by allowlist mode. Used for
+     * classes that otherwise stay reachable (e.g. Asset is commonly used in templates for
+     * filename/thumbnail access) but expose a handful of methods that return raw secrets or
+     * file contents.
+     */
+    private const ALWAYS_BLOCKED_METHODS = [
+        \Pimcore\Model\User::class => ['getPassword', 'getPasswordRecoveryToken'],
+        \Pimcore\Model\Asset::class => ['getData', 'getStream', 'getLocalFile', 'getTemporaryFile'],
     ];
 
     private array $allowedTags;
@@ -152,6 +166,8 @@ final class SecurityPolicy implements SecurityPolicyInterface
      */
     public function checkMethodAllowed($obj, $method): void
     {
+        $this->assertNotAlwaysBlockedMethod($obj, $method);
+
         if ($this->isAllowlistMode()) {
             if (!$this->matchesAnyClass($obj, $this->allowedClasses)) {
                 $class = $obj::class;
@@ -205,6 +221,29 @@ final class SecurityPolicy implements SecurityPolicyInterface
                 $class,
                 $property,
             );
+        }
+    }
+
+    /**
+     * @param object $obj
+     * @param string $method
+     */
+    private function assertNotAlwaysBlockedMethod($obj, $method): void
+    {
+        foreach (self::ALWAYS_BLOCKED_METHODS as $class => $methods) {
+            if (!class_exists($class, false) && !interface_exists($class, false)) {
+                continue;
+            }
+
+            if ($obj instanceof $class && in_array($method, $methods, true)) {
+                $objClass = $obj::class;
+
+                throw new SecurityNotAllowedMethodError(
+                    sprintf('Calling method "%s" on "%s" is not allowed in templates.', $method, $objClass),
+                    $objClass,
+                    $method,
+                );
+            }
         }
     }
 

--- a/tests/Unit/Twig/Sandbox/SecurityPolicyTest.php
+++ b/tests/Unit/Twig/Sandbox/SecurityPolicyTest.php
@@ -103,14 +103,28 @@ final class SecurityPolicyTest extends TestCase
         $policy->checkMethodAllowed(new stdClass(), 'anything');
     }
 
-    public function testUserIsBlockedByDefault(): void
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function userSecretMethodsProvider(): iterable
     {
-        // GHSA-7gfm-v2fx-xrxm: User::getPassword()/getPasswordRecoveryToken() must not be
-        // template-reachable. The whole class is blocked by default (defense in depth).
+        yield 'getPassword' => ['getPassword'];
+        yield 'getPasswordRecoveryToken' => ['getPasswordRecoveryToken'];
+        yield 'getTwoFactorAuthentication' => ['getTwoFactorAuthentication'];
+    }
+
+    /**
+     * @dataProvider userSecretMethodsProvider
+     */
+    public function testUserIsBlockedByDefault(string $method): void
+    {
+        // GHSA-7gfm-v2fx-xrxm: User::getPassword()/getPasswordRecoveryToken() and
+        // getTwoFactorAuthentication() (returns the MFA secret, models/User.php:679) must
+        // not be template-reachable. The whole class is blocked by default (defense in depth).
         $policy = new SecurityPolicy();
 
         $this->expectException(SecurityNotAllowedMethodError::class);
-        $policy->checkMethodAllowed(new User(), 'getPassword');
+        $policy->checkMethodAllowed(new User(), $method);
     }
 
     public function testUserPropertyAccessIsBlockedByDefault(): void
@@ -155,14 +169,18 @@ final class SecurityPolicyTest extends TestCase
         $this->addToAssertionCount(2);
     }
 
-    public function testAlwaysBlockedMethodsSurviveAllowlistModeForUser(): void
+    /**
+     * @dataProvider userSecretMethodsProvider
+     */
+    public function testAlwaysBlockedMethodsSurviveAllowlistModeForUser(string $method): void
     {
         // Even if a site explicitly allowlists User (e.g. to expose getFirstname()), the
-        // secret-returning methods must remain unreachable.
+        // secret-returning methods - including getTwoFactorAuthentication(), which returns
+        // the MFA secret - must remain unreachable.
         $policy = new SecurityPolicy(allowedClasses: [User::class]);
 
         $this->expectException(SecurityNotAllowedMethodError::class);
-        $policy->checkMethodAllowed(new User(), 'getPasswordRecoveryToken');
+        $policy->checkMethodAllowed(new User(), $method);
     }
 
     public function testAlwaysBlockedMethodsSurviveAllowlistModeForAsset(): void

--- a/tests/Unit/Twig/Sandbox/SecurityPolicyTest.php
+++ b/tests/Unit/Twig/Sandbox/SecurityPolicyTest.php
@@ -21,6 +21,7 @@ use Pimcore\Model\Asset;
 use Pimcore\Model\User;
 use Pimcore\Twig\Sandbox\SecurityPolicy;
 use stdClass;
+use Twig\Sandbox\SecurityNotAllowedFunctionError;
 use Twig\Sandbox\SecurityNotAllowedMethodError;
 use Twig\Sandbox\SecurityNotAllowedPropertyError;
 
@@ -174,5 +175,115 @@ final class SecurityPolicyTest extends TestCase
         // ... but getData is hard-blocked regardless.
         $this->expectException(SecurityNotAllowedMethodError::class);
         $policy->checkMethodAllowed(new Asset(), 'getData');
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function idLookupPimcoreFunctionsProvider(): iterable
+    {
+        yield 'pimcore_asset' => ['pimcore_asset'];
+        yield 'pimcore_asset_by_path' => ['pimcore_asset_by_path'];
+        yield 'pimcore_document' => ['pimcore_document'];
+        yield 'pimcore_document_by_path' => ['pimcore_document_by_path'];
+        yield 'pimcore_document_wrap_hardlink' => ['pimcore_document_wrap_hardlink'];
+        yield 'pimcore_object' => ['pimcore_object'];
+        yield 'pimcore_object_by_path' => ['pimcore_object_by_path'];
+        yield 'pimcore_object_classificationstore_group' => ['pimcore_object_classificationstore_group'];
+        yield 'pimcore_object_brick_definition_key' => ['pimcore_object_brick_definition_key'];
+        yield 'pimcore_site' => ['pimcore_site'];
+        yield 'pimcore_site_by_root_id' => ['pimcore_site_by_root_id'];
+        yield 'pimcore_site_by_domain' => ['pimcore_site_by_domain'];
+        yield 'pimcore_site_current' => ['pimcore_site_current'];
+        yield 'pimcore_user' => ['pimcore_user'];
+    }
+
+    #[DataProvider('idLookupPimcoreFunctionsProvider')]
+    public function testIdLookupPimcoreFunctionsAreNotAutoAllowedByDefault(string $function): void
+    {
+        // GHSA-7gfm-v2fx-xrxm remediation #3: the pimcore_* auto-allow must not cover
+        // functions that hand back a live model instance looked up by id/path.
+        $policy = new SecurityPolicy();
+
+        $this->expectException(SecurityNotAllowedFunctionError::class);
+        $policy->checkSecurity([], [], [$function]);
+    }
+
+    public function testIdLookupPimcoreFunctionCanBeExplicitlyAllowed(): void
+    {
+        $policy = new SecurityPolicy(allowedFunctions: ['pimcore_user']);
+
+        // no exception expected
+        $policy->checkSecurity([], [], ['pimcore_user']);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testOtherPimcoreFunctionsRemainAutoAllowedByDefault(): void
+    {
+        $policy = new SecurityPolicy();
+
+        // a rendering/helper pimcore_* function not on the explicit-allow list
+        $policy->checkSecurity([], [], ['pimcore_dump']);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testNonPimcoreFunctionsStillRequireExplicitAllow(): void
+    {
+        $policy = new SecurityPolicy();
+
+        $this->expectException(SecurityNotAllowedFunctionError::class);
+        $policy->checkSecurity([], [], ['file_get_contents']);
+    }
+
+    public function testBlockedFunctionsExtendsTheBuiltInDenylist(): void
+    {
+        $policy = new SecurityPolicy(blockedFunctions: ['pimcore_dump']);
+
+        $this->expectException(SecurityNotAllowedFunctionError::class);
+        $policy->checkSecurity([], [], ['pimcore_dump']);
+    }
+
+    public function testAllowedFunctionsSwitchesToAllowlistModeAndDeactivatesDenylist(): void
+    {
+        // A non-empty allow list must take over completely: a pimcore_* function normally
+        // blocked by the built-in denylist is allowed once it is itself allowlisted.
+        $policy = new SecurityPolicy(allowedPimcoreFunctions: ['pimcore_user']);
+
+        $policy->checkSecurity([], [], ['pimcore_user']);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testAllowlistModeDeniesPimcoreFunctionsNotOnTheAllowlist(): void
+    {
+        // In allowlist mode the prefix auto-allow is fully deactivated: even a function
+        // that was previously auto-allowed (not on the built-in denylist) is now denied
+        // unless explicitly listed.
+        $policy = new SecurityPolicy(allowedPimcoreFunctions: ['pimcore_user']);
+
+        $this->expectException(SecurityNotAllowedFunctionError::class);
+        $policy->checkSecurity([], [], ['pimcore_dump']);
+    }
+
+    public function testAllowedFunctionsIsIndependentOfTheGeneralFunctionsAllowlist(): void
+    {
+        // $allowedFunctions (the pre-existing `functions` config) keeps working
+        // unconditionally, in either mode.
+        $policy = new SecurityPolicy(allowedFunctions: ['path'], allowedPimcoreFunctions: ['pimcore_user']);
+
+        $policy->checkSecurity([], [], ['path']);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testSetBlockedFunctionsAndSetAllowedPimcoreFunctionsSwitchModeAtRuntime(): void
+    {
+        $policy = new SecurityPolicy();
+
+        // starts in denylist mode: a non-denylisted pimcore_* function is auto-allowed
+        $policy->checkSecurity([], [], ['pimcore_dump']);
+
+        $policy->setAllowedPimcoreFunctions(['pimcore_user']);
+
+        $this->expectException(SecurityNotAllowedFunctionError::class);
+        $policy->checkSecurity([], [], ['pimcore_dump']);
     }
 }

--- a/tests/Unit/Twig/Sandbox/SecurityPolicyTest.php
+++ b/tests/Unit/Twig/Sandbox/SecurityPolicyTest.php
@@ -254,9 +254,16 @@ final class SecurityPolicyTest extends TestCase
     }
 
     /**
+     * All `pimcore_*` id/path lookup functions - each hands back a live model instance
+     * looked up by an arbitrary id/path (GHSA-7gfm-v2fx-xrxm remediation #3). Only
+     * `pimcore_user` ships blocked by default (see testPimcoreUserIsNotAutoAllowedByDefault());
+     * the rest are shipped commented out in default.yaml's `blocked_functions` and are
+     * covered here to confirm they still block correctly once a site re-adds them for a
+     * high-security setup (doc/26_Best_Practice/80_Twig_Sandbox_Object_Access.md).
+     *
      * @return iterable<string, array{string}>
      */
-    public static function idLookupPimcoreFunctionsProvider(): iterable
+    public static function allIdLookupPimcoreFunctionsProvider(): iterable
     {
         yield 'pimcore_asset' => ['pimcore_asset'];
         yield 'pimcore_asset_by_path' => ['pimcore_asset_by_path'];
@@ -275,13 +282,66 @@ final class SecurityPolicyTest extends TestCase
     }
 
     /**
-     * @dataProvider idLookupPimcoreFunctionsProvider
+     * Same list as allIdLookupPimcoreFunctionsProvider() minus pimcore_user, which is
+     * the only one still blocked by default.
+     *
+     * @return iterable<string, array{string}>
      */
-    public function testIdLookupPimcoreFunctionsAreNotAutoAllowedByDefault(string $function): void
+    public static function idLookupPimcoreFunctionsAutoAllowedByDefaultProvider(): iterable
     {
-        // GHSA-7gfm-v2fx-xrxm remediation #3: the pimcore_* auto-allow must not cover
-        // functions that hand back a live model instance looked up by id/path.
+        yield 'pimcore_asset' => ['pimcore_asset'];
+        yield 'pimcore_asset_by_path' => ['pimcore_asset_by_path'];
+        yield 'pimcore_document' => ['pimcore_document'];
+        yield 'pimcore_document_by_path' => ['pimcore_document_by_path'];
+        yield 'pimcore_document_wrap_hardlink' => ['pimcore_document_wrap_hardlink'];
+        yield 'pimcore_object' => ['pimcore_object'];
+        yield 'pimcore_object_by_path' => ['pimcore_object_by_path'];
+        yield 'pimcore_object_classificationstore_group' => ['pimcore_object_classificationstore_group'];
+        yield 'pimcore_object_brick_definition_key' => ['pimcore_object_brick_definition_key'];
+        yield 'pimcore_site' => ['pimcore_site'];
+        yield 'pimcore_site_by_root_id' => ['pimcore_site_by_root_id'];
+        yield 'pimcore_site_by_domain' => ['pimcore_site_by_domain'];
+        yield 'pimcore_site_current' => ['pimcore_site_current'];
+    }
+
+    public function testPimcoreUserIsNotAutoAllowedByDefault(): void
+    {
+        // GHSA-7gfm-v2fx-xrxm remediation #3: pimcore_user(1) hands back a live User
+        // instance looked up by id - this is the one id/path lookup function still
+        // blocked out of the box.
         $policy = new SecurityPolicy(blockedFunctions: self::defaultSandboxSecurityPolicyConfig()['blocked_functions']);
+
+        $this->expectException(SecurityNotAllowedFunctionError::class);
+        $policy->checkSecurity([], [], ['pimcore_user']);
+    }
+
+    /**
+     * @dataProvider idLookupPimcoreFunctionsAutoAllowedByDefaultProvider
+     */
+    public function testOtherIdLookupPimcoreFunctionsAreAutoAllowedByDefault(string $function): void
+    {
+        // These are shipped commented out in default.yaml's blocked_functions for a
+        // lower-friction default - a high-security setup should re-add them (see
+        // doc/26_Best_Practice/80_Twig_Sandbox_Object_Access.md).
+        $policy = new SecurityPolicy(blockedFunctions: self::defaultSandboxSecurityPolicyConfig()['blocked_functions']);
+
+        // no exception expected - not blocked by default
+        $policy->checkSecurity([], [], [$function]);
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @dataProvider allIdLookupPimcoreFunctionsProvider
+     */
+    public function testIdLookupPimcoreFunctionsCanBeBlockedForHighSecurity(string $function): void
+    {
+        // Confirms the high-security config recommended in
+        // doc/26_Best_Practice/80_Twig_Sandbox_Object_Access.md - re-adding every
+        // id/path lookup function to blocked_functions - still blocks correctly.
+        $policy = new SecurityPolicy(blockedFunctions: array_column(
+            iterator_to_array(self::allIdLookupPimcoreFunctionsProvider()),
+            0,
+        ));
 
         $this->expectException(SecurityNotAllowedFunctionError::class);
         $policy->checkSecurity([], [], [$function]);

--- a/tests/Unit/Twig/Sandbox/SecurityPolicyTest.php
+++ b/tests/Unit/Twig/Sandbox/SecurityPolicyTest.php
@@ -15,7 +15,10 @@ declare(strict_types=1);
 namespace Pimcore\Tests\Unit\Twig\Sandbox;
 
 use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Pimcore\Model\Asset;
+use Pimcore\Model\User;
 use Pimcore\Twig\Sandbox\SecurityPolicy;
 use stdClass;
 use Twig\Sandbox\SecurityNotAllowedMethodError;
@@ -98,5 +101,78 @@ final class SecurityPolicyTest extends TestCase
 
         $this->expectException(SecurityNotAllowedMethodError::class);
         $policy->checkMethodAllowed(new stdClass(), 'anything');
+    }
+
+    public function testUserIsBlockedByDefault(): void
+    {
+        // GHSA-7gfm-v2fx-xrxm: User::getPassword()/getPasswordRecoveryToken() must not be
+        // template-reachable. The whole class is blocked by default (defense in depth).
+        $policy = new SecurityPolicy();
+
+        $this->expectException(SecurityNotAllowedMethodError::class);
+        $policy->checkMethodAllowed(new User(), 'getPassword');
+    }
+
+    public function testUserPropertyAccessIsBlockedByDefault(): void
+    {
+        $policy = new SecurityPolicy();
+
+        $this->expectException(SecurityNotAllowedPropertyError::class);
+        $policy->checkPropertyAllowed(new User(), 'password');
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function assetContentMethodsProvider(): iterable
+    {
+        yield 'getData' => ['getData'];
+        yield 'getStream' => ['getStream'];
+        yield 'getLocalFile' => ['getLocalFile'];
+        yield 'getTemporaryFile' => ['getTemporaryFile'];
+    }
+
+    #[DataProvider('assetContentMethodsProvider')]
+    public function testAssetContentMethodsAreAlwaysBlockedByDefault(string $method): void
+    {
+        // GHSA-7gfm-v2fx-xrxm: Asset stays reachable (needed for filename/thumbnail access
+        // in templates), but its content-returning methods must never be callable.
+        $policy = new SecurityPolicy();
+
+        $this->expectException(SecurityNotAllowedMethodError::class);
+        $policy->checkMethodAllowed(new Asset(), $method);
+    }
+
+    public function testAssetIsOtherwiseReachableByDefault(): void
+    {
+        $policy = new SecurityPolicy();
+
+        // no exception expected: only the content-returning methods are blocked
+        $policy->checkMethodAllowed(new Asset(), 'getId');
+        $policy->checkMethodAllowed(new Asset(), 'getFilename');
+        $this->addToAssertionCount(2);
+    }
+
+    public function testAlwaysBlockedMethodsSurviveAllowlistModeForUser(): void
+    {
+        // Even if a site explicitly allowlists User (e.g. to expose getFirstname()), the
+        // secret-returning methods must remain unreachable.
+        $policy = new SecurityPolicy(allowedClasses: [User::class]);
+
+        $this->expectException(SecurityNotAllowedMethodError::class);
+        $policy->checkMethodAllowed(new User(), 'getPasswordRecoveryToken');
+    }
+
+    public function testAlwaysBlockedMethodsSurviveAllowlistModeForAsset(): void
+    {
+        $policy = new SecurityPolicy(allowedClasses: [Asset::class]);
+
+        // getId remains reachable via the allowlist ...
+        $policy->checkMethodAllowed(new Asset(), 'getId');
+        $this->addToAssertionCount(1);
+
+        // ... but getData is hard-blocked regardless.
+        $this->expectException(SecurityNotAllowedMethodError::class);
+        $policy->checkMethodAllowed(new Asset(), 'getData');
     }
 }

--- a/tests/Unit/Twig/Sandbox/SecurityPolicyTest.php
+++ b/tests/Unit/Twig/Sandbox/SecurityPolicyTest.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace Pimcore\Tests\Unit\Twig\Sandbox;
 
 use PDO;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Pimcore\Model\Asset;
 use Pimcore\Model\User;
@@ -35,7 +34,7 @@ final class SecurityPolicyTest extends TestCase
         $policy = new SecurityPolicy();
 
         $this->expectException(SecurityNotAllowedMethodError::class);
-        $policy->checkMethodAllowed(new PDO('sqlite::memory:'), 'query');
+        $policy->checkMethodAllowed($this->createStub(PDO::class), 'query');
     }
 
     public function testDenylistModeAllowsArbitraryObjectsNotOnTheList(): void
@@ -79,7 +78,7 @@ final class SecurityPolicyTest extends TestCase
         // blocked by the built-in denylist is allowed once it is itself allowlisted.
         $policy = new SecurityPolicy(allowedClasses: [PDO::class]);
 
-        $policy->checkMethodAllowed(new PDO('sqlite::memory:'), 'query');
+        $policy->checkMethodAllowed($this->createStub(PDO::class), 'query');
         $this->addToAssertionCount(1);
     }
 
@@ -88,7 +87,7 @@ final class SecurityPolicyTest extends TestCase
         $policy = new SecurityPolicy(allowedClasses: [stdClass::class]);
 
         $this->expectException(SecurityNotAllowedPropertyError::class);
-        $policy->checkPropertyAllowed(new PDO('sqlite::memory:'), 'secret');
+        $policy->checkPropertyAllowed($this->createStub(PDO::class), 'secret');
     }
 
     public function testSetAllowedClassesSwitchesModeAtRuntime(): void
@@ -133,7 +132,9 @@ final class SecurityPolicyTest extends TestCase
         yield 'getTemporaryFile' => ['getTemporaryFile'];
     }
 
-    #[DataProvider('assetContentMethodsProvider')]
+    /**
+     * @dataProvider assetContentMethodsProvider
+     */
     public function testAssetContentMethodsAreAlwaysBlockedByDefault(string $method): void
     {
         // GHSA-7gfm-v2fx-xrxm: Asset stays reachable (needed for filename/thumbnail access
@@ -198,7 +199,9 @@ final class SecurityPolicyTest extends TestCase
         yield 'pimcore_user' => ['pimcore_user'];
     }
 
-    #[DataProvider('idLookupPimcoreFunctionsProvider')]
+    /**
+     * @dataProvider idLookupPimcoreFunctionsProvider
+     */
     public function testIdLookupPimcoreFunctionsAreNotAutoAllowedByDefault(string $function): void
     {
         // GHSA-7gfm-v2fx-xrxm remediation #3: the pimcore_* auto-allow must not cover

--- a/tests/Unit/Twig/Sandbox/SecurityPolicyTest.php
+++ b/tests/Unit/Twig/Sandbox/SecurityPolicyTest.php
@@ -263,48 +263,4 @@ final class SecurityPolicyTest extends TestCase
         $this->expectException(SecurityNotAllowedFunctionError::class);
         $policy->checkSecurity([], [], ['pimcore_dump']);
     }
-
-    public function testAllowedFunctionsSwitchesToAllowlistModeAndDeactivatesDenylist(): void
-    {
-        // A non-empty allow list must take over completely: a pimcore_* function normally
-        // blocked by the built-in denylist is allowed once it is itself allowlisted.
-        $policy = new SecurityPolicy(allowedPimcoreFunctions: ['pimcore_user']);
-
-        $policy->checkSecurity([], [], ['pimcore_user']);
-        $this->addToAssertionCount(1);
-    }
-
-    public function testAllowlistModeDeniesPimcoreFunctionsNotOnTheAllowlist(): void
-    {
-        // In allowlist mode the prefix auto-allow is fully deactivated: even a function
-        // that was previously auto-allowed (not on the built-in denylist) is now denied
-        // unless explicitly listed.
-        $policy = new SecurityPolicy(allowedPimcoreFunctions: ['pimcore_user']);
-
-        $this->expectException(SecurityNotAllowedFunctionError::class);
-        $policy->checkSecurity([], [], ['pimcore_dump']);
-    }
-
-    public function testAllowedFunctionsIsIndependentOfTheGeneralFunctionsAllowlist(): void
-    {
-        // $allowedFunctions (the pre-existing `functions` config) keeps working
-        // unconditionally, in either mode.
-        $policy = new SecurityPolicy(allowedFunctions: ['path'], allowedPimcoreFunctions: ['pimcore_user']);
-
-        $policy->checkSecurity([], [], ['path']);
-        $this->addToAssertionCount(1);
-    }
-
-    public function testSetBlockedFunctionsAndSetAllowedPimcoreFunctionsSwitchModeAtRuntime(): void
-    {
-        $policy = new SecurityPolicy();
-
-        // starts in denylist mode: a non-denylisted pimcore_* function is auto-allowed
-        $policy->checkSecurity([], [], ['pimcore_dump']);
-
-        $policy->setAllowedPimcoreFunctions(['pimcore_user']);
-
-        $this->expectException(SecurityNotAllowedFunctionError::class);
-        $policy->checkSecurity([], [], ['pimcore_dump']);
-    }
 }

--- a/tests/Unit/Twig/Sandbox/SecurityPolicyTest.php
+++ b/tests/Unit/Twig/Sandbox/SecurityPolicyTest.php
@@ -20,6 +20,7 @@ use Pimcore\Model\Asset;
 use Pimcore\Model\User;
 use Pimcore\Twig\Sandbox\SecurityPolicy;
 use stdClass;
+use Symfony\Component\Yaml\Yaml;
 use Twig\Sandbox\SecurityNotAllowedFunctionError;
 use Twig\Sandbox\SecurityNotAllowedMethodError;
 use Twig\Sandbox\SecurityNotAllowedPropertyError;
@@ -29,9 +30,56 @@ use Twig\Sandbox\SecurityNotAllowedPropertyError;
  */
 final class SecurityPolicyTest extends TestCase
 {
+    /**
+     * The built-in denylists (blocked_classes/blocked_functions/hard_blocked_methods)
+     * live entirely in bundles/CoreBundle/config/pimcore/default.yaml, not in
+     * SecurityPolicy itself - read them from there so the "*ByDefault" tests below
+     * exercise the actual shipped defaults instead of a duplicated PHP fixture.
+     *
+     * @return array{blocked_classes: string[], blocked_functions: string[], hard_blocked_methods: array<string, string[]>}
+     */
+    private static function defaultSandboxSecurityPolicyConfig(): array
+    {
+        static $config = null;
+
+        if (null !== $config) {
+            return $config;
+        }
+
+        $path = __DIR__ . '/../../../../bundles/CoreBundle/config/pimcore/default.yaml';
+        $lines = file($path);
+
+        // Isolate the `templating_engine` block by indentation rather than parsing the
+        // whole file - default.yaml also contains an `!php/const` mapping key elsewhere
+        // (Doctrine connection options) that Symfony\Yaml cannot parse as a plain value.
+        $start = null;
+        $end = count($lines);
+        foreach ($lines as $i => $line) {
+            if (null === $start && str_starts_with($line, '    templating_engine:')) {
+                $start = $i;
+
+                continue;
+            }
+            if (null !== $start && $i > $start && preg_match('/^ {4}\S/', $line)) {
+                $end = $i;
+
+                break;
+            }
+        }
+
+        $fragment = implode('', array_map(
+            static fn (string $line): string => str_starts_with($line, '    ') ? substr($line, 4) : $line,
+            array_slice($lines, $start, $end - $start),
+        ));
+
+        $config = Yaml::parse($fragment)['templating_engine']['twig']['sandbox_security_policy'];
+
+        return $config;
+    }
+
     public function testBuiltInDenylistBlocksInfrastructureClassesByDefault(): void
     {
-        $policy = new SecurityPolicy();
+        $policy = new SecurityPolicy(blockedClasses: self::defaultSandboxSecurityPolicyConfig()['blocked_classes']);
 
         $this->expectException(SecurityNotAllowedMethodError::class);
         $policy->checkMethodAllowed($this->createStub(PDO::class), 'query');
@@ -39,7 +87,7 @@ final class SecurityPolicyTest extends TestCase
 
     public function testDenylistModeAllowsArbitraryObjectsNotOnTheList(): void
     {
-        $policy = new SecurityPolicy();
+        $policy = new SecurityPolicy(blockedClasses: self::defaultSandboxSecurityPolicyConfig()['blocked_classes']);
 
         // no exception expected
         $policy->checkMethodAllowed(new stdClass(), 'anything');
@@ -49,7 +97,10 @@ final class SecurityPolicyTest extends TestCase
 
     public function testBlockedClassesExtendsTheBuiltInDenylist(): void
     {
-        $policy = new SecurityPolicy(blockedClasses: [stdClass::class]);
+        $policy = new SecurityPolicy(blockedClasses: [
+            ...self::defaultSandboxSecurityPolicyConfig()['blocked_classes'],
+            stdClass::class,
+        ]);
 
         $this->expectException(SecurityNotAllowedMethodError::class);
         $policy->checkMethodAllowed(new stdClass(), 'anything');
@@ -121,7 +172,7 @@ final class SecurityPolicyTest extends TestCase
         // GHSA-7gfm-v2fx-xrxm: User::getPassword()/getPasswordRecoveryToken() and
         // getTwoFactorAuthentication() (returns the MFA secret, models/User.php:679) must
         // not be template-reachable. The whole class is blocked by default (defense in depth).
-        $policy = new SecurityPolicy();
+        $policy = new SecurityPolicy(blockedClasses: self::defaultSandboxSecurityPolicyConfig()['blocked_classes']);
 
         $this->expectException(SecurityNotAllowedMethodError::class);
         $policy->checkMethodAllowed(new User(), $method);
@@ -129,7 +180,7 @@ final class SecurityPolicyTest extends TestCase
 
     public function testUserPropertyAccessIsBlockedByDefault(): void
     {
-        $policy = new SecurityPolicy();
+        $policy = new SecurityPolicy(blockedClasses: self::defaultSandboxSecurityPolicyConfig()['blocked_classes']);
 
         $this->expectException(SecurityNotAllowedPropertyError::class);
         $policy->checkPropertyAllowed(new User(), 'password');
@@ -149,11 +200,11 @@ final class SecurityPolicyTest extends TestCase
     /**
      * @dataProvider assetContentMethodsProvider
      */
-    public function testAssetContentMethodsAreAlwaysBlockedByDefault(string $method): void
+    public function testAssetContentMethodsAreHardBlockedByDefault(string $method): void
     {
         // GHSA-7gfm-v2fx-xrxm: Asset stays reachable (needed for filename/thumbnail access
         // in templates), but its content-returning methods must never be callable.
-        $policy = new SecurityPolicy();
+        $policy = new SecurityPolicy(hardBlockedMethods: self::defaultSandboxSecurityPolicyConfig()['hard_blocked_methods']);
 
         $this->expectException(SecurityNotAllowedMethodError::class);
         $policy->checkMethodAllowed(new Asset(), $method);
@@ -161,7 +212,7 @@ final class SecurityPolicyTest extends TestCase
 
     public function testAssetIsOtherwiseReachableByDefault(): void
     {
-        $policy = new SecurityPolicy();
+        $policy = new SecurityPolicy(hardBlockedMethods: self::defaultSandboxSecurityPolicyConfig()['hard_blocked_methods']);
 
         // no exception expected: only the content-returning methods are blocked
         $policy->checkMethodAllowed(new Asset(), 'getId');
@@ -172,20 +223,26 @@ final class SecurityPolicyTest extends TestCase
     /**
      * @dataProvider userSecretMethodsProvider
      */
-    public function testAlwaysBlockedMethodsSurviveAllowlistModeForUser(string $method): void
+    public function testHardBlockedMethodsSurviveAllowlistModeForUser(string $method): void
     {
         // Even if a site explicitly allowlists User (e.g. to expose getFirstname()), the
         // secret-returning methods - including getTwoFactorAuthentication(), which returns
         // the MFA secret - must remain unreachable.
-        $policy = new SecurityPolicy(allowedClasses: [User::class]);
+        $policy = new SecurityPolicy(
+            allowedClasses: [User::class],
+            hardBlockedMethods: self::defaultSandboxSecurityPolicyConfig()['hard_blocked_methods'],
+        );
 
         $this->expectException(SecurityNotAllowedMethodError::class);
         $policy->checkMethodAllowed(new User(), $method);
     }
 
-    public function testAlwaysBlockedMethodsSurviveAllowlistModeForAsset(): void
+    public function testHardBlockedMethodsSurviveAllowlistModeForAsset(): void
     {
-        $policy = new SecurityPolicy(allowedClasses: [Asset::class]);
+        $policy = new SecurityPolicy(
+            allowedClasses: [Asset::class],
+            hardBlockedMethods: self::defaultSandboxSecurityPolicyConfig()['hard_blocked_methods'],
+        );
 
         // getId remains reachable via the allowlist ...
         $policy->checkMethodAllowed(new Asset(), 'getId');
@@ -224,7 +281,7 @@ final class SecurityPolicyTest extends TestCase
     {
         // GHSA-7gfm-v2fx-xrxm remediation #3: the pimcore_* auto-allow must not cover
         // functions that hand back a live model instance looked up by id/path.
-        $policy = new SecurityPolicy();
+        $policy = new SecurityPolicy(blockedFunctions: self::defaultSandboxSecurityPolicyConfig()['blocked_functions']);
 
         $this->expectException(SecurityNotAllowedFunctionError::class);
         $policy->checkSecurity([], [], [$function]);
@@ -241,7 +298,7 @@ final class SecurityPolicyTest extends TestCase
 
     public function testOtherPimcoreFunctionsRemainAutoAllowedByDefault(): void
     {
-        $policy = new SecurityPolicy();
+        $policy = new SecurityPolicy(blockedFunctions: self::defaultSandboxSecurityPolicyConfig()['blocked_functions']);
 
         // a rendering/helper pimcore_* function not on the explicit-allow list
         $policy->checkSecurity([], [], ['pimcore_dump']);
@@ -258,7 +315,10 @@ final class SecurityPolicyTest extends TestCase
 
     public function testBlockedFunctionsExtendsTheBuiltInDenylist(): void
     {
-        $policy = new SecurityPolicy(blockedFunctions: ['pimcore_dump']);
+        $policy = new SecurityPolicy(blockedFunctions: [
+            ...self::defaultSandboxSecurityPolicyConfig()['blocked_functions'],
+            'pimcore_dump',
+        ]);
 
         $this->expectException(SecurityNotAllowedFunctionError::class);
         $policy->checkSecurity([], [], ['pimcore_dump']);

--- a/tests/Unit/Twig/Sandbox/SecurityPolicyTest.php
+++ b/tests/Unit/Twig/Sandbox/SecurityPolicyTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Twig\Sandbox;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Pimcore\Twig\Sandbox\SecurityPolicy;
+use stdClass;
+use Twig\Sandbox\SecurityNotAllowedMethodError;
+use Twig\Sandbox\SecurityNotAllowedPropertyError;
+
+/**
+ * @internal
+ */
+final class SecurityPolicyTest extends TestCase
+{
+    public function testBuiltInDenylistBlocksInfrastructureClassesByDefault(): void
+    {
+        $policy = new SecurityPolicy();
+
+        $this->expectException(SecurityNotAllowedMethodError::class);
+        $policy->checkMethodAllowed(new PDO('sqlite::memory:'), 'query');
+    }
+
+    public function testDenylistModeAllowsArbitraryObjectsNotOnTheList(): void
+    {
+        $policy = new SecurityPolicy();
+
+        // no exception expected
+        $policy->checkMethodAllowed(new stdClass(), 'anything');
+        $policy->checkPropertyAllowed(new stdClass(), 'anything');
+        $this->addToAssertionCount(2);
+    }
+
+    public function testBlockedClassesExtendsTheBuiltInDenylist(): void
+    {
+        $policy = new SecurityPolicy(blockedClasses: [stdClass::class]);
+
+        $this->expectException(SecurityNotAllowedMethodError::class);
+        $policy->checkMethodAllowed(new stdClass(), 'anything');
+    }
+
+    public function testAllowlistModeDeniesEverythingNotOnTheAllowlist(): void
+    {
+        $policy = new SecurityPolicy(allowedClasses: [PDO::class]);
+
+        $this->expectException(SecurityNotAllowedMethodError::class);
+        $policy->checkMethodAllowed(new stdClass(), 'anything');
+    }
+
+    public function testAllowlistModeAllowsListedClasses(): void
+    {
+        $policy = new SecurityPolicy(allowedClasses: [stdClass::class]);
+
+        $policy->checkMethodAllowed(new stdClass(), 'anything');
+        $policy->checkPropertyAllowed(new stdClass(), 'anything');
+        $this->addToAssertionCount(2);
+    }
+
+    public function testAllowlistModeDeactivatesTheDenylistEvenForBuiltInBlockedClasses(): void
+    {
+        // A non-empty allow list must take over completely: an infra class normally
+        // blocked by the built-in denylist is allowed once it is itself allowlisted.
+        $policy = new SecurityPolicy(allowedClasses: [PDO::class]);
+
+        $policy->checkMethodAllowed(new PDO('sqlite::memory:'), 'query');
+        $this->addToAssertionCount(1);
+    }
+
+    public function testAllowlistModeIsPropertyAware(): void
+    {
+        $policy = new SecurityPolicy(allowedClasses: [stdClass::class]);
+
+        $this->expectException(SecurityNotAllowedPropertyError::class);
+        $policy->checkPropertyAllowed(new PDO('sqlite::memory:'), 'secret');
+    }
+
+    public function testSetAllowedClassesSwitchesModeAtRuntime(): void
+    {
+        $policy = new SecurityPolicy();
+
+        // starts in denylist mode: unrelated object is reachable
+        $policy->checkMethodAllowed(new stdClass(), 'anything');
+
+        $policy->setAllowedClasses([PDO::class]);
+
+        $this->expectException(SecurityNotAllowedMethodError::class);
+        $policy->checkMethodAllowed(new stdClass(), 'anything');
+    }
+}


### PR DESCRIPTION
## Changes in this pull request
Resolves GHSA-7gfm-v2fx-xrxm

`Pimcore\Twig\Sandbox\SecurityPolicy` enforced a single hardcoded denylist of
infrastructure classes for object access, and unconditionally auto-allowed any
Twig function whose name starts with `pimcore_`. This PR:

1. Makes object access configurable via `blocked_classes` (extends the built-in
   denylist) and `allowed_classes` (switches to allowlist mode, deactivating the
   denylist entirely once non-empty).
2. Hardens the shipped defaults: `Pimcore\Model\User` is added to the built-in
   denylist (so `getPassword()`/`getPasswordRecoveryToken()` are no longer
   template-reachable out of the box), and `Asset::getData()`/`getStream()`/
   `getLocalFile()`/`getTemporaryFile()` are hard-blocked unconditionally
   (independent of blocklist/allowlist mode), while `Asset` otherwise stays
   reachable for filename/thumbnail use.
3. Makes the `pimcore_*` function auto-allow configurable the same way, via
   `blocked_functions`/`allowed_functions`, and excludes from the default
   auto-allow the functions that look up a live model instance by id/path
   (`pimcore_user`, `pimcore_asset`, `pimcore_document`, `pimcore_site*`, ...),
   since those are the ones a sandboxed template can use to fetch and read data
   outside its intended scope.

New config options, all under `templating_engine.twig.sandbox_security_policy`:
`blocked_classes`, `allowed_classes`, `blocked_functions`, `allowed_functions`
(all default to `[]`, preserving prior behavior unless configured).

Documentation added at `doc/26_Best_Practice/80_Twig_Sandbox_Object_Access.md`,
cross-linked from the Email Framework docs. Unit tests added in
`tests/Unit/Twig/Sandbox/SecurityPolicyTest.php`.

## Additional info
- [x] Read and accept our contributing guidelines before you submit a PR.
- [x] Features need to be proper documented in `doc/`
- [x] Meet all coding standards (see PhpStan actions)