### PR TITLE
Fix TypeError when DatabaseVersionStorageAdapter finds no matching row

### DIFF
--- a/models/Version/Adapter/DatabaseVersionStorageAdapter.php
+++ b/models/Version/Adapter/DatabaseVersionStorageAdapter.php
@@ -59,16 +59,18 @@ class DatabaseVersionStorageAdapter implements VersionStorageAdapterInterface
     protected function loadData(int $id,
         int $cId,
         string $cType,
-        bool $binaryData = false): mixed
+        bool $binaryData = false): ?string
     {
         $dataColumn = $binaryData ? 'binaryData' : 'metaData';
 
-        return $this->databaseConnection->fetchOne('SELECT ' . $dataColumn . ' FROM ' . self::versionsTableName . ' WHERE id = :id AND cid = :cid and ctype = :ctype',
+        $data = $this->databaseConnection->fetchOne('SELECT ' . $dataColumn . ' FROM ' . self::versionsTableName . ' WHERE id = :id AND cid = :cid and ctype = :ctype',
             [
                 'id' => $id,
                 'cid' => $cId,
                 'ctype' => $cType,
             ]);
+
+        return $data === false ? null : $data;
     }
 
     public function loadMetaData(Version $version): ?string
@@ -76,7 +78,7 @@ class DatabaseVersionStorageAdapter implements VersionStorageAdapterInterface
         return $this->loadData($version->getId(), $version->getCid(), $version->getCtype());
     }
 
-    protected function getStream(string $data): mixed
+    protected function getStream(?string $data): mixed
     {
         if ($data) {
             $fileName = tmpfile();

--- a/tests/Service/Element/VersionTest.php
+++ b/tests/Service/Element/VersionTest.php
@@ -173,6 +173,55 @@ class VersionTest extends TestCase
         $this->assertEmpty($result['binaryData'], 'binaryData must be empty.');
     }
 
+    /**
+     * Regression test for https://github.com/pimcore/pimcore/issues/18522
+     *
+     * fetchOne() yields false when no versionsData row matches. That false has to be
+     * normalized to null, otherwise the ?string return type of loadMetaData() and the
+     * string argument type of getStream() raise a TypeError under strict_types.
+     */
+    public function testDbStorageAdapterReturnsNullWhenNoDataRowExists(): void
+    {
+        $adapter = new DatabaseVersionStorageAdapter(Db::get());
+
+        // a version that never had a corresponding versionsData row
+        $version = new Version();
+        $version->setId(999999999);
+        $version->setCid(999999999);
+        $version->setCtype('object');
+
+        $this->assertNull($adapter->loadMetaData($version), 'loadMetaData must return null when no data row exists.');
+        $this->assertNull($adapter->getFileStream($version), 'getFileStream must return null when no data row exists.');
+        $this->assertNull($adapter->loadBinaryData($version), 'loadBinaryData must return null when no data row exists.');
+        $this->assertNull($adapter->getBinaryFileStream($version), 'getBinaryFileStream must return null when no data row exists.');
+    }
+
+    /**
+     * Regression test for https://github.com/pimcore/pimcore/issues/18522
+     *
+     * Same missing-row path as above, but reached the way it happens in practice: the
+     * versions row outlives its versionsData row.
+     */
+    public function testDbStorageAdapterReturnsNullAfterDataRowRemoved(): void
+    {
+        $this->setStorageAdapter($this->mockDbStorageAdapter());
+        $object = TestHelper::createEmptyObject();
+        $version = $this->getNewestVersion($object->getId());
+
+        $adapter = new DatabaseVersionStorageAdapter(Db::get());
+        $this->assertNotNull($adapter->loadMetaData($version), 'metaData must be readable before the data row is removed.');
+
+        Db::get()->delete(DatabaseVersionStorageAdapter::versionsTableName, [
+            'id' => $version->getId(),
+            'cid' => $version->getCid(),
+            'ctype' => $version->getCtype(),
+        ]);
+
+        $this->assertNull($adapter->loadMetaData($version), 'loadMetaData must return null once the data row is gone.');
+        $this->assertNull($adapter->getFileStream($version), 'getFileStream must return null once the data row is gone.');
+        $this->assertNull($adapter->loadBinaryData($version), 'loadBinaryData must return null once the data row is gone.');
+    }
+
     // Size of metadata exceeds "byteThreshold". Therefore, the fallback adapter (fs) should be used.
     public function testStorageAdapterDelegate(): void
     {


### PR DESCRIPTION
fetchOne() returns false when no row matches, but loadData() declared mixed and loadMetaData()/getStream() expect ?string. With strict_types, that false value throws a TypeError instead of being treated as "no data". Normalize false to null in loadData() and widen getStream()'s parameter to ?string to match.

Originally reported as pimcore/pimcore#18522

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `12.3`
- Feature/Improvement: choose `2026.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`2026.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `12.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves pimcore/platform-version#331 (originally reported as pimcore/pimcore#18522)

## Additional info

