### PR TITLE
[security] GHSA-3hv6-4774-vpmf: enforce rename permission on WebDAV same-directory MOVE

### DIFF
--- a/models/Asset/WebDAV/Tree.php
+++ b/models/Asset/WebDAV/Tree.php
@@ -79,7 +79,11 @@ class Tree extends DAV\Tree
                     $asset = Asset::getByPath('/' . $sourcePath);
                 }
 
-                if (!$asset->isAllowed('rename', $user)) {
+                // Only require the "rename" permission when the filename actually changes. On the
+                // overwrite paths above $asset is resolved from the destination, so setFilename()
+                // below is a no-op there and the MOVE is not a rename - gating it would break the
+                // safe-save flow of third party software described above.
+                if ($asset->getFilename() !== basename($destinationPath) && !$asset->isAllowed('rename', $user)) {
                     throw new Forbidden('Missing "rename" permission');
                 }
 

--- a/models/Asset/WebDAV/Tree.php
+++ b/models/Asset/WebDAV/Tree.php
@@ -78,6 +78,11 @@ class Tree extends DAV\Tree
                 if (!$asset) {
                     $asset = Asset::getByPath('/' . $sourcePath);
                 }
+
+                if (!$asset->isAllowed('rename', $user)) {
+                    throw new Forbidden('Missing "rename" permission');
+                }
+
                 $asset->setFilename(basename($destinationPath));
             } else {
                 $asset = Asset::getByPath('/' . $sourcePath);

--- a/tests/Model/Asset/WebDAV/TreeMoveRenamePermissionTest.php
+++ b/tests/Model/Asset/WebDAV/TreeMoveRenamePermissionTest.php
@@ -1,0 +1,151 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\Asset\WebDAV;
+
+use Pimcore;
+use Pimcore\Model\Asset;
+use Pimcore\Model\Asset\WebDAV\Folder;
+use Pimcore\Model\Asset\WebDAV\Tree;
+use Pimcore\Model\User;
+use Pimcore\Model\User\Workspace\Asset as AssetWorkspace;
+use Pimcore\Security\User\User as SecurityUser;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+use Sabre\DAV\Exception\Forbidden;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+
+/**
+ * Regression test for GHSA-3hv6-4774-vpmf: a WebDAV same-directory MOVE (rename) must be gated by
+ * the "rename" workspace permission, not just "publish". A user granted publish-but-not-rename on
+ * an asset must not be able to rename it by issuing a same-directory MOVE.
+ *
+ * @group model.asset.webdav
+ */
+class TreeMoveRenamePermissionTest extends ModelTestCase
+{
+    private ?User $createdUser = null;
+
+    private ?User\Role $createdRole = null;
+
+    private ?TokenInterface $originalToken = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalToken = $this->tokenStorage()->getToken();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tokenStorage()->setToken($this->originalToken);
+
+        $this->createdUser?->delete();
+        $this->createdRole?->delete();
+
+        parent::tearDown();
+    }
+
+    public function testSameDirectoryMoveIsForbiddenWithoutRenamePermission(): void
+    {
+        $asset = $this->createAsset('rename-source-forbidden.txt');
+        $this->loginAs($this->createUserWithWorkspace($asset, publish: true, rename: false));
+
+        try {
+            $this->createTree()->move($asset->getFilename(), 'rename-target-forbidden.txt');
+            $this->fail('Expected a Forbidden exception because the user lacks the "rename" permission.');
+        } catch (Forbidden $e) {
+            // expected
+        }
+
+        $reloaded = Asset::getById($asset->getId(), ['force' => true]);
+        $this->assertSame(
+            'rename-source-forbidden.txt',
+            $reloaded->getFilename(),
+            'a user with publish but not rename permission must not be able to rename the asset via WebDAV MOVE'
+        );
+    }
+
+    public function testSameDirectoryMoveSucceedsWithRenamePermission(): void
+    {
+        $asset = $this->createAsset('rename-source-allowed.txt');
+        $this->loginAs($this->createUserWithWorkspace($asset, publish: true, rename: true));
+
+        $this->createTree()->move($asset->getFilename(), 'rename-target-allowed.txt');
+
+        $reloaded = Asset::getById($asset->getId(), ['force' => true]);
+        $this->assertSame(
+            'rename-target-allowed.txt',
+            $reloaded->getFilename(),
+            'a user with both publish and rename permission must still be able to rename the asset via WebDAV MOVE'
+        );
+    }
+
+    private function createAsset(string $filename): Asset
+    {
+        $asset = new Asset();
+        $asset->setParent(Asset::getByPath('/'));
+        $asset->setFilename($filename);
+        $asset->setData('some content');
+        $asset->save();
+
+        return $asset;
+    }
+
+    private function createUserWithWorkspace(Asset $asset, bool $publish, bool $rename): User
+    {
+        $workspace = new AssetWorkspace();
+        $workspace->setCid($asset->getId());
+        $workspace->setCpath($asset->getRealFullPath());
+        $workspace->setList(true);
+        $workspace->setView(true);
+        $workspace->setPublish($publish);
+        $workspace->setRename($rename);
+
+        $role = new User\Role();
+        $role->setParentId(0);
+        $role->setName('webdav_rename_role_' . uniqid());
+        $role->setPermissions(['assets']);
+        $role->setWorkspacesAsset([$workspace]);
+        $role->save();
+        $this->createdRole = $role;
+
+        $user = new User();
+        $user->setParentId(0);
+        $user->setName('webdav_rename_user_' . uniqid());
+        $user->setActive(true);
+        $user->setAdmin(false);
+        $user->setPermissions(['assets']);
+        $user->setRoles([$role->getId()]);
+        $user->save();
+        $this->createdUser = $user;
+
+        return $user;
+    }
+
+    private function createTree(): Tree
+    {
+        return new Tree(new Folder(Asset::getById(1)));
+    }
+
+    private function loginAs(User $user): void
+    {
+        $this->tokenStorage()->setToken(new UsernamePasswordToken(new SecurityUser($user), 'pimcore_admin'));
+    }
+
+    private function tokenStorage(): TokenStorageInterface
+    {
+        return Pimcore::getContainer()->get('security.token_storage');
+    }
+}

