### PR TITLE
[Bug]: Fix lost group-collection mapping for empty classification store groups

### DIFF
--- a/models/DataObject/Classificationstore/Dao.php
+++ b/models/DataObject/Classificationstore/Dao.php
@@ -71,9 +71,12 @@ class Dao extends Model\Dao\AbstractDao
 
         // check and exclude if an object is the top of the hierarchy
         // otherwise it wouldn't be able to distinguish whether the exact collections are from itself, rather from a common parent
-        if ($allowInherit && DataObject\Service::hasInheritableParentObject($object)) {
-            $parentCollectionMapping = DataObject\Service::useInheritedValues(true, $this->model->getGroupCollectionMappings(...));
-            $collectionToAdd = array_diff($collectionToAdd, $parentCollectionMapping);
+        if ($allowInherit && ($parent = DataObject\Service::hasInheritableParentObject($object))) {
+            $parentStore = $parent->{'get' . ucfirst($fieldname)}();
+            if ($parentStore instanceof DataObject\Classificationstore) {
+                $parentCollectionMapping = DataObject\Service::useInheritedValues(true, $parentStore->getGroupCollectionMappings(...));
+                $collectionToAdd = array_diff_assoc($collectionToAdd, $parentCollectionMapping);
+            }
         }
 
         $groupsTable = $this->getGroupsTableName();
@@ -96,7 +99,6 @@ class Dao extends Model\Dao\AbstractDao
         }
 
         $alreadySavedGroups = [];
-        $alreadySavedKeyIds = [];
 
         foreach ($items as $groupId => $group) {
             foreach ($group as $keyId => $keyData) {
@@ -143,7 +145,6 @@ class Dao extends Model\Dao\AbstractDao
 
                     Helper::upsert($this->db, $dataTable, $data, $this->getPrimaryKey($dataTable));
                     $alreadySavedGroups[] = $groupId;
-                    $alreadySavedKeyIds[] = $keyId;
                 }
             }
         }
@@ -154,26 +155,25 @@ class Dao extends Model\Dao\AbstractDao
             // Ignore the groups that are already saved and those without any collection id
             if ($collectionId && !in_array($groupId, $alreadySavedGroups)) {
                 $group = GroupConfig::getById($groupId);
-                $groupKeys = $group->getRelations();
-                // make sure that any of the group keys are not among those already saved
-                // if so, skip as there no need for a placeholder
-                if (!in_array(array_keys($groupKeys), $alreadySavedKeyIds)) {
-                    $firstKey = reset($groupKeys);
-                    $keyId = $firstKey->getKeyId();
-                    $keyConfig = DefinitionCache::get($keyId);
-                    $data = [
-                        'id' => $objectId,
-                        'collectionId' => $collectionId,
-                        'groupId' => $groupId,
-                        'keyId' => $keyId,
-                        'fieldname' => $fieldname,
-                        'language' => 'default',
-                        'type' => $keyConfig->getType(),
-                        'value' => null,
-                        'value2' => null,
-                    ];
-                    $this->db->insert($dataTable, $data);
+                $groupKeys = $group?->getRelations();
+                if (!$groupKeys) {
+                    continue;
                 }
+                $firstKey = reset($groupKeys);
+                $keyId = $firstKey->getKeyId();
+                $keyConfig = DefinitionCache::get($keyId);
+                $data = [
+                    'id' => $objectId,
+                    'collectionId' => $collectionId,
+                    'groupId' => $groupId,
+                    'keyId' => $keyId,
+                    'fieldname' => $fieldname,
+                    'language' => 'default',
+                    'type' => $keyConfig->getType(),
+                    'value' => null,
+                    'value2' => null,
+                ];
+                $this->db->insert($dataTable, $data);
             }
         }
     }

--- a/tests/Model/Inheritance/ClassificationstoreTest.php
+++ b/tests/Model/Inheritance/ClassificationstoreTest.php
@@ -109,6 +109,35 @@ class ClassificationstoreTest extends ModelTestCase
             $keygroup2->save();
         }
 
