### PR TITLE
Add enabled_adapters config to enable/disable Custom Reports adapters (12.3 backport)

### DIFF
--- a/bundles/CustomReportsBundle/config/pimcore/config.yaml
+++ b/bundles/CustomReportsBundle/config/pimcore/config.yaml
@@ -1,4 +1,6 @@
 pimcore_custom_reports:
     adapters:
         sql: pimcore.custom_report.adapter.factory.sql
+    enabled_adapters:
+        sql: true
 

--- a/bundles/CustomReportsBundle/src/DependencyInjection/Configuration.php
+++ b/bundles/CustomReportsBundle/src/DependencyInjection/Configuration.php
@@ -69,6 +69,11 @@ class Configuration implements ConfigurationInterface
                             ->prototype('scalar')
                         ->end()
                     ->end()
+                    ->arrayNode('enabled_adapters')
+                        ->useAttributeAsKey('name')
+                            ->prototype('boolean')
+                        ->end()
+                    ->end()
                 ->end()
             ->end();
 

--- a/bundles/CustomReportsBundle/src/DependencyInjection/PimcoreCustomReportsExtension.php
+++ b/bundles/CustomReportsBundle/src/DependencyInjection/PimcoreCustomReportsExtension.php
@@ -23,12 +23,16 @@ use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 
 class PimcoreCustomReportsExtension extends ConfigurableExtension implements PrependExtensionInterface
 {
-    private function configureAdapterFactories(ContainerBuilder $container, array $factories, string $serviceLocatorId): void
+    private function configureAdapterFactories(ContainerBuilder $container, array $factories, array $enabledAdapters, string $serviceLocatorId): void
     {
         $serviceLocator = $container->getDefinition($serviceLocatorId);
         $arguments = [];
 
         foreach ($factories as $key => $serviceId) {
+            if (($enabledAdapters[$key] ?? true) === false) {
+                continue;
+            }
+
             $arguments[$key] = new Reference($serviceId);
         }
 
@@ -44,7 +48,7 @@ class PimcoreCustomReportsExtension extends ConfigurableExtension implements Pre
 
         $loader->load('services.yaml');
 
-        $this->configureAdapterFactories($container, $config['adapters'], 'pimcore.custom_report.adapter.factories');
+        $this->configureAdapterFactories($container, $config['adapters'], $config['enabled_adapters'] ?? [], 'pimcore.custom_report.adapter.factories');
         $container->setParameter('pimcore_custom_reports.definitions', $config['definitions'] ?? []);
         $container->setParameter('pimcore_custom_reports.config_location', $config['config_location'] ?? []);
     }

--- a/doc/18_Tools_and_Features/29_Custom_Reports.md
+++ b/doc/18_Tools_and_Features/29_Custom_Reports.md
@@ -74,6 +74,29 @@ pimcore_custom_reports:
         myAdapter: app.custom_report.adapter.factory.custom
 ```
 
+#### Enabling/Disabling Adapters
+
+Each registered adapter can be enabled or disabled via the `enabled_adapters` option. Adapters that are not listed
+default to enabled.
+
+```yaml
+pimcore_custom_reports:
+    enabled_adapters:
+        sql: true
+        myAdapter: false
+```
+
+Trying to use a disabled adapter throws an exception.
+
+:::caution
+
+We recommend disabling the built-in `sql` adapter (`enabled_adapters: { sql: false }`) unless you specifically need
+it. Any user with the `reports_config` permission can use it to define arbitrary `SELECT` statements against your
+application's database, including tables it was never intended to expose (e.g. the users table). Only keep it
+enabled for trusted users, and grant `reports_config` sparingly.
+
+:::
+
 ## Custom JS Class for Report Visualization
 If you need to fully customize the appearance of the report, you can specify a custom javascript class that should 
 be used when opening the report in Pimcore Backend. This class can be specified in `Report Class` option and should extend

--- a/tests/Unit/CustomReportsBundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/CustomReportsBundle/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\CustomReportsBundle\DependencyInjection;
+
+use Pimcore\Bundle\CustomReportsBundle\DependencyInjection\Configuration;
+use Pimcore\Tests\Support\Test\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidTypeException;
+use Symfony\Component\Config\Definition\Processor;
+
+final class ConfigurationTest extends TestCase
+{
+    private function process(array $configs): array
+    {
+        return (new Processor())->processConfiguration(new Configuration(), $configs);
+    }
+
+    public function testEnabledAdaptersAcceptsABooleanMap(): void
+    {
+        $config = $this->process([[
+            'enabled_adapters' => [
+                'sql' => false,
+                'myAdapter' => true,
+            ],
+        ]]);
+
+        $this->assertSame(['sql' => false, 'myAdapter' => true], $config['enabled_adapters']);
+    }
+
+    public function testEnabledAdaptersDefaultsToAnEmptyMapWhenOmitted(): void
+    {
+        $config = $this->process([[]]);
+
+        $this->assertSame([], $config['enabled_adapters']);
+    }
+
+    public function testEnabledAdaptersRejectsNonBooleanValues(): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        $this->process([[
+            'enabled_adapters' => [
+                'sql' => 'yes',
+            ],
+        ]]);
+    }
+}

--- a/tests/Unit/CustomReportsBundle/DependencyInjection/PimcoreCustomReportsExtensionTest.php
+++ b/tests/Unit/CustomReportsBundle/DependencyInjection/PimcoreCustomReportsExtensionTest.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\CustomReportsBundle\DependencyInjection;
+
+use Pimcore\Bundle\CustomReportsBundle\DependencyInjection\PimcoreCustomReportsExtension;
+use Pimcore\Tests\Support\Test\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Verifies that a disabled adapter is never registered into the shared
+ * 'pimcore.custom_report.adapter.factories' ServiceLocator, since that's the mechanism every
+ * consumer (the classic admin controller, the Studio backend bundle's AdapterService, or any
+ * third-party code) relies on to resolve an adapter by type.
+ */
+final class PimcoreCustomReportsExtensionTest extends TestCase
+{
+    /**
+     * @return string[]
+     */
+    private function registeredAdapterKeys(array $enabledAdapters): array
+    {
+        $container = new ContainerBuilder();
+
+        (new PimcoreCustomReportsExtension())->load([[
+            'adapters' => [
+                'sql' => 'pimcore.custom_report.adapter.factory.sql',
+                'other' => 'some.other.factory',
+            ],
+            'enabled_adapters' => $enabledAdapters,
+        ]], $container);
+
+        $arguments = $container->getDefinition('pimcore.custom_report.adapter.factories')->getArgument(0);
+
+        return array_keys($arguments);
+    }
+
+    public function testAdaptersNotListedInEnabledAdaptersDefaultToEnabled(): void
+    {
+        $this->assertSame(['sql', 'other'], $this->registeredAdapterKeys([]));
+    }
+
+    public function testAdapterExplicitlyDisabledIsExcludedFromTheServiceLocator(): void
+    {
+        $this->assertSame(['other'], $this->registeredAdapterKeys(['sql' => false]));
+    }
+
+    public function testAdapterExplicitlyEnabledStaysRegistered(): void
+    {
+        $this->assertSame(['sql', 'other'], $this->registeredAdapterKeys(['sql' => true]));
+    }
+}


### PR DESCRIPTION
## Summary

Backport of #19304 to `12.3`.

Adds a `pimcore_custom_reports.enabled_adapters` option so individual Custom Reports data-source adapters (e.g. the built-in `sql` adapter, which lets report authors run arbitrary SQL against the application database) can be turned off per project. Adapters not listed default to enabled, so this is backward compatible with existing `pimcore_custom_reports.adapters` registrations. Enforcement happens in `PimcoreCustomReportsExtension`: a disabled adapter is never registered into the shared `pimcore.custom_report.adapter.factories` service locator.

Also documents the option and recommends disabling the `sql` adapter unless explicitly needed.

**Note on this backport:** `12.3`'s docs are organized differently than `2026.2` (no `doc/06_Reporting/`), so the doc changes were applied to the equivalent existing file at `doc/18_Tools_and_Features/29_Custom_Reports.md` instead of being cherry-picked verbatim (which would otherwise have created a stray duplicate file). Code and test changes were cherry-picked as-is.

## Test plan

- [ ] CI passes on this branch (Codeception suite)
- [ ] Manual check: set `enabled_adapters: { sql: false }` and confirm the `sql` adapter is no longer available in Custom Reports

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>