--- a/tests/Model/Asset/WebDAV/TreeMoveRenamePermissionTest.php
+++ b/tests/Model/Asset/WebDAV/TreeMoveRenamePermissionTest.php
@@ -33,6 +33,9 @@ use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
  * the "rename" workspace permission, not just "publish". A user granted publish-but-not-rename on
  * an asset must not be able to rename it by issuing a same-directory MOVE.
  *
+ * A same-directory MOVE onto an existing destination is an overwrite, not a rename (safe-save flow
+ * of third party software like Photoshop), and must keep working without the "rename" permission.
+ *
  * @group model.asset.webdav
  */
 class TreeMoveRenamePermissionTest extends ModelTestCase
@@ -94,18 +97,57 @@ class TreeMoveRenamePermissionTest extends ModelTestCase
         );
     }
 
-    private function createAsset(string $filename): Asset
+    public function testSameDirectoryOverwriteMoveSucceedsWithoutRenamePermission(): void
+    {
+        $destination = $this->createAsset('overwrite-target.txt', 'destination content');
+        $destinationId = $destination->getId();
+        $source = $this->createAsset('overwrite-source.txt', 'source content');
+        $sourceId = $source->getId();
+
+        // the workspace is granted on the parent folder because the overwrite touches both assets:
+        // publish on the destination and delete on the source, but never rename.
+        $this->loginAs($this->createUserWithWorkspace(
+            Asset::getByPath('/'),
+            publish: true,
+            rename: false,
+            delete: true
+        ));
+
+        $this->createTree()->move($source->getFilename(), $destination->getFilename());
+
+        $reloaded = Asset::getById($destinationId, ['force' => true]);
+        $this->assertNotNull(
+            $reloaded,
+            'an overwriting MOVE must keep the destination asset and its id, not replace it'
+        );
+        $this->assertSame(
+            'overwrite-target.txt',
+            $reloaded->getFilename(),
+            'an overwriting MOVE does not rename anything and must not require the "rename" permission'
+        );
+        $this->assertSame(
+            'source content',
+            $reloaded->getData(),
+            'the destination asset must carry the source data after the overwrite'
+        );
+        $this->assertNull(
+            Asset::getById($sourceId, ['force' => true]),
+            'the source asset must be removed after the overwrite'
+        );
+    }
+
+    private function createAsset(string $filename, string $data = 'some content'): Asset
     {
         $asset = new Asset();
         $asset->setParent(Asset::getByPath('/'));
         $asset->setFilename($filename);
-        $asset->setData('some content');
+        $asset->setData($data);
         $asset->save();
 
         return $asset;
     }
 
