### PR TITLE
[Contracts][PimcoreAgent] Initiator-owned MCP tool groups via resolver

### DIFF
--- a/lib/Contracts/PimcoreAgent/AgentTaskRequest.php
+++ b/lib/Contracts/PimcoreAgent/AgentTaskRequest.php
@@ -17,9 +17,11 @@ namespace Pimcore\Contracts\PimcoreAgent;
  * Immutable request to create an agent task.
  *
  * `initiator` is an opaque identifier (e.g. `"studio"`, `"copilot"`, `"collab"`) that
- * routes the resulting session to an initiator-specific access resolver.
+ * routes the resulting session to an initiator-specific access resolver, and drives which
+ * MCP tool groups get attached via `InitiatorMcpServerResolverInterface`.
  * `initiatorContext` carries whatever payload that initiator wants a resolver (or an
- * MCP tool) to see later — e.g. collab passes `['threadId' => 42]`.
+ * MCP tool) to see later — e.g. collab passes `['threadId' => 42]`. Callers do NOT
+ * specify tool groups here: the initiator's resolver alone decides what a task gets.
  */
 final readonly class AgentTaskRequest
 {
@@ -31,14 +33,6 @@ final readonly class AgentTaskRequest
      *                                                                  session (e.g. `copilot-importProducts`); the
      *                                                                  implementation normalizes it (trimmed, empty
      *                                                                  string becomes null, truncated to 190 chars).
-     * @param list<string>|null                       $extraPimcoreMcpServers Pimcore MCP tool groups the initiator
-     *                                                                  needs available in the task session on top of
-     *                                                                  the agent's own configuration (e.g. collab
-     *                                                                  passes `['pimcore-collab-tasks']` so any agent
-     *                                                                  can post task comments). Deduplicated against
-     *                                                                  the agent's configured groups by the
-     *                                                                  implementation; unknown groups resolve to
-     *                                                                  empty tool servers and are harmless.
      */
     public function __construct(
         public string $agentName,
@@ -52,7 +46,6 @@ final readonly class AgentTaskRequest
         public ?int $maxAutoContinues = null,
         public array $initiatorContext = [],
         public ?string $origin = null,
-        public ?array $extraPimcoreMcpServers = null,
     ) {
     }
 }

--- a/lib/Contracts/PimcoreAgent/InitiatorMcpServerResolverInterface.php
+++ b/lib/Contracts/PimcoreAgent/InitiatorMcpServerResolverInterface.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Contracts\PimcoreAgent;
+
+/**
+ * One resolver per initiator. Given the initiator identifier, its opaque per-task context,
+ * and the caller identity, returns the Pimcore MCP tool-group slugs a task originating from
+ * this initiator should have attached to its session (on top of the agent's own
+ * configuration).
+ *
+ * The bundle calls this at every dispatch — task start, `continueTask`, and each
+ * auto-continue turn — so the resolver is authoritative live authz: revoking or widening an
+ * initiator's grants takes effect on the next dispatch without any persisted state to
+ * migrate. Return `[]` to attach no extras.
+ *
+ * The returned slugs are the ATTACHED set, not an allowlist to intersect with a caller
+ * request: there is no caller-supplied field to filter. Any per-task variation the
+ * initiator wants to express should be encoded in `$initiatorContext` and read here.
+ *
+ * Consumers register an implementation as a service tagged
+ * `pimcore_agent.mcp_server_resolver` with an `initiator` attribute equal to
+ * `initiator()`; the bundle's compiler pass builds the registry.
+ *
+ * Slugs must match `[a-z][a-z0-9]*(-[a-z0-9]+)*` (ASCII-only — the bundle interpolates
+ * them into agent-server URL paths). Malformed slugs are silently dropped by the bundle.
+ */
+interface InitiatorMcpServerResolverInterface
+{
+    /**
+     * The initiator identifier this resolver handles. MUST match `AgentTaskRequest::$initiator`
+     * of every task this resolver applies to.
+     */
+    public function initiator(): string;
+
+    /**
+     * @param array<string, mixed> $initiatorContext Verbatim from `AgentTaskRequest::$initiatorContext`
+     *                                               at task creation; preserved unchanged across
+     *                                               `continueTask` and auto-continue.
+     * @param int                  $callerUserId     The effective user identity the task runs as
+     *                                               (persisted `AgentTask::$actingUserId` or the
+     *                                               agent's execution user).
+     *
+     * @return list<string> MCP tool-group slugs to attach; `[]` to attach none.
+     */
+    public function allowedMcpServers(string $initiator, array $initiatorContext, int $callerUserId): array;
+}

