### PR TITLE
Remove 12.3 from the scheduled CE->EE sync workflow

### DIFF
--- a/.github/workflows/sync-changes-scheduled.yml
+++ b/.github/workflows/sync-changes-scheduled.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - '2026.x'
       - '2026.2'
-      - '12.3'
 
 concurrency:
   group: ${{ github.workflow }}
@@ -20,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ref: [{'base': '2026.x', 'destination': '2026.x'}, {'base': '2026.2', 'destination': '2026.2'}, {'base': '12.3', 'destination': '12.3'}]
+        ref: [{'base': '2026.x', 'destination': '2026.x'}, {'base': '2026.2', 'destination': '2026.2'}]
     with:
       base_ref: ${{ matrix.ref.base }}
       ref_name: ${{ matrix.ref.destination }}


### PR DESCRIPTION
## Summary
- resolves https://github.com/pimcore/pimcore/issues/19311
- Drops the `12.3` line from `sync-changes-scheduled.yml`'s `push.branches` trigger and `strategy.matrix.ref` sync list, so it's no longer synced from pimcore/pimcore to ee-pimcore on push or via the nightly schedule.
- `2026.x` and `2026.2` are unaffected.

## Test plan
- [ ] Confirm no other workflow or process still expects `12.3` to be synced to `ee-pimcore`.