-    private function createUserWithWorkspace(Asset $asset, bool $publish, bool $rename): User
+    private function createUserWithWorkspace(Asset $asset, bool $publish, bool $rename, bool $delete = false): User
     {
         $workspace = new AssetWorkspace();
         $workspace->setCid($asset->getId());
@@ -114,6 +156,7 @@ class TreeMoveRenamePermissionTest extends ModelTestCase
         $workspace->setView(true);
         $workspace->setPublish($publish);
         $workspace->setRename($rename);
+        $workspace->setDelete($delete);
 
         $role = new User\Role();
         $role->setParentId(0);

--- a/tests/Model/Asset/WebDAV/TreeMoveRenamePermissionTest.php
+++ b/tests/Model/Asset/WebDAV/TreeMoveRenamePermissionTest.php
@@ -22,8 +22,10 @@ use Pimcore\Model\User\Workspace\Asset as AssetWorkspace;
 use Pimcore\Security\User\TokenStorageUserResolver;
 use Pimcore\Security\User\User as SecurityUser;
 use Pimcore\Tests\Support\Test\ModelTestCase;
+use ReflectionProperty;
 use Sabre\DAV\Exception\Forbidden;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
@@ -39,19 +41,17 @@ class TreeMoveRenamePermissionTest extends ModelTestCase
 
     private ?User\Role $createdRole = null;
 
-    private ?TokenStorageUserResolver $originalUserResolver = null;
+    private ?TokenInterface $originalToken = null;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->originalUserResolver = Pimcore::getContainer()->get(TokenStorageUserResolver::class);
+        $this->originalToken = $this->tokenStorage()->getToken();
     }
 
     protected function tearDown(): void
     {
-        if ($this->originalUserResolver !== null) {
-            Pimcore::getContainer()->set(TokenStorageUserResolver::class, $this->originalUserResolver);
-        }
+        $this->tokenStorage()->setToken($this->originalToken);
 
         $this->createdUser?->delete();
         $this->createdRole?->delete();
@@ -143,16 +143,17 @@ class TreeMoveRenamePermissionTest extends ModelTestCase
 
     private function loginAs(User $user): void
     {
-        // security.token_storage is inlined out of the compiled container and cannot be fetched
-        // directly. Tree::move() resolves the current user via Admin::getCurrentUser(), which reads
-        // the public TokenStorageUserResolver service, so we swap in a resolver backed by a token
-        // storage we control (mirroring how other model tests override public services).
-        $tokenStorage = new TokenStorage();
-        $tokenStorage->setToken(new UsernamePasswordToken(new SecurityUser($user), 'pimcore_admin'));
+        $this->tokenStorage()->setToken(new UsernamePasswordToken(new SecurityUser($user), 'pimcore_admin'));
+    }
 
-        Pimcore::getContainer()->set(
-            TokenStorageUserResolver::class,
-            new TokenStorageUserResolver($tokenStorage)
-        );
+    private function tokenStorage(): TokenStorageInterface
+    {
+        // security.token_storage is inlined out of the compiled container and cannot be fetched by
+        // id. Tree::move() resolves the current user via Admin::getCurrentUser(), which reads the
+        // token storage held by the public TokenStorageUserResolver service, so we reach the same
+        // shared instance through that resolver rather than replacing the service.
+        $resolver = Pimcore::getContainer()->get(TokenStorageUserResolver::class);
+
+        return (new ReflectionProperty(TokenStorageUserResolver::class, 'tokenStorage'))->getValue($resolver);
     }
 }