+        $group2 = Classificationstore\GroupConfig::getByName('group2', $store->getId());
+        if (!$group2) {
+            $group2 = new Classificationstore\GroupConfig();
+            $group2->setStoreId($store->getId());
+            $group2->setName('group2');
+            $group2->save();
+        }
+
+        $key3 = Classificationstore\KeyConfig::getByName('field3', $store->getId());
+        if (!$key3) {
+            $key3 = new Classificationstore\KeyConfig();
+            $key3->setDefinition(json_encode(new ClassDefinition\Data\Input()));
+            $key3->setStoreId($store->getId());
+            $key3->setName('field3');
+            $key3->setDescription('Input Field 3');
+            $key3->setEnabled(true);
+            $key3->setType('input');
+            $key3->save();
+        }
+
+        $keygroup3 = Classificationstore\KeyGroupRelation::getByGroupAndKeyId($group2->getId(), $key3->getId());
+        if (!$keygroup3) {
+            $keygroup3 = new Classificationstore\KeyGroupRelation();
+            $keygroup3->setKeyId($key3->getId());
+            $keygroup3->setGroupId($group2->getId());
+            $keygroup3->setSorter(1);
+            $keygroup3->save();
+        }
+
         $collection = Classificationstore\CollectionConfig::getByName('collection1', $store->getId());
         if (!$collection) {
             $collection = new Classificationstore\CollectionConfig();
@@ -266,5 +295,53 @@ class ClassificationstoreTest extends ModelTestCase
                 'mapping covered by the parent must be available through inheritance'
             );
         });
+    }
+
+    /**
+     * When the parent maps one group to a collection and the child maps a *different* group to
+     * that same collection, the child's mapping must survive a save/reload round-trip.
+     *
+     * This is the key regression for the array_diff_assoc() fix: the old array_diff() compared
+     * only values, so a child mapping whose collectionId happened to equal any parent collectionId
+     * was silently discarded even when the groupId was different.
+     */
+    public function testChildMappingForDifferentGroupToSameCollectionIsNotStripped(): void
+    {
+        $group1 = Classificationstore\GroupConfig::getByName('group1');
+        $group2 = Classificationstore\GroupConfig::getByName('group2');
+        $collection = Classificationstore\CollectionConfig::getByName('collection1');
+
+        $parent = new Inheritance();
+        $parent->setKey('mapping-parent');
+        $parent->setParentId(1);
+        $parent->setPublished(true);
+
+        /** @var Classificationstore $parentStore */
+        $parentStore = $parent->getTeststore();
+        $parentStore->setActiveGroups([$group1->getId() => true]);
+        $parentStore->setGroupCollectionMapping($group1->getId(), $collection->getId());
+        $parent->save();
+
+        $child = new Inheritance();
+        $child->setKey('mapping-child');
+        $child->setParentId($parent->getId());
+        $child->setPublished(true);
+
+        /** @var Classificationstore $childStore */
+        $childStore = $child->getTeststore();
+        $childStore->setActiveGroups([$group2->getId() => true]);
+        $childStore->setGroupCollectionMapping($group2->getId(), $collection->getId());
+        $child->save();
+
+        /** @var Inheritance $reloadedChild */
+        $reloadedChild = Inheritance::getById($child->getId(), ['force' => true]);
+        /** @var Classificationstore $reloadedStore */
+        $reloadedStore = $reloadedChild->getTeststore();
+
+        $this->assertEquals(
+            [$group2->getId() => $collection->getId()],
+            $reloadedStore->getGroupCollectionMappings(),
+            'child mapping for a different group to the same collection must not be stripped'
+        );
     }
 }

--- a/tests/Model/Inheritance/ClassificationstoreTest.php
+++ b/tests/Model/Inheritance/ClassificationstoreTest.php
@@ -238,12 +238,14 @@ class ClassificationstoreTest extends ModelTestCase
         /** @var Classificationstore $reloadedStore */
         $reloadedStore = $reloadedChild->getTeststore();
 
-        $this->assertEquals([$group->getId() => true], $reloadedStore->getActiveGroups());
-        $this->assertEquals(
-            [$group->getId() => $collection->getId()],
-            $reloadedStore->getGroupCollectionMappings(),
-            'group-collection mapping of an empty group must survive a save/reload round-trip'
-        );
+        DataObject\Service::useInheritedValues(false, function () use ($reloadedStore, $group, $collection) {
+            $this->assertEquals([$group->getId() => true], $reloadedStore->getActiveGroups());
+            $this->assertEquals(
+                [$group->getId() => $collection->getId()],
+                $reloadedStore->getGroupCollectionMappings(),
+                'group-collection mapping of an empty group must survive a save/reload round-trip'
+            );
+        });
     }
 
     /**
@@ -282,11 +284,13 @@ class ClassificationstoreTest extends ModelTestCase
         /** @var Classificationstore $reloadedStore */
         $reloadedStore = $reloadedChild->getTeststore();
 
