### PR TITLE
[security] GHSA-7m33-xgw9-j3g7: Block pimcore_file_exists in Twig sandbox by default

### DIFF
--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -380,6 +380,7 @@ pimcore:
                     # - pimcore_site_by_domain
                     # - pimcore_site_current
                     - pimcore_user
+                    - pimcore_file_exists
                 hard_blocked_methods:
                     Pimcore\Model\User:
                         - getPassword

--- a/bundles/CoreBundle/src/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Configuration.php
@@ -2105,7 +2105,8 @@ final class Configuration implements ConfigurationInterface
                             ->arrayNode('blocked_functions')
                                 ->info('`pimcore_*` function names that must not be covered by the blanket
                                 `pimcore_*` prefix auto-allow. Defaults to Pimcore\'s built-in denylist of
-                                functions that look up and return a live model instance by id/path - a site can
+                                functions that look up and return a live model instance by id/path, or that
+                                expose a filesystem/state oracle (e.g. `pimcore_file_exists`) - a site can
                                 append further function names on top of that default.')
                                 ->scalarPrototype()->end()
                             ->end()

--- a/doc/09_Development_Tools/03_Security_and_Authentication/07_Twig_Sandbox_Object_Access.md
+++ b/doc/09_Development_Tools/03_Security_and_Authentication/07_Twig_Sandbox_Object_Access.md
@@ -65,9 +65,13 @@ The `functions` option (see [Email Framework](../05_Email_Framework/README.md#sa
 is an explicit allowlist: a function must be listed there to be callable from a
 sandboxed template. Independently, any Twig function whose name starts with
 `pimcore_` is additionally auto-allowed, except for the `blocked_functions` denylist.
-By default, that denylist only contains `pimcore_user` (see
+By default, that denylist contains `pimcore_user` (see
 [Hard-blocked methods](#hard-blocked-methods) above for why `User` getters are
-additionally hard-blocked at the object layer regardless).
+additionally hard-blocked at the object layer regardless) and
+`pimcore_file_exists`, which calls PHP's `is_file()` directly on its argument and
+would otherwise let a sandboxed template use its boolean result as a
+filesystem-existence oracle for any path reachable by the PHP process
+(GHSA-7m33-xgw9-j3g7).
 
 All other `pimcore_*` functions - including the other id/path lookup functions,
 `pimcore_asset`, `pimcore_asset_by_path`, `pimcore_document`,
@@ -132,10 +136,10 @@ pimcore:
                 # Non-empty => object allowlist mode. Deactivates the class denylist entirely.
                 allowed_classes: []
                 # Defaults to the built-in pimcore_* function denylist - a site's own
-                # config is appended to it. Only pimcore_user is blocked out of the
-                # box; the id/path lookup functions below are shipped commented out -
-                # uncomment them (or add the equivalent to a site's own config) for a
-                # high-security setup.
+                # config is appended to it. Only pimcore_user and pimcore_file_exists
+                # are blocked out of the box; the id/path lookup functions below are
+                # shipped commented out - uncomment them (or add the equivalent to a
+                # site's own config) for a high-security setup.
                 blocked_functions:
                     # - pimcore_asset
                     # - pimcore_asset_by_path
@@ -151,6 +155,7 @@ pimcore:
                     # - pimcore_site_by_domain
                     # - pimcore_site_current
                     - pimcore_user
+                    - pimcore_file_exists
                 # FQCN => method names that are never callable, regardless of
                 # blocked_classes/allowed_classes. Defaults to a small set of
                 # secret/content-returning getters - a site's own config is merged

--- a/tests/Unit/Twig/Sandbox/SecurityPolicyTest.php
+++ b/tests/Unit/Twig/Sandbox/SecurityPolicyTest.php
@@ -315,6 +315,17 @@ final class SecurityPolicyTest extends TestCase
         $policy->checkSecurity([], [], ['pimcore_user']);
     }
 
+    public function testPimcoreFileExistsIsNotAutoAllowedByDefault(): void
+    {
+        // GHSA-7m33-xgw9-j3g7: pimcore_file_exists() calls PHP's is_file() directly on
+        // its argument, letting a sandboxed template use the boolean result as a
+        // filesystem-existence oracle for any path reachable by the PHP process.
+        $policy = new SecurityPolicy(blockedFunctions: self::defaultSandboxSecurityPolicyConfig()['blocked_functions']);
+
+        $this->expectException(SecurityNotAllowedFunctionError::class);
+        $policy->checkSecurity([], [], ['pimcore_file_exists']);
+    }
+
     /**
      * @dataProvider idLookupPimcoreFunctionsAutoAllowedByDefaultProvider
      */


### PR DESCRIPTION
Resolves https://github.com/pimcore/platform-version/issues/315

## Vulnerability

`Pimcore\Twig\Sandbox\SecurityPolicy::checkSecurity()` auto-allows any Twig function whose name starts with `pimcore_`, unless it is listed in the `blocked_functions` denylist (`lib/Twig/Sandbox/SecurityPolicy.php:158-166`). `HelpersExtension` registers `pimcore_file_exists` (`lib/Twig/Extension/HelpersExtension.php:51-53`) as a closure that calls PHP's `is_file()` directly on its template-controlled argument.

`DataObject\ClassDefinition\Layout\Text::enrichLayoutDefinition()` renders `Text::$html` inside this sandbox (`getTwigEnvironment(true)`), so a template that can influence a `Text` layout's `html` (or otherwise trigger this rendering path) can call `{{ pimcore_file_exists('<path>') }}` and observe a different boolean result for existing vs. missing paths — a filesystem-existence oracle for any path reachable by the PHP process. `pimcore_file_exists` was not on the shipped `blocked_functions` list (only `pimcore_user` was), so it stayed reachable through the `pimcore_*` wildcard by default.

## Root cause

The `pimcore_*` prefix auto-allow is a wildcard; `pimcore_file_exists` performs a direct, argument-controlled filesystem stat with no further access control, and it wasn't added to the existing denylist mechanism.

## Fix

Add `pimcore_file_exists` to the built-in `blocked_functions` default in `bundles/CoreBundle/config/pimcore/default.yaml`, alongside the existing `pimcore_user` entry. This follows the exact precedent already established in this codebase for `pimcore_user` (added for the earlier GHSA-7gfm-v2fx-xrxm fix): a specifically dangerous `pimcore_*` function is denylisted by default while the general wildcard mechanism (documented and used by many legitimate `pimcore_*` helpers) is left in place. Also updated the `Configuration.php` option description and `doc/09_Development_Tools/03_Security_and_Authentication/07_Twig_Sandbox_Object_Access.md` to document the new default and its rationale.

I scoped this narrowly to `pimcore_file_exists`, the function demonstrated in the advisory. I did not replace the whole `pimcore_*` wildcard with a full allowlist (the advisory's broader suggested remediation) — that would be a much larger behavior change affecting every other auto-allowed `pimcore_*` helper and is out of scope for a minimal, targeted fix.

## Backward compatibility

This changes the *default value* of the `sandbox_security_policy.blocked_functions` config option, not any public method signature, return type, class, or visibility. It is a behavior change: a sandboxed template that was previously able to call `pimcore_file_exists()` will now get `SecurityNotAllowedFunctionError` unless a site explicitly re-allows it.

This class of change (tightening a built-in denylist default for a specific dangerous `pimcore_*` function) is the same category of change this codebase's own prior security fix (GHSA-7gfm-v2fx-xrxm, which added `pimcore_user` and `hard_blocked_methods` to these same defaults) already shipped on this branch line — i.e., there is direct precedent in this repository for treating this as an acceptable security-hardening default rather than a BC-breaking API change. A site that legitimately needs `pimcore_file_exists()` in a sandboxed template retains an explicit escape hatch: add it to the `functions` allowlist (`sandbox_security_policy.functions`), which is checked before the `blocked_functions` denylist and bypasses it.

## Tests

Tests added: `tests/Unit/Twig/Sandbox/SecurityPolicyTest.php` — `testPimcoreFileExistsIsNotAutoAllowedByDefault()` asserts that, with the shipped default `blocked_functions` config, `SecurityPolicy::checkSecurity()` throws `SecurityNotAllowedFunctionError` for `pimcore_file_exists`. This test fails against the vulnerable state (function was not in `blocked_functions`, so no exception is thrown) and passes with the fix. It follows the exact pattern of the existing `testPimcoreUserIsNotAutoAllowedByDefault()` test, reading the default config from `default.yaml` via the test's existing `defaultSandboxSecurityPolicyConfig()` helper so it exercises the real shipped default, not a duplicated fixture. Existing tests (`testOtherPimcoreFunctionsRemainAutoAllowedByDefault`, `testNonPimcoreFunctionsStillRequireExplicitAllow`, etc.) continue to cover that unrelated `pimcore_*` functions and the general wildcard mechanism are unaffected.

I could not execute the suite in this sandbox (no Composer/vendor, no network access), but confirmed `php -l` passes on all changed PHP files and manually verified the YAML fragment extraction/parsing used by the test's `defaultSandboxSecurityPolicyConfig()` helper picks up the new entry correctly.

Security-Advisory: pimcore/pimcore/GHSA-7m33-xgw9-j3g7




> Generated by [Draft a security-advisory fix](https://github.com/pimcore/workflows-centralized/actions/runs/30613522108) · sonnet50 · 100.6 AIC · ⌖ 18.4 AIC · ⊞ 6.2K · [◷](https://github.com/search?q=repo%3Apimcore%2Fpimcore+%22gh-aw-workflow-id%3A+advisory-fix%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Draft a security-advisory fix, engine: claude, model: claude-sonnet-5, id: 30613522108, workflow_id: advisory-fix, run: https://github.com/pimcore/workflows-centralized/actions/runs/30613522108 -->

<!-- gh-aw-workflow-id: advisory-fix -->
<!-- gh-aw-workflow-call-id: pimcore/workflows-centralized/advisory-fix -->