--- a/tests/Model/Asset/WebDAV/TreeMoveRenamePermissionTest.php
+++ b/tests/Model/Asset/WebDAV/TreeMoveRenamePermissionTest.php
@@ -19,11 +19,11 @@ use Pimcore\Model\Asset\WebDAV\Folder;
 use Pimcore\Model\Asset\WebDAV\Tree;
 use Pimcore\Model\User;
 use Pimcore\Model\User\Workspace\Asset as AssetWorkspace;
+use Pimcore\Security\User\TokenStorageUserResolver;
 use Pimcore\Security\User\User as SecurityUser;
 use Pimcore\Tests\Support\Test\ModelTestCase;
 use Sabre\DAV\Exception\Forbidden;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
@@ -39,17 +39,19 @@ class TreeMoveRenamePermissionTest extends ModelTestCase
 
     private ?User\Role $createdRole = null;
 
-    private ?TokenInterface $originalToken = null;
+    private ?TokenStorageUserResolver $originalUserResolver = null;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->originalToken = $this->tokenStorage()->getToken();
+        $this->originalUserResolver = Pimcore::getContainer()->get(TokenStorageUserResolver::class);
     }
 
     protected function tearDown(): void
     {
-        $this->tokenStorage()->setToken($this->originalToken);
+        if ($this->originalUserResolver !== null) {
+            Pimcore::getContainer()->set(TokenStorageUserResolver::class, $this->originalUserResolver);
+        }
 
         $this->createdUser?->delete();
         $this->createdRole?->delete();
@@ -141,11 +143,16 @@ class TreeMoveRenamePermissionTest extends ModelTestCase
 
     private function loginAs(User $user): void
     {
-        $this->tokenStorage()->setToken(new UsernamePasswordToken(new SecurityUser($user), 'pimcore_admin'));
-    }
+        // security.token_storage is inlined out of the compiled container and cannot be fetched
+        // directly. Tree::move() resolves the current user via Admin::getCurrentUser(), which reads
+        // the public TokenStorageUserResolver service, so we swap in a resolver backed by a token
+        // storage we control (mirroring how other model tests override public services).
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken(new UsernamePasswordToken(new SecurityUser($user), 'pimcore_admin'));
 
-    private function tokenStorage(): TokenStorageInterface
-    {
-        return Pimcore::getContainer()->get('security.token_storage');
+        Pimcore::getContainer()->set(
+            TokenStorageUserResolver::class,
+            new TokenStorageUserResolver($tokenStorage)
+        );
     }
 }


### PR DESCRIPTION
## Vulnerability

`Asset\WebDAV\Tree::move()` handles a WebDAV `MOVE` request. When source and destination share the same directory (a rename), it resolves `$asset` and then checks only `publish` before calling `$asset->setFilename()` and `save()`:

```php
if (!$asset->isAllowed('publish', $user)) {
    throw new Forbidden('No publish permission on target asset');
}
```

GHSA-wc7j-g8wx-m2qx (CVE-2026-45260) had already flagged that WebDAV MOVE didn't enforce `rename`, `delete`, `create`, or `publish`. Its fix added `create` (destination-folder check), `publish`, and `delete` (source, overwrite case) — but not `rename`. The two sibling WebDAV handlers that perform the equivalent operation, `Asset\WebDAV\File::setName()` and `Asset\WebDAV\Folder::setName()`, both gate on `isAllowed('rename')`. `Tree::move()`'s same-directory branch reaches the identical `setFilename()`/`save()` call with no such gate.

