### PR TITLE
Add arguments to the asset save version function

### DIFF
--- a/doc/13_Upgrade_Notes/README.md
+++ b/doc/13_Upgrade_Notes/README.md
@@ -19,6 +19,7 @@
 
 ### [Assets]
 - [Thumbnails] The cache lifetime used for the `Cache-Control` and `Expires` HTTP headers when a thumbnail is delivered on-the-fly through the thumbnail service is now configurable via `pimcore.assets.thumbnails.cache_lifetime` (in seconds). It defaults to `604800` (one week), which preserves the previous hard-coded behavior.
+- Added a new optional `$parameters` argument to `Asset::saveVersion()` to allow passing custom arguments to the `PRE_UPDATE` / `POST_UPDATE` / `POST_UPDATE_FAILURE` versioning events, analogous to `Concrete::saveVersion()`. To stay backwards-compatible for classes overriding `saveVersion()`, the argument is documented in the docblock but not yet part of the method signature (it is read via `func_get_arg()`); it will become a regular signature parameter in the next major version.
 
 ### [DataObject]
 - [Relations] The `ownername` column has been widened from `VARCHAR(70)` to `VARCHAR(190)` in the per-class relation tables (`object_relations_*`), the advanced-relation metadata tables (`object_metadata_*`) and `object_url_slugs`. The generated `ownername` for a localized field nested inside an object brick or field collection (e.g. `/objectbrick~<field>/<brickKey>/localizedfield~localizedfield`) can exceed 70 characters, which caused "Data too long for column 'ownername'" on save under strict SQL mode. Existing installations are updated automatically by the migration `Version20260721000000`; no code or configuration changes are required.

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -27,9 +27,6 @@ Editable dialog boxes work differently in the new Studio UI, so these options no
 -   The MIME type is now read from the storage adapter after the file is written, with a fallback to stream sniffing and finally `application/octet-stream`. Existing assets (e.g. `.doc`/`.xls`/`.ppt` files previously misdetected as `application/octet-stream`) need to be re-uploaded or have their MIME type rewritten to pick up the corrected MIME type.
 -   Added a new command `pimcore:assets:rewrite-mime-type` to rewrite the MIME type of existing assets without re-uploading them.
 
-#### [Assets]
-
-- Added a new optional `$parameters` argument to `Asset::saveVersion()` to allow passing of arguments to events.
 ## Pimcore 12.3.0
 
 ### [General]

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -29,7 +29,7 @@ Editable dialog boxes work differently in the new Studio UI, so these options no
 
 #### [Assets]
 
-- Added a new option `$parameters` argument to `Concrete::saveVersion()` to allow passing of arguments to events.
+- Added a new optional `$parameters` argument to `Asset::saveVersion()` to allow passing of arguments to events.
 ## Pimcore 12.3.0
 
 ### [General]

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -27,6 +27,9 @@ Editable dialog boxes work differently in the new Studio UI, so these options no
 -   The MIME type is now read from the storage adapter after the file is written, with a fallback to stream sniffing and finally `application/octet-stream`. Existing assets (e.g. `.doc`/`.xls`/`.ppt` files previously misdetected as `application/octet-stream`) need to be re-uploaded or have their MIME type rewritten to pick up the corrected MIME type.
 -   Added a new command `pimcore:assets:rewrite-mime-type` to rewrite the MIME type of existing assets without re-uploading them.
 
+#### [Assets]
+
+- Added a new option `$parameters` argument to `Concrete::saveVersion()` to allow passing of arguments to events.
 ## Pimcore 12.3.0
 
 ### [General]

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -828,15 +828,16 @@ class Asset extends Element\AbstractElement
      *
      * @throws Exception
      */
