### PR TITLE
[security] GHSA-mfxm-7h2h-p8xw: Classificationstore bypasses field-name identifier validation

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -556,7 +556,7 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
 
     public function setName(string $name): static
     {
-        $this->name = $name;
+        parent::setName($name);
 
         return $this;
     }

--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
 use Exception;
+use InvalidArgumentException;
 use Pimcore\Model;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
@@ -554,6 +555,9 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
         return $this->layout;
     }
 
+    /**
+     * @throws InvalidArgumentException
+     */
     public function setName(string $name): static
     {
         parent::setName($name);

--- a/tests/Unit/Models/DataObject/ClassDefinition/SetNameValidationTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/SetNameValidationTest.php
@@ -15,6 +15,7 @@ namespace Pimcore\Tests\Unit\Model\DataObject\ClassDefinition;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Classificationstore;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Input;
 
 /**
@@ -76,5 +77,37 @@ class SetNameValidationTest extends TestCase
             'contains dash' => ['my-field'],
             'too long (64)' => [str_repeat('a', 64)],
         ];
+    }
+
+    /**
+     * Classificationstore overrides setName()/getName() and, unlike every other field type, did not
+     * delegate to Data::setName(), so it bypassed the identifier validation entirely (GHSA-mfxm-7h2h-p8xw).
+     *
+     * @dataProvider validNameProvider
+     */
+    public function testValidNamesAreAcceptedForClassificationstore(string $name): void
+    {
+        $field = new Classificationstore();
+        $field->setName($name);
+
+        $this->assertSame($name, $field->getName());
+    }
+
+    public function testEmptyNameIsAcceptedForClassificationstore(): void
+    {
+        $field = new Classificationstore();
+        $field->setName('');
+
+        $this->assertSame('', $field->getName());
+    }
+
+    /**
+     * @dataProvider invalidNameProvider
+     */
+    public function testInvalidNamesAreRejectedForClassificationstore(string $name): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new Classificationstore())->setName($name);
     }
 }


### PR DESCRIPTION
## Vulnerability

GHSA-mfxm-7h2h-p8xw describes unsanitized Data Object field names being emitted verbatim into generated, autoloaded PHP class files (docblocks, `@method` tags, `const FIELD_*`, and generated getter/setter method names/bodies), allowing a user with the "classes" permission to inject arbitrary PHP into a compiled class file.

## Root cause / existing fix

The base `ClassDefinition\(redacted) (`models/DataObject/ClassDefinition/Data.php:168`) already validates field names against `/^[a-zA-Z_][a-zA-Z0-9_]{0,62}$/` and throws `InvalidArgumentException` otherwise — this closes the vulnerability for the field types that rely on the inherited setter (e.g. `CalculatedValue`, the type used in the advisory's PoC).

However, `ClassDefinition\Data\Classificationstore` (`models/DataObject/ClassDefinition/Data/Classificationstore.php:557`) overrides `setName()` and assigns `$this->name = $name;` directly, completely bypassing that validation. `Classificationstore` extends `Data` and does not override `getGetterCode()`/`getSetterCode()`, `isFilterable()`, or the docblock builders, so its (unvalidated) name still flows through every sink named in the advisory: `FieldDefinitionDocBlockBuilder`, `ClassBuilder`'s `@method` docblocks, `Service::buildFieldConstantCode()`, and the inherited `(redacted) A classificationstore-type field named with the same kind of payload as the advisory's `CalculatedValue` PoC reopens the identical RCE-adjacent code-injection path.

## Fix

`Classificationstore::setName()` now delegates to `parent::setName($name)` instead of duplicating the raw assignment, so it goes through the same identifier validation as every other field type. This is a 1-line change scoped exactly to the bypassed validation; `getName()` is left untouched.

## Backward compatibility

`Classificationstore::setName()` is public, non-`@internal` API, so per the BC promise this is evaluated as tightening validation on an existing public method — normally BC-sensitive. However:
- This isn't a new BC decision: the identical validation was already accepted and shipped in `(redacted) for every other field type on this same branch. `Classificationstore` was an inconsistent override that accidentally escaped an already-approved, repo-wide security control — this change closes that gap rather than introducing a new behavior change.
- No legitimate caller could have relied on the rejected inputs: a classificationstore field name is compiled into a PHP property name, getter/setter method name, and class constant. Any name that fails the identifier regex (spaces, semicolons, backticks, parens, etc.) already produced broken/uncompilable generated PHP before this fix — i.e. not a working configuration to begin with.
- No signature, default value, or return type changes; only previously-broken/malicious inputs now fail fast with `InvalidArgumentException` instead of corrupting a generated file.

## Verification

Tests added: `tests/Unit/Models/DataObject/ClassDefinition/SetNameValidationTest.php` (new methods `testValidNamesAreAcceptedForClassificationstore`, `testEmptyNameIsAcceptedForClassificationstore`, `testInvalidNamesAreRejectedForClassificationstore`), extending the existing regression test for the original `(redacted) fix to also cover `Classificationstore`. These fail against the vulnerable code (no exception thrown for malicious names, e.g. `x;function __construct(){}//`) and pass against the fix, while confirming legitimate names (including the empty-string transient case) still work. I could not execute the suite in this sandbox (no Composer/`vendor/`, no network access) — verified with `php -l` for syntax only; CI is the actual validator.

Security-Advisory: pimcore/pimcore/GHSA-mfxm-7h2h-p8xw




> Generated by [Draft a security-advisory fix](https://github.com/pimcore/workflows-centralized/actions/runs/30611248571) · sonnet50 · 152.7 AIC · ⌖ 17.7 AIC · ⊞ 6.2K · [◷](https://github.com/search?q=repo%3Apimcore%2Fpimcore+%22gh-aw-workflow-id%3A+advisory-fix%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Draft a security-advisory fix, engine: claude, model: claude-sonnet-5, id: 30611248571, workflow_id: advisory-fix, run: https://github.com/pimcore/workflows-centralized/actions/runs/30611248571 -->

<!-- gh-aw-workflow-id: advisory-fix -->
<!-- gh-aw-workflow-call-id: pimcore/workflows-centralized/advisory-fix -->