### PR TITLE
[security] GHSA-qr7g-3424-h9pr: prevent blind SSRF via email test-send CSS (link) fetch

### DIFF
--- a/lib/Helper/Mail.php
+++ b/lib/Helper/Mail.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace Pimcore\Helper;
 
 use Exception;
+use GuzzleHttp\RequestOptions;
 use Net_URL2;
+use Pimcore\Http\SsrfProtection;
 use Pimcore\Mail as MailClient;
 use Pimcore\Model;
 use Pimcore\Tool;
@@ -293,10 +295,18 @@ CSS;
                         $fileContent = file_get_contents($fileInfo['filePathNormalized']);
                     }
                 } elseif (str_starts_with($path, 'http')) {
-                    $fileContent = \Pimcore\Tool::getHttpData($path);
-                    $fileInfo = [
-                        'fileUrlNormalized' => $path,
-                    ];
+                    // The href comes from (potentially user-supplied) mail content, so guard the
+                    // server-side fetch against SSRF: only fetch http(s) URLs that resolve to a
+                    // public host, never redirect (a redirect could target an internal host) and
+                    // pin the connection to the validated address to defeat DNS rebinding.
+                    $safeIps = SsrfProtection::resolvePublicIps($path);
+                    if ($safeIps !== []) {
+                        $options = self::getSsrfSafeRequestOptions($path, $safeIps);
+                        $fileContent = \Pimcore\Tool::getHttpData($path, [], [], $options);
+                        $fileInfo = [
+                            'fileUrlNormalized' => $path,
+                        ];
+                    }
                 }
 
                 if ($fileContent) {
@@ -315,6 +325,40 @@ CSS;
         $string = $cssToInlineStyles->convert($string, $css);
 
         return $string;
+    }
+
+    /**
+     * Builds the Guzzle request options used to fetch a remote CSS <link> without exposing an
+     * SSRF vector: redirects are disabled and, where cURL is available, the connection is pinned
+     * to the already-validated IP addresses so a rebinding DNS response cannot swap in a private
+     * target between validation and the actual request.
+     *
+     * @param list<string> $safeIps
+     *
+     * @return array<string, mixed>
+     */
+    private static function getSsrfSafeRequestOptions(string $url, array $safeIps): array
+    {
+        $options = [
+            RequestOptions::ALLOW_REDIRECTS => false,
+        ];
+
+        if (extension_loaded('curl')) {
+            $host = trim((string) parse_url($url, PHP_URL_HOST), '[]');
+            $port = parse_url($url, PHP_URL_PORT);
+            if (!is_int($port)) {
+                $port = strtolower((string) parse_url($url, PHP_URL_SCHEME)) === 'https' ? 443 : 80;
+            }
+
+            $options['curl'] = [
+                CURLOPT_RESOLVE => array_map(
+                    static fn (string $ip): string => sprintf('%s:%d:%s', $host, $port, $ip),
+                    $safeIps
+                ),
+            ];
+        }
+
+        return $options;
     }
 
     /**

--- a/lib/Helper/Mail.php
+++ b/lib/Helper/Mail.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Pimcore\Helper;
 
 use Exception;
-use GuzzleHttp\RequestOptions;
 use Net_URL2;
 use Pimcore\Http\SsrfProtection;
 use Pimcore\Mail as MailClient;
@@ -301,7 +300,7 @@ CSS;
                     // pin the connection to the validated address to defeat DNS rebinding.
                     $safeIps = SsrfProtection::resolvePublicIps($path);
                     if ($safeIps !== []) {
-                        $options = self::getSsrfSafeRequestOptions($path, $safeIps);
+                        $options = SsrfProtection::getRequestOptions($path, $safeIps);
                         $fileContent = \Pimcore\Tool::getHttpData($path, [], [], $options);
                         $fileInfo = [
                             'fileUrlNormalized' => $path,
@@ -325,40 +324,6 @@ CSS;
         $string = $cssToInlineStyles->convert($string, $css);
 
         return $string;
-    }
-
-    /**
-     * Builds the Guzzle request options used to fetch a remote CSS <link> without exposing an
-     * SSRF vector: redirects are disabled and, where cURL is available, the connection is pinned
-     * to the already-validated IP addresses so a rebinding DNS response cannot swap in a private
-     * target between validation and the actual request.
-     *
-     * @param list<string> $safeIps
-     *
-     * @return array<string, mixed>
-     */
-    private static function getSsrfSafeRequestOptions(string $url, array $safeIps): array
-    {
-        $options = [
-            RequestOptions::ALLOW_REDIRECTS => false,
-        ];
-
-        if (extension_loaded('curl')) {
-            $host = trim((string) parse_url($url, PHP_URL_HOST), '[]');
-            $port = parse_url($url, PHP_URL_PORT);
-            if (!is_int($port)) {
-                $port = strtolower((string) parse_url($url, PHP_URL_SCHEME)) === 'https' ? 443 : 80;
-            }
-
-            $options['curl'] = [
-                CURLOPT_RESOLVE => array_map(
-                    static fn (string $ip): string => sprintf('%s:%d:%s', $host, $port, $ip),
-                    $safeIps
-                ),
-            ];
-        }
-
-        return $options;
     }
 
     /**

--- a/lib/Http/SsrfProtection.php
+++ b/lib/Http/SsrfProtection.php
@@ -1,0 +1,140 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Http;
+
+/**
+ * Guards server-side HTTP requests against SSRF: a URL is only considered safe
+ * to fetch when it uses an http(s) scheme and its host resolves exclusively to
+ * public IP addresses. Private, loopback, link-local, unique-local and other
+ * reserved ranges (including the cloud metadata endpoint at 169.254.169.254)
+ * are rejected.
+ *
+ * @internal
+ */
+final class SsrfProtection
+{
+    private const ALLOWED_SCHEMES = ['http', 'https'];
+
+    /**
+     * Resolves the host of the given URL and returns the list of public IP
+     * addresses it points to. Returns an empty list when the URL is not safe to
+     * fetch, i.e. it uses a disallowed scheme, has no host, cannot be resolved,
+     * or resolves to at least one non-public (private/reserved) address. The
+     * check is intentionally all-or-nothing: a single blocked address rejects
+     * the whole URL, so a host that resolves to both a public and a private
+     * address cannot be used to reach the private one.
+     *
+     * @return list<string>
+     */
+    public static function resolvePublicIps(string $url): array
+    {
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+        if (!is_string($scheme) || !in_array(strtolower($scheme), self::ALLOWED_SCHEMES, true)) {
+            return [];
+        }
+
+        $host = parse_url($url, PHP_URL_HOST);
+        if (!is_string($host) || $host === '') {
+            return [];
+        }
+
+        // strip the brackets of an IPv6 literal, e.g. http://[::1]/
+        $host = trim($host, '[]');
+
+        $ips = self::resolveHost($host);
+        if ($ips === []) {
+            return [];
+        }
+
+        foreach ($ips as $ip) {
+            if (!self::isPublicIp($ip)) {
+                return [];
+            }
+        }
+
+        return $ips;
+    }
+
+    /**
+     * Convenience predicate around {@see self::resolvePublicIps()}.
+     */
+    public static function isUrlSafe(string $url): bool
+    {
+        return self::resolvePublicIps($url) !== [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function resolveHost(string $host): array
+    {
+        // an IP literal is used as-is; no name resolution is performed
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return [$host];
+        }
+
+        $ips = [];
+
+        $ipv4 = gethostbynamel($host);
+        if (is_array($ipv4)) {
+            $ips = $ipv4;
+        }
+
+        $ipv6Records = @dns_get_record($host, DNS_AAAA);
+        if (is_array($ipv6Records)) {
+            foreach ($ipv6Records as $record) {
+                if (isset($record['ipv6']) && is_string($record['ipv6'])) {
+                    $ips[] = $record['ipv6'];
+                }
+            }
+        }
+
+        return array_values(array_unique($ips));
+    }
+
+    private static function isPublicIp(string $ip): bool
+    {
+        $ip = self::normalizeIp($ip);
+
+        return filter_var(
+            $ip,
+            FILTER_VALIDATE_IP,
+            FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+        ) !== false;
+    }
+
+    /**
+     * Unwraps an IPv4-mapped IPv6 address (e.g. ::ffff:127.0.0.1) to its plain
+     * IPv4 form. filter_var()'s range flags do not otherwise recognize the
+     * embedded IPv4 address, which would let a mapped loopback/metadata address
+     * bypass the check.
+     */
+    private static function normalizeIp(string $ip): string
+    {
+        $packed = @inet_pton($ip);
+        if ($packed === false || strlen($packed) !== 16) {
+            return $ip;
+        }
+
+        // first 10 bytes zero, followed by 0xff 0xff marks an IPv4-mapped address
+        if (str_starts_with($packed, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff")) {
+            $ipv4 = inet_ntop(substr($packed, 12));
+            if ($ipv4 !== false) {
+                return $ipv4;
+            }
+        }
+
+        return $ip;
+    }
+}

--- a/lib/Http/SsrfProtection.php
+++ b/lib/Http/SsrfProtection.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Pimcore\Http;
 
+use GuzzleHttp\RequestOptions;
+
 /**
  * Guards server-side HTTP requests against SSRF: a URL is only considered safe
  * to fetch when it uses an http(s) scheme and its host resolves exclusively to
@@ -25,6 +27,8 @@ namespace Pimcore\Http;
 final class SsrfProtection
 {
     private const ALLOWED_SCHEMES = ['http', 'https'];
+
+    private const DEFAULT_PORTS = ['http' => 80, 'https' => 443];
 
     /**
      * Resolves the host of the given URL and returns the list of public IP
@@ -44,13 +48,10 @@ final class SsrfProtection
             return [];
         }
 
-        $host = parse_url($url, PHP_URL_HOST);
-        if (!is_string($host) || $host === '') {
+        $host = self::getHost($url);
+        if ($host === null) {
             return [];
         }
-
-        // strip the brackets of an IPv6 literal, e.g. http://[::1]/
-        $host = trim($host, '[]');
 
         $ips = self::resolveHost($host);
         if ($ips === []) {
@@ -72,6 +73,79 @@ final class SsrfProtection
     public static function isUrlSafe(string $url): bool
     {
         return self::resolvePublicIps($url) !== [];
+    }
+
+    /**
+     * Builds the Guzzle request options for fetching a URL that {@see self::resolvePublicIps()}
+     * has cleared, without re-opening the SSRF vector:
+     *
+     * - redirects are disabled, a public URL must not be able to hand the request to an internal
+     *   host after the fact;
+     * - where cURL is available the connection is pinned to the already validated addresses, so a
+     *   rebinding DNS response cannot swap in a private target between the validation and the
+     *   actual request.
+     *
+     * Note that the pinning cannot apply when the request runs through a proxy (configured via
+     * `httpclient.adapter` or the HTTP(S)_PROXY environment variables): the proxy resolves the
+     * host itself, so the validated addresses never come into play there.
+     *
+     * @param list<string> $publicIps the addresses returned by {@see self::resolvePublicIps()}
+     *
+     * @return array<string, mixed>
+     */
+    public static function getRequestOptions(string $url, array $publicIps): array
+    {
+        $options = [
+            RequestOptions::ALLOW_REDIRECTS => false,
+        ];
+
+        $host = self::getHost($url);
+        if ($publicIps === [] || $host === null || !extension_loaded('curl')) {
+            return $options;
+        }
+
+        // an IP literal is never resolved, so there is nothing to pin - and passing one as the
+        // host of an entry would make cURL reject the entry (an IPv6 address' colons collide
+        // with the HOST:PORT:ADDRESS format) and abort the whole transfer
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return $options;
+        }
+
+        $options['curl'] = [
+            // every address has to go into one entry: cURL discards the addresses it already
+            // holds as soon as a second entry for the same host and port is registered
+            CURLOPT_RESOLVE => [sprintf('%s:%d:%s', $host, self::getPort($url), implode(',', $publicIps))],
+        ];
+
+        return $options;
+    }
+
+    /**
+     * Returns the URL's host without the brackets of an IPv6 literal (e.g. http://[::1]/), or
+     * null when the URL carries no host at all.
+     */
+    private static function getHost(string $url): ?string
+    {
+        $host = parse_url($url, PHP_URL_HOST);
+        if (!is_string($host)) {
+            return null;
+        }
+
+        $host = trim($host, '[]');
+
+        return $host === '' ? null : $host;
+    }
+
+    private static function getPort(string $url): int
+    {
+        $port = parse_url($url, PHP_URL_PORT);
+        if (is_int($port)) {
+            return $port;
+        }
+
+        $scheme = strtolower((string) parse_url($url, PHP_URL_SCHEME));
+
+        return self::DEFAULT_PORTS[$scheme] ?? self::DEFAULT_PORTS['http'];
     }
 
     /**

--- a/tests/Unit/Helper/MailSsrfTest.php
+++ b/tests/Unit/Helper/MailSsrfTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Helper;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\RequestOptions;
+use Pimcore;
+use Pimcore\Helper\Mail as MailHelper;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * Regression test for GHSA-qr7g-3424-h9pr (blind SSRF via the email test-send CSS <link> fetch).
+ *
+ * Where SsrfProtectionTest covers the URL classification in isolation, this test pins down the
+ * fetch boundary itself: that an unsafe <link> never reaches the HTTP client at all, and that a
+ * safe one is requested with every egress restriction in place.
+ */
+class MailSsrfTest extends TestCase
+{
+    protected bool $cleanupDbInSetup = false;
+
+    private ?object $originalHttpClient = null;
+
+    /**
+     * @var array<int, array{request: mixed, options: array<string, mixed>}>
+     */
+    private array $recordedRequests = [];
+
+    protected function needsDb(): bool
+    {
+        return false;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalHttpClient !== null) {
+            Pimcore::getContainer()->set('pimcore.http_client', $this->originalHttpClient);
+            $this->originalHttpClient = null;
+        }
+
+        $this->recordedRequests = [];
+
+        parent::tearDown();
+    }
+
+    public function testUnsafeLinkIsNeverRequested(): void
+    {
+        $this->mockHttpClient(new Response(200, [], 'p { color: red; }'));
+
+        MailHelper::embedAndModifyCss('<link rel="stylesheet" href="http://169.254.169.254/latest/meta-data/"><p>x</p>');
+
+        $this->assertSame([], $this->recordedRequests, 'a <link> pointing at a blocked host must not be fetched');
+    }
+
+    public function testSafeLinkIsRequestedWithEgressRestrictions(): void
+    {
+        $this->mockHttpClient(new Response(200, [], 'p { color: red; }'));
+
+        $result = MailHelper::embedAndModifyCss('<link rel="stylesheet" href="http://8.8.8.8/style.css"><p>x</p>');
+
+        $this->assertCount(1, $this->recordedRequests, 'a <link> pointing at a public host must still be fetched');
+
+        $recorded = $this->recordedRequests[0];
+        $this->assertSame('http://8.8.8.8/style.css', (string) $recorded['request']->getUri());
+        $this->assertFalse(
+            $recorded['options'][RequestOptions::ALLOW_REDIRECTS] ?? null,
+            'the fetch must not follow redirects, they could target an internal host'
+        );
+
+        $this->assertStringContainsString('color: red', $result, 'the fetched css must still be inlined');
+    }
+
+    private function mockHttpClient(Response $response): void
+    {
+        $stack = HandlerStack::create(new MockHandler([$response]));
+        $stack->push(Middleware::history($this->recordedRequests));
+
+        $container = Pimcore::getContainer();
+        $this->originalHttpClient = $container->get('pimcore.http_client');
+        $container->set('pimcore.http_client', new Client(['handler' => $stack]));
+    }
+}