-    public function saveVersion(bool $setModificationDate = true, bool $saveOnlyVersion = true, ?string $versionNote = null): ?Version
+    public function saveVersion(bool $setModificationDate = true, bool $saveOnlyVersion = true, ?string $versionNote = null, array $parameters = []): ?Version
     {
+        $coreParameters = ['saveVersionOnly' => true];
+        $eventParameters = array_merge($parameters, $coreParameters);
         try {
             // hook should be also called if "save only new version" is selected
             if ($saveOnlyVersion) {
-                $event = new AssetEvent($this, [
-                    'saveVersionOnly' => true,
-                ]);
+                $event = new AssetEvent($this, $eventParameters);
                 $this->dispatchEvent($event, AssetEvents::PRE_UPDATE);
+                $eventParameters = $event->getArguments();
             }
 
             // set date
@@ -863,18 +864,13 @@ class Asset extends Element\AbstractElement
 
             // hook should be also called if "save only new version" is selected
             if ($saveOnlyVersion) {
-                $event = new AssetEvent($this, [
-                    'saveVersionOnly' => true,
-                ]);
+                $event = new AssetEvent($this, array_merge($eventParameters, $coreParameters));
                 $this->dispatchEvent($event, AssetEvents::POST_UPDATE);
             }
 
             return $version;
         } catch (Exception $e) {
-            $event = new AssetEvent($this, [
-                'saveVersionOnly' => true,
-                'exception' => $e,
-            ]);
+            $event = new AssetEvent($this, array_merge($eventParameters, $coreParameters, ['exception' => $e]));
             $this->dispatchEvent($event, AssetEvents::POST_UPDATE_FAILURE);
 
             throw $e;

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -824,14 +824,20 @@ class Asset extends Element\AbstractElement
     }
 
     /**
+     * Accepts an additional optional argument `array $parameters = []` (read via func_get_arg())
+     * with custom arguments that are passed on to the versioning events. It will become a regular
+     * method parameter in the next major version.
+     *
      * @param string|null $versionNote version note
      *
      * @throws Exception
      */
-    public function saveVersion(bool $setModificationDate = true, bool $saveOnlyVersion = true, ?string $versionNote = null, array $parameters = []): ?Version
+    public function saveVersion(bool $setModificationDate = true, bool $saveOnlyVersion = true, ?string $versionNote = null /* , array $parameters = [] */): ?Version
     {
+        $parameters = 4 <= func_num_args() ? (array) func_get_arg(3) : [];
         $coreParameters = ['saveVersionOnly' => true];
         $eventParameters = array_merge($parameters, $coreParameters);
+
         try {
             // hook should be also called if "save only new version" is selected
             if ($saveOnlyVersion) {

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -57,6 +57,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\LockInterface;
 use Throwable;
+use TypeError;
 
 /**
  * @method Dao getDao()
@@ -834,7 +835,10 @@ class Asset extends Element\AbstractElement
      */
     public function saveVersion(bool $setModificationDate = true, bool $saveOnlyVersion = true, ?string $versionNote = null /* , array $parameters = [] */): ?Version
     {
-        $parameters = 4 <= func_num_args() ? (array) func_get_arg(3) : [];
+        $parameters = 4 <= func_num_args() ? func_get_arg(3) : [];
+        if (!is_array($parameters)) {
+            throw new TypeError(sprintf('%s(): Argument #4 ($parameters) must be of type array, %s given', __METHOD__, get_debug_type($parameters)));
+        }
         $coreParameters = ['saveVersionOnly' => true];
         $eventParameters = array_merge($parameters, $coreParameters);
 

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -835,6 +835,7 @@ class Asset extends Element\AbstractElement
      */
     public function saveVersion(bool $setModificationDate = true, bool $saveOnlyVersion = true, ?string $versionNote = null /* , array $parameters = [] */): ?Version
     {
+        // TODO: promote $parameters to a regular signature parameter in the next major version (2027.1)
         $parameters = 4 <= func_num_args() ? func_get_arg(3) : [];
         if (!is_array($parameters)) {
             throw new TypeError(sprintf('%s(): Argument #4 ($parameters) must be of type array, %s given', __METHOD__, get_debug_type($parameters)));

--- a/tests/Model/Asset/SaveVersionParametersTest.php
+++ b/tests/Model/Asset/SaveVersionParametersTest.php
@@ -13,12 +13,14 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Model\Asset;
 
+use Exception;
 use Pimcore;
 use Pimcore\Event\AssetEvents;
 use Pimcore\Event\Model\AssetEvent;
 use Pimcore\Model\Asset;
 use Pimcore\Tests\Support\Test\ModelTestCase;
 use Pimcore\Tests\Support\Util\TestHelper;
+use TypeError;
 
 /**
  * @group model.asset.asset
@@ -110,6 +112,42 @@ class SaveVersionParametersTest extends ModelTestCase
         $this->assertSame('listenerValue', $postUpdateArguments['addedByListener']);
         $this->assertSame('customValue', $postUpdateArguments['customParameter']);
         $this->assertTrue($postUpdateArguments['saveVersionOnly']);
+    }
+
+    public function testCustomParametersAreForwardedToPostUpdateFailureEvent(): void
+    {
+        $capturedArguments = [];
+        $this->addListener(AssetEvents::POST_UPDATE_FAILURE, function (AssetEvent $event) use (&$capturedArguments): void {
+            if ($event->getAsset() === $this->testAsset) {
+                $capturedArguments = $event->getArguments();
+            }
+        });
+
+        $listenerException = new Exception('listener failure');
+        $this->addListener(AssetEvents::PRE_UPDATE, function (AssetEvent $event) use ($listenerException): void {
+            if ($event->getAsset() === $this->testAsset) {
+                throw $listenerException;
+            }
+        });
+
+        try {
+            $this->testAsset->saveVersion(true, true, null, ['customParameter' => 'customValue', 'saveVersionOnly' => false]);
+            $this->fail('Expected the exception thrown in the PRE_UPDATE listener to be rethrown');
+        } catch (Exception $exception) {
+            $this->assertSame($listenerException, $exception);
+        }
+
+        $this->assertSame('customValue', $capturedArguments['customParameter']);
+        $this->assertTrue($capturedArguments['saveVersionOnly']);
+        $this->assertSame($listenerException, $capturedArguments['exception']);
+    }
+
+    public function testSaveVersionRejectsNonArrayParameters(): void
+    {
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage('Argument #4 ($parameters) must be of type array, string given');
+
+        $this->testAsset->saveVersion(true, true, null, 'not-an-array');
     }
 
     public function testSaveVersionWithoutParametersKeepsPreviousBehavior(): void

--- a/tests/Model/Asset/SaveVersionParametersTest.php
+++ b/tests/Model/Asset/SaveVersionParametersTest.php
@@ -1,0 +1,127 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\Asset;
+
+use Pimcore;
+use Pimcore\Event\AssetEvents;
+use Pimcore\Event\Model\AssetEvent;
+use Pimcore\Model\Asset;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+use Pimcore\Tests\Support\Util\TestHelper;
+
+/**
+ * @group model.asset.asset
+ */
+class SaveVersionParametersTest extends ModelTestCase
+{
+    private array $registeredListeners = [];
+
+    protected Asset $testAsset;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->testAsset = TestHelper::createImageAsset();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->registeredListeners as [$eventName, $listener]) {
+            Pimcore::getEventDispatcher()->removeListener($eventName, $listener);
+        }
+        $this->registeredListeners = [];
+
+        parent::tearDown();
+    }
+
+    private function addListener(string $eventName, callable $listener): void
+    {
+        Pimcore::getEventDispatcher()->addListener($eventName, $listener);
+        $this->registeredListeners[] = [$eventName, $listener];
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $capturedArguments
+     */
+    private function captureVersioningEventArguments(array &$capturedArguments): void
+    {
+        foreach ([AssetEvents::PRE_UPDATE, AssetEvents::POST_UPDATE] as $eventName) {
+            $this->addListener($eventName, function (AssetEvent $event) use ($eventName, &$capturedArguments): void {
+                if ($event->getAsset() === $this->testAsset) {
+                    $capturedArguments[$eventName] = $event->getArguments();
+                }
+            });
+        }
+    }
+
+    public function testCustomParametersAreForwardedToVersioningEvents(): void
+    {
+        $capturedArguments = [];
+        $this->captureVersioningEventArguments($capturedArguments);
+
+        $this->testAsset->saveVersion(true, true, null, ['customParameter' => 'customValue']);
+
+        foreach ([AssetEvents::PRE_UPDATE, AssetEvents::POST_UPDATE] as $eventName) {
+            $this->assertArrayHasKey($eventName, $capturedArguments);
+            $this->assertSame('customValue', $capturedArguments[$eventName]['customParameter']);
+            $this->assertTrue($capturedArguments[$eventName]['saveVersionOnly']);
+        }
+    }
+
+    public function testCoreParametersCannotBeOverriddenByCustomParameters(): void
+    {
+        $capturedArguments = [];
+        $this->captureVersioningEventArguments($capturedArguments);
+
+        $this->testAsset->saveVersion(true, true, null, ['saveVersionOnly' => false]);
+
+        foreach ([AssetEvents::PRE_UPDATE, AssetEvents::POST_UPDATE] as $eventName) {
+            $this->assertArrayHasKey($eventName, $capturedArguments);
+            $this->assertTrue($capturedArguments[$eventName]['saveVersionOnly']);
+        }
+    }
+
+    public function testListenerArgumentMutationsPropagateToPostUpdateEvent(): void
+    {
+        $this->addListener(AssetEvents::PRE_UPDATE, function (AssetEvent $event): void {
+            if ($event->getAsset() === $this->testAsset) {
+                $event->setArgument('addedByListener', 'listenerValue');
+            }
+        });
+
+        $capturedArguments = [];
+        $this->captureVersioningEventArguments($capturedArguments);
+
+        $this->testAsset->saveVersion(true, true, null, ['customParameter' => 'customValue']);
+
+        $postUpdateArguments = $capturedArguments[AssetEvents::POST_UPDATE];
+        $this->assertSame('listenerValue', $postUpdateArguments['addedByListener']);
+        $this->assertSame('customValue', $postUpdateArguments['customParameter']);
+        $this->assertTrue($postUpdateArguments['saveVersionOnly']);
+    }
+
+    public function testSaveVersionWithoutParametersKeepsPreviousBehavior(): void
+    {
+        $capturedArguments = [];
+        $this->captureVersioningEventArguments($capturedArguments);
+
+        $this->testAsset->saveVersion(true, true, null);
+
+        foreach ([AssetEvents::PRE_UPDATE, AssetEvents::POST_UPDATE] as $eventName) {
+            $this->assertArrayHasKey($eventName, $capturedArguments);
+            $this->assertTrue($capturedArguments[$eventName]['saveVersionOnly']);
+        }
+    }
+}


### PR DESCRIPTION
Supersedes #19018 (the fork does not allow maintainer edits), addressing the review feedback there.

Adds an optional `$parameters` argument to `Asset::saveVersion()` to allow passing custom arguments to the `PRE_UPDATE` / `POST_UPDATE` / `POST_UPDATE_FAILURE` versioning events — similar to #18425, but for assets. Contains the original commits by @cameronfromtorq with authorship preserved.

Changes on top of #19018:

- **BC-safe signature** as requested in https://github.com/pimcore/pimcore/pull/19018#discussion_r3720168171: the method signature stays unchanged and the optional 4th argument is read via `func_num_args()`/`func_get_arg()` (Symfony-style `/* , array $parameters = [] */` comment in the signature), so classes overriding `Asset::saveVersion()` remain signature-compatible. To be promoted to a real parameter in the next major.
- Documented the virtual argument in the docblock (as prose, since `no_superfluous_phpdoc_tags` strips `@param` tags for parameters not present in the signature).
- Moved the upgrade note to `doc/13_Upgrade_Notes/README.md` under Pimcore 2026.3.0, where unreleased 2026.x notes live now (the file edited in #19018 only contains historical 12.x notes), and extended it with the BC mechanics.
- Added `tests/Model/Asset/SaveVersionParametersTest.php` covering: custom parameters forwarded to both events, `saveVersionOnly` not overridable by callers, listener argument mutations propagating from `PRE_UPDATE` to `POST_UPDATE`, and the unchanged 3-argument call path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)