-        $this->assertEquals(
-            [],
-            $reloadedStore->getGroupCollectionMappings(),
-            'mapping covered by the parent must not be persisted on the child'
-        );
+        DataObject\Service::useInheritedValues(false, function () use ($reloadedStore) {
+            $this->assertEquals(
+                [],
+                $reloadedStore->getGroupCollectionMappings(),
+                'mapping covered by the parent must not be persisted on the child'
+            );
+        });
 
         DataObject\Service::useInheritedValues(true, function () use ($reloadedStore, $group, $collection) {
             $this->assertEquals(
@@ -338,10 +342,12 @@ class ClassificationstoreTest extends ModelTestCase
         /** @var Classificationstore $reloadedStore */
         $reloadedStore = $reloadedChild->getTeststore();
 
-        $this->assertEquals(
-            [$group2->getId() => $collection->getId()],
-            $reloadedStore->getGroupCollectionMappings(),
-            'child mapping for a different group to the same collection must not be stripped'
-        );
+        DataObject\Service::useInheritedValues(false, function () use ($reloadedStore, $group2, $collection) {
+            $this->assertEquals(
+                [$group2->getId() => $collection->getId()],
+                $reloadedStore->getGroupCollectionMappings(),
+                'child mapping for a different group to the same collection must not be stripped'
+            );
+        });
     }
 }

--- a/tests/Model/Inheritance/ClassificationstoreTest.php
+++ b/tests/Model/Inheritance/ClassificationstoreTest.php
@@ -108,6 +108,19 @@ class ClassificationstoreTest extends ModelTestCase
             $keygroup2->setSorter(2);
             $keygroup2->save();
         }
+
+        $collection = Classificationstore\CollectionConfig::getByName('collection1', $store->getId());
+        if (!$collection) {
+            $collection = new Classificationstore\CollectionConfig();
+            $collection->setStoreId($store->getId());
+            $collection->setName('collection1');
+            $collection->save();
+        }
+
+        $collectionRelation = new Classificationstore\CollectionGroupRelation();
+        $collectionRelation->setColId($collection->getId());
+        $collectionRelation->setGroupId($group->getId());
+        $collectionRelation->save();
     }
 
     /**
@@ -160,6 +173,98 @@ class ClassificationstoreTest extends ModelTestCase
             //check inherited & overriden value from parent
             $this->assertEquals('oneinput1', $oneStore->getLocalizedKeyValue($group->getId(), $key1->getId()));
             $this->assertEquals('oneinput2', $oneStore->getLocalizedKeyValue($group->getId(), $key2->getId()));
+        });
+    }
+
+    /**
+     * An empty group added via a collection must keep its group-collection mapping after a
+     * save/reload round-trip, also when the object has an inheritable parent without an own mapping.
+     *
+     * @see https://pimcore.atlassian.net/browse/PEES-1225
+     */
+    public function testGroupCollectionMappingPersistsForEmptyGroups(): void
+    {
+        $group = Classificationstore\GroupConfig::getByName('group1');
+        $collection = Classificationstore\CollectionConfig::getByName('collection1');
+
+        $parent = new Inheritance();
+        $parent->setKey('mapping-parent');
+        $parent->setParentId(1);
+        $parent->setPublished(true);
+        $parent->save();
+
+        $child = new Inheritance();
+        $child->setKey('mapping-child');
+        $child->setParentId($parent->getId());
+        $child->setPublished(true);
+
+        /** @var Classificationstore $childStore */
+        $childStore = $child->getTeststore();
+        $childStore->setActiveGroups([$group->getId() => true]);
+        $childStore->setGroupCollectionMapping($group->getId(), $collection->getId());
+        $child->save();
+
+        /** @var Inheritance $reloadedChild */
+        $reloadedChild = Inheritance::getById($child->getId(), ['force' => true]);
+        /** @var Classificationstore $reloadedStore */
+        $reloadedStore = $reloadedChild->getTeststore();
+
+        $this->assertEquals([$group->getId() => true], $reloadedStore->getActiveGroups());
+        $this->assertEquals(
+            [$group->getId() => $collection->getId()],
+            $reloadedStore->getGroupCollectionMappings(),
+            'group-collection mapping of an empty group must survive a save/reload round-trip'
+        );
+    }
+
+    /**
+     * A mapping that matches the inheritable parent's mapping is not persisted on the child,
+     * but stays available through inheritance.
+     */
+    public function testInheritedGroupCollectionMappingIsNotPersistedOnChild(): void
+    {
+        $group = Classificationstore\GroupConfig::getByName('group1');
+        $collection = Classificationstore\CollectionConfig::getByName('collection1');
+
+        $parent = new Inheritance();
+        $parent->setKey('mapping-parent');
+        $parent->setParentId(1);
+        $parent->setPublished(true);
+
+        /** @var Classificationstore $parentStore */
+        $parentStore = $parent->getTeststore();
+        $parentStore->setActiveGroups([$group->getId() => true]);
+        $parentStore->setGroupCollectionMapping($group->getId(), $collection->getId());
+        $parent->save();
+
+        $child = new Inheritance();
+        $child->setKey('mapping-child');
+        $child->setParentId($parent->getId());
+        $child->setPublished(true);
+
+        /** @var Classificationstore $childStore */
+        $childStore = $child->getTeststore();
+        $childStore->setActiveGroups([$group->getId() => true]);
+        $childStore->setGroupCollectionMapping($group->getId(), $collection->getId());
+        $child->save();
+
+        /** @var Inheritance $reloadedChild */
+        $reloadedChild = Inheritance::getById($child->getId(), ['force' => true]);
+        /** @var Classificationstore $reloadedStore */
+        $reloadedStore = $reloadedChild->getTeststore();
+
+        $this->assertEquals(
+            [],
+            $reloadedStore->getGroupCollectionMappings(),
+            'mapping covered by the parent must not be persisted on the child'
+        );
+
+        DataObject\Service::useInheritedValues(true, function () use ($reloadedStore, $group, $collection) {
+            $this->assertEquals(
+                [$group->getId() => $collection->getId()],
+                $reloadedStore->getGroupCollectionMappings(),
+                'mapping covered by the parent must be available through inheritance'
+            );
         });
     }
 }