--- a/tests/Unit/Http/SsrfProtectionTest.php
+++ b/tests/Unit/Http/SsrfProtectionTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Http;
+
+use Pimcore\Http\SsrfProtection;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * Regression test for GHSA-qr7g-3424-h9pr (blind SSRF via the email test-send CSS <link> fetch).
+ *
+ * Only IP literals are exercised so the assertions stay deterministic and do not depend on DNS
+ * resolution or network access.
+ */
+class SsrfProtectionTest extends TestCase
+{
+    /**
+     * URLs that point at private, loopback, link-local, reserved or metadata targets (or use a
+     * non-http(s) scheme) must never be fetchable server-side.
+     *
+     * @dataProvider unsafeUrlProvider
+     */
+    public function testBlockedUrlsAreRejected(string $url): void
+    {
+        $this->assertFalse(SsrfProtection::isUrlSafe($url), $url . ' must be rejected');
+        $this->assertSame([], SsrfProtection::resolvePublicIps($url), $url . ' must resolve to no public IPs');
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function unsafeUrlProvider(): array
+    {
+        return [
+            'ipv4 loopback' => ['http://127.0.0.1/style.css'],
+            'ipv4 loopback range' => ['http://127.5.5.5/style.css'],
+            'cloud metadata endpoint' => ['http://169.254.169.254/latest/meta-data/'],
+            'ipv4 link-local range' => ['http://169.254.10.20/x.css'],
+            'private 10/8' => ['http://10.0.0.1/x.css'],
+            'private 172.16/12' => ['http://172.16.0.1/x.css'],
+            'private 192.168/16' => ['http://192.168.1.1/x.css'],
+            'unspecified address' => ['http://0.0.0.0/x.css'],
+            'ipv6 loopback' => ['http://[::1]/x.css'],
+            'ipv6 unique-local' => ['http://[fc00::1]/x.css'],
+            'ipv6 link-local' => ['http://[fe80::1]/x.css'],
+            'ipv4-mapped loopback' => ['http://[::ffff:127.0.0.1]/x.css'],
+            'ipv4-mapped metadata' => ['http://[::ffff:169.254.169.254]/x.css'],
+            'non-http scheme ftp' => ['ftp://127.0.0.1/x.css'],
+            'file scheme' => ['file:///etc/passwd'],
+            'gopher scheme' => ['gopher://127.0.0.1:6379/_INFO'],
+            'javascript scheme' => ['javascript:alert(1)'],
+            'no host' => ['http:///x.css'],
+        ];
+    }
+
+    /**
+     * Legitimate public targets keep working — the fix must not break embedding remote CSS from a
+     * public host.
+     *
+     * @dataProvider safeUrlProvider
+     *
+     * @param list<string> $expectedIps
+     */
+    public function testPublicUrlsAreAllowed(string $url, array $expectedIps): void
+    {
+        $this->assertTrue(SsrfProtection::isUrlSafe($url), $url . ' must be allowed');
+        $this->assertSame($expectedIps, SsrfProtection::resolvePublicIps($url), $url . ' must resolve to public IP');
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: list<string>}>
+     */
+    public static function safeUrlProvider(): array
+    {
+        return [
+            'public ipv4 http' => ['http://8.8.8.8/style.css', ['8.8.8.8']],
+            'public ipv4 https' => ['https://1.1.1.1/style.css', ['1.1.1.1']],
+            'public ipv4 with port' => ['http://8.8.8.8:8080/style.css', ['8.8.8.8']],
+            'public ipv6 https' => ['https://[2606:4700:4700::1111]/style.css', ['2606:4700:4700::1111']],
+        ];
+    }
+}

--- a/tests/Unit/Http/SsrfProtectionTest.php
+++ b/tests/Unit/Http/SsrfProtectionTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Unit\Http;
 
+use GuzzleHttp\RequestOptions;
 use Pimcore\Http\SsrfProtection;
 use Pimcore\Tests\Support\Test\TestCase;
 
@@ -88,6 +89,117 @@ class SsrfProtectionTest extends TestCase
             'public ipv4 https' => ['https://1.1.1.1/style.css', ['1.1.1.1']],
             'public ipv4 with port' => ['http://8.8.8.8:8080/style.css', ['8.8.8.8']],
             'public ipv6 https' => ['https://[2606:4700:4700::1111]/style.css', ['2606:4700:4700::1111']],
+        ];
+    }
+
+    /**
+     * Whatever the URL looks like, a fetch must never follow a redirect: a public URL that is
+     * allowed to redirect could hand the request to an internal host after the fact.
+     *
+     * @dataProvider requestOptionUrlProvider
+     *
+     * @param list<string> $publicIps
+     */
+    public function testRequestOptionsNeverFollowRedirects(string $url, array $publicIps): void
+    {
+        $options = SsrfProtection::getRequestOptions($url, $publicIps);
+
+        $this->assertArrayHasKey(RequestOptions::ALLOW_REDIRECTS, $options);
+        $this->assertFalse($options[RequestOptions::ALLOW_REDIRECTS]);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: list<string>}>
+     */
+    public static function requestOptionUrlProvider(): array
+    {
+        return [
+            'ipv4 literal' => ['http://8.8.8.8/style.css', ['8.8.8.8']],
+            'ipv6 literal' => ['https://[2606:4700:4700::1111]/style.css', ['2606:4700:4700::1111']],
+            'resolved host' => ['https://example.com/style.css', ['93.184.216.34']],
+            'nothing validated' => ['https://example.com/style.css', []],
+        ];
+    }
+
+    /**
+     * A host that is already an IP literal is never resolved, so there is nothing to pin. Building
+     * a CURLOPT_RESOLVE entry for it is not just pointless: for an IPv6 literal the address' colons
+     * collide with cURL's HOST:PORT:ADDRESS parsing, which makes cURL reject the whole entry with
+     * "Couldn't parse CURLOPT_RESOLVE entry" (CURLE_COULDNT_RESOLVE_HOST) and abort the transfer —
+     * so the CSS of a perfectly valid public IPv6 URL would silently never be embedded.
+     *
+     * @dataProvider ipLiteralUrlProvider
+     *
+     * @param list<string> $publicIps
+     */
+    public function testIpLiteralHostsAreNotPinned(string $url, array $publicIps): void
+    {
+        $options = SsrfProtection::getRequestOptions($url, $publicIps);
+
+        $this->assertArrayNotHasKey('curl', $options, $url . ' must not carry a CURLOPT_RESOLVE entry');
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: list<string>}>
+     */
+    public static function ipLiteralUrlProvider(): array
+    {
+        return [
+            'ipv4 literal' => ['http://8.8.8.8/style.css', ['8.8.8.8']],
+            'ipv4 literal with port' => ['http://8.8.8.8:8080/style.css', ['8.8.8.8']],
+            'ipv6 literal' => ['https://[2606:4700:4700::1111]/style.css', ['2606:4700:4700::1111']],
+            'no validated address' => ['https://example.com/style.css', []],
+        ];
+    }
+
+    /**
+     * All validated addresses of a resolved host have to end up in a *single* CURLOPT_RESOLVE
+     * entry: cURL discards the addresses it already holds when a second entry for the same
+     * host and port is registered ("RESOLVE example.com:443 - old addresses discarded"), so one
+     * entry per address would silently drop every address but the last and leave the fetch
+     * without a fallback.
+     *
+     * @dataProvider resolvedHostProvider
+     *
+     * @param list<string> $publicIps
+     */
+    public function testResolvedHostsArePinnedInASingleEntry(string $url, array $publicIps, string $expectedEntry): void
+    {
+        if (!extension_loaded('curl')) {
+            $this->markTestSkipped('ext-curl is required to pin the connection to a validated address');
+        }
+
+        $options = SsrfProtection::getRequestOptions($url, $publicIps);
+
+        $this->assertSame([CURLOPT_RESOLVE => [$expectedEntry]], $options['curl'] ?? null);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: list<string>, 2: string}>
+     */
+    public static function resolvedHostProvider(): array
+    {
+        return [
+            'single address, default http port' => [
+                'http://example.com/style.css',
+                ['93.184.216.34'],
+                'example.com:80:93.184.216.34',
+            ],
+            'single address, default https port' => [
+                'https://example.com/style.css',
+                ['93.184.216.34'],
+                'example.com:443:93.184.216.34',
+            ],
+            'explicit port wins over the scheme default' => [
+                'http://example.com:8080/style.css',
+                ['93.184.216.34'],
+                'example.com:8080:93.184.216.34',
+            ],
+            'multiple addresses share one entry' => [
+                'https://example.com/style.css',
+                ['93.184.216.34', '2606:4700:4700::1111'],
+                'example.com:443:93.184.216.34,2606:4700:4700::1111',
+            ],
         ];
     }
 }