--- a/lib/Contracts/PimcoreAgent/InitiatorMcpServerResolverInterface.php
+++ b/lib/Contracts/PimcoreAgent/InitiatorMcpServerResolverInterface.php
@@ -14,35 +14,39 @@ declare(strict_types=1);
 namespace Pimcore\Contracts\PimcoreAgent;
 
 /**
- * One resolver per initiator. Given the initiator identifier, its opaque per-task context,
- * and the caller identity, returns the Pimcore MCP tool-group slugs a task originating from
- * this initiator should have attached to its session (on top of the agent's own
- * configuration).
+ * Decides which Pimcore MCP tool-group slugs get attached to a task session, given the
+ * initiator's opaque per-task context and the caller identity. Implementations are routed
+ * to by initiator string (e.g. `"studio"`, `"collab"`); each integration registers its own
+ * resolver rather than teaching the agent-bundle every initiator's tool matrix.
  *
- * The bundle calls this at every dispatch — task start, `continueTask`, and each
- * auto-continue turn — so the resolver is authoritative live authz: revoking or widening an
- * initiator's grants takes effect on the next dispatch without any persisted state to
- * migrate. Return `[]` to attach no extras.
+ * Called at every dispatch (start, `continueTask`, auto-continue) so grants are live authz:
+ * revoking or widening an initiator's tool set takes effect on the next turn without any
+ * persisted state to migrate. Return `[]` to attach no extras.
  *
  * The returned slugs are the ATTACHED set, not an allowlist to intersect with a caller
  * request: there is no caller-supplied field to filter. Any per-task variation the
- * initiator wants to express should be encoded in `$initiatorContext` and read here.
+ * initiator wants to express should be encoded in `$initiatorContext` (verbatim from
+ * `AgentTaskRequest::$initiatorContext`) and read here.
  *
- * Consumers register an implementation as a service tagged
- * `pimcore_agent.mcp_server_resolver` with an `initiator` attribute equal to
- * `initiator()`; the bundle's compiler pass builds the registry.
+ * ## Trust model
+ *
+ * `AgentTaskServiceInterface::start()` is a bundle-integration facade, not a user-facing
+ * endpoint. The `$initiator` string on `AgentTaskRequest` is set by the integrating bundle
+ * itself (e.g. collab-bundle hardcodes `initiator: 'collab'` on every delegation), never
+ * derived from untrusted caller input. Bundle integrations that forward user input into
+ * `$initiator` bypass this trust model and let a caller pick which resolver runs. Don't do
+ * that.
+ *
+ * Given that model, this resolver is called for tasks whose initiator identity has already
+ * been vetted by the integrating bundle. `$initiatorContext + $callerUserId` are what a
+ * resolver reasons about — the initiator identity itself is not passed, because the resolver
+ * IS the resolver for its initiator (routed by service-tag attribute).
  *
  * Slugs must match `[a-z][a-z0-9]*(-[a-z0-9]+)*` (ASCII-only — the bundle interpolates
  * them into agent-server URL paths). Malformed slugs are silently dropped by the bundle.
  */
 interface InitiatorMcpServerResolverInterface
 {
-    /**
-     * The initiator identifier this resolver handles. MUST match `AgentTaskRequest::$initiator`
-     * of every task this resolver applies to.
-     */
-    public function initiator(): string;
-
     /**
      * @param array<string, mixed> $initiatorContext Verbatim from `AgentTaskRequest::$initiatorContext`
      *                                               at task creation; preserved unchanged across
@@ -53,5 +57,5 @@ interface InitiatorMcpServerResolverInterface
      *
      * @return list<string> MCP tool-group slugs to attach; `[]` to attach none.
      */
-    public function allowedMcpServers(string $initiator, array $initiatorContext, int $callerUserId): array;
+    public function allowedMcpServers(array $initiatorContext, int $callerUserId): array;
 }


### PR DESCRIPTION
## What

Follow-up to #19258. Moves ownership of the per-task MCP tool-group list from the caller (via `AgentTaskRequest::$extraPimcoreMcpServers`) to the initiator (via a new `InitiatorMcpServerResolverInterface`).

### Contract changes

**Adds** `Pimcore\Contracts\PimcoreAgent\InitiatorMcpServerResolverInterface`:

```php
interface InitiatorMcpServerResolverInterface
{
    public function initiator(): string;

    /** @return list<string> MCP tool-group slugs to attach */
    public function allowedMcpServers(string \$initiator, array \$initiatorContext, int \$callerUserId): array;
}
```

One implementation per initiator, registered via `pimcore_agent.mcp_server_resolver` tag. The bundle calls it at every dispatch — start, `continueTask`, auto-continue — so grants are live authz.

**Removes** `AgentTaskRequest::$extraPimcoreMcpServers`. The initiator's resolver is the sole source of truth for which tool groups a task gets. Callers wanting per-task variation encode it in `$initiatorContext` and let the resolver read it.

## Why

Two problems in the current shape:

1. **No authorization.** `extraPimcoreMcpServers` accepts an arbitrary list from any caller with `start()` access. The bundle's `normalizeExtraMcpServers` only validates slug syntax — it does not check whether the initiator is entitled to attach a given tool group.
2. **Redundant state.** With `initiator + initiatorContext + callerUserId` all persisted on the task, the toolset is fully derivable at every dispatch. Persisting the list as well means two sources of truth to keep in sync (and a DB column + migration to carry).

Moving the decision behind the initiator abstraction eliminates both. Callers no longer think about MCP tool groups at all — they pass what they know (initiator, context, identity) and the resolver decides.

## BC break (intentional — 2026.3 unreleased)

- `AgentTaskRequest` constructor no longer accepts `extraPimcoreMcpServers`.
- Consumers that were using it must register an `InitiatorMcpServerResolverInterface` service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)