**Impact:** an authenticated user with WebDAV access whose workspace grants `publish` but denies `rename` on an asset can rename that asset by issuing a same-directory `MOVE`, bypassing the `rename` permission. Root cause: a missing permission check (CWE-862/CWE-863), not an authentication gap — the anchor advisory's authentication issue is already fixed.

## Fix

Add the same `rename` check the sibling handlers use, in the same-directory branch of `Tree::move()`, right before the `setFilename()` call (covering both the plain-rename path and the overwrite-then-rename path, since both flow through the same statement):

```php
if (!$asset->isAllowed('rename', $user)) {
    throw new Forbidden('Missing "rename" permission');
}
$asset->setFilename(basename($destinationPath));
```

This is minimal and scoped to the same-directory branch only. The advisory separately raises whether the cross-directory move branch should also require `rename` — that's flagged in the advisory as an open product question, not a confirmed omission, so it's left untouched here to keep this fix tightly scoped to the confirmed vulnerability.

## Backward compatibility

`Pimcore\Model\Asset\WebDAV\Tree` is annotated `@internal` at the class level, so it is not covered by the BC promise — a behavior change here doesn't require a deprecation path. For completeness: the change only narrows behavior for the specific case the advisory describes (workspace with `publish` granted and `rename` denied issuing a same-directory MOVE), matching the enforcement already present on the two sibling entry points for the same operation, so there is no legitimate workflow this newly forbids.

## Tests

Tests added: `tests/Model/Asset/WebDAV/TreeMoveRenamePermissionTest.php`

Two Codeception/PHPUnit "Model" tests (real DB, real `Asset`/`User`/`User\Role`/`User\Workspace\Asset` models):

- `testSameDirectoryMoveIsForbiddenWithoutRenamePermission`: creates an asset and a user whose workspace on that asset grants `publish` but denies `rename`, logs the user in via the security token storage, then calls `Tree::move()` with a same-directory destination. Asserts a `Sabre\DAV\Exception\Forbidden` is thrown and that the asset's filename in the DB is unchanged. This fails against the vulnerable code (rename would silently succeed) and passes with the fix.
- `testSameDirectoryMoveSucceedsWithRenamePermission`: same setup but with `rename` also granted; asserts the move succeeds and the filename is updated — confirming the legitimate rename workflow (and the sibling `File`/`Folder` handlers' existing behavior) still works.

I could not execute the suite in this sandbox (no Composer-installed `vendor/`, no network/DB access), so I cannot report a green run. The tests were written directly against the confirmed vulnerable code path (verified by reading `Tree::move()`, `Asset\Dao::isAllowed()`, and the sibling `File::setName()`/`Folder::setName()` implementations) and follow the existing `tests/Model/Element/WorkspacePermissionPathBoundaryTest.php` pattern for building a scoped-permission user in a Model test.

## Verification

Code-traced: read `Tree.php` in full at HEAD, confirmed the same-directory branch has no `rename` check before `setFilename()`/`save()`, confirmed `Asset\Dao::isAllowed()` resolves workspace permissions per-column so `publish` and `rename` are independently gate-able, and confirmed the sibling `File`/`Folder` handlers already use `isAllowed('rename')` for the equivalent action.

Security-Advisory: pimcore/pimcore/GHSA-3hv6-4774-vpmf




> Generated by [Draft a security-advisory fix](https://github.com/pimcore/workflows-centralized/actions/runs/30613476534) · sonnet50 · 178.4 AIC · ⌖ 8.19 AIC · ⊞ 6.2K · [◷](https://github.com/search?q=repo%3Apimcore%2Fpimcore+%22gh-aw-workflow-id%3A+advisory-fix%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Draft a security-advisory fix, engine: claude, model: claude-sonnet-5, id: 30613476534, workflow_id: advisory-fix, run: https://github.com/pimcore/workflows-centralized/actions/runs/30613476534 -->

<!-- gh-aw-workflow-id: advisory-fix -->
<!-- gh-aw-workflow-call-id: pimcore/workflows-centralized/advisory-fix -->