### PR DESCRIPTION
## Changes in this pull request

Resolves https://pimcore.atlassian.net/browse/PEES-1225 (internal ref: pimcore/service-operations#855)

Classification store groups added via a collection disappeared after **Save & Publish + reload** when they contained no values — even with *Hide empty data* disabled. Groups added via collections rely on a NULL-value placeholder row in the data table to persist their `collectionId` across round-trips (introduced in #16769); that placeholder was never written for objects that have an inheritable parent:

- In `Dao::save()`, the "parent" collection mapping was read via `$this->model->getGroupCollectionMappings()` under `useInheritedValues(true)`. But the inheritance walk (`getAllDataFromField()`) merges the **object's own mapping first**, so the mapping used to exclude "inherited" entries always contained the object's own entries — and the subsequent `array_diff()` emptied `$collectionToAdd` entirely. No placeholders were written, the mapping was lost on reload, and the UI could no longer associate the groups with their collection. Now the mapping is read from the parent object's store instead.
- `array_diff()` compares **values** only (collectionIds), so a mapping was also wrongly dropped when a *different* group on the parent pointed to the same collection. Now `array_diff_assoc()` compares `groupId => collectionId` pairs.
- The `in_array(array_keys($groupKeys), $alreadySavedKeyIds)` guard compared an array needle against a list of int key ids, which is always `false` (so the check was a no-op); the intent is already covered by the `$alreadySavedGroups` check, so the dead guard is removed. Groups without key relations are now skipped instead of fataling on `reset()` returning `false`.

ExtJS masked the data loss because it renders groups from `activeGroups`; the Studio UI resolves groups through the group-collection mapping, which made the lost placeholders visible as missing groups.

### How to reproduce

1. Class with a classification store field (*Hide empty data* off, inheritance allowed on the class), object placed **under a parent object of the same class**.
2. Add a classification store collection to the object; all groups/keys show up.
3. Enter no values (or a value in only one attribute of a single group) and Save & Publish.
4. Reload the object → groups without values are gone (their `groupId => collectionId` mapping was not persisted).

## Additional info

Regression tests included (`tests/Model/Inheritance/ClassificationstoreTest.php`): empty-group mapping survives a save/reload round-trip with an inheritable parent, and a mapping identical to the parent's is intentionally not duplicated on the child but stays readable through inheritance.

Targets `12.3` as the oldest supported affected line; needs the usual forward-merge to `2026.2` / `2026.x` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)