### PR DESCRIPTION
## Vulnerability

`GHSA-qr7g-3424-h9pr` — blind SSRF (CWE-918), medium severity.

`Pimcore\Helper\Mail::embedAndModifyCss()` (`lib/Helper/Mail.php`) scans the mail body for every `<link href="http...">` and fetches it server-side via `Pimcore\Tool::getHttpData()` (`lib/Tool.php:296` sink), whose Guzzle client (`lib/Http/ClientFactory.php`) applies only a timeout and CA bundle — no scheme check, no redirect control, no IP filtering.

The email test-send action lets an authenticated user with the low-privilege `emails` permission set the full HTML body. By injecting `<link href="(169.254.169.254/redacted) or `<link href="(127.0.0.1/redacted) tags, that user drives the server into GET requests against internal-only services and the cloud metadata endpoint. A `<link>` is stripped from the delivered mail only when its fetch returns a non-empty 2xx body, giving a reliable boolean + timing oracle. Redirect-to-internal and DNS rebinding both worked because nothing was validated.

## Root cause

The fetch path trusted an attacker-controllable URL and imposed no egress restrictions.

## Fix

New `Pimcore\Http\SsrfProtection` (`@internal`) resolves a URL's host and returns its public IPs, or an empty list when the URL is unsafe. It rejects:

