### PR TITLE
[Documents] Emit `data-key` alongside `key` on editmode block/areablock entries

### DIFF
--- a/models/Document/Editable/Areablock.php
+++ b/models/Document/Editable/Areablock.php
@@ -367,6 +367,10 @@ class Areablock extends Model\Document\Editable implements BlockInterface
 
         $outerAttributes = [
             'key' => $this->indices[$this->current]['key'],
+            // `data-key` mirrors `key` for editmode consumers: `key` is a reserved
+            // React prop / non-standard attribute and can be stripped downstream,
+            // while `data-*` survives. The editmode UI must read `data-key` first.
+            'data-key' => $this->indices[$this->current]['key'],
             'type' => $this->indices[$this->current]['type'],
             'data-hidden' => $hidden,
         ];

--- a/models/Document/Editable/Block.php
+++ b/models/Document/Editable/Block.php
@@ -239,6 +239,8 @@ class Block extends Model\Document\Editable implements BlockInterface
 
         $outerAttributes = [
             'key' => $this->indices[$this->current] ?? null,
+            // see Areablock::blockStart(): `data-key` is the robust mirror of `key`
+            'data-key' => $this->indices[$this->current] ?? null,
         ];
         $oAttr = HtmlUtils::assembleAttributeString($outerAttributes);
 

--- a/models/Document/Editable/Scheduledblock.php
+++ b/models/Document/Editable/Scheduledblock.php
@@ -182,6 +182,8 @@ class Scheduledblock extends Block implements BlockInterface
 
         $outerAttributes = [
             'key' => $this->indices[$this->current]['key'],
+            // see Areablock::blockStart(): `data-key` is the robust mirror of `key`
+            'data-key' => $this->indices[$this->current]['key'],
             'date' => $this->indices[$this->current]['date'],
         ];
 


### PR DESCRIPTION
### Problem

In the Studio document editor, opening a document created in an earlier version and saving it — without adding, removing or reordering anything — can renumber an areablock's item keys to a fresh contiguous sequence (`1..N`) while the child editables keep their original identifiers. Parent and children become disconnected and the stored values disappear from the editor (data still exists in `documents_editables` under the old names).

See pimcore/platform-version#248.

### Root cause

The editmode area/block entry `<div>` carries the item key in a **`key`** attribute (built in `blockStart()` → `editmodeOuterAttributes`). `key` is a **reserved React prop and a non-standard HTML attribute**, so it can be silently dropped between the server render and the point where the editor reads it (React re-render, an HTML sanitizer, a reverse proxy, …). Note `type` and `data-*` on the same element survive — the loss is specific to `key`.

When the editor reads no usable key from the entry it falls back to inventing sequential keys (`1..N`), which is exactly the renumbering users observe. Core renders `key` correctly (verified against the raw editmode response), so the loss is downstream — but the fix belongs here: make the key travel in an attribute that cannot be stripped.

### Change

Mirror the key into a **`data-key`** attribute (valid HTML, survives that processing) next to the existing `key`, in the editmode outer attributes of:

- `Areablock::blockStart()`
- `Block::blockStart()`
- `Scheduledblock::blockStart()`

No template changes are needed — the attribute string is already rendered via `editmodeOuterAttributes`. `key` is kept for backward compatibility.

### Counterpart

The Studio UI must read `data-key` first (falling back to `key`) and must never fabricate a key for an existing entry. That is a separate PR against `pimcore/studio-ui-bundle`.

### Backward compatibility

Additive only — a new attribute alongside the existing one; no signature, behavior or template contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)