### PR TITLE
[security] GHSA-8h86-9g29-q362: restrict ImageGallery hotspot unserialize

### DIFF
--- a/models/DataObject/ClassDefinition/Data/ImageGallery.php
+++ b/models/DataObject/ClassDefinition/Data/ImageGallery.php
@@ -139,7 +139,7 @@ class ImageGallery extends Data implements ResourcePersistenceAwareInterface, Qu
 
         $images = $data[$this->getName() . '__images'];
         $hotspots = $data[$this->getName() . '__hotspots'];
-        $hotspots = $hotspots ? Serialize::unserialize($hotspots, true) : [];
+        $hotspots = $hotspots ? Serialize::unserialize($hotspots, false) : [];
 
         if (!$images) {
             return $this->createEmptyImageGallery($params);

--- a/tests/Unit/Models/DataObject/ClassDefinition/Data/ImageGalleryTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/Data/ImageGalleryTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\DataObject\ClassDefinition\Data;
+
+use Pimcore\Model\DataObject\ClassDefinition\Data\ImageGallery;
+use Pimcore\Model\DataObject\Data\ImageGallery as ImageGalleryValue;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * Regression test for GHSA-8h86-9g29-q362: ImageGallery::getDataFromResource() unserialized the
+ * `__hotspots` resource column with allowed_classes true, letting a stored value that was not
+ * produced through the normal write path instantiate arbitrary classes (POP-gadget chain).
+ */
+class ImageGalleryTest extends TestCase
+{
+    private function buildField(): ImageGallery
+    {
+        $field = new ImageGallery();
+        $field->setName('gallery');
+
+        return $field;
+    }
+
+    public function testGetDataFromResourceDoesNotInstantiateArbitraryClasses(): void
+    {
+        ImageGalleryDeserializeCanary::$fired = false;
+
+        // A legitimate `__hotspots` column only ever contains an array of already-serialized
+        // strings (see ImageGallery::getDataForResource()). This payload instead places a real
+        // object directly in the outer array, simulating a value that reached the column via
+        // some path other than the normal write flow.
+        $payload = serialize([new ImageGalleryDeserializeCanary()]);
+
+        $this->buildField()->getDataFromResource([
+            'gallery__images' => '',
+            'gallery__hotspots' => $payload,
+        ]);
+
+        $this->assertFalse(
+            ImageGalleryDeserializeCanary::$fired,
+            'Unserializing the __hotspots column must not instantiate arbitrary classes.'
+        );
+    }
+
+    public function testGetDataFromResourceStillAcceptsLegitimateHotspotStrings(): void
+    {
+        // Legitimate shape produced by getDataForResource(): an array of per-item serialized
+        // strings. Unserializing this shape must keep working (no exception) after restricting
+        // allowed_classes.
+        $payload = serialize(['a:1:{s:1:"x";s:1:"y";}', 'b:0;']);
+
+        $result = $this->buildField()->getDataFromResource([
+            'gallery__images' => '',
+            'gallery__hotspots' => $payload,
+        ]);
+
+        $this->assertInstanceOf(ImageGalleryValue::class, $result);
+    }
+
+    public function testGetDataFromResourceReturnsEmptyGalleryWhenNoImages(): void
+    {
+        $result = $this->buildField()->getDataFromResource([
+            'gallery__images' => '',
+            'gallery__hotspots' => null,
+        ]);
+
+        $this->assertInstanceOf(ImageGalleryValue::class, $result);
+        $this->assertSame([], $result->getItems());
+    }
+}
+
+/**
+ * Canary whose magic method flips a static flag, so a test can detect whether it was
+ * instantiated during deserialization.
+ */
+class ImageGalleryDeserializeCanary
+{
+    public static bool $fired = false;
+
+    public function __wakeup(): void
+    {
+        self::$fired = true;
+    }
+}


### PR DESCRIPTION
## Vulnerability

`ImageGallery::getDataFromResource()` (`models/DataObject/ClassDefinition/Data/ImageGallery.php:142`) deserialized the `__hotspots` resource column with `Serialize::unserialize($hotspots, true)`. `Serialize::unserialize()` passes its second argument straight through as PHP `unserialize()`'s `allowed_classes`, so `true` permits reconstruction of *any* class present in the serialized payload.

This is the same allow-all sink that was closed on the sibling field `Hotspotimage` for GHSA-w23p-wrp7-ch38 (published 2026-07-30). `ImageGallery` reads the same kind of object-store column through the same helper and was left on allow-all. Anything able to influence the stored `__hotspots` value reaches an unrestricted `unserialize()`, with the usual POP-gadget-chain consequences.

## Root cause and fix

The legitimate write path, `ImageGallery::getDataForResource()` (line 118), only ever produces an array whose elements are *already-serialized strings* — each one coming from `Hotspotimage::getDataForResource()`, which serializes its own metadata before handing it back. So at the outer `unserialize()` call in `getDataFromResource()`, no PHP object should ever need to be reconstructed; the expected shape is a plain array of strings.

Given that, the correct restriction here is tighter than the `Hotspotimage` fix (which needed to allow `Element\Data\MarkerHotspotItem` because its *own* structure legitimately contains those objects): `ImageGallery`'s outer unserialize needs no classes at all, so it now passes `false` — "forbid object deserialization entirely", per `Serialize::unserialize()`'s own docblock, which explicitly calls this "the safe choice for scalar/array data".

```php
$hotspots = $hotspots ? Serialize::unserialize($hotspots, false) : [];
```

`models/DataObject/ClassDefinition/Data/Table.php` was flagged in the advisory as looking like a third sibling of the same cluster, but the advisory explicitly does not claim it (no traced write path), so it is out of scope for this PR.

## Backward compatibility

Checked against the BC promise: this only changes an internal call site's argument to the existing `Serialize::unserialize()` helper (mirroring the deprecation path already used for `Hotspotimage` — the shared default of `Serialize::unserialize()` itself is untouched, it stays permissive for callers that omit the argument). `getDataFromResource()`'s own signature, return type, and behavior for all legitimate input are unchanged: the write path never places a bare object at this level, so no genuine stored gallery data will be affected. Only a payload that would previously have triggered arbitrary object instantiation is now correctly rejected (falls back to `__PHP_Incomplete_Class`, consistent with how the rest of the codebase already handles restricted unserialize). Not a BC break.

## Verification

Tests added: `tests/Unit/Models/DataObject/ClassDefinition/Data/ImageGalleryTest.php`

- `testGetDataFromResourceDoesNotInstantiateArbitraryClasses` — regression test for the vulnerability: builds a payload with a real object (a canary with `__wakeup()`) placed directly in the outer array, the shape an attacker-influenced value could take but the legitimate write path never produces, and asserts the canary's magic method never fires after the fix (it would have fired against the vulnerable `true` argument).
- `testGetDataFromResourceStillAcceptsLegitimateHotspotStrings` — confirms the legitimate array-of-serialized-strings shape still unserializes without error under the restriction.
- `testGetDataFromResourceReturnsEmptyGalleryWhenNoImages` — confirms the pre-existing empty-gallery behavior is unchanged.

This sandbox has no Composer/network access to execute the test suite, so these were written but not run; they follow the same structure and `TestCase` base (`needsDb(): false`) as existing unit tests for sibling `ClassDefinition\Data` fields (e.g. `GeoboundsTest`) and the existing `Serialize::unserialize()` canary pattern in `tests/Unit/Tool/SerializeTest.php`.

Security-Advisory: pimcore/pimcore/GHSA-8h86-9g29-q362




> Generated by [Draft a security-advisory fix](https://github.com/pimcore/workflows-centralized/actions/runs/30681522069) · sonnet50 · 94.9 AIC · ⌖ 16.3 AIC · ⊞ 6.2K · [◷](https://github.com/search?q=repo%3Apimcore%2Fpimcore+%22gh-aw-workflow-id%3A+advisory-fix%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Draft a security-advisory fix, engine: claude, model: claude-sonnet-5, id: 30681522069, workflow_id: advisory-fix, run: https://github.com/pimcore/workflows-centralized/actions/runs/30681522069 -->

<!-- gh-aw-workflow-id: advisory-fix -->
<!-- gh-aw-workflow-call-id: pimcore/workflows-centralized/advisory-fix -->