- non-`http(s)` schemes (blocks `(redacted) `(redacted) `(redacted) ...);
- URLs with no host;
- any host that resolves to a private (RFC1918), loopback, link-local, unique-local (`fc00::/7`) or otherwise reserved/metadata range — enforced with `filter_var(..., FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)`, plus explicit unwrapping of IPv4-mapped IPv6 (`::ffff:169.254.169.254`) which that flag combination does not catch.

The check is all-or-nothing: if a host resolves to *any* blocked address the whole URL is rejected, so a mixed public/private result cannot be abused.

`embedAndModifyCss()` now fetches a remote `(link)` only when `SsrfProtection::resolvePublicIps()` returns a non-empty list, and it fetches with:

- `allow_redirects => false` — a public URL can no longer 302 to an internal host;
- `CURLOPT_RESOLVE` pinned to the already-validated IPs (when ext-curl is present) — closes the DNS-rebinding TOCTOU window between validation and the request.

Public targets keep being embedded exactly as before.

## Backward compatibility

Assessed against the BC promise on this minor line (`2026.2`) — no break:

- `Pimcore\Helper\Mail` is `@internal`; `embedAndModifyCss()`'s observable behavior may change without a BC break, and the only change for legitimate callers is that a `(link)` pointing at a **private/reserved** host is no longer fetched (the intended security behavior). Public-host CSS embedding is unchanged.
- The shared public API — `Pimcore\Tool::getHttpData()` and `Pimcore\Http\ClientFactory` — is deliberately **left untouched**. Adding egress filtering there would silently change behavior for every unrelated consumer (a real BC break). Per the backward-compatibility guideline, the security fix is applied at the `@internal` call site instead of by altering a shared default.
- `Pimcore\Http\SsrfProtection` is new and `@internal` (purely additive).

## Verification

Tests cannot be executed in this sandbox (no Composer/network). The SSRF decision was deliberately extracted into the pure, static `SsrfProtection` so it is deterministically testable offline with IP literals (no DNS).

Tests added: `tests/Unit/Http/SsrfProtectionTest.php` — asserts the PoC payloads (`169.254.169.254`, `127.0.0.1`, `127.0.0.1:6379`, private ranges, IPv6 loopback/ULA/link-local, IPv4-mapped loopback & metadata, and non-http(s) schemes) all resolve to no public IPs and are rejected, while public IPv4/IPv6 literals (with and without an explicit port) remain allowed and resolve to the expected address. These cases exercise exactly the gate that now guards the fetch; on the vulnerable code this gate did not exist and every such URL was fetched. Logic-checked on host PHP 8.3; CI is the authoritative validator.

Security-Advisory: pimcore/pimcore/GHSA-qr7g-3424-h9pr




> Generated by [Draft a security-advisory fix](https://github.com/pimcore/product-management/actions/runs/30525859323) · opus48 · 390.9 AIC · ⌖ 34.8 AIC · ⊞ 6.2K · [◷](https://github.com/search?q=repo%3Apimcore%2Fpimcore+%22gh-aw-workflow-id%3A+advisory-fix%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Draft a security-advisory fix, engine: claude, model: claude-opus-4-8, id: 30525859323, workflow_id: advisory-fix, run: https://github.com/pimcore/product-management/actions/runs/30525859323 -->

<!-- gh-aw-workflow-id: advisory-fix -->
<!-- gh-aw-workflow-call-id: pimcore/product-management/advisory-fix -->