### PR TITLE
[Telemetry] Server-side product telemetry

### DIFF
--- a/bundles/CoreBundle/config/commands.yaml
+++ b/bundles/CoreBundle/config/commands.yaml
@@ -13,6 +13,12 @@ services:
         exclude: '../src/Command/Bundle/Helper'
         tags: ['console.command']
 
+    # the instance identifier is a scalar parameter and cannot be autowired
+    Pimcore\Bundle\CoreBundle\Command\TelemetrySendSnapshotCommand:
+        arguments:
+            $instanceIdentifier: '%pimcore.product_registration.instance_identifier%'
+        tags: ['console.command']
+
     Pimcore\Bundle\CoreBundle\Command\Bundle\Helper\PostStateChange:
         arguments:
             - '@Pimcore\Cache\Symfony\CacheClearer'

--- a/bundles/CoreBundle/config/event_listeners.yaml
+++ b/bundles/CoreBundle/config/event_listeners.yaml
@@ -4,6 +4,16 @@ services:
         autoconfigure: true
 
     #
+    # TELEMETRY (behavioral seam example - autoconfigured as event subscriber)
+    #
+
+    # flushes events buffered during a web request, after the response is sent
+    Pimcore\Bundle\CoreBundle\EventListener\Telemetry\TelemetryFlushSubscriber: ~
+
+    # flushes events buffered during a console command (CLI has no kernel.terminate)
+    Pimcore\Bundle\CoreBundle\EventListener\Telemetry\ConsoleTelemetryFlushSubscriber: ~
+
+    #
     # REQUEST + ROUTING
     #
 

--- a/bundles/CoreBundle/config/maintenance.yaml
+++ b/bundles/CoreBundle/config/maintenance.yaml
@@ -19,6 +19,23 @@ services:
         tags:
             - { name: pimcore.maintenance.task, type: cleanuplogfiles }
 
+    Pimcore\Maintenance\Tasks\TelemetrySnapshotTask:
+        arguments:
+            $instanceIdentifier: '%pimcore.product_registration.instance_identifier%'
+            $intervalSeconds: '%pimcore.telemetry.snapshot_interval_seconds%'
+        tags:
+            - { name: pimcore.maintenance.task, type: telemetry }
+
+    # primary drainer: forward spooled batches to the relay (ack only on confirmed success)
+    Pimcore\Maintenance\Tasks\TelemetrySpoolDrainTask:
+        tags:
+            - { name: pimcore.maintenance.task, type: telemetry_spool_drain }
+
+    # keeps the telemetry outbox bounded (reclaim expired leases + delete events past TTL)
+    Pimcore\Maintenance\Tasks\TelemetrySpoolGcTask:
+        tags:
+            - { name: pimcore.maintenance.task, type: telemetry_spool_gc }
+
     Pimcore\Maintenance\Tasks\DataObject\DataObjectTaskHelper:
         arguments:
             - '@logger'

--- a/bundles/CoreBundle/config/services.yaml
+++ b/bundles/CoreBundle/config/services.yaml
@@ -3,13 +3,9 @@ services:
         autowire: true
         autoconfigure: true
 
-    # any service implementing the contributor interface is auto-tagged, so other
-    # bundles only need to register their contributor - no CoreBundle changes required
-    _instanceof:
-        Pimcore\Telemetry\Snapshot\SnapshotCollectorInterface:
-            tags: ['pimcore.telemetry.snapshot_collector']
-        Pimcore\Telemetry\Usage\BundleUsageProviderInterface:
-            tags: ['pimcore.telemetry.bundle_usage_provider']
+    # NOTE: the telemetry contributor interfaces are autoconfigured container-wide in
+    # PimcoreCoreExtension, not with `_instanceof` here - `_instanceof` would only tag services
+    # defined in this file, leaving collectors shipped by other bundles undiscovered.
 
     #
     # SECURITY

--- a/bundles/CoreBundle/config/services.yaml
+++ b/bundles/CoreBundle/config/services.yaml
@@ -3,6 +3,14 @@ services:
         autowire: true
         autoconfigure: true
 
+    # any service implementing the contributor interface is auto-tagged, so other
+    # bundles only need to register their contributor - no CoreBundle changes required
+    _instanceof:
+        Pimcore\Telemetry\Snapshot\SnapshotCollectorInterface:
+            tags: ['pimcore.telemetry.snapshot_collector']
+        Pimcore\Telemetry\Usage\BundleUsageProviderInterface:
+            tags: ['pimcore.telemetry.bundle_usage_provider']
+
     #
     # SECURITY
     #
@@ -225,6 +233,93 @@ services:
         arguments:
             $instanceIdentifier: '%pimcore.product_registration.instance_identifier%'
             $config: '%pimcore.config%'
+
+    #
+    # TELEMETRY (collected -> durable spool -> product-key-encrypted -> first-party relay; content-never)
+    #
+    Pimcore\Telemetry\TelemetryInterface:
+        class: Pimcore\Telemetry\Telemetry
+        arguments:
+            $instanceIdentifier: '%pimcore.product_registration.instance_identifier%'
+            $productKey: '%pimcore.product_registration.product_key%'
+            $spool: '@Pimcore\Telemetry\Spool\TelemetrySpool'
+
+    # authenticated encryption of the batch envelope, keyed by the product key (mirrored on the relay)
+    Pimcore\Telemetry\Crypto\EnvelopeCipher: ~
+
+    Pimcore\Telemetry\Spool\TelemetrySpool:
+        arguments:
+            $cap: '%pimcore.telemetry.spool.cap%'
+            $ttlDays: '%pimcore.telemetry.spool.ttl_days%'
+            $leaseSeconds: '%pimcore.telemetry.spool.lease_seconds%'
+
+    # drain seam: claim -> encrypt with the product key -> hand to a drainer (maintenance job / Studio UI)
+    Pimcore\Telemetry\Spool\TelemetryOutboxInterface:
+        class: Pimcore\Telemetry\Spool\TelemetryOutboxService
+        arguments:
+            $spool: '@Pimcore\Telemetry\Spool\TelemetrySpool'
+            $instanceIdentifier: '%pimcore.product_registration.instance_identifier%'
+            $productKey: '%pimcore.product_registration.product_key%'
+
+    # direct HTTP delivery to the relay, used by the maintenance drain task
+    Pimcore\Telemetry\Relay\RelayClientInterface:
+        class: Pimcore\Telemetry\Relay\RelayClient
+        arguments:
+            $endpoint: '%pimcore.telemetry.relay_endpoint%'
+
+    # framework-level content-never guard (event-name taxonomy + scalar-only properties)
+    Pimcore\Telemetry\EventSanitizer: ~
+
+    Pimcore\Telemetry\Snapshot\Bucketizer: ~
+
+    # time-boxes every snapshot collector query so a full scan on a huge table (path-depth, GROUP BY)
+    # aborts instead of stalling the maintenance run; collectors autowire this in place of Connection
+    Pimcore\Telemetry\Snapshot\SnapshotQueryRunner:
+        arguments:
+            $timeoutSeconds: '%pimcore.telemetry.snapshot_query_timeout_seconds%'
+
+    # element statistics (counts-by-type, tree depth, fan-out) behind an interface so a bundle that
+    # owns a search index (Studio via the Generic Data Index) can decorate it with index aggregations;
+    # the SQL default is always available and is the runtime fallback.
+    Pimcore\Telemetry\Snapshot\Statistics\ElementStatisticsProviderInterface:
+        class: Pimcore\Telemetry\Snapshot\Statistics\SqlElementStatisticsProvider
+
+    Pimcore\Telemetry\Snapshot\CoreSnapshotCollector:
+        arguments:
+            $environment: '%kernel.environment%'
+
+    # evidence for EM question #1 - which pillars (DAM/PIM/MDM/DXP/Commerce) are actually used
+    Pimcore\Telemetry\Snapshot\PillarUsageCollector: ~
+
+    Pimcore\Telemetry\Snapshot\FieldTreeAnalyzer: ~
+
+    Pimcore\Telemetry\Snapshot\DataModelComplexityCollector: ~
+
+    Pimcore\Telemetry\Snapshot\CatalogShapeCollector: ~
+
+    # active-bundle list, resolved once per snapshot (enumerating them costs ~1 statement per bundle)
+    Pimcore\Telemetry\Snapshot\ActiveBundles: ~
+
+    # reads the session statement counter so the snapshot can report its own DB cost as meta.*
+    Pimcore\Telemetry\Snapshot\StatementCounter: ~
+
+    Pimcore\Telemetry\Snapshot\SnapshotBuilder:
+        arguments:
+            $collectors: !tagged_iterator pimcore.telemetry.snapshot_collector
+            $statementCounter: '@Pimcore\Telemetry\Snapshot\StatementCounter'
+
+    # last-snapshot marker (SettingsStore-backed) used to throttle snapshot production
+    Pimcore\Telemetry\Snapshot\TelemetrySnapshotStateInterface:
+        class: Pimcore\Telemetry\Snapshot\SettingsStoreSnapshotState
+
+    # bundle usage: is a bundle actually USED (not just installed)? Aggregates every tagged
+    # BundleUsageProviderInterface into usage.<bundleKey>. Other bundles just register a provider.
+    Pimcore\Telemetry\Usage\BundleUsageCollector:
+        arguments:
+            $providers: !tagged_iterator pimcore.telemetry.bundle_usage_provider
+
+    # reference provider (core capability): are any workflows configured?
+    Pimcore\Telemetry\Usage\WorkflowUsageProvider: ~
 
     # Doctrine schema filter to only include managed tables
     Pimcore\Db\ManagedTablesOnlyFilter.default:

--- a/bundles/CoreBundle/src/Command/TelemetrySendSnapshotCommand.php
+++ b/bundles/CoreBundle/src/Command/TelemetrySendSnapshotCommand.php
@@ -29,7 +29,7 @@ use function json_encode;
  */
 #[AsCommand(
     name: 'pimcore:telemetry:send-snapshot',
-    description: 'Build the anonymized telemetry snapshot and send it to PostHog (server-side)',
+    description: 'Build the deployment snapshot and enqueue it for delivery to the telemetry relay',
 )]
 class TelemetrySendSnapshotCommand extends AbstractCommand
 {
@@ -67,7 +67,10 @@ class TelemetrySendSnapshotCommand extends AbstractCommand
         }
 
         if (!$this->telemetry->isEnabled()) {
-            $this->io->warning('Telemetry is disabled (opt-out or missing endpoint). Nothing was sent.');
+            $this->io->warning(
+                'Telemetry is inactive: this instance needs both an instance identifier '
+                . '(PIMCORE_INSTANCE_IDENTIFIER) and a product key (PIMCORE_PRODUCT_KEY). Nothing was enqueued.'
+            );
 
             return self::SUCCESS;
         }

--- a/bundles/CoreBundle/src/Command/TelemetrySendSnapshotCommand.php
+++ b/bundles/CoreBundle/src/Command/TelemetrySendSnapshotCommand.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Command;
+
+use Pimcore\Console\AbstractCommand;
+use Pimcore\Telemetry\Snapshot\SnapshotBuilder;
+use Pimcore\Telemetry\TelemetryInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+use function json_encode;
+
+/**
+ * @internal
+ */
+#[AsCommand(
+    name: 'pimcore:telemetry:send-snapshot',
+    description: 'Build the anonymized telemetry snapshot and send it to PostHog (server-side)',
+)]
+class TelemetrySendSnapshotCommand extends AbstractCommand
+{
+    private const EVENT_INSTANCE_SNAPSHOT = 'instance.snapshot';
+
+    private const INSTANCE_GROUP_TYPE = 'instance';
+
+    public function __construct(
+        private readonly TelemetryInterface $telemetry,
+        private readonly SnapshotBuilder $builder,
+        private readonly string $instanceIdentifier,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            'dry-run',
+            null,
+            InputOption::VALUE_NONE,
+            'Print the snapshot that would be sent and exit without contacting PostHog'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $snapshot = $this->builder->build();
+
+        if ($input->getOption('dry-run')) {
+            $this->io->title('Telemetry snapshot (dry-run, nothing sent)');
+            $this->io->writeln(json_encode($snapshot, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR));
+
+            return self::SUCCESS;
+        }
+
+        if (!$this->telemetry->isEnabled()) {
+            $this->io->warning('Telemetry is disabled (opt-out or missing endpoint). Nothing was sent.');
+
+            return self::SUCCESS;
+        }
+
+        $this->telemetry->groupIdentify(self::INSTANCE_GROUP_TYPE, $this->instanceIdentifier, $snapshot);
+        $this->telemetry->capture(self::EVENT_INSTANCE_SNAPSHOT, $snapshot);
+        $this->telemetry->flush();
+
+        // Transport-neutral: "flushed" means handed to the configured transport - posted to the
+        // relay (http) or persisted to the outbox for the UI to drain (spool).
+        $this->io->success('Telemetry snapshot flushed.');
+
+        return self::SUCCESS;
+    }
+}

--- a/bundles/CoreBundle/src/Command/TelemetrySpoolCommand.php
+++ b/bundles/CoreBundle/src/Command/TelemetrySpoolCommand.php
@@ -1,0 +1,141 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Command;
+
+use Pimcore\Console\AbstractCommand;
+use Pimcore\Telemetry\Relay\RelayClientInterface;
+use Pimcore\Telemetry\Spool\TelemetryOutboxInterface;
+use Pimcore\Telemetry\Spool\TelemetrySpool;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+use function json_encode;
+
+/**
+ * Inspect, drain, or garbage-collect the telemetry spool (the durable outbox). In production the
+ * drain also runs unattended from the maintenance job ({@see \Pimcore\Maintenance\Tasks\TelemetrySpoolDrainTask})
+ * and from the Studio UI; `--drain` here forwards encrypted batches to the relay the same way, for
+ * operators and local testing.
+ *
+ * @internal
+ */
+#[AsCommand(
+    name: 'pimcore:telemetry:spool',
+    description: 'Inspect, drain, or garbage-collect the telemetry spool (outbox)',
+)]
+class TelemetrySpoolCommand extends AbstractCommand
+{
+    public function __construct(
+        private readonly TelemetrySpool $spool,
+        private readonly TelemetryOutboxInterface $outbox,
+        private readonly RelayClientInterface $relay,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('peek', null, InputOption::VALUE_REQUIRED, 'Print the N oldest pending events without leasing them')
+            ->addOption('drain', null, InputOption::VALUE_NONE, 'Encrypt and forward pending batches to the relay (ack only on success)')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'With --drain: show pending events without leasing or forwarding')
+            ->addOption('gc', null, InputOption::VALUE_NONE, 'Release expired leases and delete events past their TTL');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        // The outbox table is provisioned by the installer or by migration Version20260720120000,
+        // never at runtime. Say so plainly instead of surfacing a driver stack trace.
+        if (!$this->spool->isProvisioned()) {
+            $this->io->error(
+                'The telemetry_spool table does not exist. Run "bin/console doctrine:migrations:migrate" '
+                . '(or reinstall) to create it.'
+            );
+
+            return self::FAILURE;
+        }
+
+        if ($input->getOption('gc')) {
+            $released = $this->spool->releaseExpiredClaims();
+            $deleted = $this->spool->gc();
+            $this->io->success("Spool GC: released $released expired lease(s), deleted $deleted expired event(s).");
+
+            return self::SUCCESS;
+        }
+
+        if ($input->getOption('drain')) {
+            return $input->getOption('dry-run') ? $this->dryRun() : $this->drain();
+        }
+
+        $this->io->title('Telemetry spool');
+        $this->io->definitionList(
+            ['pending' => (string)$this->spool->countPending()],
+            ['claimed (in flight)' => (string)$this->spool->countClaimed()],
+        );
+
+        $peek = $input->getOption('peek');
+        if ($peek !== null) {
+            $events = $this->spool->peekPending((int)$peek);
+            $this->io->section('Oldest pending events (not leased)');
+            $this->io->writeln(json_encode($events, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR));
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function dryRun(): int
+    {
+        $events = $this->spool->peekPending(50);
+        $this->io->title(sprintf('%d pending event(s) (dry-run, nothing leased or forwarded)', count($events)));
+        $this->io->writeln(json_encode($events, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR));
+
+        return self::SUCCESS;
+    }
+
+    private function drain(): int
+    {
+        if (!$this->outbox->isReady()) {
+            $this->io->warning('Outbox not ready (missing instance identifier or product key). Nothing drained.');
+
+            return self::SUCCESS;
+        }
+
+        if (!$this->relay->isConfigured()) {
+            $this->io->warning('No relay endpoint configured. Nothing drained.');
+
+            return self::SUCCESS;
+        }
+
+        $forwarded = 0;
+
+        while (($batch = $this->outbox->nextBatch()) !== null) {
+            if (!$this->relay->send($batch->instanceIdentifier, $batch->ciphertext)) {
+                $this->outbox->release($batch->nonce);
+                $this->io->warning(sprintf('Forward failed after %d batch(es) - released the rest back to the spool for retry.', $forwarded));
+
+                return self::FAILURE;
+            }
+
+            $this->outbox->ack($batch->nonce);
+            $forwarded += $batch->count;
+        }
+
+        $this->io->success(sprintf('Drained and acked %d event(s) to the relay.', $forwarded));
+
+        return self::SUCCESS;
+    }
+}

--- a/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php
+++ b/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php
@@ -28,6 +28,7 @@ use Pimcore\Loader\ImplementationLoader\PrefixLoader;
 use Pimcore\Model\Document\Editable\Loader\EditableLoader;
 use Pimcore\Model\Document\Editable\Loader\PrefixLoader as DocumentEditablePrefixLoader;
 use Pimcore\Model\Factory;
+use Pimcore\Telemetry\TelemetrySettings;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -96,6 +97,17 @@ final class PimcoreCoreExtension extends ConfigurableExtension implements Prepen
         // TODO is this bad practice?
         // TODO only extract what we need as parameter?
         $container->setParameter('pimcore.config', $config);
+
+        // telemetry - deliberately not configurable (see TelemetrySettings): the relay is a
+        // first-party service at a known address, and cadence/outbox bounds must behave identically
+        // everywhere. Published as parameters so each service keeps one seam tests can drive.
+        // Reporting is gated by the instance identifier + product key, not by a setting.
+        $container->setParameter('pimcore.telemetry.relay_endpoint', TelemetrySettings::RELAY_ENDPOINT);
+        $container->setParameter('pimcore.telemetry.snapshot_interval_seconds', TelemetrySettings::SNAPSHOT_INTERVAL_SECONDS);
+        $container->setParameter('pimcore.telemetry.snapshot_query_timeout_seconds', TelemetrySettings::SNAPSHOT_QUERY_TIMEOUT_SECONDS);
+        $container->setParameter('pimcore.telemetry.spool.cap', TelemetrySettings::SPOOL_CAP);
+        $container->setParameter('pimcore.telemetry.spool.ttl_days', TelemetrySettings::SPOOL_TTL_DAYS);
+        $container->setParameter('pimcore.telemetry.spool.lease_seconds', TelemetrySettings::SPOOL_LEASE_SECONDS);
 
         // set default domain for router to main domain if configured
         // this will be overridden from the request in web context but is handy for CLI scripts
@@ -352,6 +364,9 @@ final class PimcoreCoreExtension extends ConfigurableExtension implements Prepen
     {
         $productIdentifier = $config['product_registration']['instance_identifier'] ?? null;
         $container->setParameter('pimcore.product_registration.instance_identifier', $productIdentifier);
+        // Expose the product key as a parameter too: telemetry uses it as the symmetric secret to
+        // encrypt batches for the relay (which looks the same key up by the instance identifier).
+        $container->setParameter('pimcore.product_registration.product_key', $config['product_registration']['product_key'] ?? '');
 
         // Pimcore not installed — env vars are empty (fallback defaults), so skip
         // the product registration check when the install marker exists.

--- a/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php
+++ b/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php
@@ -28,7 +28,9 @@ use Pimcore\Loader\ImplementationLoader\PrefixLoader;
 use Pimcore\Model\Document\Editable\Loader\EditableLoader;
 use Pimcore\Model\Document\Editable\Loader\PrefixLoader as DocumentEditablePrefixLoader;
 use Pimcore\Model\Factory;
+use Pimcore\Telemetry\Snapshot\SnapshotCollectorInterface;
 use Pimcore\Telemetry\TelemetrySettings;
+use Pimcore\Telemetry\Usage\BundleUsageProviderInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -108,6 +110,15 @@ final class PimcoreCoreExtension extends ConfigurableExtension implements Prepen
         $container->setParameter('pimcore.telemetry.spool.cap', TelemetrySettings::SPOOL_CAP);
         $container->setParameter('pimcore.telemetry.spool.ttl_days', TelemetrySettings::SPOOL_TTL_DAYS);
         $container->setParameter('pimcore.telemetry.spool.lease_seconds', TelemetrySettings::SPOOL_LEASE_SECONDS);
+
+        // Registered here rather than via `_instanceof` in services.yaml: `_instanceof` only applies
+        // to services defined in that same file, so a collector or usage provider shipped by another
+        // bundle would never be tagged. These are the telemetry extension points, so they have to be
+        // autoconfigured container-wide.
+        $container->registerForAutoconfiguration(SnapshotCollectorInterface::class)
+            ->addTag('pimcore.telemetry.snapshot_collector');
+        $container->registerForAutoconfiguration(BundleUsageProviderInterface::class)
+            ->addTag('pimcore.telemetry.bundle_usage_provider');
 
         // set default domain for router to main domain if configured
         // this will be overridden from the request in web context but is handy for CLI scripts

--- a/bundles/CoreBundle/src/EventListener/Telemetry/ConsoleTelemetryFlushSubscriber.php
+++ b/bundles/CoreBundle/src/EventListener/Telemetry/ConsoleTelemetryFlushSubscriber.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\CoreBundle\EventListener\Telemetry;
+
+use Pimcore\Telemetry\TelemetryInterface;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Flushes telemetry buffered during a console command to the spool on console.terminate.
+ *
+ * Web requests flush on kernel.terminate ({@see TelemetryFlushSubscriber}); CLI has no equivalent
+ * hook, so behavioral events captured by commands would otherwise be lost. Runs at a late priority
+ * so it fires after any other terminate work. A no-op when nothing was buffered or telemetry is off.
+ *
+ * @internal
+ */
+final readonly class ConsoleTelemetryFlushSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private TelemetryInterface $telemetry,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ConsoleEvents::TERMINATE => ['onConsoleTerminate', -256],
+        ];
+    }
+
+    public function onConsoleTerminate(ConsoleTerminateEvent $event): void
+    {
+        $this->telemetry->flush();
+    }
+}

--- a/bundles/CoreBundle/src/EventListener/Telemetry/TelemetryFlushSubscriber.php
+++ b/bundles/CoreBundle/src/EventListener/Telemetry/TelemetryFlushSubscriber.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\CoreBundle\EventListener\Telemetry;
+
+use Pimcore\Telemetry\TelemetryInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Delivers behavioral telemetry buffered during a web request.
+ *
+ * Event subscribers only buffer events via {@see TelemetryInterface::capture()};
+ * this listener flushes that buffer on
+ * kernel.terminate, which runs after the response has been sent to the client, so the
+ * relay round-trip never adds latency to the user's request. When nothing was captured
+ * the flush is a no-op (empty buffer returns immediately). CLI and maintenance contexts
+ * flush explicitly and do not rely on this listener.
+ *
+ * @internal
+ */
+final readonly class TelemetryFlushSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private TelemetryInterface $telemetry,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::TERMINATE => 'onKernelTerminate',
+        ];
+    }
+
+    public function onKernelTerminate(TerminateEvent $event): void
+    {
+        $this->telemetry->flush();
+    }
+}

--- a/bundles/CoreBundle/src/Migrations/Version20260720120000.php
+++ b/bundles/CoreBundle/src/Migrations/Version20260720120000.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * This source file is available under the terms of the

--- a/bundles/CoreBundle/src/Migrations/Version20260720120000.php
+++ b/bundles/CoreBundle/src/Migrations/Version20260720120000.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Create the `telemetry_spool` durable outbox table used by server-side product telemetry.
+ *
+ * The table is also created lazily at runtime (CREATE TABLE IF NOT EXISTS) so telemetry works before
+ * this migration runs; the statements here are idempotent (IF NOT EXISTS) and simply make the schema
+ * an explicit, versioned artifact for clean installs.
+ */
+final class Version20260720120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create the telemetry_spool outbox table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(
+            'CREATE TABLE IF NOT EXISTS `telemetry_spool` (
+                `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+                `event_uid` VARCHAR(36) NOT NULL,
+                `created_at` DATETIME NOT NULL,
+                `payload` LONGTEXT NOT NULL,
+                `claimed_at` DATETIME NULL DEFAULT NULL,
+                `claim_nonce` VARCHAR(32) NULL DEFAULT NULL,
+                `attempts` SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+                PRIMARY KEY (`id`),
+                UNIQUE KEY `uniq_telemetry_spool_event_uid` (`event_uid`),
+                KEY `idx_telemetry_spool_claim_nonce` (`claim_nonce`),
+                KEY `idx_telemetry_spool_created_at` (`created_at`)
+            ) DEFAULT CHARSET=utf8mb4'
+        );
+
+        // The table may already exist from the lazy runtime create before `attempts` was introduced.
+        // Guarded via schema introspection because `ADD COLUMN IF NOT EXISTS` is MariaDB-only.
+        if ($schema->hasTable('telemetry_spool') && !$schema->getTable('telemetry_spool')->hasColumn('attempts')) {
+            $this->addSql(
+                'ALTER TABLE `telemetry_spool` ADD COLUMN `attempts` SMALLINT UNSIGNED NOT NULL DEFAULT 0'
+            );
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS `telemetry_spool`');
+    }
+}

--- a/bundles/CoreBundle/src/Migrations/Version20260720120000.php
+++ b/bundles/CoreBundle/src/Migrations/Version20260720120000.php
@@ -19,9 +19,10 @@ use Doctrine\Migrations\AbstractMigration;
 /**
  * Create the `telemetry_spool` durable outbox table used by server-side product telemetry.
  *
- * The table is also created lazily at runtime (CREATE TABLE IF NOT EXISTS) so telemetry works before
- * this migration runs; the statements here are idempotent (IF NOT EXISTS) and simply make the schema
- * an explicit, versioned artifact for clean installs.
+ * The table is never created at runtime: new installs get it from the installer dump
+ * (`bundles/InstallBundle/dump/install.sql`) and existing installs from this migration, so telemetry
+ * is inert until one of those has run. The statements are idempotent, and the guarded ALTER covers
+ * instances created before the `attempts` column existed.
  */
 final class Version20260720120000 extends AbstractMigration
 {

--- a/bundles/InstallBundle/dump/install.sql
+++ b/bundles/InstallBundle/dump/install.sql
@@ -402,6 +402,21 @@ CREATE TABLE `settings_store` (
   KEY `scope` (`scope`)
 ) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
+DROP TABLE IF EXISTS `telemetry_spool`;
+CREATE TABLE `telemetry_spool` (
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `event_uid` varchar(36) NOT NULL,
+  `created_at` datetime NOT NULL,
+  `payload` longtext NOT NULL,
+  `claimed_at` datetime NULL DEFAULT NULL,
+  `claim_nonce` varchar(32) NULL DEFAULT NULL,
+  `attempts` SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uniq_telemetry_spool_event_uid` (`event_uid`),
+  KEY `idx_telemetry_spool_claim_nonce` (`claim_nonce`),
+  KEY `idx_telemetry_spool_created_at` (`created_at`)
+) DEFAULT CHARSET=utf8mb4;
+
 DROP TABLE IF EXISTS `translations_messages`;
 CREATE TABLE `translations_messages` (
   `key` varchar(190) NOT NULL DEFAULT '' COLLATE 'utf8mb4_bin',

--- a/lib/Maintenance/Tasks/TelemetrySnapshotTask.php
+++ b/lib/Maintenance/Tasks/TelemetrySnapshotTask.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Maintenance\Tasks;
+
+use Pimcore\Maintenance\TaskInterface;
+use Pimcore\Telemetry\Snapshot\SnapshotBuilder;
+use Pimcore\Telemetry\Snapshot\TelemetrySnapshotStateInterface;
+use Pimcore\Telemetry\TelemetryInterface;
+use function time;
+
+/**
+ * Produces the periodic deployment snapshot (Layer 1) and adds it to the spool. The snapshot is a
+ * slow-changing structural census, so it is **throttled**: even though maintenance may run every few
+ * minutes, a new snapshot is only produced once the last one is older than the configured interval.
+ * Delivery is a separate concern - the maintenance drain task and the Studio UI ship whatever is in
+ * the spool (snapshots and behavioral events alike) on their own cadence.
+ *
+ * @internal
+ */
+final readonly class TelemetrySnapshotTask implements TaskInterface
+{
+    private const EVENT_INSTANCE_SNAPSHOT = 'instance.snapshot';
+
+    private const INSTANCE_GROUP_TYPE = 'instance';
+
+    public function __construct(
+        private TelemetryInterface $telemetry,
+        private SnapshotBuilder $builder,
+        private TelemetrySnapshotStateInterface $state,
+        private string $instanceIdentifier,
+        private int $intervalSeconds,
+    ) {
+    }
+
+    public function execute(): void
+    {
+        if (!$this->telemetry->isEnabled()) {
+            return;
+        }
+
+        $now = time();
+        $lastAt = $this->state->getLastSnapshotAt();
+
+        if ($lastAt !== null && ($now - $lastAt) < $this->intervalSeconds) {
+            // A recent snapshot already captures the (slow-changing) structure - skip this run.
+            return;
+        }
+
+        $snapshot = $this->builder->build();
+        $this->telemetry->groupIdentify(self::INSTANCE_GROUP_TYPE, $this->instanceIdentifier, $snapshot);
+        $this->telemetry->capture(self::EVENT_INSTANCE_SNAPSHOT, $snapshot);
+        $this->telemetry->flush();
+
+        $this->state->markSnapshotTaken($now);
+    }
+}

--- a/lib/Maintenance/Tasks/TelemetrySpoolDrainTask.php
+++ b/lib/Maintenance/Tasks/TelemetrySpoolDrainTask.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Maintenance\Tasks;
+
+use Pimcore\Maintenance\TaskInterface;
+use Pimcore\Telemetry\Relay\RelayClientInterface;
+use Pimcore\Telemetry\Spool\TelemetryOutboxInterface;
+
+/**
+ * The primary telemetry drainer: on each maintenance run it forwards spooled batches to the relay.
+ *
+ * Transactional outbox discipline - **a batch leaves the pool only after the relay confirms it**:
+ * claim (lease) -> encrypt -> POST -> ack on success, release on failure. On the first failure it
+ * stops and leaves the rest for the next run (or for the Studio UI to drain), so a relay outage or a
+ * DMZ with no outbound access simply lets the pool fill until it can be delivered. A per-run cap
+ * bounds how long one maintenance tick spends here.
+ *
+ * @internal
+ */
+final readonly class TelemetrySpoolDrainTask implements TaskInterface
+{
+    private const MAX_BATCHES_PER_RUN = 20;
+
+    public function __construct(
+        private TelemetryOutboxInterface $outbox,
+        private RelayClientInterface $relay,
+    ) {
+    }
+
+    public function execute(): void
+    {
+        // isReady() is the gate: an unidentified instance, or one without a product key, cannot
+        // produce a decryptable batch, so there is nothing to drain.
+        if (!$this->outbox->isReady() || !$this->relay->isConfigured()) {
+            return;
+        }
+
+        for ($i = 0; $i < self::MAX_BATCHES_PER_RUN; $i++) {
+            $batch = $this->outbox->nextBatch();
+
+            if ($batch === null) {
+                // pool drained
+                return;
+            }
+
+            if ($this->relay->send($batch->instanceIdentifier, $batch->ciphertext)) {
+                $this->outbox->ack($batch->nonce);
+
+                continue;
+            }
+
+            // Delivery failed: hand the batch back and stop; retry on the next run.
+            $this->outbox->release($batch->nonce);
+
+            return;
+        }
+    }
+}

--- a/lib/Maintenance/Tasks/TelemetrySpoolGcTask.php
+++ b/lib/Maintenance/Tasks/TelemetrySpoolGcTask.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Maintenance\Tasks;
+
+use Pimcore\Maintenance\TaskInterface;
+use Pimcore\Telemetry\Spool\TelemetrySpool;
+
+/**
+ * Keeps the telemetry outbox bounded: reclaims leases whose drain never completed and deletes
+ * events past their TTL. Runs unconditionally (even when telemetry is disabled) so a spool that
+ * stopped being drained - e.g. nobody opens the UI - cannot grow without limit.
+ *
+ * @internal
+ */
+final readonly class TelemetrySpoolGcTask implements TaskInterface
+{
+    public function __construct(
+        private TelemetrySpool $spool,
+    ) {
+    }
+
+    public function execute(): void
+    {
+        $this->spool->releaseExpiredClaims();
+        $this->spool->gc();
+    }
+}

--- a/lib/Telemetry/Crypto/EnvelopeCipher.php
+++ b/lib/Telemetry/Crypto/EnvelopeCipher.php
@@ -1,0 +1,204 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Crypto;
+
+use JsonException;
+use Throwable;
+use function base64_decode;
+use function base64_encode;
+use function gzdecode;
+use function gzencode;
+use function hash_hkdf;
+use function is_array;
+use function json_decode;
+use function json_encode;
+use function openssl_decrypt;
+use function openssl_encrypt;
+use function random_bytes;
+use function strlen;
+use function substr;
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+use const OPENSSL_RAW_DATA;
+
+/**
+ * Authenticated, product-key-based encryption for a telemetry envelope.
+ *
+ * The instance encrypts the batch with a symmetric key derived (HKDF-SHA256) from its **product
+ * key** - the value it received from license.pimcore.com at registration. The relay looks the same
+ * product key up by the (cleartext) instance identifier and decrypts. Because only the genuine
+ * instance and the relay share that key, a batch that decrypts is authentic: this AEAD both
+ * protects confidentiality/integrity AND authenticates the sender, so no separate HMAC or bearer
+ * token is needed.
+ *
+ * Wire format (base64 of): [ 1 version byte = 0x02 ][ 12-byte IV ][ 16-byte GCM tag ][ ciphertext ].
+ * The payload is gzip-compressed JSON before encryption. The version byte is bound as the AEAD's
+ * additional authenticated data, so an algorithm/version downgrade fails authentication, and it
+ * lets us rotate the algorithm later without a flag day.
+ *
+ * This class MUST stay byte-for-byte compatible with its mirror in the license-server relay
+ * ({@see \App\Telemetry\Crypto\EnvelopeCipher}); the shared round-trip fixture guards that.
+ *
+ * @internal
+ */
+final class EnvelopeCipher
+{
+    /**
+     * Format/algorithm version. v2 = OpenSSL AES-256-GCM over gzip'd JSON.
+     */
+    private const VERSION = "\x02";
+
+    /**
+     * HKDF context string. Domain-separates the telemetry key from any other use of the product key.
+     */
+    private const HKDF_INFO = 'pimcore-telemetry-aead-v2';
+
+    private const CIPHER = 'aes-256-gcm';
+
+    private const KEY_LEN = 32;
+
+    private const IV_LEN = 12;
+
+    private const TAG_LEN = 16;
+
+    private const GZIP_LEVEL = 6;
+
+    /**
+     * Upper bound for the decompressed envelope. Bounds memory on decrypt: without it, a tiny
+     * authenticated ciphertext could gzip-expand until PHP exhausts memory. Product keys are
+     * distributed to customer instances, so authentication alone does not protect against this.
+     */
+    private const MAX_PLAINTEXT_BYTES = 10_485_760;
+
+    /**
+     * @param array<string, mixed> $envelope
+     *
+     * @throws EnvelopeCipherException
+     */
+    public function encrypt(array $envelope, string $productKey): string
+    {
+        try {
+            $json = json_encode($envelope, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+            $packed = gzencode($json, self::GZIP_LEVEL);
+
+            if ($packed === false) {
+                throw new EnvelopeCipherException('Unable to compress telemetry envelope');
+            }
+
+            $iv = random_bytes(self::IV_LEN);
+            $tag = '';
+            $cipher = openssl_encrypt(
+                $packed,
+                self::CIPHER,
+                $this->deriveKey($productKey),
+                OPENSSL_RAW_DATA,
+                $iv,
+                $tag,
+                self::VERSION,
+                self::TAG_LEN,
+            );
+
+            if ($cipher === false) {
+                throw new EnvelopeCipherException('Unable to encrypt telemetry envelope');
+            }
+
+            return base64_encode(self::VERSION . $iv . $tag . $cipher);
+        } catch (EnvelopeCipherException $exception) {
+            throw $exception;
+        } catch (Throwable $exception) {
+            throw new EnvelopeCipherException('Unable to encrypt telemetry envelope', 0, $exception);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @throws EnvelopeCipherException
+     */
+    public function decrypt(string $blob, string $productKey): array
+    {
+        $raw = base64_decode($blob, true);
+
+        if ($raw === false) {
+            throw new EnvelopeCipherException('Telemetry blob is not valid base64');
+        }
+
+        // 1 version byte + IV + at least the GCM tag (empty message is still TAG_LEN long)
+        if (strlen($raw) < 1 + self::IV_LEN + self::TAG_LEN) {
+            throw new EnvelopeCipherException('Telemetry blob is too short');
+        }
+
+        if ($raw[0] !== self::VERSION) {
+            throw new EnvelopeCipherException('Unsupported telemetry envelope version');
+        }
+
+        $iv = substr($raw, 1, self::IV_LEN);
+        $tag = substr($raw, 1 + self::IV_LEN, self::TAG_LEN);
+        $cipher = substr($raw, 1 + self::IV_LEN + self::TAG_LEN);
+
+        $packed = openssl_decrypt(
+            $cipher,
+            self::CIPHER,
+            $this->deriveKey($productKey),
+            OPENSSL_RAW_DATA,
+            $iv,
+            $tag,
+            self::VERSION,
+        );
+
+        if ($packed === false) {
+            // wrong key or tampered ciphertext - GCM tag verification failed
+            throw new EnvelopeCipherException('Telemetry envelope failed authentication');
+        }
+
+        // The extra byte lets us tell "exactly at the cap" apart from "truncated at the cap".
+        $json = gzdecode($packed, self::MAX_PLAINTEXT_BYTES + 1);
+
+        if ($json === false) {
+            throw new EnvelopeCipherException('Unable to decompress telemetry envelope');
+        }
+
+        if (strlen($json) > self::MAX_PLAINTEXT_BYTES) {
+            throw new EnvelopeCipherException('Telemetry envelope exceeds the size limit');
+        }
+
+        try {
+            $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new EnvelopeCipherException('Telemetry envelope is not valid JSON', 0, $exception);
+        }
+
+        if (!is_array($data)) {
+            throw new EnvelopeCipherException('Telemetry envelope did not decode to an array');
+        }
+
+        return $data;
+    }
+
+    /**
+     * Derive the symmetric key from the product key. Both sides derive it identically, so the same
+     * product key yields the same key - the whole scheme rests on this being deterministic.
+     *
+     * @throws EnvelopeCipherException
+     */
+    private function deriveKey(string $productKey): string
+    {
+        if ($productKey === '') {
+            throw new EnvelopeCipherException('Cannot derive a telemetry key from an empty product key');
+        }
+
+        return hash_hkdf('sha256', $productKey, self::KEY_LEN, self::HKDF_INFO);
+    }
+}

--- a/lib/Telemetry/Crypto/EnvelopeCipherException.php
+++ b/lib/Telemetry/Crypto/EnvelopeCipherException.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Crypto;
+
+use RuntimeException;
+
+/**
+ * Thrown when a telemetry envelope cannot be encrypted or (more importantly) decrypted - a wrong
+ * product key, a tampered or truncated blob, or an unsupported format version. On the relay a
+ * decryption failure is the authentication failure: a batch that will not decrypt is rejected.
+ *
+ * @internal
+ */
+final class EnvelopeCipherException extends RuntimeException
+{
+}

--- a/lib/Telemetry/EventSanitizer.php
+++ b/lib/Telemetry/EventSanitizer.php
@@ -1,0 +1,106 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry;
+
+use Psr\Log\LoggerInterface;
+use function get_debug_type;
+use function is_array;
+use function is_scalar;
+use function preg_match;
+
+/**
+ * Framework-level guard that makes the "content-never, behavior-only" contract a property of
+ * the telemetry framework rather than a per-caller promise.
+ *
+ * It does two things, both at the single {@see Telemetry::capture()}/{@see Telemetry::groupIdentify()}
+ * seam: it validates event names against the taxonomy convention (`domain.object_action`), and it
+ * drops any non-scalar property value so an accidental array/object payload - which could carry
+ * customer content - can never leave the instance. Violations are logged, never thrown: telemetry
+ * must never disrupt the host process.
+ *
+ * @internal
+ */
+final class EventSanitizer
+{
+    /**
+     * Lowercase, dot-separated segments, at least two of them - e.g. `object.opened`,
+     * `importer.run_started`. Deliberately strict so the dataset stays queryable and cheap.
+     */
+    private const EVENT_NAME_PATTERN = '/^[a-z0-9]+(?:\.[a-z0-9_]+)+$/';
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function isValidEventName(string $event): bool
+    {
+        return preg_match(self::EVENT_NAME_PATTERN, $event) === 1;
+    }
+
+    /**
+     * Keep scalar/null values and arrays whose leaves are all scalar (e.g. the list of installed
+     * bundle names); drop and log objects, resources, and closures, which can stringify to
+     * arbitrary customer content. A guard cannot tell a safe string from a content-bearing one -
+     * that stays the caller's responsibility, enforced by the taxonomy - but it can keep live
+     * objects out of the payload entirely.
+     *
+     * @param array<string, mixed> $properties
+     *
+     * @return array<string, mixed>
+     */
+    public function sanitizeProperties(array $properties, string $context): array
+    {
+        $safe = [];
+
+        foreach ($properties as $key => $value) {
+            if ($this->isSafeValue($value)) {
+                $safe[$key] = $value;
+
+                continue;
+            }
+
+            $this->logger->warning('Dropped unsafe telemetry property before send', [
+                'context' => $context,
+                'property' => $key,
+                'type' => get_debug_type($value),
+            ]);
+        }
+
+        return $safe;
+    }
+
+    /**
+     * Safe = scalar, null, or an array whose values are all safe (recursively). Objects,
+     * resources, and closures are rejected.
+     */
+    private function isSafeValue(mixed $value): bool
+    {
+        if ($value === null || is_scalar($value)) {
+            return true;
+        }
+
+        if (is_array($value)) {
+            foreach ($value as $item) {
+                if (!$this->isSafeValue($item)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/lib/Telemetry/Relay/RelayClient.php
+++ b/lib/Telemetry/Relay/RelayClient.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Relay;
+
+use GuzzleHttp\ClientInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use function is_array;
+use function json_decode;
+
+/**
+ * Direct HTTP delivery to the first-party relay. POSTs the cleartext outer envelope
+ * `{instanceIdentifier, v, ciphertext}` - only the instance identifier is visible; the relay uses it
+ * to look up the product key and decrypt the rest. Holds no PostHog key and no relay secret: the
+ * encryption itself authenticates the instance.
+ *
+ * @internal
+ */
+final class RelayClient implements RelayClientInterface
+{
+    private const FORMAT_VERSION = 1;
+
+    private const TIMEOUT_SECONDS = 5;
+
+    public function __construct(
+        private readonly string $endpoint,
+        private readonly ClientInterface $httpClient,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->endpoint !== '';
+    }
+
+    public function send(string $instanceIdentifier, string $ciphertext): bool
+    {
+        if ($this->endpoint === '') {
+            return false;
+        }
+
+        try {
+            $response = $this->httpClient->request('POST', $this->endpoint, [
+                'json' => [
+                    'instanceIdentifier' => $instanceIdentifier,
+                    'v' => self::FORMAT_VERSION,
+                    'ciphertext' => $ciphertext,
+                ],
+                'timeout' => self::TIMEOUT_SECONDS,
+                'http_errors' => false,
+            ]);
+
+            $status = $response->getStatusCode();
+
+            if ($status < 200 || $status >= 300) {
+                $this->logger->warning('Telemetry relay rejected a batch', ['status' => $status]);
+
+                return false;
+            }
+
+            $body = json_decode((string)$response->getBody(), true);
+
+            // Success is a confirmed acceptance, not merely a 2xx - so a proxy 200 without the relay
+            // body never causes us to drop an undelivered batch.
+            return is_array($body) && ($body['status'] ?? null) === 'ok';
+        } catch (Throwable $exception) {
+            $this->logger->error('Unable to send telemetry batch to the relay', [
+                'endpoint' => $this->endpoint,
+                'exception' => $exception,
+            ]);
+
+            return false;
+        }
+    }
+}

--- a/lib/Telemetry/Relay/RelayClient.php
+++ b/lib/Telemetry/Relay/RelayClient.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Pimcore\Telemetry\Relay;
 
+use Exception;
 use GuzzleHttp\ClientInterface;
 use Psr\Log\LoggerInterface;
-use Throwable;
 use function is_array;
 use function json_decode;
 
@@ -75,7 +75,7 @@ final class RelayClient implements RelayClientInterface
             // Success is a confirmed acceptance, not merely a 2xx - so a proxy 200 without the relay
             // body never causes us to drop an undelivered batch.
             return is_array($body) && ($body['status'] ?? null) === 'ok';
-        } catch (Throwable $exception) {
+        } catch (Exception $exception) {
             $this->logger->error('Unable to send telemetry batch to the relay', [
                 'endpoint' => $this->endpoint,
                 'exception' => $exception,

--- a/lib/Telemetry/Relay/RelayClientInterface.php
+++ b/lib/Telemetry/Relay/RelayClientInterface.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Relay;
+
+/**
+ * Sends an encrypted telemetry batch to the first-party relay. The seam keeps the maintenance drain
+ * task unit testable and lets the delivery mechanism evolve independently.
+ *
+ * @internal
+ */
+interface RelayClientInterface
+{
+    /**
+     * Whether a relay endpoint is configured (nothing can be delivered otherwise).
+     */
+    public function isConfigured(): bool;
+
+    /**
+     * POST the encrypted batch to the relay. Returns true ONLY on a confirmed acceptance
+     * (HTTP 2xx + an `{status: ok}` body); any other outcome returns false so the caller keeps the
+     * batch for a later retry. Never throws - telemetry is best-effort.
+     */
+    public function send(string $instanceIdentifier, string $ciphertext): bool;
+}

--- a/lib/Telemetry/Snapshot/ActiveBundles.php
+++ b/lib/Telemetry/Snapshot/ActiveBundles.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Snapshot;
+
+use Pimcore\Extension\Bundle\PimcoreBundleManager;
+use function array_map;
+use function array_values;
+use function count;
+use function str_contains;
+use function strrchr;
+use function substr;
+
+/**
+ * The active bundles' short class names, resolved once per snapshot.
+ *
+ * {@see PimcoreBundleManager::getActiveBundles()} checks each bundle's enabled state individually,
+ * so enumerating them costs roughly one statement per installed bundle. Several collectors need the
+ * same list, so it is memoized here rather than re-queried by each of them - and the name-shortening
+ * and needle-matching they all repeated now live in one place.
+ *
+ * Content-never: bundle short names are Pimcore's own class identifiers, never customer data.
+ *
+ * @internal
+ */
+final class ActiveBundles
+{
+    /**
+     * @var list<string>|null
+     */
+    private ?array $names = null;
+
+    public function __construct(
+        private readonly PimcoreBundleManager $bundleManager,
+    ) {
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function names(): array
+    {
+        return $this->names ??= array_values(array_map(
+            static function (object $bundle): string {
+                $class = $bundle::class;
+                $shortName = strrchr($class, '\\');
+
+                return $shortName === false ? $class : substr($shortName, 1);
+            },
+            $this->bundleManager->getActiveBundles()
+        ));
+    }
+
+    public function count(): int
+    {
+        return count($this->names());
+    }
+
+    /**
+     * Whether any active bundle's short name contains the given needle.
+     */
+    public function has(string $needle): bool
+    {
+        foreach ($this->names() as $name) {
+            if (str_contains($name, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/lib/Telemetry/Snapshot/ActiveBundles.php
+++ b/lib/Telemetry/Snapshot/ActiveBundles.php
@@ -14,31 +14,47 @@ declare(strict_types=1);
 namespace Pimcore\Telemetry\Snapshot;
 
 use Pimcore\Extension\Bundle\PimcoreBundleManager;
-use function array_map;
-use function array_values;
 use function count;
 use function str_contains;
+use function str_starts_with;
 use function strrchr;
 use function substr;
 
 /**
- * The active bundles' short class names, resolved once per snapshot.
+ * The active bundles, resolved once per snapshot and split into first-party and everything else.
  *
- * {@see PimcoreBundleManager::getActiveBundles()} checks each bundle's enabled state individually,
- * so enumerating them costs roughly one statement per installed bundle. Several collectors need the
- * same list, so it is memoized here rather than re-queried by each of them - and the name-shortening
- * and needle-matching they all repeated now live in one place.
+ * {@see PimcoreBundleManager::getActiveBundles()} returns every bundle implementing
+ * `PimcoreBundleInterface` - which is precisely how customers and agencies build their own bundles,
+ * so the raw list contains customer-authored class names. Only first-party bundles are ever named;
+ * anything else is counted but never identified, because a bundle class name is customer content
+ * and must not leave the installation.
  *
- * Content-never: bundle short names are Pimcore's own class identifiers, never customer data.
+ * Membership is decided by namespace rather than a per-bundle allow-list, so new Pimcore bundles are
+ * covered automatically and an unknown namespace fails safe (counted, not named).
+ *
+ * Enumerating the bundles costs roughly one statement per installed bundle, so the result is
+ * memoized here rather than re-queried by each collector.
  *
  * @internal
  */
 final class ActiveBundles
 {
     /**
+     * Namespaces owned by Pimcore. The two non-`Pimcore\` entries are Pimcore products that predate
+     * the current namespace convention.
+     */
+    private const FIRST_PARTY_NAMESPACES = [
+        'Pimcore\\',
+        'CustomerManagementFrameworkBundle\\',
+        'FrontendPermissionToolkitBundle\\',
+    ];
+
+    /**
      * @var list<string>|null
      */
-    private ?array $names = null;
+    private ?array $firstParty = null;
+
+    private int $thirdPartyCount = 0;
 
     public function __construct(
         private readonly PimcoreBundleManager $bundleManager,
@@ -46,33 +62,79 @@ final class ActiveBundles
     }
 
     /**
+     * Short class names of the active first-party bundles - safe to emit.
+     *
      * @return list<string>
      */
-    public function names(): array
+    public function firstPartyNames(): array
     {
-        return $this->names ??= array_values(array_map(
-            static function (object $bundle): string {
-                $class = $bundle::class;
-                $shortName = strrchr($class, '\\');
+        $this->resolve();
 
-                return $shortName === false ? $class : substr($shortName, 1);
-            },
-            $this->bundleManager->getActiveBundles()
-        ));
+        return $this->firstParty;
+    }
+
+    /**
+     * How many active bundles are not first-party. A count only: these are customer, agency or
+     * third-party bundles and their names never leave the instance.
+     */
+    public function thirdPartyCount(): int
+    {
+        $this->resolve();
+
+        return $this->thirdPartyCount;
     }
 
     public function count(): int
     {
-        return count($this->names());
+        return count($this->firstPartyNames()) + $this->thirdPartyCount();
     }
 
     /**
-     * Whether any active bundle's short name contains the given needle.
+     * Whether an active *first-party* bundle's short name contains the given needle. Third-party
+     * bundles are deliberately not considered, so a customer bundle called e.g. `AcmeDataHubSync`
+     * can never flip a Pimcore capability flag.
      */
     public function has(string $needle): bool
     {
-        foreach ($this->names() as $name) {
+        foreach ($this->firstPartyNames() as $name) {
             if (str_contains($name, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function resolve(): void
+    {
+        if ($this->firstParty !== null) {
+            return;
+        }
+
+        $firstParty = [];
+        $thirdParty = 0;
+
+        foreach ($this->bundleManager->getActiveBundles() as $bundle) {
+            $class = $bundle::class;
+
+            if (!$this->isFirstParty($class)) {
+                $thirdParty++;
+
+                continue;
+            }
+
+            $shortName = strrchr($class, '\\');
+            $firstParty[] = $shortName === false ? $class : substr($shortName, 1);
+        }
+
+        $this->firstParty = $firstParty;
+        $this->thirdPartyCount = $thirdParty;
+    }
+
+    private function isFirstParty(string $class): bool
+    {
+        foreach (self::FIRST_PARTY_NAMESPACES as $namespace) {
+            if (str_starts_with($class, $namespace)) {
                 return true;
             }
         }

--- a/lib/Telemetry/Snapshot/Bucketizer.php
+++ b/lib/Telemetry/Snapshot/Bucketizer.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Snapshot;
+
+/**
+ * Maps an exact count to a coarse bucket so the shape of a customer's catalog or data
+ * model cannot be used to re-identify them. Shared by all snapshot collectors so every
+ * count is bucketed identically.
+ *
+ * @internal
+ */
+final readonly class Bucketizer
+{
+    public function bucket(int $count): string
+    {
+        return match (true) {
+            $count <= 0 => '0',
+            $count <= 10 => '1-10',
+            $count <= 50 => '11-50',
+            $count <= 200 => '51-200',
+            $count <= 1000 => '201-1000',
+            default => '1000+',
+        };
+    }
+}

--- a/lib/Telemetry/Snapshot/CatalogShapeCollector.php
+++ b/lib/Telemetry/Snapshot/CatalogShapeCollector.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Snapshot;
+
+use Pimcore\Telemetry\Snapshot\Statistics\ElementKind;
+use Pimcore\Telemetry\Snapshot\Statistics\ElementStatisticsProviderInterface;
+
+/**
+ * Evidence for "what is the shape of the managed catalog/content landscape?" (EM question #3).
+ *
+ * Emits the *shape* of the catalog - how deep the element hierarchies go, how products fan out into
+ * variants, and how wide folders get - to complement the element *counts* already emitted by
+ * {@see CoreSnapshotCollector} and {@see PillarUsageCollector}. The scale facets of #3 (size buckets,
+ * asset volumes) are answered by those; this adds only depth/variant/organization shape.
+ *
+ * Everything is content-never: counts, buckets, and small depth integers only - never a path, name,
+ * or value. All figures come from {@see ElementStatisticsProviderInterface}: in the SQL default these
+ * are the snapshot's heaviest queries (path-depth and GROUP BY aggregates that no MySQL index serves,
+ * time-boxed so they can never stall the run); when Studio's decorating provider is active they are
+ * served as cheap search-index aggregations that never touch the transactional DB.
+ *
+ * "Likely vertical inferred from configured standards" (the remaining #3 facet) is intentionally NOT
+ * collected here - it needs domain-revealing signals the content-never contract excludes; see the
+ * design doc for the deferred, privacy-safe approach.
+ *
+ * Increment {@see self::SCHEMA_VERSION} whenever the emitted set changes.
+ *
+ * @internal
+ */
+final readonly class CatalogShapeCollector implements SnapshotCollectorInterface
+{
+    private const SCHEMA_VERSION = 1;
+
+    public function __construct(
+        private ElementStatisticsProviderInterface $statistics,
+        private Bucketizer $bucketizer,
+    ) {
+    }
+
+    public function getNamespace(): string
+    {
+        return 'catalog';
+    }
+
+    public function collect(): array
+    {
+        $objectDepth = $this->statistics->treeDepth(ElementKind::DataObject);
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+
+            // Tree shape - how deep each element hierarchy goes.
+            'object_tree_max_depth' => $objectDepth->max,
+            'object_tree_avg_depth' => $objectDepth->avg,
+            'asset_tree_max_depth' => $this->statistics->treeDepth(ElementKind::Asset)->max,
+            'document_tree_max_depth' => $this->statistics->treeDepth(ElementKind::Document)->max,
+
+            // Product/variant shape.
+            'products_with_variants_bucket' => $this->bucketizer->bucket($this->statistics->objectsWithVariants()),
+            'max_variants_per_product' => $this->statistics->maxVariantsPerObject(),
+
+            // Organization shape.
+            'max_folder_fanout' => $this->statistics->maxObjectFanout(),
+        ];
+    }
+}

--- a/lib/Telemetry/Snapshot/CoreSnapshotCollector.php
+++ b/lib/Telemetry/Snapshot/CoreSnapshotCollector.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Pimcore\Telemetry\Snapshot;
 
+use Exception;
 use Pimcore\Tool;
 use Pimcore\Version;
-use Throwable;
 use function count;
 use function is_numeric;
 use function is_string;
@@ -101,7 +101,7 @@ final readonly class CoreSnapshotCollector implements SnapshotCollectorInterface
             $version = $this->queryRunner->fetchOne('SELECT VERSION()');
 
             return is_string($version) ? $version : 'unknown';
-        } catch (Throwable) {
+        } catch (Exception) {
             return 'unknown';
         }
     }
@@ -128,7 +128,7 @@ final readonly class CoreSnapshotCollector implements SnapshotCollectorInterface
             );
 
             return is_numeric($rows) ? (int)$rows : 0;
-        } catch (Throwable) {
+        } catch (Exception) {
             return 0;
         }
     }
@@ -141,7 +141,7 @@ final readonly class CoreSnapshotCollector implements SnapshotCollectorInterface
             );
 
             return is_numeric($count) ? (int)$count : 0;
-        } catch (Throwable) {
+        } catch (Exception) {
             return 0;
         }
     }

--- a/lib/Telemetry/Snapshot/CoreSnapshotCollector.php
+++ b/lib/Telemetry/Snapshot/CoreSnapshotCollector.php
@@ -55,7 +55,8 @@ final readonly class CoreSnapshotCollector implements SnapshotCollectorInterface
 
     public function collect(): array
     {
-        $bundles = $this->activeBundles->names();
+        // Only first-party bundles are named; customer/agency bundles are counted (see ActiveBundles).
+        $bundles = $this->activeBundles->firstPartyNames();
 
         return [
             'pimcore_version' => Version::getVersion(),
@@ -65,8 +66,9 @@ final readonly class CoreSnapshotCollector implements SnapshotCollectorInterface
             'mysql_version' => $this->getMysqlVersion(),
             'mode' => $this->mode(),
             'language_count' => count(Tool::getValidLanguages()),
-            'active_bundle_count' => count($bundles),
+            'active_bundle_count' => $this->activeBundles->count(),
             'bundles' => $bundles,
+            'third_party_bundle_count' => $this->activeBundles->thirdPartyCount(),
             'dataobject_class_count_bucket' => $this->bucketizer->bucket($this->countTable('classes')),
             'object_count_bucket' => $this->bucketizer->bucket($this->countTable('objects')),
             'asset_count_bucket' => $this->bucketizer->bucket($this->countTable('assets')),

--- a/lib/Telemetry/Snapshot/CoreSnapshotCollector.php
+++ b/lib/Telemetry/Snapshot/CoreSnapshotCollector.php
@@ -1,0 +1,146 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Snapshot;
+
+use Pimcore\Tool;
+use Pimcore\Version;
+use Throwable;
+use function count;
+use function is_numeric;
+use function is_string;
+use function strtolower;
+use function trim;
+
+/**
+ * Core snapshot collector: versions, environment, bucketed catalog/model sizes, and the
+ * set of active bundle names. Behavior- and structure-only - no names, domains, or content.
+ *
+ * Serves as the reference implementation other bundles copy to add their own metrics.
+ *
+ * @internal
+ */
+final readonly class CoreSnapshotCollector implements SnapshotCollectorInterface
+{
+    /**
+     * Above this the optimizer's row estimate already lands in the top ("1000+") bucket, so we trust
+     * it and skip a full `COUNT(*)` on a potentially huge table. At or below it an exact count is
+     * cheap (small table) and keeps the bucket precise where precision actually matters. InnoDB
+     * estimates are never off by the >80% it would take to misclassify across this margin.
+     */
+    private const ESTIMATE_TRUST_THRESHOLD = 5000;
+
+    public function __construct(
+        private ActiveBundles $activeBundles,
+        private SnapshotQueryRunner $queryRunner,
+        private Bucketizer $bucketizer,
+        private string $environment,
+    ) {
+    }
+
+    public function getNamespace(): string
+    {
+        return 'core';
+    }
+
+    public function collect(): array
+    {
+        $bundles = $this->activeBundles->names();
+
+        return [
+            'pimcore_version' => Version::getVersion(),
+            'pimcore_major_version' => Version::getMajorVersion(),
+            'pimcore_platform_version' => Version::getPlatformVersion(),
+            'php_version' => PHP_VERSION,
+            'mysql_version' => $this->getMysqlVersion(),
+            'mode' => $this->mode(),
+            'language_count' => count(Tool::getValidLanguages()),
+            'active_bundle_count' => count($bundles),
+            'bundles' => $bundles,
+            'dataobject_class_count_bucket' => $this->bucketizer->bucket($this->countTable('classes')),
+            'object_count_bucket' => $this->bucketizer->bucket($this->countTable('objects')),
+            'asset_count_bucket' => $this->bucketizer->bucket($this->countTable('assets')),
+            'document_count_bucket' => $this->bucketizer->bucket($this->countTable('documents')),
+            'datahub_enabled' => $this->activeBundles->has('DataHub'),
+        ];
+    }
+
+    /**
+     * The Symfony environment, reduced to a fixed vocabulary.
+     *
+     * `APP_ENV` is customer-authored free text (agency deployments legitimately use values like
+     * `prod_<clientname>`), so the raw value is never emitted - that would be the only free-form
+     * string in the snapshot and would break the content-never contract. Anything outside the known
+     * set collapses to `other`, which is a useful signal in itself.
+     */
+    private function mode(): string
+    {
+        return match (strtolower(trim($this->environment))) {
+            'prod' => 'prod',
+            'dev' => 'dev',
+            'test' => 'test',
+            default => 'other',
+        };
+    }
+
+    private function getMysqlVersion(): string
+    {
+        try {
+            $version = $this->queryRunner->fetchOne('SELECT VERSION()');
+
+            return is_string($version) ? $version : 'unknown';
+        } catch (Throwable) {
+            return 'unknown';
+        }
+    }
+
+    /**
+     * Element-table size for bucketing. Uses the optimizer's cached row estimate (O(1), no scan) so
+     * a multi-million-row table costs nothing; only small/unknown tables fall back to an exact
+     * COUNT(*), where the scan is cheap and the bucket precision is worth it.
+     */
+    private function countTable(string $table): int
+    {
+        $estimate = $this->estimateRows($table);
+
+        return $estimate >= self::ESTIMATE_TRUST_THRESHOLD ? $estimate : $this->exactCount($table);
+    }
+
+    private function estimateRows(string $table): int
+    {
+        try {
+            $rows = $this->queryRunner->fetchOne(
+                'SELECT TABLE_ROWS FROM information_schema.TABLES'
+                . ' WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?',
+                [$table]
+            );
+
+            return is_numeric($rows) ? (int)$rows : 0;
+        } catch (Throwable) {
+            return 0;
+        }
+    }
+
+    private function exactCount(string $table): int
+    {
+        try {
+            $count = $this->queryRunner->fetchOne(
+                'SELECT COUNT(*) FROM ' . $this->queryRunner->quoteIdentifier($table)
+            );
+
+            return is_numeric($count) ? (int)$count : 0;
+        } catch (Throwable) {
+            return 0;
+        }
+    }
+}

--- a/lib/Telemetry/Snapshot/DataModelComplexityCollector.php
+++ b/lib/Telemetry/Snapshot/DataModelComplexityCollector.php
@@ -1,0 +1,232 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Snapshot;
+
+use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\Fieldcollection;
+use Pimcore\Model\DataObject\Objectbrick;
+use Throwable;
+use function count;
+use function is_numeric;
+use function max;
+use function round;
+
+/**
+ * Evidence for "how complex is each customer's data model?" (EM question #2).
+ *
+ * Emits instance-level structural aggregates over the DataObject data model (classes, field
+ * collections, object bricks, classification store, custom layouts). The complexity *score* and
+ * tiering are left to the analysis layer (HogQL over these group properties) so thresholds can be
+ * tuned without shipping a Pimcore release - the same approach as {@see PillarUsageCollector}.
+ *
+ * Everything here is content-never: counts, buckets, booleans, and Pimcore's own field-type
+ * identifiers only - never class, field, product, or any customer names/values. Reads cached
+ * definition files (not data tables) so it is cheap and runs only on the periodic snapshot. Any
+ * failure degrades to zero, never an exception.
+ *
+ * Increment {@see self::SCHEMA_VERSION} whenever the emitted evidence set changes.
+ *
+ * @internal
+ */
+final readonly class DataModelComplexityCollector implements SnapshotCollectorInterface
+{
+    private const SCHEMA_VERSION = 1;
+
+    public function __construct(
+        private FieldTreeAnalyzer $analyzer,
+        private Bucketizer $bucketizer,
+        private SnapshotQueryRunner $queryRunner,
+    ) {
+    }
+
+    public function getNamespace(): string
+    {
+        return 'datamodel';
+    }
+
+    public function collect(): array
+    {
+        $classes = $this->analyzeClasses();
+        /** @var FieldTreeMetrics $aggregate */
+        $aggregate = $classes['aggregate'];
+
+        // Fold field collections and object bricks into the model-wide totals (not per-class stats).
+        foreach ($this->satelliteFieldSets() as $fieldSet) {
+            $aggregate = $aggregate->combine($this->analyzer->analyze($fieldSet));
+        }
+
+        $classCount = $classes['count'];
+        $avgFields = $classCount > 0 ? (int)round($classes['sumFields'] / $classCount) : 0;
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+
+            // Breadth.
+            'class_count' => $classCount,
+            'fieldcollection_count' => $this->fieldcollectionCount(),
+            'objectbrick_count' => $this->objectbrickCount(),
+            'custom_layout_count' => $this->customLayoutCount(),
+            'classificationstore_group_count' => $this->tableCount('classificationstore_groups'),
+            'classificationstore_key_count' => $this->bucketizer->bucket($this->tableCount('classificationstore_keys')),
+
+            // Depth.
+            'total_field_count' => $this->bucketizer->bucket($aggregate->fieldCount),
+            'max_fields_per_class' => $classes['maxFields'],
+            'avg_fields_per_class' => $avgFields,
+            'max_nesting_depth' => $aggregate->maxDepth,
+            'classes_with_inheritance' => $classes['withInheritance'],
+
+            // Richness.
+            'distinct_fieldtype_count' => $aggregate->distinctTypeCount(),
+            'relation_field_count' => $this->bucketizer->bucket($aggregate->relationFieldCount),
+            'fieldtype_usage' => $aggregate->typeUsage,
+            'uses_localizedfields' => $aggregate->usesLocalizedfields,
+            'uses_blocks' => $aggregate->usesBlocks,
+            'uses_classificationstore' => $aggregate->usesClassificationstore,
+            'uses_calculated_value' => $aggregate->usesCalculatedValue,
+            'uses_advanced_relations' => $aggregate->usesAdvancedRelations,
+        ];
+    }
+
+    /**
+     * @return array{aggregate: FieldTreeMetrics, count: int, maxFields: int, sumFields: int, withInheritance: int}
+     */
+    private function analyzeClasses(): array
+    {
+        $aggregate = new FieldTreeMetrics();
+        $count = 0;
+        $maxFields = 0;
+        $sumFields = 0;
+        $withInheritance = 0;
+
+        try {
+            $classes = (new ClassDefinition\Listing())->getClasses();
+        } catch (Throwable) {
+            $classes = [];
+        }
+
+        foreach ($classes as $class) {
+            if (!$class instanceof ClassDefinition) {
+                continue;
+            }
+
+            try {
+                $fields = $class->getFieldDefinitions(['suppressEnrichment' => true]);
+            } catch (Throwable) {
+                continue;
+            }
+
+            $metrics = $this->analyzer->analyze($fields);
+            $aggregate = $aggregate->combine($metrics);
+            $count++;
+            $sumFields += $metrics->fieldCount;
+            $maxFields = max($maxFields, $metrics->fieldCount);
+
+            if ($class->getAllowInherit()) {
+                $withInheritance++;
+            }
+        }
+
+        return [
+            'aggregate' => $aggregate,
+            'count' => $count,
+            'maxFields' => $maxFields,
+            'sumFields' => $sumFields,
+            'withInheritance' => $withInheritance,
+        ];
+    }
+
+    /**
+     * @return list<array<int|string, mixed>>
+     */
+    private function satelliteFieldSets(): array
+    {
+        $sets = [];
+
+        try {
+            $fieldCollections = (new Fieldcollection\Definition\Listing())->load();
+        } catch (Throwable) {
+            $fieldCollections = [];
+        }
+
+        foreach ($fieldCollections as $definition) {
+            try {
+                $sets[] = $definition->getFieldDefinitions(['suppressEnrichment' => true]);
+            } catch (Throwable) {
+                continue;
+            }
+        }
+
+        try {
+            $objectBricks = (new Objectbrick\Definition\Listing())->load();
+        } catch (Throwable) {
+            $objectBricks = [];
+        }
+
+        foreach ($objectBricks as $definition) {
+            try {
+                $sets[] = $definition->getFieldDefinitions(['suppressEnrichment' => true]);
+            } catch (Throwable) {
+                continue;
+            }
+        }
+
+        return $sets;
+    }
+
+    private function fieldcollectionCount(): int
+    {
+        try {
+            return count((new Fieldcollection\Definition\Listing())->loadNames());
+        } catch (Throwable) {
+            return 0;
+        }
+    }
+
+    private function objectbrickCount(): int
+    {
+        try {
+            return count((new Objectbrick\Definition\Listing())->loadNames());
+        } catch (Throwable) {
+            return 0;
+        }
+    }
+
+    private function customLayoutCount(): int
+    {
+        try {
+            return count((new ClassDefinition\CustomLayout\Listing())->getLayoutDefinitions());
+        } catch (Throwable) {
+            return 0;
+        }
+    }
+
+    /**
+     * Routed through {@see SnapshotQueryRunner} like every other collector, so a classification
+     * store with millions of keys is aborted at the per-statement cap instead of stalling the
+     * maintenance run.
+     */
+    private function tableCount(string $table): int
+    {
+        try {
+            $count = $this->queryRunner->fetchOne(
+                'SELECT COUNT(*) FROM ' . $this->queryRunner->quoteIdentifier($table)
+            );
+
+            return is_numeric($count) ? (int)$count : 0;
+        } catch (Throwable) {
+            return 0;
+        }
+    }
+}

--- a/lib/Telemetry/Snapshot/DataModelComplexityCollector.php
+++ b/lib/Telemetry/Snapshot/DataModelComplexityCollector.php
@@ -117,10 +117,6 @@ final readonly class DataModelComplexityCollector implements SnapshotCollectorIn
         }
 
         foreach ($classes as $class) {
-            if (!$class instanceof ClassDefinition) {
-                continue;
-            }
-
             try {
                 $fields = $class->getFieldDefinitions(['suppressEnrichment' => true]);
             } catch (Throwable) {

--- a/lib/Telemetry/Snapshot/DataModelComplexityCollector.php
+++ b/lib/Telemetry/Snapshot/DataModelComplexityCollector.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Pimcore\Telemetry\Snapshot;
 
+use Exception;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\DataObject\Fieldcollection;
 use Pimcore\Model\DataObject\Objectbrick;
-use Throwable;
 use function count;
 use function is_numeric;
 use function max;
@@ -112,14 +112,14 @@ final readonly class DataModelComplexityCollector implements SnapshotCollectorIn
 
         try {
             $classes = (new ClassDefinition\Listing())->getClasses();
-        } catch (Throwable) {
+        } catch (Exception) {
             $classes = [];
         }
 
         foreach ($classes as $class) {
             try {
                 $fields = $class->getFieldDefinitions(['suppressEnrichment' => true]);
-            } catch (Throwable) {
+            } catch (Exception) {
                 continue;
             }
 
@@ -152,28 +152,28 @@ final readonly class DataModelComplexityCollector implements SnapshotCollectorIn
 
         try {
             $fieldCollections = (new Fieldcollection\Definition\Listing())->load();
-        } catch (Throwable) {
+        } catch (Exception) {
             $fieldCollections = [];
         }
 
         foreach ($fieldCollections as $definition) {
             try {
                 $sets[] = $definition->getFieldDefinitions(['suppressEnrichment' => true]);
-            } catch (Throwable) {
+            } catch (Exception) {
                 continue;
             }
         }
 
         try {
             $objectBricks = (new Objectbrick\Definition\Listing())->load();
-        } catch (Throwable) {
+        } catch (Exception) {
             $objectBricks = [];
         }
 
         foreach ($objectBricks as $definition) {
             try {
                 $sets[] = $definition->getFieldDefinitions(['suppressEnrichment' => true]);
-            } catch (Throwable) {
+            } catch (Exception) {
                 continue;
             }
         }
@@ -185,7 +185,7 @@ final readonly class DataModelComplexityCollector implements SnapshotCollectorIn
     {
         try {
             return count((new Fieldcollection\Definition\Listing())->loadNames());
-        } catch (Throwable) {
+        } catch (Exception) {
             return 0;
         }
     }
@@ -194,7 +194,7 @@ final readonly class DataModelComplexityCollector implements SnapshotCollectorIn
     {
         try {
             return count((new Objectbrick\Definition\Listing())->loadNames());
-        } catch (Throwable) {
+        } catch (Exception) {
             return 0;
         }
     }
@@ -203,7 +203,7 @@ final readonly class DataModelComplexityCollector implements SnapshotCollectorIn
     {
         try {
             return count((new ClassDefinition\CustomLayout\Listing())->getLayoutDefinitions());
-        } catch (Throwable) {
+        } catch (Exception) {
             return 0;
         }
     }
@@ -221,7 +221,7 @@ final readonly class DataModelComplexityCollector implements SnapshotCollectorIn
             );
 
             return is_numeric($count) ? (int)$count : 0;
-        } catch (Throwable) {
+        } catch (Exception) {
             return 0;
         }
     }

--- a/lib/Telemetry/Snapshot/ElementTypeCounts.php
+++ b/lib/Telemetry/Snapshot/ElementTypeCounts.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Snapshot;
+
+use function array_sum;
+use function count;
+
+/**
+ * The result of a single `SELECT type, COUNT(*) ... GROUP BY type` over an element table
+ * (objects/assets/documents): a `type => count` map from which the total, any per-type count, and
+ * the distinct-type variety are all derived without another scan. Content-never - `type` values are
+ * Pimcore's own element-type identifiers (image/video/object/variant/page/...), never customer data.
+ *
+ * @internal
+ */
+final readonly class ElementTypeCounts
+{
+    /**
+     * @param array<string, int> $byType element-type identifier => row count
+     */
+    public function __construct(
+        private array $byType = [],
+    ) {
+    }
+
+    public function total(): int
+    {
+        return (int)array_sum($this->byType);
+    }
+
+    public function ofType(string $type): int
+    {
+        return $this->byType[$type] ?? 0;
+    }
+
+    public function distinctTypes(): int
+    {
+        return count($this->byType);
+    }
+}

--- a/lib/Telemetry/Snapshot/FieldTreeAnalyzer.php
+++ b/lib/Telemetry/Snapshot/FieldTreeAnalyzer.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Snapshot;
+
+use Pimcore\Model\DataObject\ClassDefinition\Data;
+use Pimcore\Model\DataObject\ClassDefinition\Data\AdvancedManyToManyObjectRelation;
+use Pimcore\Model\DataObject\ClassDefinition\Data\AdvancedManyToManyRelation;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Block;
+use Pimcore\Model\DataObject\ClassDefinition\Data\CalculatedValue;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Classificationstore;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Localizedfields;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Relations\AbstractRelations;
+
+/**
+ * Walks a data-model field-definition tree and returns structural {@see FieldTreeMetrics}.
+ *
+ * Recursion descends only into the two inline container field types - {@see Block} and
+ * {@see Localizedfields} - via their `getChildren()`. Field collections and object bricks are NOT
+ * followed from a class here (they reference external definitions); the collector analyzes those
+ * definitions separately so their fields are counted exactly once. Reads structure only, never
+ * `getName()` values.
+ *
+ * @internal
+ */
+final class FieldTreeAnalyzer
+{
+    /**
+     * @param array<int|string, mixed> $fieldDefinitions
+     */
+    public function analyze(array $fieldDefinitions): FieldTreeMetrics
+    {
+        return $this->walk($fieldDefinitions, 1);
+    }
+
+    /**
+     * @param array<int|string, mixed> $fieldDefinitions
+     */
+    private function walk(array $fieldDefinitions, int $depth): FieldTreeMetrics
+    {
+        $metrics = new FieldTreeMetrics();
+
+        foreach ($fieldDefinitions as $fieldDefinition) {
+            if (!$fieldDefinition instanceof Data) {
+                continue;
+            }
+
+            $isAdvancedRelation = $fieldDefinition instanceof AdvancedManyToManyRelation
+                || $fieldDefinition instanceof AdvancedManyToManyObjectRelation;
+
+            $metrics = $metrics->combine(new FieldTreeMetrics(
+                fieldCount: 1,
+                maxDepth: $depth,
+                typeUsage: [$fieldDefinition->getFieldType() => 1],
+                relationFieldCount: $fieldDefinition instanceof AbstractRelations ? 1 : 0,
+                usesLocalizedfields: $fieldDefinition instanceof Localizedfields,
+                usesBlocks: $fieldDefinition instanceof Block,
+                usesClassificationstore: $fieldDefinition instanceof Classificationstore,
+                usesCalculatedValue: $fieldDefinition instanceof CalculatedValue,
+                usesAdvancedRelations: $isAdvancedRelation,
+            ));
+
+            if ($fieldDefinition instanceof Localizedfields || $fieldDefinition instanceof Block) {
+                $metrics = $metrics->combine($this->walk($fieldDefinition->getChildren(), $depth + 1));
+            }
+        }
+
+        return $metrics;
+    }
+}

--- a/lib/Telemetry/Snapshot/FieldTreeMetrics.php
+++ b/lib/Telemetry/Snapshot/FieldTreeMetrics.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Snapshot;
+
+use function count;
+use function max;
+
+/**
+ * Immutable, additive metrics for one data-model field tree (a class, field collection, or object
+ * brick). Instances are combined with {@see self::combine()} to aggregate the whole model. Holds
+ * only counts, a max depth, per-field-type tallies, and capability flags - content-never.
+ *
+ * @internal
+ */
+final readonly class FieldTreeMetrics
+{
+    /**
+     * @param array<string, int> $typeUsage field-type identifier => occurrence count
+     */
+    public function __construct(
+        public int $fieldCount = 0,
+        public int $maxDepth = 0,
+        public array $typeUsage = [],
+        public int $relationFieldCount = 0,
+        public bool $usesLocalizedfields = false,
+        public bool $usesBlocks = false,
+        public bool $usesClassificationstore = false,
+        public bool $usesCalculatedValue = false,
+        public bool $usesAdvancedRelations = false,
+    ) {
+    }
+
+    public function combine(self $other): self
+    {
+        $typeUsage = $this->typeUsage;
+        foreach ($other->typeUsage as $type => $count) {
+            $typeUsage[$type] = ($typeUsage[$type] ?? 0) + $count;
+        }
+
+        return new self(
+            $this->fieldCount + $other->fieldCount,
+            max($this->maxDepth, $other->maxDepth),
+            $typeUsage,
+            $this->relationFieldCount + $other->relationFieldCount,
+            $this->usesLocalizedfields || $other->usesLocalizedfields,
+            $this->usesBlocks || $other->usesBlocks,
+            $this->usesClassificationstore || $other->usesClassificationstore,
+            $this->usesCalculatedValue || $other->usesCalculatedValue,
+            $this->usesAdvancedRelations || $other->usesAdvancedRelations,
+        );
+    }
+
+    public function distinctTypeCount(): int
+    {
+        return count($this->typeUsage);
+    }
+}

--- a/lib/Telemetry/Snapshot/PillarUsageCollector.php
+++ b/lib/Telemetry/Snapshot/PillarUsageCollector.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Pimcore\Telemetry\Snapshot;
 
+use Exception;
 use Pimcore\Telemetry\Snapshot\Statistics\ElementKind;
 use Pimcore\Telemetry\Snapshot\Statistics\ElementStatisticsProviderInterface;
-use Throwable;
 use function is_numeric;
 
 /**
@@ -113,7 +113,7 @@ final readonly class PillarUsageCollector implements SnapshotCollectorInterface
             );
 
             return is_numeric($count) ? (int)$count : 0;
-        } catch (Throwable) {
+        } catch (Exception) {
             return 0;
         }
     }

--- a/lib/Telemetry/Snapshot/PillarUsageCollector.php
+++ b/lib/Telemetry/Snapshot/PillarUsageCollector.php
@@ -1,0 +1,125 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Snapshot;
+
+use Pimcore\Telemetry\Snapshot\Statistics\ElementKind;
+use Pimcore\Telemetry\Snapshot\Statistics\ElementStatisticsProviderInterface;
+use Throwable;
+use function is_numeric;
+
+/**
+ * Evidence for "which Pimcore pillars does each customer actually use?" (EM question #1).
+ *
+ * The pillars (DAM, PIM, MDM, DXP, Commerce) are not bundles - they are core capabilities every
+ * install technically has - so we cannot answer by checking a feature flag. Instead we emit the
+ * *structural evidence* of real usage: bucketed element-type volumes and a few capability bundle
+ * flags. The actual pillar classification (and the "combination" label) is deliberately left to
+ * the analysis layer (HogQL over these group properties), so the definition can be tuned without
+ * shipping a new Pimcore release.
+ *
+ * Everything here is content-never: counts, buckets, types, and booleans only - never class,
+ * product, asset, document, or field names. Per-element-kind counts come from
+ * {@see ElementStatisticsProviderInterface} - a single type aggregation per kind (a SQL `GROUP BY
+ * type`, or a search-index terms aggregation when Studio's decorating provider is active) yielding
+ * every per-type count, the type variety, and the total. Runs on the periodic maintenance snapshot
+ * only; failures degrade to zero, never an exception.
+ *
+ * Increment {@see self::SCHEMA_VERSION} whenever the emitted evidence set changes, so the analysis
+ * layer can tell which signals a given snapshot carried.
+ *
+ * @internal
+ */
+final readonly class PillarUsageCollector implements SnapshotCollectorInterface
+{
+    private const SCHEMA_VERSION = 1;
+
+    public function __construct(
+        private ActiveBundles $activeBundles,
+        private SnapshotQueryRunner $queryRunner,
+        private ElementStatisticsProviderInterface $statistics,
+        private Bucketizer $bucketizer,
+    ) {
+    }
+
+    public function getNamespace(): string
+    {
+        return 'pillars';
+    }
+
+    public function collect(): array
+    {
+        // One aggregation per element kind (SQL GROUP BY, or a search-index terms aggregation when a
+        // decorating provider is active) - every per-type count below is read from these.
+        $assets = $this->statistics->typeCounts(ElementKind::Asset);
+        $objects = $this->statistics->typeCounts(ElementKind::DataObject);
+        $documents = $this->statistics->typeCounts(ElementKind::Document);
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+
+            // DAM - digital asset volume and the variety of rich-media types managed.
+            'asset_count_bucket' => $this->bucket($assets->total()),
+            'asset_image_count_bucket' => $this->bucket($assets->ofType('image')),
+            'asset_video_count_bucket' => $this->bucket($assets->ofType('video')),
+            'asset_document_count_bucket' => $this->bucket($assets->ofType('document')),
+            'asset_audio_count_bucket' => $this->bucket($assets->ofType('audio')),
+            'asset_type_variety' => $assets->distinctTypes(),
+
+            // PIM - modelled data objects, product-like variant depth, and class-model breadth.
+            'class_count_bucket' => $this->bucket($this->count('classes')),
+            'object_count_bucket' => $this->bucket($objects->ofType('object')),
+            'object_variant_count_bucket' => $this->bucket($objects->ofType('variant')),
+
+            // DXP - web documents, page vs. transactional content, and multi-site footprint.
+            'document_page_count_bucket' => $this->bucket($documents->ofType('page')),
+            'document_email_count_bucket' => $this->bucket($documents->ofType('email')),
+            'document_link_count_bucket' => $this->bucket($documents->ofType('link')),
+            'site_count' => $this->count('sites'),
+            'seo_bundle_active' => $this->activeBundles->has('Seo'),
+            'personalization_bundle_active' => $this->activeBundles->has('Personalization'),
+            'headless_documents_bundle_active' => $this->activeBundles->has('HeadlessDocuments'),
+            'portal_engine_bundle_active' => $this->activeBundles->has('PortalEngine'),
+
+            // Commerce - capability signal only. "Actually transacting" (order/product object
+            // counts) belongs in a collector shipped by the ecommerce bundle itself, not core.
+            'commerce_bundle_active' => $this->activeBundles->has('Ecommerce'),
+
+            // Integration - Data Hub as a cross-cutting maturity signal (see also question #5).
+            'datahub_bundle_active' => $this->activeBundles->has('DataHub'),
+        ];
+    }
+
+
+    /**
+     * Low-cardinality COUNT(*) for tables that are not part of the element index (classes, sites);
+     * these are tiny, so a direct count is fine. Time-boxed; degrades to 0 on failure.
+     */
+    private function count(string $table): int
+    {
+        try {
+            $count = $this->queryRunner->fetchOne(
+                'SELECT COUNT(*) FROM ' . $this->queryRunner->quoteIdentifier($table)
+            );
+
+            return is_numeric($count) ? (int)$count : 0;
+        } catch (Throwable) {
+            return 0;
+        }
+    }
+
+    private function bucket(int $count): string
+    {
+        return $this->bucketizer->bucket($count);
+    }
+}

--- a/lib/Telemetry/Snapshot/SettingsStoreSnapshotState.php
+++ b/lib/Telemetry/Snapshot/SettingsStoreSnapshotState.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Snapshot;
+
+use Pimcore\Model\Tool\SettingsStore;
+
+/**
+ * Stores the last-snapshot timestamp in the Pimcore settings-store (no extra table needed).
+ *
+ * @internal
+ */
+final class SettingsStoreSnapshotState implements TelemetrySnapshotStateInterface
+{
+    private const SETTING_ID = 'telemetry.last_snapshot_at';
+
+    private const SCOPE = 'pimcore_telemetry';
+
+    public function getLastSnapshotAt(): ?int
+    {
+        $entry = SettingsStore::get(self::SETTING_ID, self::SCOPE);
+
+        return $entry === null ? null : (int) $entry->getData();
+    }
+
+    public function markSnapshotTaken(int $timestamp): void
+    {
+        SettingsStore::set(self::SETTING_ID, $timestamp, SettingsStore::TYPE_INTEGER, self::SCOPE);
+    }
+}

--- a/lib/Telemetry/Snapshot/SnapshotBuilder.php
+++ b/lib/Telemetry/Snapshot/SnapshotBuilder.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Snapshot;
+
+use function microtime;
+use function round;
+
+/**
+ * Builds the telemetry snapshot (Layer 1): runs every tagged
+ * {@see SnapshotCollectorInterface} and merges their output into a single, flat,
+ * namespaced array ready to be sent as PostHog group properties.
+ *
+ * It also reports on itself under `meta.*` - how long collecting took and how many statements it
+ * cost - so the fleet data shows whether the snapshot is getting slower or heavier on real
+ * installations, which is the one thing that cannot be measured on a development machine. Both are
+ * plain integers about our own job, never anything about the customer.
+ *
+ * @internal
+ */
+final readonly class SnapshotBuilder
+{
+    /**
+     * @param iterable<SnapshotCollectorInterface> $collectors
+     */
+    public function __construct(
+        private iterable $collectors,
+        private ?StatementCounter $statementCounter = null,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function build(): array
+    {
+        $statementsBefore = $this->statementCounter?->read();
+        $startedAt = microtime(true);
+
+        $snapshot = [];
+        foreach ($this->collectors as $collector) {
+            $namespace = $collector->getNamespace();
+            foreach ($collector->collect() as $key => $value) {
+                $snapshot[$namespace . '.' . $key] = $value;
+            }
+        }
+
+        $snapshot['meta.duration_ms'] = (int) round((microtime(true) - $startedAt) * 1000);
+
+        $statements = $this->statementCounter?->between($statementsBefore, $this->statementCounter->read());
+        if ($statements !== null) {
+            $snapshot['meta.db_statements'] = $statements;
+        }
+
+        return $snapshot;
+    }
+}

--- a/lib/Telemetry/Snapshot/SnapshotBuilder.php
+++ b/lib/Telemetry/Snapshot/SnapshotBuilder.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Pimcore\Telemetry\Snapshot;
 
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Throwable;
 use function microtime;
 use function round;
 
@@ -36,6 +39,7 @@ final readonly class SnapshotBuilder
     public function __construct(
         private iterable $collectors,
         private ?StatementCounter $statementCounter = null,
+        private LoggerInterface $logger = new NullLogger(),
     ) {
     }
 
@@ -49,8 +53,24 @@ final readonly class SnapshotBuilder
 
         $snapshot = [];
         foreach ($this->collectors as $collector) {
-            $namespace = $collector->getNamespace();
-            foreach ($collector->collect() as $key => $value) {
+            // This is the fault-isolation boundary for collectors, which are a public extension
+            // point: a bundle's collector must not be able to take down the snapshot - nor, since
+            // Maintenance\Executor only catches Exception, the whole maintenance run. Everything
+            // inside a collector therefore narrows to Exception and any real defect surfaces here,
+            // logged with its namespace, while the remaining collectors still report.
+            try {
+                $namespace = $collector->getNamespace();
+                $metrics = $collector->collect();
+            } catch (Throwable $exception) {
+                $this->logger->error('Telemetry snapshot collector failed', [
+                    'collector' => $collector::class,
+                    'exception' => $exception,
+                ]);
+
+                continue;
+            }
+
+            foreach ($metrics as $key => $value) {
                 $snapshot[$namespace . '.' . $key] = $value;
             }
         }

--- a/lib/Telemetry/Snapshot/SnapshotCollectorInterface.php
+++ b/lib/Telemetry/Snapshot/SnapshotCollectorInterface.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Snapshot;
+
+/**
+ * Extension point for the telemetry snapshot (Layer 1). Any bundle can contribute
+ * structural, anonymized metrics by implementing this interface and tagging the service
+ * with `pimcore.telemetry.snapshot_collector`; the {@see SnapshotBuilder} gathers all
+ * registered collectors into a single periodic snapshot.
+ *
+ * Implementations MUST return safe data only: counts, buckets, booleans, categoricals,
+ * versions - never class/field/product names, domains, or any customer content.
+ *
+ * This is a public extension point and therefore intentionally not `@internal`.
+ */
+interface SnapshotCollectorInterface
+{
+    /**
+     * Short, stable key the builder uses to namespace this collector's metrics
+     * (e.g. "core" -> "core.asset_count_bucket").
+     */
+    public function getNamespace(): string;
+
+    /**
+     * @return array<string, mixed> flat map of safe metric name => value
+     */
+    public function collect(): array;
+}

--- a/lib/Telemetry/Snapshot/SnapshotQueryRunner.php
+++ b/lib/Telemetry/Snapshot/SnapshotQueryRunner.php
@@ -1,0 +1,123 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Snapshot;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Throwable;
+use function ltrim;
+use function preg_replace;
+use function sprintf;
+use function str_starts_with;
+use function strtoupper;
+
+/**
+ * Runs snapshot-collector SELECTs with a per-statement execution-time cap.
+ *
+ * The snapshot is produced by the maintenance job, off the request path - but its heaviest
+ * collectors still run unbounded aggregates over the largest tables (e.g. a path-depth MAX/AVG
+ * over every object row, or a GROUP BY on an unindexed column). On a big instance one of those can
+ * run for minutes and evict the buffer pool. This runner caps each statement so a pathological
+ * table aborts fast; the driver then throws and the collector's existing try/catch degrades that
+ * one metric to 0/unknown rather than stalling the whole maintenance run.
+ *
+ * The cap is expressed per statement (no session state that could leak into sibling maintenance
+ * tasks sharing the connection) using the platform-native mechanism:
+ *   - MariaDB: `SET STATEMENT max_statement_time=<seconds> FOR <select>`
+ *   - MySQL:   the `MAX_EXECUTION_TIME(<milliseconds>)` optimizer hint
+ * Both only apply to read-only SELECTs (all snapshot queries are). A non-positive timeout, or a
+ * non-SELECT statement, disables the cap and the SQL is passed through unchanged.
+ *
+ * @internal
+ */
+final readonly class SnapshotQueryRunner
+{
+    public function __construct(
+        private Connection $connection,
+        private int $timeoutSeconds,
+    ) {
+    }
+
+    /**
+     * @param array<int|string, mixed> $params
+     */
+    public function fetchOne(string $sql, array $params = []): mixed
+    {
+        return $this->connection->fetchOne($this->timebox($sql), $params);
+    }
+
+    /**
+     * @param array<int|string, mixed> $params
+     *
+     * @return array<string, mixed>|false
+     */
+    public function fetchAssociative(string $sql, array $params = []): array|false
+    {
+        return $this->connection->fetchAssociative($this->timebox($sql), $params);
+    }
+
+    /**
+     * @param array<int|string, mixed> $params
+     *
+     * @return array<int|string, mixed>
+     */
+    public function fetchAllKeyValue(string $sql, array $params = []): array
+    {
+        return $this->connection->fetchAllKeyValue($this->timebox($sql), $params);
+    }
+
+    public function quoteIdentifier(string $identifier): string
+    {
+        return $this->connection->quoteIdentifier($identifier);
+    }
+
+    /**
+     * Pure, platform-parameterised builder so the wrapping is unit-testable without a connection.
+     */
+    public static function buildTimeoutSql(string $sql, bool $isMariaDb, int $timeoutSeconds): string
+    {
+        // Both mechanisms only bound read-only SELECTs; leave anything else (and a disabled cap) as-is.
+        if ($timeoutSeconds <= 0 || !str_starts_with(strtoupper(ltrim($sql)), 'SELECT')) {
+            return $sql;
+        }
+
+        if ($isMariaDb) {
+            return sprintf('SET STATEMENT max_statement_time=%d FOR %s', $timeoutSeconds, $sql);
+        }
+
+        // MySQL: inject the hint immediately after the leading SELECT keyword.
+        $hint = sprintf('SELECT /*+ MAX_EXECUTION_TIME(%d) */', $timeoutSeconds * 1000);
+
+        return preg_replace('/^\s*SELECT\b/i', $hint, $sql, 1) ?? $sql;
+    }
+
+    private function timebox(string $sql): string
+    {
+        if ($this->timeoutSeconds <= 0) {
+            return $sql;
+        }
+
+        return self::buildTimeoutSql($sql, $this->isMariaDb(), $this->timeoutSeconds);
+    }
+
+    private function isMariaDb(): bool
+    {
+        try {
+            return $this->connection->getDatabasePlatform() instanceof MariaDBPlatform;
+        } catch (Throwable) {
+            // Unknown platform: fall back to the MySQL hint form (a bare SELECT if it is neither).
+            return false;
+        }
+    }
+}

--- a/lib/Telemetry/Snapshot/SnapshotQueryRunner.php
+++ b/lib/Telemetry/Snapshot/SnapshotQueryRunner.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Pimcore\Telemetry\Snapshot;
 
+use Exception;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\MariaDBPlatform;
-use Throwable;
 use function ltrim;
 use function preg_replace;
 use function sprintf;
@@ -115,7 +115,7 @@ final readonly class SnapshotQueryRunner
     {
         try {
             return $this->connection->getDatabasePlatform() instanceof MariaDBPlatform;
-        } catch (Throwable) {
+        } catch (Exception) {
             // Unknown platform: fall back to the MySQL hint form (a bare SELECT if it is neither).
             return false;
         }

--- a/lib/Telemetry/Snapshot/StatementCounter.php
+++ b/lib/Telemetry/Snapshot/StatementCounter.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Snapshot;
+
+use Doctrine\DBAL\Connection;
+use Throwable;
+use function is_numeric;
+use function max;
+
+/**
+ * Reads the session's executed-statement counter, so the snapshot can report how much database work
+ * it did ({@see SnapshotBuilder} emits it as `meta.db_statements`).
+ *
+ * This deliberately uses MySQL's own `Questions` session counter rather than a DBAL middleware: a
+ * middleware would wrap every statement in the entire application, permanently, to serve a metric
+ * that is produced once a day. Reading the counter costs one statement and only happens inside the
+ * snapshot. It also counts *all* work - including queries issued outside
+ * {@see SnapshotQueryRunner}, such as bundle enumeration - which is exactly the blind spot a
+ * collector-level counter would miss.
+ *
+ * Every value is a plain integer; nothing here can carry customer content. Failures degrade to
+ * `null`, which simply omits the metric.
+ *
+ * @internal
+ */
+final readonly class StatementCounter
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    /**
+     * Statements executed on this session so far, or null when the counter is unavailable.
+     */
+    public function read(): ?int
+    {
+        try {
+            $row = $this->connection->fetchAssociative("SHOW SESSION STATUS LIKE 'Questions'");
+        } catch (Throwable) {
+            return null;
+        }
+
+        $value = $row['Value'] ?? null;
+
+        return is_numeric($value) ? (int) $value : null;
+    }
+
+    /**
+     * Statements executed between two {@see self::read()} values, discounting the closing read
+     * itself so the figure reflects only the work done in between.
+     */
+    public function between(?int $before, ?int $after): ?int
+    {
+        if ($before === null || $after === null) {
+            return null;
+        }
+
+        return max(0, $after - $before - 1);
+    }
+}

--- a/lib/Telemetry/Snapshot/StatementCounter.php
+++ b/lib/Telemetry/Snapshot/StatementCounter.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Pimcore\Telemetry\Snapshot;
 
+use Exception;
 use Doctrine\DBAL\Connection;
-use Throwable;
 use function is_numeric;
 use function max;
 
@@ -48,7 +48,7 @@ final readonly class StatementCounter
     {
         try {
             $row = $this->connection->fetchAssociative("SHOW SESSION STATUS LIKE 'Questions'");
-        } catch (Throwable) {
+        } catch (Exception) {
             return null;
         }
 

--- a/lib/Telemetry/Snapshot/Statistics/ElementKind.php
+++ b/lib/Telemetry/Snapshot/Statistics/ElementKind.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Snapshot\Statistics;
+
+/**
+ * The three top-level Pimcore element kinds a statistics query can target. The enum keeps the SQL
+ * table name in one place; a search-index-backed provider maps the same kinds to its own index
+ * aliases. Content-never - these are Pimcore's own structural identifiers.
+ *
+ * @internal
+ */
+enum ElementKind: string
+{
+    case DataObject = 'object';
+    case Asset = 'asset';
+    case Document = 'document';
+
+    /**
+     * The element-index table backing this kind.
+     */
+    public function table(): string
+    {
+        return match ($this) {
+            self::DataObject => 'objects',
+            self::Asset => 'assets',
+            self::Document => 'documents',
+        };
+    }
+}

--- a/lib/Telemetry/Snapshot/Statistics/ElementStatisticsProviderInterface.php
+++ b/lib/Telemetry/Snapshot/Statistics/ElementStatisticsProviderInterface.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Snapshot\Statistics;
+
+use Pimcore\Telemetry\Snapshot\ElementTypeCounts;
+
+/**
+ * The structural, data-volume-scaling statistics the snapshot's heaviest collectors need over the
+ * objects/assets/documents element tables (counts by type, hierarchy depth, variant/fan-out shape).
+ *
+ * Extracting these behind an interface lets the data source be swapped without touching the
+ * collectors: core ships an always-available SQL implementation ({@see SqlElementStatisticsProvider}),
+ * and a bundle that owns a search index (Studio via the Generic Data Index) can decorate this with an
+ * aggregation-backed implementation that never touches the transactional DB, falling back to SQL when
+ * the index is unavailable.
+ *
+ * Every implementation is content-never (counts / small integers only) and must degrade gracefully
+ * (never throw) so a statistics failure can only cost precision, never the snapshot.
+ *
+ * @internal
+ */
+interface ElementStatisticsProviderInterface
+{
+    /**
+     * Row count per element subtype (e.g. image/video/… for assets, object/variant/folder for objects).
+     */
+    public function typeCounts(ElementKind $kind): ElementTypeCounts;
+
+    /**
+     * Hierarchy depth (max and average) for the element kind, in slash-count semantics.
+     */
+    public function treeDepth(ElementKind $kind): TreeDepth;
+
+    /**
+     * Number of objects that have variants (distinct parents among variant objects).
+     */
+    public function objectsWithVariants(): int;
+
+    /**
+     * Deepest single assortment: the largest number of variants under one parent.
+     */
+    public function maxVariantsPerObject(): int;
+
+    /**
+     * Widest folder: the largest number of child objects under any one parent.
+     */
+    public function maxObjectFanout(): int;
+}

--- a/lib/Telemetry/Snapshot/Statistics/SqlElementStatisticsProvider.php
+++ b/lib/Telemetry/Snapshot/Statistics/SqlElementStatisticsProvider.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Snapshot\Statistics;
+
+use Pimcore\Telemetry\Snapshot\ElementTypeCounts;
+use Pimcore\Telemetry\Snapshot\SnapshotQueryRunner;
+use Throwable;
+use function is_array;
+use function is_numeric;
+use function round;
+
+/**
+ * Always-available {@see ElementStatisticsProviderInterface} backed by SQL aggregates over the
+ * element tables, run through the time-boxed {@see SnapshotQueryRunner}. One `GROUP BY type` scan per
+ * table for the type counts, and a single combined MAX/AVG scan for depth. Every query degrades to a
+ * zero/empty result on failure so the snapshot is never broken.
+ *
+ * @internal
+ */
+final readonly class SqlElementStatisticsProvider implements ElementStatisticsProviderInterface
+{
+    public function __construct(
+        private SnapshotQueryRunner $queryRunner,
+    ) {
+    }
+
+    public function typeCounts(ElementKind $kind): ElementTypeCounts
+    {
+        try {
+            $rows = $this->queryRunner->fetchAllKeyValue(
+                'SELECT ' . $this->quote('type') . ', COUNT(*) FROM ' . $this->quote($kind->table())
+                . ' GROUP BY ' . $this->quote('type')
+            );
+        } catch (Throwable) {
+            return new ElementTypeCounts();
+        }
+
+        $byType = [];
+        foreach ($rows as $type => $count) {
+            $byType[(string) $type] = (int) $count;
+        }
+
+        return new ElementTypeCounts($byType);
+    }
+
+    public function treeDepth(ElementKind $kind): TreeDepth
+    {
+        $path = $this->quote('path');
+        $depth = 'LENGTH(' . $path . ') - LENGTH(REPLACE(' . $path . ", '/', ''))";
+
+        try {
+            $row = $this->queryRunner->fetchAssociative(
+                'SELECT MAX(d) AS max_d, AVG(d) AS avg_d FROM (SELECT ' . $depth . ' AS d FROM '
+                . $this->quote($kind->table()) . ') t'
+            );
+        } catch (Throwable) {
+            $row = false;
+        }
+
+        if (!is_array($row)) {
+            return new TreeDepth();
+        }
+
+        return new TreeDepth(
+            is_numeric($row['max_d'] ?? null) ? (int) $row['max_d'] : 0,
+            is_numeric($row['avg_d'] ?? null) ? (int) round((float) $row['avg_d']) : 0,
+        );
+    }
+
+    public function objectsWithVariants(): int
+    {
+        return $this->intResult(
+            'SELECT COUNT(DISTINCT ' . $this->quote('parentId') . ') FROM ' . $this->quote('objects')
+            . ' WHERE ' . $this->quote('type') . " = 'variant'"
+        );
+    }
+
+    public function maxVariantsPerObject(): int
+    {
+        return $this->intResult(
+            'SELECT MAX(c) FROM (SELECT COUNT(*) c FROM ' . $this->quote('objects')
+            . ' WHERE ' . $this->quote('type') . " = 'variant'"
+            . ' GROUP BY ' . $this->quote('parentId') . ') t'
+        );
+    }
+
+    public function maxObjectFanout(): int
+    {
+        return $this->intResult(
+            'SELECT MAX(c) FROM (SELECT COUNT(*) c FROM ' . $this->quote('objects')
+            . ' GROUP BY ' . $this->quote('parentId') . ') t'
+        );
+    }
+
+    private function intResult(string $sql): int
+    {
+        try {
+            $value = $this->queryRunner->fetchOne($sql);
+
+            return is_numeric($value) ? (int) $value : 0;
+        } catch (Throwable) {
+            return 0;
+        }
+    }
+
+    private function quote(string $identifier): string
+    {
+        return $this->queryRunner->quoteIdentifier($identifier);
+    }
+}

--- a/lib/Telemetry/Snapshot/Statistics/SqlElementStatisticsProvider.php
+++ b/lib/Telemetry/Snapshot/Statistics/SqlElementStatisticsProvider.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Pimcore\Telemetry\Snapshot\Statistics;
 
+use Exception;
 use Pimcore\Telemetry\Snapshot\ElementTypeCounts;
 use Pimcore\Telemetry\Snapshot\SnapshotQueryRunner;
-use Throwable;
 use function is_array;
 use function is_numeric;
 use function round;
@@ -42,7 +42,7 @@ final readonly class SqlElementStatisticsProvider implements ElementStatisticsPr
                 'SELECT ' . $this->quote('type') . ', COUNT(*) FROM ' . $this->quote($kind->table())
                 . ' GROUP BY ' . $this->quote('type')
             );
-        } catch (Throwable) {
+        } catch (Exception) {
             return new ElementTypeCounts();
         }
 
@@ -64,7 +64,7 @@ final readonly class SqlElementStatisticsProvider implements ElementStatisticsPr
                 'SELECT MAX(d) AS max_d, AVG(d) AS avg_d FROM (SELECT ' . $depth . ' AS d FROM '
                 . $this->quote($kind->table()) . ') t'
             );
-        } catch (Throwable) {
+        } catch (Exception) {
             $row = false;
         }
 
@@ -109,7 +109,7 @@ final readonly class SqlElementStatisticsProvider implements ElementStatisticsPr
             $value = $this->queryRunner->fetchOne($sql);
 
             return is_numeric($value) ? (int) $value : 0;
-        } catch (Throwable) {
+        } catch (Exception) {
             return 0;
         }
     }

--- a/lib/Telemetry/Snapshot/Statistics/TreeDepth.php
+++ b/lib/Telemetry/Snapshot/Statistics/TreeDepth.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Snapshot\Statistics;
+
+/**
+ * Hierarchy-depth statistics for one element kind, expressed in path-segment (slash-count) semantics:
+ * a top-level element has depth 1. Both values are small integers - content-never.
+ *
+ * @internal
+ */
+final readonly class TreeDepth
+{
+    public function __construct(
+        public int $max = 0,
+        public int $avg = 0,
+    ) {
+    }
+}

--- a/lib/Telemetry/Snapshot/TelemetrySnapshotStateInterface.php
+++ b/lib/Telemetry/Snapshot/TelemetrySnapshotStateInterface.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Snapshot;
+
+/**
+ * Persists when the last deployment snapshot was produced, so the snapshot task can throttle itself:
+ * the snapshot is a slow-changing structural census, so it is created at most once per configured
+ * interval regardless of how often maintenance runs. Draining (delivery) is independent of this.
+ *
+ * @internal
+ */
+interface TelemetrySnapshotStateInterface
+{
+    /**
+     * Unix timestamp of the last produced snapshot, or null if one has never been produced.
+     */
+    public function getLastSnapshotAt(): ?int;
+
+    /**
+     * Record that a snapshot was produced at the given Unix timestamp.
+     */
+    public function markSnapshotTaken(int $timestamp): void;
+}

--- a/lib/Telemetry/Spool/EncryptedBatch.php
+++ b/lib/Telemetry/Spool/EncryptedBatch.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Spool;
+
+/**
+ * A leased batch, encrypted and ready for the relay. The {@see $ciphertext} is the product-key
+ * encrypted inner envelope (`{instanceIdentifier, ts, events}`); {@see $instanceIdentifier} travels
+ * in the clear so the relay can look the product key up to decrypt. Both the maintenance drain and
+ * the Studio UI treat the ciphertext as opaque and forward it verbatim, then pass {@see $nonce} to
+ * {@see TelemetryOutboxService::ack()} once the relay has accepted it.
+ *
+ * @internal
+ */
+final readonly class EncryptedBatch
+{
+    public function __construct(
+        public string $nonce,
+        public string $instanceIdentifier,
+        public string $ciphertext,
+        public int $count,
+    ) {
+    }
+}

--- a/lib/Telemetry/Spool/SpooledBatch.php
+++ b/lib/Telemetry/Spool/SpooledBatch.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Spool;
+
+use function count;
+
+/**
+ * A leased set of spooled events: the events to forward plus the {@see $nonce} that identifies the
+ * lease. The drainer forwards the events, then calls {@see TelemetrySpool::ack()} with the nonce to
+ * delete them - or {@see TelemetrySpool::release()} to hand them back on failure.
+ *
+ * @internal
+ */
+final readonly class SpooledBatch
+{
+    /**
+     * @param list<array<string, mixed>> $events
+     */
+    public function __construct(
+        public string $nonce,
+        public array $events,
+    ) {
+    }
+
+    public function count(): int
+    {
+        return count($this->events);
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->events === [];
+    }
+}

--- a/lib/Telemetry/Spool/TelemetryOutboxInterface.php
+++ b/lib/Telemetry/Spool/TelemetryOutboxInterface.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Spool;
+
+/**
+ * Hands out the next encrypted batch to a drainer and acks/releases it. Both drainers depend on this
+ * seam: the maintenance {@see \Pimcore\Maintenance\Tasks\TelemetrySpoolDrainTask} and the Studio
+ * backend outbox endpoints. Implemented by {@see TelemetryOutboxService}.
+ *
+ * @internal
+ */
+interface TelemetryOutboxInterface
+{
+    /**
+     * Whether the outbox can produce batches (instance identity + product key present).
+     */
+    public function isReady(): bool;
+
+    /**
+     * Claim, wrap, and encrypt the next pending batch, or null when the pool is empty.
+     */
+    public function nextBatch(): ?EncryptedBatch;
+
+    /**
+     * Delete a delivered batch (call only after the relay confirmed it).
+     */
+    public function ack(string $nonce): int;
+
+    /**
+     * Return an undelivered batch to the pool for a later retry.
+     */
+    public function release(string $nonce): int;
+}

--- a/lib/Telemetry/Spool/TelemetryOutboxService.php
+++ b/lib/Telemetry/Spool/TelemetryOutboxService.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace Pimcore\Telemetry\Spool;
 
+use Exception;
 use Pimcore\Telemetry\Crypto\EnvelopeCipher;
 use Pimcore\Telemetry\Crypto\EnvelopeCipherException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Throwable;
 use function time;
 
 /**
@@ -61,7 +61,7 @@ final class TelemetryOutboxService implements TelemetryOutboxInterface
     {
         try {
             $claimed = $this->spool->claim();
-        } catch (Throwable $exception) {
+        } catch (Exception $exception) {
             // The outbox is best-effort and is read from an HTTP endpoint (the Studio drain) as well
             // as from maintenance. A storage-level problem - most plausibly the table not existing
             // yet because the code was deployed before migrations ran - must read as "nothing to
@@ -97,7 +97,7 @@ final class TelemetryOutboxService implements TelemetryOutboxInterface
     {
         try {
             return $this->spool->ack($nonce);
-        } catch (Throwable $exception) {
+        } catch (Exception $exception) {
             $this->logger->error('Telemetry outbox ack failed', ['exception' => $exception]);
 
             return 0;
@@ -108,7 +108,7 @@ final class TelemetryOutboxService implements TelemetryOutboxInterface
     {
         try {
             return $this->spool->release($nonce);
-        } catch (Throwable $exception) {
+        } catch (Exception $exception) {
             $this->logger->error('Telemetry outbox release failed', ['exception' => $exception]);
 
             return 0;

--- a/lib/Telemetry/Spool/TelemetryOutboxService.php
+++ b/lib/Telemetry/Spool/TelemetryOutboxService.php
@@ -1,0 +1,117 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Spool;
+
+use Pimcore\Telemetry\Crypto\EnvelopeCipher;
+use Pimcore\Telemetry\Crypto\EnvelopeCipherException;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Throwable;
+use function time;
+
+/**
+ * Prepares the next batch for delivery: it claims a leased set of spooled events, wraps them in an
+ * envelope, and **encrypts that envelope with the instance's product key**. The relay looks the same
+ * product key up (by the cleartext instance identifier) and decrypts - which authenticates the batch,
+ * so no separate signature or bearer token is needed.
+ *
+ * The same encrypted batch feeds both drainers: the maintenance job POSTs it to the relay directly,
+ * and the Studio UI fetches it and forwards it from the browser. Because encryption happens here, on
+ * the server, the browser only ever holds opaque ciphertext - it can neither read the telemetry nor
+ * forge a batch. A batch leaves the pool (ack) only after the relay confirms it.
+ *
+ * @internal
+ */
+final class TelemetryOutboxService implements TelemetryOutboxInterface
+{
+    public function __construct(
+        private readonly TelemetrySpoolReaderInterface $spool,
+        private readonly EnvelopeCipher $cipher,
+        private readonly string $instanceIdentifier,
+        private readonly string $productKey,
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    /**
+     * Whether the outbox can hand out batches at all: we need an instance identity and a product key
+     * (the relay could not decrypt - and so would reject - a batch produced without the key).
+     */
+    public function isReady(): bool
+    {
+        return $this->instanceIdentifier !== '' && $this->productKey !== '';
+    }
+
+    /**
+     * Claim, wrap, and encrypt the next pending batch. Returns null when the spool is empty or the
+     * batch could not be encrypted (in which case the rows are released, not lost).
+     */
+    public function nextBatch(): ?EncryptedBatch
+    {
+        try {
+            $claimed = $this->spool->claim();
+        } catch (Throwable $exception) {
+            // The outbox is best-effort and is read from an HTTP endpoint (the Studio drain) as well
+            // as from maintenance. A storage-level problem - most plausibly the table not existing
+            // yet because the code was deployed before migrations ran - must read as "nothing to
+            // send", never as a failed request.
+            $this->logger->error('Telemetry outbox is unavailable', ['exception' => $exception]);
+
+            return null;
+        }
+
+        if ($claimed === null) {
+            return null;
+        }
+
+        $envelope = [
+            'instanceIdentifier' => $this->instanceIdentifier,
+            'ts' => time(),
+            'events' => $claimed->events,
+        ];
+
+        try {
+            $ciphertext = $this->cipher->encrypt($envelope, $this->productKey);
+        } catch (EnvelopeCipherException) {
+            // Could not encrypt - hand the rows back rather than lose or block them.
+            $this->spool->release($claimed->nonce);
+
+            return null;
+        }
+
+        return new EncryptedBatch($claimed->nonce, $this->instanceIdentifier, $ciphertext, $claimed->count());
+    }
+
+    public function ack(string $nonce): int
+    {
+        try {
+            return $this->spool->ack($nonce);
+        } catch (Throwable $exception) {
+            $this->logger->error('Telemetry outbox ack failed', ['exception' => $exception]);
+
+            return 0;
+        }
+    }
+
+    public function release(string $nonce): int
+    {
+        try {
+            return $this->spool->release($nonce);
+        } catch (Throwable $exception) {
+            $this->logger->error('Telemetry outbox release failed', ['exception' => $exception]);
+
+            return 0;
+        }
+    }
+}

--- a/lib/Telemetry/Spool/TelemetrySpool.php
+++ b/lib/Telemetry/Spool/TelemetrySpool.php
@@ -1,0 +1,276 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Spool;
+
+use Doctrine\DBAL\Connection;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use function bin2hex;
+use function count;
+use function is_array;
+use function json_decode;
+use function json_encode;
+use function max;
+use function random_bytes;
+
+/**
+ * Durable outbox (transactional-outbox pattern) for telemetry that cannot be sent inline.
+ *
+ * Events are enqueued as they are collected and drained later by the Studio UI: a drain claims a
+ * batch (leasing the rows with a nonce so concurrent tabs can't grab the same ones), the browser
+ * forwards it to the relay, then acks (delete) - or releases (unlease) on failure. Unacked leases
+ * expire and become claimable again, and each row carries a stable event_uid the relay dedupes on,
+ * so an occasional double-send is harmless.
+ *
+ * The `telemetry_spool` table is provisioned by the installer (`install.sql`) for new installs and
+ * by migration `Version20260720120000` for existing ones - it is never created at runtime, so no
+ * request path issues DDL. All rows hold already-sanitized, content-never events.
+ *
+ * @internal
+ */
+final class TelemetrySpool implements TelemetrySpoolWriterInterface, TelemetrySpoolReaderInterface
+{
+    private const TABLE = 'telemetry_spool';
+
+    private const DEFAULT_CAP = 10000;
+
+    private const DEFAULT_CLAIM_LIMIT = 500;
+
+    private const DEFAULT_LEASE_SECONDS = 600;
+
+    private const DEFAULT_TTL_DAYS = 30;
+
+    /**
+     * A batch the relay keeps rejecting for a non-transient reason (an instance it does not know, a
+     * payload it will never accept) would otherwise be released and re-claimed forever, blocking
+     * everything behind it until the TTL expires. After this many failed deliveries a row stops
+     * being claimable and is cleaned up by the next {@see self::gc()}.
+     */
+    private const MAX_DELIVERY_ATTEMPTS = 5;
+
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly int $cap = self::DEFAULT_CAP,
+        private readonly int $ttlDays = self::DEFAULT_TTL_DAYS,
+        private readonly int $leaseSeconds = self::DEFAULT_LEASE_SECONDS,
+        private readonly ?LoggerInterface $logger = null,
+    ) {
+    }
+
+    /**
+     * Append events to the outbox. Bounded: once the pending backlog hits $cap we shed new events
+     * rather than grow without limit (an instance whose UI is never opened must not fill its disk).
+     *
+     * @param list<array<string, mixed>> $events
+     */
+    public function enqueue(array $events, ?int $cap = null): void
+    {
+        if ($events === []) {
+            return;
+        }
+
+        $cap = $cap ?? $this->cap;
+        $pending = $this->countPending();
+        $table = $this->connection->quoteIdentifier(self::TABLE);
+        $shed = 0;
+
+        foreach ($events as $event) {
+            // Re-checked per event, not once per call: a single flush can carry far more events
+            // than the whole cap (a CLI import buffers one per created element).
+            if ($pending >= $cap) {
+                $shed++;
+
+                continue;
+            }
+
+            $payload = json_encode($event);
+
+            if ($payload === false) {
+                // Never persist a non-encodable event (would poison the drain's json_decode).
+                continue;
+            }
+
+            $this->connection->executeStatement(
+                'INSERT INTO ' . $table . ' (event_uid, created_at, payload) VALUES (?, NOW(), ?)',
+                [$this->uid(), $payload]
+            );
+            $pending++;
+        }
+
+        if ($shed > 0) {
+            // Silent shedding looks identical to "this instance reports nothing" in support.
+            $this->logger?->warning(
+                'Telemetry spool is full ({cap} pending); dropped {shed} of {total} new events. '
+                . 'The outbox is not being drained - check relay reachability or the maintenance job.',
+                ['cap' => $cap, 'shed' => $shed, 'total' => count($events)]
+            );
+        }
+    }
+
+    /**
+     * Lease the oldest pending events under a fresh nonce and return them for forwarding.
+     * Returns null when nothing is pending.
+     */
+    public function claim(int $limit = self::DEFAULT_CLAIM_LIMIT, ?int $leaseSeconds = null): ?SpooledBatch
+    {
+        $this->releaseExpiredClaims($leaseSeconds ?? $this->leaseSeconds);
+
+        $table = $this->connection->quoteIdentifier(self::TABLE);
+        $nonce = $this->uid();
+        $limit = max(1, $limit);
+
+        $claimed = (int)$this->connection->executeStatement(
+            'UPDATE ' . $table . ' SET claimed_at = NOW(), claim_nonce = ?'
+            . ' WHERE claim_nonce IS NULL AND attempts < ' . self::MAX_DELIVERY_ATTEMPTS
+            . ' ORDER BY id LIMIT ' . $limit,
+            [$nonce]
+        );
+
+        if ($claimed === 0) {
+            return null;
+        }
+
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT event_uid, payload FROM ' . $table . ' WHERE claim_nonce = ? ORDER BY id',
+            [$nonce]
+        );
+
+        $events = [];
+        foreach ($rows as $row) {
+            $event = json_decode((string)$row['payload'], true);
+            if (is_array($event)) {
+                // stable dedupe key the relay uses to drop repeats from lease expiry / double drain
+                $event['eventUid'] = $row['event_uid'];
+                $events[] = $event;
+            }
+        }
+
+        return new SpooledBatch($nonce, $events);
+    }
+
+    /**
+     * Delete a leased batch after it was successfully forwarded.
+     */
+    public function ack(string $nonce): int
+    {
+        return (int)$this->connection->executeStatement(
+            'DELETE FROM ' . $this->connection->quoteIdentifier(self::TABLE) . ' WHERE claim_nonce = ?',
+            [$nonce]
+        );
+    }
+
+    /**
+     * Hand a leased batch back to the pending pool (forward failed).
+     */
+    public function release(string $nonce): int
+    {
+        return (int)$this->connection->executeStatement(
+            'UPDATE ' . $this->connection->quoteIdentifier(self::TABLE)
+            . ' SET claim_nonce = NULL, claimed_at = NULL, attempts = attempts + 1 WHERE claim_nonce = ?',
+            [$nonce]
+        );
+    }
+
+    /**
+     * Reclaim leases whose drainer never acked (browser closed mid-drain).
+     */
+    public function releaseExpiredClaims(?int $leaseSeconds = null): int
+    {
+        $leaseSeconds = max(1, $leaseSeconds ?? $this->leaseSeconds);
+
+        return (int)$this->connection->executeStatement(
+            'UPDATE ' . $this->connection->quoteIdentifier(self::TABLE)
+            . ' SET claim_nonce = NULL, claimed_at = NULL, attempts = attempts + 1'
+            . ' WHERE claim_nonce IS NOT NULL AND claimed_at < (NOW() - INTERVAL ' . $leaseSeconds . ' SECOND)'
+        );
+    }
+
+    /**
+     * Delete events older than the TTL. Meant to run from the maintenance task.
+     */
+    public function gc(?int $ttlDays = null): int
+    {
+        $ttlDays = max(1, $ttlDays ?? $this->ttlDays);
+
+        return (int)$this->connection->executeStatement(
+            'DELETE FROM ' . $this->connection->quoteIdentifier(self::TABLE)
+            . ' WHERE created_at < (NOW() - INTERVAL ' . $ttlDays . ' DAY)'
+            . ' OR attempts >= ' . self::MAX_DELIVERY_ATTEMPTS
+        );
+    }
+
+    public function countPending(): int
+    {
+        return (int)$this->connection->fetchOne(
+            'SELECT COUNT(*) FROM ' . $this->connection->quoteIdentifier(self::TABLE) . ' WHERE claim_nonce IS NULL AND attempts < ' . self::MAX_DELIVERY_ATTEMPTS
+        );
+    }
+
+    public function countClaimed(): int
+    {
+        return (int)$this->connection->fetchOne(
+            'SELECT COUNT(*) FROM ' . $this->connection->quoteIdentifier(self::TABLE) . ' WHERE claim_nonce IS NOT NULL'
+        );
+    }
+
+    /**
+     * Read (without leasing) the oldest pending payloads - for inspection/debugging only.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function peekPending(int $limit = 10): array
+    {
+        $limit = max(1, $limit);
+
+        $rows = $this->connection->fetchFirstColumn(
+            'SELECT payload FROM ' . $this->connection->quoteIdentifier(self::TABLE)
+            . ' WHERE claim_nonce IS NULL AND attempts < ' . self::MAX_DELIVERY_ATTEMPTS
+            . ' ORDER BY id LIMIT ' . $limit
+        );
+
+        $events = [];
+        foreach ($rows as $payload) {
+            $event = json_decode((string)$payload, true);
+            if (is_array($event)) {
+                $events[] = $event;
+            }
+        }
+
+        return $events;
+    }
+
+    /**
+     * Whether the outbox table has been provisioned (installer or migration). The table is never
+     * created at runtime, so tooling can report a clear "run your migrations" instead of surfacing
+     * a driver error.
+     */
+    public function isProvisioned(): bool
+    {
+        try {
+            $this->connection->fetchOne(
+                'SELECT 1 FROM ' . $this->connection->quoteIdentifier(self::TABLE) . ' LIMIT 1'
+            );
+
+            return true;
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    private function uid(): string
+    {
+        return bin2hex(random_bytes(16));
+    }
+
+}

--- a/lib/Telemetry/Spool/TelemetrySpool.php
+++ b/lib/Telemetry/Spool/TelemetrySpool.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Pimcore\Telemetry\Spool;
 
+use Exception;
 use Doctrine\DBAL\Connection;
 use Psr\Log\LoggerInterface;
-use Throwable;
 use function bin2hex;
 use function count;
 use function is_array;
@@ -263,7 +263,7 @@ final class TelemetrySpool implements TelemetrySpoolWriterInterface, TelemetrySp
             );
 
             return true;
-        } catch (Throwable) {
+        } catch (Exception) {
             return false;
         }
     }

--- a/lib/Telemetry/Spool/TelemetrySpoolReaderInterface.php
+++ b/lib/Telemetry/Spool/TelemetrySpoolReaderInterface.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Spool;
+
+/**
+ * The drain side of the telemetry outbox: lease a batch, then either delete it (successfully
+ * forwarded) or hand it back (failed). {@see TelemetryOutboxService} depends only on this seam so it
+ * can be unit tested without a database, and so the "claim / ack / release" role stays separate from
+ * the producer's write-only role ({@see TelemetrySpoolWriterInterface}).
+ *
+ * @internal
+ */
+interface TelemetrySpoolReaderInterface
+{
+    /**
+     * Lease the oldest pending events under a fresh nonce for forwarding. Null when nothing pending.
+     */
+    public function claim(int $limit = 500): ?SpooledBatch;
+
+    /**
+     * Delete a leased batch after the relay confirmed it (ack-only-on-success).
+     */
+    public function ack(string $nonce): int;
+
+    /**
+     * Hand a leased batch back to the pending pool (forward failed) for a later retry.
+     */
+    public function release(string $nonce): int;
+}

--- a/lib/Telemetry/Spool/TelemetrySpoolWriterInterface.php
+++ b/lib/Telemetry/Spool/TelemetrySpoolWriterInterface.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Spool;
+
+/**
+ * The write side of the telemetry outbox. {@see Telemetry} depends only on this narrow seam - it
+ * produces events and never claims, acks, or garbage-collects - which keeps the collector unit
+ * testable without a database and honours interface segregation.
+ *
+ * @internal
+ */
+interface TelemetrySpoolWriterInterface
+{
+    /**
+     * Append already-sanitized, content-never events to the durable outbox. Best-effort and bounded:
+     * once the pending backlog reaches the cap, new events are shed rather than grow without limit.
+     *
+     * @param list<array<string, mixed>> $events
+     */
+    public function enqueue(array $events, ?int $cap = null): void;
+}

--- a/lib/Telemetry/Telemetry.php
+++ b/lib/Telemetry/Telemetry.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry;
+
+use Pimcore\Telemetry\Spool\TelemetrySpoolWriterInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Buffering implementation of {@see TelemetryInterface}.
+ *
+ * Events are collected in memory (behavior-only, content-never, guarded by {@see EventSanitizer})
+ * and, on {@see self::flush()}, persisted to the durable outbox ({@see TelemetrySpoolWriterInterface}).
+ * Nothing is sent inline: the maintenance job and the Studio UI later drain the outbox, encrypt each
+ * batch with the instance's product key, and forward it to the first-party relay. The instance never
+ * talks to PostHog directly and holds no PostHog API key.
+ *
+ * Telemetry is active only when the instance is identified AND a product key is present - the product
+ * key is the shared secret the relay uses to decrypt (and thereby authenticate) this instance's
+ * batches, so without it nothing could be delivered anyway. That also makes unlicensed installations
+ * (development checkouts, CI runs) inert without any configuration.
+ *
+ * @internal
+ */
+final class Telemetry implements TelemetryInterface
+{
+    private const INSTANCE_GROUP_TYPE = 'instance';
+
+    /**
+     * @var list<array<string, mixed>>
+     */
+    private array $buffer = [];
+
+    public function __construct(
+        private readonly string $instanceIdentifier,
+        private readonly string $productKey,
+        private readonly TelemetrySpoolWriterInterface $spool,
+        private readonly LoggerInterface $logger,
+        private readonly EventSanitizer $sanitizer,
+    ) {
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->instanceIdentifier !== '' && $this->productKey !== '';
+    }
+
+    public function capture(string $event, array $properties = [], array $groups = []): void
+    {
+        if (!$this->isEnabled()) {
+            return;
+        }
+
+        if (!$this->sanitizer->isValidEventName($event)) {
+            $this->logger->warning('Telemetry event name does not follow the taxonomy convention', [
+                'event' => $event,
+            ]);
+        }
+
+        $this->buffer[] = [
+            'type' => 'capture',
+            'event' => $event,
+            'properties' => $this->sanitizer->sanitizeProperties($properties, $event),
+            'groups' => [self::INSTANCE_GROUP_TYPE => $this->instanceIdentifier] + $groups,
+        ];
+    }
+
+    public function groupIdentify(string $type, string $key, array $properties): void
+    {
+        if (!$this->isEnabled()) {
+            return;
+        }
+
+        $this->buffer[] = [
+            'type' => 'group_identify',
+            'groupType' => $type,
+            'groupKey' => $key,
+            'properties' => $this->sanitizer->sanitizeProperties($properties, 'group:' . $type),
+        ];
+    }
+
+    public function flush(): void
+    {
+        if ($this->buffer === []) {
+            return;
+        }
+
+        $events = $this->buffer;
+
+        // Clear the buffer up front so a failed enqueue is never retried implicitly on the next
+        // flush (telemetry is best-effort and must never disrupt the host process). Durability is
+        // the spool's job from here: once written, the maintenance job / UI drain deliver it.
+        $this->buffer = [];
+
+        try {
+            $this->spool->enqueue($events);
+        } catch (Throwable $exception) {
+            $this->logger->error('Telemetry flush to spool failed', ['exception' => $exception]);
+        }
+    }
+}

--- a/lib/Telemetry/TelemetryInterface.php
+++ b/lib/Telemetry/TelemetryInterface.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry;
+
+/**
+ * Server-side product telemetry. Other bundles depend on this interface to emit
+ * behavior-only, content-never events to the first-party telemetry relay (which
+ * forwards them to PostHog).
+ *
+ * All methods are no-ops when telemetry is disabled and never throw: failures are
+ * logged, never propagated into a request or CLI run.
+ *
+ * @internal
+ */
+interface TelemetryInterface
+{
+    /**
+     * Whether this instance can report at all: it must be identified and carry a product key.
+     * When false every method below is a no-op and nothing leaves the instance.
+     */
+    public function isEnabled(): bool;
+
+    /**
+     * Capture a domain-meaningful event. Properties must contain behavior/counts/types
+     * only - never field values, names, paths, or any customer content.
+     *
+     * @param array<string, mixed> $properties
+     * @param array<string, string> $groups extra PostHog groups; the instance group is added automatically
+     */
+    public function capture(string $event, array $properties = [], array $groups = []): void;
+
+    /**
+     * Attach properties to a PostHog group (B2B account/instance rollup).
+     *
+     * @param array<string, mixed> $properties
+     */
+    public function groupIdentify(string $type, string $key, array $properties): void;
+
+    /**
+     * Send the buffered events to the relay as a single batch. Call this before the
+     * process exits (CLI/maintenance).
+     */
+    public function flush(): void;
+}

--- a/lib/Telemetry/TelemetryInterface.php
+++ b/lib/Telemetry/TelemetryInterface.php
@@ -48,8 +48,9 @@ interface TelemetryInterface
     public function groupIdentify(string $type, string $key, array $properties): void;
 
     /**
-     * Send the buffered events to the relay as a single batch. Call this before the
-     * process exits (CLI/maintenance).
+     * Persist the buffered events to the durable outbox. This does NOT contact the relay - a
+     * drainer (the maintenance job or the Studio UI) delivers them later. Call it before the
+     * process exits (CLI/maintenance) so nothing buffered in memory is lost.
      */
     public function flush(): void;
 }

--- a/lib/Telemetry/TelemetrySettings.php
+++ b/lib/Telemetry/TelemetrySettings.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry;
+
+/**
+ * Fixed settings for product telemetry.
+ *
+ * These are constants rather than configuration on purpose: the relay is a first-party service at a
+ * known address, and the collection cadence and outbox bounds are product decisions that must behave
+ * identically on every installation. {@see \Pimcore\Bundle\CoreBundle\DependencyInjection\PimcoreCoreExtension}
+ * publishes them as `pimcore.telemetry.*` container parameters, so every consuming service keeps a
+ * single constructor seam that tests can drive with other values.
+ *
+ * Whether an instance reports at all is not a setting either: telemetry is inert unless the instance
+ * is identified and carries a product key ({@see Telemetry::isEnabled()}) - the same secret the relay
+ * needs to decrypt, and thereby authenticate, that instance's batches.
+ *
+ * @internal
+ */
+final class TelemetrySettings
+{
+    /**
+     * First-party relay. It owns the PostHog key; instances never talk to PostHog directly.
+     */
+    public const RELAY_ENDPOINT = 'https://license.pimcore.com/telemetry/v1/ingest';
+
+    /**
+     * The deployment snapshot is a slow-changing structural census, so it is produced at most once
+     * per day no matter how often the maintenance job runs.
+     */
+    public const SNAPSHOT_INTERVAL_SECONDS = 86400;
+
+    /**
+     * Per-query execution-time cap for the snapshot collectors. A structural aggregate over a
+     * multi-million-row table is aborted rather than allowed to stall the maintenance run; the
+     * affected metric degrades to 0 for that cycle.
+     */
+    public const SNAPSHOT_QUERY_TIMEOUT_SECONDS = 5;
+
+    /**
+     * Pending events retained before new ones are dropped - bounds disk use if nothing drains.
+     */
+    public const SPOOL_CAP = 10000;
+
+    /**
+     * Spooled events older than this many days are garbage-collected.
+     */
+    public const SPOOL_TTL_DAYS = 30;
+
+    /**
+     * How long a claimed (in-flight) batch stays leased before an unacked drain may reclaim it.
+     */
+    public const SPOOL_LEASE_SECONDS = 600;
+}

--- a/lib/Telemetry/Usage/BundleUsageCollector.php
+++ b/lib/Telemetry/Usage/BundleUsageCollector.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Usage;
+
+use Pimcore\Telemetry\Snapshot\SnapshotCollectorInterface;
+use Throwable;
+
+/**
+ * Aggregates every tagged {@see BundleUsageProviderInterface} into the `usage.*` snapshot namespace -
+ * one `usage.<bundleKey>` boolean per provider. Cross-referenced with `core.bundles` (installed) in
+ * PostHog, `installed && usage=false` is the "installed but not used" signal (stakeholder Q12).
+ *
+ * A provider that throws is recorded as `false` rather than breaking the snapshot - telemetry is
+ * best-effort. Bundles without a provider are simply absent (unknown), which is intended: usage
+ * reporting is opt-in per bundle.
+ *
+ * @internal
+ */
+final readonly class BundleUsageCollector implements SnapshotCollectorInterface
+{
+    /**
+     * @param iterable<BundleUsageProviderInterface> $providers
+     */
+    public function __construct(
+        private iterable $providers,
+    ) {
+    }
+
+    public function getNamespace(): string
+    {
+        return 'usage';
+    }
+
+    public function collect(): array
+    {
+        $usage = [];
+
+        foreach ($this->providers as $provider) {
+            $key = $provider->getBundleKey();
+
+            try {
+                $usage[$key] = $provider->isUsed();
+            } catch (Throwable) {
+                // A provider must never break the snapshot; treat a failure as "not used".
+                $usage[$key] = false;
+            }
+        }
+
+        return $usage;
+    }
+}

--- a/lib/Telemetry/Usage/BundleUsageCollector.php
+++ b/lib/Telemetry/Usage/BundleUsageCollector.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Pimcore\Telemetry\Usage;
 
+use Exception;
 use Pimcore\Telemetry\Snapshot\SnapshotCollectorInterface;
-use Throwable;
 
 /**
  * Aggregates every tagged {@see BundleUsageProviderInterface} into the `usage.*` snapshot namespace -
@@ -51,7 +51,7 @@ final readonly class BundleUsageCollector implements SnapshotCollectorInterface
 
             try {
                 $usage[$key] = $provider->isUsed();
-            } catch (Throwable) {
+            } catch (Exception) {
                 // A provider must never break the snapshot; treat a failure as "not used".
                 $usage[$key] = false;
             }

--- a/lib/Telemetry/Usage/BundleUsageProviderInterface.php
+++ b/lib/Telemetry/Usage/BundleUsageProviderInterface.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Usage;
+
+/**
+ * Extension point that lets a bundle report whether it is actually **used**, not merely installed.
+ *
+ * A bundle (or a core capability) implements this and is auto-discovered - exactly like
+ * {@see \Pimcore\Telemetry\Snapshot\SnapshotCollectorInterface}, with zero core changes. The
+ * "am I used?" logic lives entirely in the implementer: it is free to decide what "used" means and
+ * when it flips back to false - typically a cheap, content-never structural check ("a configuration
+ * exists", "at least one workflow is defined"). The result feeds the {@see BundleUsageCollector},
+ * which emits a `usage.<bundleKey>` boolean into the snapshot for the installed-vs-used cross-reference.
+ *
+ * @internal
+ */
+interface BundleUsageProviderInterface
+{
+    /**
+     * Stable, content-never key identifying the bundle/capability, e.g. `datahub`. Becomes the
+     * snapshot property `usage.<bundleKey>`.
+     */
+    public function getBundleKey(): string;
+
+    /**
+     * Whether this bundle/capability is actually used on this instance. Should be cheap (runs on the
+     * periodic snapshot) and must not throw - a failure is treated as "not used".
+     */
+    public function isUsed(): bool;
+}

--- a/lib/Telemetry/Usage/WorkflowUsageProvider.php
+++ b/lib/Telemetry/Usage/WorkflowUsageProvider.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Usage;
+
+use Pimcore\Workflow\Manager;
+use Throwable;
+
+/**
+ * Reference {@see BundleUsageProviderInterface} for a core capability: workflows are "used" when at
+ * least one workflow is configured. Purely structural and content-never (a boolean derived from the
+ * count) - it self-resets to false if all workflows are removed, so the bundle/capability owns the
+ * definition of "used". Bundles (Data Hub, Portal Engine, …) add their own provider the same way.
+ *
+ * @internal
+ */
+final readonly class WorkflowUsageProvider implements BundleUsageProviderInterface
+{
+    public function __construct(
+        private Manager $workflowManager,
+    ) {
+    }
+
+    public function getBundleKey(): string
+    {
+        return 'workflow';
+    }
+
+    public function isUsed(): bool
+    {
+        try {
+            return $this->workflowManager->getAllWorkflows() !== [];
+        } catch (Throwable) {
+            return false;
+        }
+    }
+}

--- a/lib/Telemetry/Usage/WorkflowUsageProvider.php
+++ b/lib/Telemetry/Usage/WorkflowUsageProvider.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Pimcore\Telemetry\Usage;
 
+use Exception;
 use Pimcore\Workflow\Manager;
-use Throwable;
 
 /**
  * Reference {@see BundleUsageProviderInterface} for a core capability: workflows are "used" when at
@@ -40,7 +40,7 @@ final readonly class WorkflowUsageProvider implements BundleUsageProviderInterfa
     {
         try {
             return $this->workflowManager->getAllWorkflows() !== [];
-        } catch (Throwable) {
+        } catch (Exception) {
             return false;
         }
     }

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -25,7 +25,7 @@ final class Version
 
     private const PLATFORM_VERSION_PACKAGE_NAME = 'pimcore/platform-version';
 
-    private const MAJOR_VERSION = 12;
+    private const MAJOR_VERSION = 2026;
 
     public static function getMajorVersion(): int
     {

--- a/tests/Unit/Telemetry/ActiveBundlesTest.php
+++ b/tests/Unit/Telemetry/ActiveBundlesTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Telemetry;
+
+use Pimcore\Extension\Bundle\PimcoreBundleManager;
+use Pimcore\Telemetry\Snapshot\ActiveBundles;
+use Pimcore\Tests\Support\Test\TestCase;
+use stdClass;
+
+// Stands in for a first-party bundle: this test namespace is under `Pimcore\`, which is exactly what
+// ActiveBundles keys off. `stdClass` stands in for anything outside Pimcore's namespaces - a
+// customer or agency bundle - since it is in the global namespace.
+class PimcoreDataHubBundle
+{
+}
+
+class ActiveBundlesTest extends TestCase
+{
+    public function testOnlyFirstPartyBundlesAreNamed(): void
+    {
+        $this->assertSame(['PimcoreDataHubBundle'], $this->activeBundles()->firstPartyNames());
+    }
+
+    /**
+     * A customer bundle's class name is customer-authored content: it is counted so the fleet data
+     * still shows how customised an install is, but it must never be transmitted.
+     */
+    public function testNonFirstPartyBundlesAreCountedButNeverNamed(): void
+    {
+        $bundles = $this->activeBundles();
+
+        $this->assertSame(1, $bundles->thirdPartyCount());
+        $this->assertSame(2, $bundles->count(), 'the total still reflects every active bundle');
+        $this->assertNotContains('stdClass', $bundles->firstPartyNames());
+    }
+
+    /**
+     * Capability flags are matched against first-party names only, so a bundle outside Pimcore's
+     * namespaces can never flip one - even if its class name contains a Pimcore product name.
+     */
+    public function testCapabilityFlagsIgnoreNonFirstPartyBundles(): void
+    {
+        $this->assertTrue($this->activeBundles()->has('DataHub'));
+
+        $onlyForeign = $this->activeBundles(withFirstParty: false);
+        $this->assertFalse($onlyForeign->has('std'), 'a non-first-party bundle must not match');
+        $this->assertSame([], $onlyForeign->firstPartyNames());
+        $this->assertSame(1, $onlyForeign->thirdPartyCount());
+    }
+
+    public function testTheBundleListIsResolvedOnlyOnce(): void
+    {
+        $bundleManager = $this->createMock(PimcoreBundleManager::class);
+        $bundleManager->expects($this->once())
+            ->method('getActiveBundles')
+            ->willReturn([new PimcoreDataHubBundle()]);
+
+        $bundles = new ActiveBundles($bundleManager);
+        $bundles->firstPartyNames();
+        $bundles->thirdPartyCount();
+        $bundles->count();
+        $bundles->has('DataHub');
+    }
+
+    private function activeBundles(bool $withFirstParty = true): ActiveBundles
+    {
+        $active = $withFirstParty
+            ? [new PimcoreDataHubBundle(), new stdClass()]
+            : [new stdClass()];
+
+        $bundleManager = $this->createMock(PimcoreBundleManager::class);
+        $bundleManager->method('getActiveBundles')->willReturn($active);
+
+        return new ActiveBundles($bundleManager);
+    }
+}

--- a/tests/Unit/Telemetry/BucketizerTest.php
+++ b/tests/Unit/Telemetry/BucketizerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Telemetry;
+
+use Pimcore\Telemetry\Snapshot\Bucketizer;
+use Pimcore\Tests\Support\Test\TestCase;
+
+class BucketizerTest extends TestCase
+{
+    private Bucketizer $bucketizer;
+
+    protected function setUp(): void
+    {
+        $this->bucketizer = new Bucketizer();
+    }
+
+    public function testBucketBoundaries(): void
+    {
+        $this->assertSame('0', $this->bucketizer->bucket(0));
+        $this->assertSame('0', $this->bucketizer->bucket(-5));
+        $this->assertSame('1-10', $this->bucketizer->bucket(1));
+        $this->assertSame('1-10', $this->bucketizer->bucket(10));
+        $this->assertSame('11-50', $this->bucketizer->bucket(11));
+        $this->assertSame('11-50', $this->bucketizer->bucket(50));
+        $this->assertSame('51-200', $this->bucketizer->bucket(51));
+        $this->assertSame('51-200', $this->bucketizer->bucket(200));
+        $this->assertSame('201-1000', $this->bucketizer->bucket(201));
+        $this->assertSame('201-1000', $this->bucketizer->bucket(1000));
+        $this->assertSame('1000+', $this->bucketizer->bucket(1001));
+        $this->assertSame('1000+', $this->bucketizer->bucket(50000));
+    }
+}

--- a/tests/Unit/Telemetry/BundleUsageCollectorTest.php
+++ b/tests/Unit/Telemetry/BundleUsageCollectorTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Telemetry;
+
+use Pimcore\Telemetry\Snapshot\SnapshotCollectorInterface;
+use Pimcore\Telemetry\Usage\BundleUsageCollector;
+use Pimcore\Telemetry\Usage\BundleUsageProviderInterface;
+use Pimcore\Tests\Support\Test\TestCase;
+use RuntimeException;
+use Throwable;
+
+class BundleUsageCollectorTest extends TestCase
+{
+    private function provider(string $key, bool|Throwable $used): BundleUsageProviderInterface
+    {
+        return new class($key, $used) implements BundleUsageProviderInterface {
+            public function __construct(private readonly string $key, private readonly bool|Throwable $used)
+            {
+            }
+
+            public function getBundleKey(): string
+            {
+                return $this->key;
+            }
+
+            public function isUsed(): bool
+            {
+                if ($this->used instanceof Throwable) {
+                    throw $this->used;
+                }
+
+                return $this->used;
+            }
+        };
+    }
+
+    public function testIsASnapshotCollectorInTheUsageNamespace(): void
+    {
+        $collector = new BundleUsageCollector([]);
+
+        $this->assertInstanceOf(SnapshotCollectorInterface::class, $collector);
+        $this->assertSame('usage', $collector->getNamespace());
+    }
+
+    public function testAggregatesProvidersToBundleKeyUsedMap(): void
+    {
+        $collector = new BundleUsageCollector([
+            $this->provider('datahub', true),
+            $this->provider('portal_engine', false),
+        ]);
+
+        $this->assertSame(['datahub' => true, 'portal_engine' => false], $collector->collect());
+    }
+
+    public function testThrowingProviderDegradesToFalse(): void
+    {
+        $collector = new BundleUsageCollector([
+            $this->provider('ok', true),
+            $this->provider('boom', new RuntimeException('kaboom')),
+        ]);
+
+        $this->assertSame(['ok' => true, 'boom' => false], $collector->collect());
+    }
+
+    public function testNoProvidersYieldsEmptyMap(): void
+    {
+        $this->assertSame([], (new BundleUsageCollector([]))->collect());
+    }
+}

--- a/tests/Unit/Telemetry/CatalogShapeCollectorTest.php
+++ b/tests/Unit/Telemetry/CatalogShapeCollectorTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Telemetry;
+
+use Pimcore\Telemetry\Snapshot\Bucketizer;
+use Pimcore\Telemetry\Snapshot\CatalogShapeCollector;
+use Pimcore\Telemetry\Snapshot\Statistics\ElementKind;
+use Pimcore\Telemetry\Snapshot\Statistics\ElementStatisticsProviderInterface;
+use Pimcore\Telemetry\Snapshot\Statistics\TreeDepth;
+use Pimcore\Tests\Support\Test\TestCase;
+
+class CatalogShapeCollectorTest extends TestCase
+{
+    public function testNamespaceIsCatalog(): void
+    {
+        $this->assertSame('catalog', $this->collector()->getNamespace());
+    }
+
+    public function testEmitsShapeMetricsFromTheStatisticsProviderAndIsContentNever(): void
+    {
+        $metrics = $this->collector()->collect();
+
+        $this->assertSame(1, $metrics['schema_version']);
+        $this->assertSame(9, $metrics['object_tree_max_depth']);
+        $this->assertSame(5, $metrics['object_tree_avg_depth']);
+        $this->assertSame(4, $metrics['asset_tree_max_depth']);
+        $this->assertSame(5, $metrics['document_tree_max_depth']);
+        $this->assertSame('11-50', $metrics['products_with_variants_bucket']); // bucket(12)
+        $this->assertSame(7, $metrics['max_variants_per_product']);
+        $this->assertSame(43, $metrics['max_folder_fanout']);
+
+        foreach ($metrics as $key => $value) {
+            $this->assertIsScalar($value, "metric '$key' must be scalar");
+        }
+    }
+
+    private function collector(): CatalogShapeCollector
+    {
+        $statistics = $this->createMock(ElementStatisticsProviderInterface::class);
+        $statistics->method('treeDepth')->willReturnCallback(
+            static fn (ElementKind $kind): TreeDepth => match ($kind) {
+                ElementKind::DataObject => new TreeDepth(9, 5),
+                ElementKind::Asset => new TreeDepth(4, 3),
+                ElementKind::Document => new TreeDepth(5, 3),
+            }
+        );
+        $statistics->method('objectsWithVariants')->willReturn(12);
+        $statistics->method('maxVariantsPerObject')->willReturn(7);
+        $statistics->method('maxObjectFanout')->willReturn(43);
+
+        return new CatalogShapeCollector($statistics, new Bucketizer());
+    }
+}

--- a/tests/Unit/Telemetry/CoreSnapshotCollectorTest.php
+++ b/tests/Unit/Telemetry/CoreSnapshotCollectorTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Telemetry;
+
+use Doctrine\DBAL\Connection;
+use Pimcore\Extension\Bundle\PimcoreBundleManager;
+use Pimcore\Telemetry\Snapshot\ActiveBundles;
+use Pimcore\Telemetry\Snapshot\Bucketizer;
+use Pimcore\Telemetry\Snapshot\CoreSnapshotCollector;
+use Pimcore\Telemetry\Snapshot\SnapshotQueryRunner;
+use Pimcore\Tests\Support\Test\TestCase;
+use function str_contains;
+
+class CoreSnapshotCollectorTest extends TestCase
+{
+    public function testNamespaceIsCore(): void
+    {
+        $this->assertSame('core', $this->collector()->getNamespace());
+    }
+
+    public function testLargeTablesTrustTheEstimateAndSmallTablesFallBackToAnExactCount(): void
+    {
+        $metrics = $this->collector()->collect();
+
+        // objects: estimate 250000 (>= threshold) -> trusted, no COUNT(*) -> top bucket.
+        $this->assertSame('1000+', $metrics['object_count_bucket']);
+        // classes: estimate 8000 (>= threshold) -> trusted -> top bucket.
+        $this->assertSame('1000+', $metrics['dataobject_class_count_bucket']);
+        // assets: estimate 3 (< threshold) -> exact COUNT(*) = 7 -> precise bucket.
+        $this->assertSame('1-10', $metrics['asset_count_bucket']);
+        // documents: estimate 0 / unknown -> exact COUNT(*) = 120 -> precise bucket.
+        $this->assertSame('51-200', $metrics['document_count_bucket']);
+    }
+
+    /**
+     * Version and language facts come from Pimcore's own statics (as in Tool\StatisticsManager), so
+     * assert their shape rather than pinning values that change with the release.
+     */
+    public function testReportsEnvironmentFacts(): void
+    {
+        $metrics = $this->collector()->collect();
+
+        $this->assertIsString($metrics['pimcore_version']);
+        $this->assertNotSame('', $metrics['pimcore_version']);
+        $this->assertIsInt($metrics['pimcore_major_version']);
+        $this->assertIsInt($metrics['language_count']);
+        $this->assertGreaterThanOrEqual(0, $metrics['language_count']);
+
+        // this one is injected, so it can still be pinned exactly
+        $this->assertSame('10.11-MariaDB', $metrics['mysql_version']);
+    }
+
+    /**
+     * The raw APP_ENV must never reach the payload: it is customer-authored text, so anything
+     * outside the known set collapses to 'other'.
+     */
+    public function testModeIsReducedToAFixedVocabulary(): void
+    {
+        $this->assertSame('prod', $this->collector('prod')->collect()['mode']);
+        $this->assertSame('dev', $this->collector('dev')->collect()['mode']);
+        $this->assertSame('test', $this->collector('test')->collect()['mode']);
+
+        // case and stray whitespace still resolve
+        $this->assertSame('prod', $this->collector('  PROD ')->collect()['mode']);
+
+        // customer-authored values never pass through verbatim
+        $this->assertSame('other', $this->collector('prod_acme')->collect()['mode']);
+        $this->assertSame('other', $this->collector('staging')->collect()['mode']);
+        $this->assertSame('other', $this->collector('')->collect()['mode']);
+    }
+
+    private function collector(string $environment = 'prod'): CoreSnapshotCollector
+    {
+        $bundleManager = $this->createMock(PimcoreBundleManager::class);
+        $bundleManager->method('getActiveBundles')->willReturn([]);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('quoteIdentifier')->willReturnArgument(0);
+        $connection->method('fetchOne')->willReturnCallback(
+            static function (string $sql, array $params = []): int|string {
+                if (str_contains($sql, 'information_schema')) {
+                    return match ($params[0] ?? null) {
+                        'objects' => 250000,
+                        'classes' => 8000,
+                        'assets' => 3,
+                        default => 0, // documents -> optimizer has no estimate
+                    };
+                }
+
+                if (str_contains($sql, 'VERSION()')) {
+                    return '10.11-MariaDB';
+                }
+
+                // exact COUNT(*) fallback for the small/unknown tables
+                return match (true) {
+                    str_contains($sql, 'assets') => 7,
+                    str_contains($sql, 'documents') => 120,
+                    default => 0,
+                };
+            }
+        );
+
+        return new CoreSnapshotCollector(
+            new ActiveBundles($bundleManager),
+            new SnapshotQueryRunner($connection, 0),
+            new Bucketizer(),
+            $environment,
+        );
+    }
+}

--- a/tests/Unit/Telemetry/DataModelComplexityCollectorTest.php
+++ b/tests/Unit/Telemetry/DataModelComplexityCollectorTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Telemetry;
+
+use Doctrine\DBAL\Connection;
+use Pimcore\Telemetry\Snapshot\Bucketizer;
+use Pimcore\Telemetry\Snapshot\DataModelComplexityCollector;
+use Pimcore\Telemetry\Snapshot\FieldTreeAnalyzer;
+use Pimcore\Telemetry\Snapshot\SnapshotQueryRunner;
+use Pimcore\Tests\Support\Test\TestCase;
+use function is_array;
+
+class DataModelComplexityCollectorTest extends TestCase
+{
+    public function testNamespaceIsDatamodel(): void
+    {
+        $this->assertSame('datamodel', $this->collector()->getNamespace());
+    }
+
+    public function testEmitsExpectedKeysAndIsContentNever(): void
+    {
+        $metrics = $this->collector()->collect();
+
+        $expectedKeys = [
+            'schema_version', 'class_count', 'fieldcollection_count', 'objectbrick_count',
+            'custom_layout_count', 'classificationstore_group_count', 'classificationstore_key_count',
+            'total_field_count', 'max_fields_per_class', 'avg_fields_per_class', 'max_nesting_depth',
+            'classes_with_inheritance', 'distinct_fieldtype_count', 'relation_field_count',
+            'fieldtype_usage', 'uses_localizedfields', 'uses_blocks', 'uses_classificationstore',
+            'uses_calculated_value', 'uses_advanced_relations',
+        ];
+        foreach ($expectedKeys as $key) {
+            $this->assertArrayHasKey($key, $metrics, "missing metric '$key'");
+        }
+
+        // Locks the emitted key-set so a future leaked/extra key - even a scalar one - is caught.
+        $this->assertCount(20, $metrics);
+
+        $this->assertSame(1, $metrics['schema_version']);
+
+        // Content-never: scalars, or (fieldtype_usage) a map whose leaves are all scalar.
+        foreach ($metrics as $key => $value) {
+            if (is_array($value)) {
+                foreach ($value as $leaf) {
+                    $this->assertIsScalar($leaf, "map metric '$key' must contain only scalars");
+                }
+                continue;
+            }
+            $this->assertIsScalar($value, "metric '$key' must be scalar");
+        }
+    }
+
+    private function collector(): DataModelComplexityCollector
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('quoteIdentifier')->willReturnArgument(0);
+        $connection->method('fetchOne')->willReturn(0);
+
+        return new DataModelComplexityCollector(
+            new FieldTreeAnalyzer(),
+            new Bucketizer(),
+            new SnapshotQueryRunner($connection, 0),
+        );
+    }
+}

--- a/tests/Unit/Telemetry/ElementTypeCountsTest.php
+++ b/tests/Unit/Telemetry/ElementTypeCountsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Telemetry;
+
+use Pimcore\Telemetry\Snapshot\ElementTypeCounts;
+use Pimcore\Tests\Support\Test\TestCase;
+
+class ElementTypeCountsTest extends TestCase
+{
+    public function testTotalSumsEveryTypeCount(): void
+    {
+        $counts = new ElementTypeCounts(['image' => 30, 'video' => 5, 'folder' => 7]);
+
+        $this->assertSame(42, $counts->total());
+    }
+
+    public function testOfTypeReturnsTheCountOrZeroWhenAbsent(): void
+    {
+        $counts = new ElementTypeCounts(['image' => 30]);
+
+        $this->assertSame(30, $counts->ofType('image'));
+        $this->assertSame(0, $counts->ofType('video'));
+    }
+
+    public function testDistinctTypesCountsTheKeys(): void
+    {
+        $counts = new ElementTypeCounts(['image' => 30, 'video' => 5, 'audio' => 1]);
+
+        $this->assertSame(3, $counts->distinctTypes());
+    }
+
+    public function testEmptyIsAllZero(): void
+    {
+        $counts = new ElementTypeCounts();
+
+        $this->assertSame(0, $counts->total());
+        $this->assertSame(0, $counts->ofType('image'));
+        $this->assertSame(0, $counts->distinctTypes());
+    }
+}

--- a/tests/Unit/Telemetry/EnvelopeCipherTest.php
+++ b/tests/Unit/Telemetry/EnvelopeCipherTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Telemetry;
+
+use Pimcore\Telemetry\Crypto\EnvelopeCipher;
+use Pimcore\Telemetry\Crypto\EnvelopeCipherException;
+use Pimcore\Tests\Support\Test\TestCase;
+
+class EnvelopeCipherTest extends TestCase
+{
+    /**
+     * Frozen fixture that pins the wire format: decrypting FIXTURE_CIPHERTEXT with
+     * FIXTURE_PRODUCT_KEY must yield the expected envelope. Any drift in HKDF info, gzip, the
+     * AES-256-GCM parameters, or the version-byte format breaks this test loudly. If the
+     * license-server relay ever grows a parity test, it should reuse these exact literals.
+     */
+    private const FIXTURE_PRODUCT_KEY = 'poc-fixture-product-key-v1';
+
+    private const FIXTURE_CIPHERTEXT = 'Av8OhJn7UYUEuro2VIRbiRTkpw9urAMMnEQRCKIzp7VuWuOepM5kqXVJxTDPO2Yyh3CqEvo7bF/7rx3TT1T3Jk9+GpG8VKOCWyune+Ww2G1qYdvxYO9DND+JjervfcnCZsSmKryhdK17J9oUBQth087msZQ8IVVCkZlmiLd9GS/jREw6HSzq7MGxUHTwR/DnHmEuOmAb+95EgoXLYiw9X6O6XS8Ui1QrAtOI4SnmwvM=';
+
+    private EnvelopeCipher $cipher;
+
+    protected function setUp(): void
+    {
+        $this->cipher = new EnvelopeCipher();
+    }
+
+    public function testRoundTripPreservesEnvelope(): void
+    {
+        $envelope = $this->sampleEnvelope();
+        $key = 'some-product-key';
+
+        $decrypted = $this->cipher->decrypt($this->cipher->encrypt($envelope, $key), $key);
+
+        $this->assertSame($envelope, $decrypted);
+    }
+
+    public function testEncryptionIsNonDeterministic(): void
+    {
+        $envelope = $this->sampleEnvelope();
+        $key = 'some-product-key';
+
+        $this->assertNotSame(
+            $this->cipher->encrypt($envelope, $key),
+            $this->cipher->encrypt($envelope, $key),
+        );
+    }
+
+    public function testEncryptProducesVersion2Blob(): void
+    {
+        $raw = base64_decode($this->cipher->encrypt($this->sampleEnvelope(), 'some-product-key'), true);
+
+        $this->assertSame("\x02", $raw[0]);
+    }
+
+    public function testDecryptWithWrongKeyThrows(): void
+    {
+        $blob = $this->cipher->encrypt($this->sampleEnvelope(), 'the-right-key');
+
+        $this->expectException(EnvelopeCipherException::class);
+        $this->cipher->decrypt($blob, 'the-wrong-key');
+    }
+
+    public function testTamperedCiphertextThrows(): void
+    {
+        $raw = base64_decode($this->cipher->encrypt($this->sampleEnvelope(), 'k'), true);
+        $raw[strlen($raw) - 1] = $raw[strlen($raw) - 1] === "\x00" ? "\x01" : "\x00";
+
+        $this->expectException(EnvelopeCipherException::class);
+        $this->cipher->decrypt(base64_encode($raw), 'k');
+    }
+
+    public function testTooShortBlobThrows(): void
+    {
+        $this->expectException(EnvelopeCipherException::class);
+        $this->cipher->decrypt('AAAA', 'k');
+    }
+
+    public function testUnsupportedVersionThrows(): void
+    {
+        $raw = "\x01" . str_repeat("\x00", 24) . str_repeat("\x00", 20);
+
+        $this->expectException(EnvelopeCipherException::class);
+        $this->cipher->decrypt(base64_encode($raw), 'k');
+    }
+
+    public function testOversizedEnvelopeIsRejected(): void
+    {
+        // Compresses to a few KB, but would decompress past the 10 MiB cap - a decompression bomb.
+        $envelope = [
+            'instanceIdentifier' => 'inst-abc',
+            'payload' => str_repeat('a', 11 * 1024 * 1024),
+        ];
+
+        $blob = $this->cipher->encrypt($envelope, 'k');
+
+        $this->expectException(EnvelopeCipherException::class);
+        $this->expectExceptionMessage('size limit');
+        $this->cipher->decrypt($blob, 'k');
+    }
+
+    public function testEmptyProductKeyThrows(): void
+    {
+        $this->expectException(EnvelopeCipherException::class);
+        $this->cipher->encrypt($this->sampleEnvelope(), '');
+    }
+
+    public function testDecryptsFrozenCrossRepoFixture(): void
+    {
+        $expected = [
+            'instanceIdentifier' => 'fixture-inst',
+            'ts' => 1720000000,
+            'events' => [
+                [
+                    'type' => 'capture',
+                    'event' => 'instance.snapshot',
+                    'properties' => ['core.version' => '2026.2'],
+                    'eventUid' => 'fixed-uid-1',
+                ],
+            ],
+        ];
+
+        $this->assertSame(
+            $expected,
+            $this->cipher->decrypt(self::FIXTURE_CIPHERTEXT, self::FIXTURE_PRODUCT_KEY),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function sampleEnvelope(): array
+    {
+        return [
+            'instanceIdentifier' => 'inst-abc',
+            'ts' => 1720000000,
+            'events' => [
+                ['type' => 'capture', 'event' => 'object.created', 'properties' => ['element_type' => 'object'], 'eventUid' => 'u1'],
+            ],
+        ];
+    }
+}

--- a/tests/Unit/Telemetry/EventSanitizerTest.php
+++ b/tests/Unit/Telemetry/EventSanitizerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Telemetry;
+
+use Pimcore\Telemetry\EventSanitizer;
+use Pimcore\Tests\Support\Test\TestCase;
+use Psr\Log\LoggerInterface;
+use stdClass;
+
+class EventSanitizerTest extends TestCase
+{
+    private EventSanitizer $sanitizer;
+
+    protected function setUp(): void
+    {
+        $this->sanitizer = new EventSanitizer($this->createMock(LoggerInterface::class));
+    }
+
+    /**
+     * @dataProvider validEventNames
+     */
+    public function testAcceptsTaxonomyConformantNames(string $event): void
+    {
+        $this->assertTrue($this->sanitizer->isValidEventName($event));
+    }
+
+    public static function validEventNames(): array
+    {
+        return [
+            ['object.opened'],
+            ['object.created'],
+            ['asset.uploaded'],
+            ['asset.version_created'],
+            ['importer.run_started'],
+            ['instance.snapshot'],
+            ['error.occurred'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidEventNames
+     */
+    public function testRejectsNonConformantNames(string $event): void
+    {
+        $this->assertFalse($this->sanitizer->isValidEventName($event));
+    }
+
+    public static function invalidEventNames(): array
+    {
+        return [
+            'single segment' => ['object'],
+            'uppercase' => ['Object.Opened'],
+            'space' => ['object opened'],
+            'trailing dot' => ['object.'],
+            'leading dot' => ['.object'],
+            'double dot' => ['object..opened'],
+            'empty' => [''],
+            'hyphen' => ['object.re-opened'],
+        ];
+    }
+
+    public function testScalarAndScalarArrayPropertiesArePreserved(): void
+    {
+        $properties = [
+            'count' => 5,
+            'flag' => true,
+            'version' => '8.4.0',
+            'ratio' => 1.5,
+            'missing' => null,
+            // arrays of scalars are legitimate telemetry (e.g. the installed-bundle list)
+            'bundles' => ['PimcoreCoreBundle', 'PimcoreDataHubBundle'],
+            'nested' => ['a' => 1, 'b' => [true, false]],
+        ];
+
+        $this->assertSame($properties, $this->sanitizer->sanitizeProperties($properties, 'instance.snapshot'));
+    }
+
+    public function testObjectValuesAreDroppedAndLogged(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->exactly(2))->method('warning');
+        $sanitizer = new EventSanitizer($logger);
+
+        $safe = $sanitizer->sanitizeProperties([
+            'count' => 3,
+            'object' => new stdClass(),                 // live object -> dropped
+            'nested_object' => ['ok' => 1, 'bad' => new stdClass()], // array containing an object -> dropped
+        ], 'object.created');
+
+        $this->assertSame(['count' => 3], $safe);
+        $this->assertArrayNotHasKey('object', $safe);
+        $this->assertArrayNotHasKey('nested_object', $safe);
+    }
+}

--- a/tests/Unit/Telemetry/FieldTreeAnalyzerTest.php
+++ b/tests/Unit/Telemetry/FieldTreeAnalyzerTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Telemetry;
+
+use Pimcore\Model\DataObject\ClassDefinition\Data;
+use Pimcore\Model\DataObject\ClassDefinition\Data\AdvancedManyToManyRelation;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Block;
+use Pimcore\Model\DataObject\ClassDefinition\Data\CalculatedValue;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Classificationstore;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Input;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Localizedfields;
+use Pimcore\Model\DataObject\ClassDefinition\Data\ManyToOneRelation;
+use Pimcore\Telemetry\Snapshot\FieldTreeAnalyzer;
+use Pimcore\Tests\Support\Test\TestCase;
+
+class FieldTreeAnalyzerTest extends TestCase
+{
+    public function testFlatTreeCountsFieldsTypesAndRelations(): void
+    {
+        $fields = [
+            $this->field(Input::class, 'title'),
+            $this->field(Input::class, 'sku'),
+            $this->field(ManyToOneRelation::class, 'brand'),
+        ];
+
+        $metrics = (new FieldTreeAnalyzer())->analyze($fields);
+
+        $this->assertSame(3, $metrics->fieldCount);
+        $this->assertSame(1, $metrics->maxDepth);
+        $this->assertSame(2, $metrics->distinctTypeCount()); // input, manyToOneRelation
+        $this->assertSame(1, $metrics->relationFieldCount);
+        $this->assertFalse($metrics->usesBlocks);
+        $this->assertFalse($metrics->usesAdvancedRelations);
+    }
+
+    public function testAdvancedRelationSetsFlag(): void
+    {
+        $metrics = (new FieldTreeAnalyzer())->analyze([
+            $this->field(AdvancedManyToManyRelation::class, 'crossSell'),
+        ]);
+
+        $this->assertSame(1, $metrics->relationFieldCount);
+        $this->assertTrue($metrics->usesAdvancedRelations);
+    }
+
+    public function testNestedContainersIncreaseDepthAndCounts(): void
+    {
+        $street = $this->field(Input::class, 'street');
+        // Localizedfields::setName() enforces the fixed name 'localizedfields' (see
+        // Pimcore\Model\DataObject\ClassDefinition\Data\Localizedfields::setName()); it is a
+        // singleton field within a class, so it cannot be named anything else.
+        $localized = $this->container(Localizedfields::class, 'localizedfields', [$street]);
+        $caption = $this->field(Input::class, 'caption');
+        $block = $this->container(Block::class, 'items', [$caption, $localized]);
+
+        $fields = [$this->field(Input::class, 'title'), $block];
+
+        $metrics = (new FieldTreeAnalyzer())->analyze($fields);
+
+        // title(d1) + block(d1) + caption(d2) + localizedfields(d2) + street(d3)
+        $this->assertSame(5, $metrics->fieldCount);
+        $this->assertSame(3, $metrics->maxDepth);
+        $this->assertTrue($metrics->usesBlocks);
+        $this->assertTrue($metrics->usesLocalizedfields);
+        $this->assertSame(3, $metrics->distinctTypeCount()); // input, block, localizedfields
+    }
+
+    public function testClassificationstoreFieldSetsFlag(): void
+    {
+        $metrics = (new FieldTreeAnalyzer())->analyze([
+            $this->field(Classificationstore::class, 'cs'),
+        ]);
+
+        $this->assertTrue($metrics->usesClassificationstore);
+    }
+
+    public function testCalculatedValueFieldSetsFlag(): void
+    {
+        $metrics = (new FieldTreeAnalyzer())->analyze([
+            $this->field(CalculatedValue::class, 'calc'),
+        ]);
+
+        $this->assertTrue($metrics->usesCalculatedValue);
+    }
+
+    public function testEmptyFieldListReturnsAllZeroMetrics(): void
+    {
+        $metrics = (new FieldTreeAnalyzer())->analyze([]);
+
+        $this->assertSame(0, $metrics->fieldCount);
+        $this->assertSame(0, $metrics->maxDepth);
+        $this->assertSame(0, $metrics->distinctTypeCount());
+        $this->assertSame(0, $metrics->relationFieldCount);
+        $this->assertFalse($metrics->usesLocalizedfields);
+        $this->assertFalse($metrics->usesBlocks);
+        $this->assertFalse($metrics->usesClassificationstore);
+        $this->assertFalse($metrics->usesCalculatedValue);
+        $this->assertFalse($metrics->usesAdvancedRelations);
+    }
+
+    public function testNonDataEntryIsSkipped(): void
+    {
+        $metrics = (new FieldTreeAnalyzer())->analyze([
+            'not-a-field',
+            $this->field(Input::class, 'title'),
+        ]);
+
+        $this->assertSame(1, $metrics->fieldCount);
+    }
+
+    private function field(string $class, string $name): Data
+    {
+        /** @var Data $field */
+        $field = new $class();
+        $field->setName($name);
+
+        return $field;
+    }
+
+    /**
+     * @param list<Data> $children
+     */
+    private function container(string $class, string $name, array $children): Data
+    {
+        /** @var Data&Block|Data&Localizedfields $field */
+        $field = new $class();
+        $field->setName($name);
+        $field->setChildren($children);
+
+        return $field;
+    }
+}

--- a/tests/Unit/Telemetry/FieldTreeMetricsTest.php
+++ b/tests/Unit/Telemetry/FieldTreeMetricsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Telemetry;
+
+use Pimcore\Telemetry\Snapshot\FieldTreeMetrics;
+use Pimcore\Tests\Support\Test\TestCase;
+
+class FieldTreeMetricsTest extends TestCase
+{
+    public function testEmptyMetricsAreZero(): void
+    {
+        $metrics = new FieldTreeMetrics();
+
+        $this->assertSame(0, $metrics->fieldCount);
+        $this->assertSame(0, $metrics->maxDepth);
+        $this->assertSame(0, $metrics->distinctTypeCount());
+        $this->assertSame([], $metrics->typeUsage);
+    }
+
+    public function testCombineSumsCountsMaxesDepthMergesTypesAndOrsFlags(): void
+    {
+        $a = new FieldTreeMetrics(
+            fieldCount: 3,
+            maxDepth: 2,
+            typeUsage: ['input' => 2, 'block' => 1],
+            relationFieldCount: 1,
+            usesBlocks: true,
+        );
+        $b = new FieldTreeMetrics(
+            fieldCount: 2,
+            maxDepth: 4,
+            typeUsage: ['input' => 1, 'manyToOneRelation' => 1],
+            relationFieldCount: 1,
+            usesLocalizedfields: true,
+            usesAdvancedRelations: true,
+        );
+
+        $c = $a->combine($b);
+
+        $this->assertSame(5, $c->fieldCount);
+        $this->assertSame(4, $c->maxDepth);
+        $this->assertSame(['input' => 3, 'block' => 1, 'manyToOneRelation' => 1], $c->typeUsage);
+        $this->assertSame(2, $c->relationFieldCount);
+        $this->assertSame(3, $c->distinctTypeCount());
+        $this->assertTrue($c->usesBlocks);
+        $this->assertTrue($c->usesLocalizedfields);
+        $this->assertTrue($c->usesAdvancedRelations);
+        $this->assertFalse($c->usesClassificationstore);
+        $this->assertFalse($c->usesCalculatedValue);
+    }
+}

--- a/tests/Unit/Telemetry/PillarUsageCollectorTest.php
+++ b/tests/Unit/Telemetry/PillarUsageCollectorTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Telemetry;
+
+use Doctrine\DBAL\Connection;
+use Pimcore\Extension\Bundle\PimcoreBundleManager;
+use Pimcore\Telemetry\Snapshot\ActiveBundles;
+use Pimcore\Telemetry\Snapshot\Bucketizer;
+use Pimcore\Telemetry\Snapshot\ElementTypeCounts;
+use Pimcore\Telemetry\Snapshot\PillarUsageCollector;
+use Pimcore\Telemetry\Snapshot\SnapshotQueryRunner;
+use Pimcore\Telemetry\Snapshot\Statistics\ElementKind;
+use Pimcore\Telemetry\Snapshot\Statistics\ElementStatisticsProviderInterface;
+use Pimcore\Tests\Support\Test\TestCase;
+use function str_contains;
+
+// Stub bundles whose short class name carries the needle the collector matches on.
+class PillarStubEcommerceFrameworkBundle
+{
+}
+class PillarStubDataHubBundle
+{
+}
+
+class PillarUsageCollectorTest extends TestCase
+{
+    public function testNamespaceIsPillars(): void
+    {
+        $this->assertSame('pillars', $this->collector([])->getNamespace());
+    }
+
+    public function testDerivesPerTypeMetricsFromTheStatisticsProviderAndIsContentNever(): void
+    {
+        $metrics = $this->collector([])->collect();
+
+        // assets: total 42 (30+5+4+0+3); each per-type count comes from the provider's type counts.
+        $this->assertSame('11-50', $metrics['asset_count_bucket']);          // bucket(42)
+        $this->assertSame('11-50', $metrics['asset_image_count_bucket']);    // bucket(30)
+        $this->assertSame('1-10', $metrics['asset_video_count_bucket']);     // bucket(5)
+        $this->assertSame('1-10', $metrics['asset_document_count_bucket']);  // bucket(4)
+        $this->assertSame('0', $metrics['asset_audio_count_bucket']);        // bucket(0)
+        $this->assertSame(5, $metrics['asset_type_variety']);                // distinct types incl. folder
+
+        $this->assertSame('11-50', $metrics['object_count_bucket']);         // bucket(40)
+        $this->assertSame('0', $metrics['object_variant_count_bucket']);     // bucket(0)
+        $this->assertSame('51-200', $metrics['document_page_count_bucket']); // bucket(60)
+        $this->assertSame('1-10', $metrics['document_email_count_bucket']);  // bucket(5)
+        $this->assertSame('1-10', $metrics['document_link_count_bucket']);   // bucket(5)
+
+        // Low-cardinality facts (classes/sites) still come from a direct count.
+        $this->assertSame(1, $metrics['schema_version']);
+        $this->assertSame('11-50', $metrics['class_count_bucket']);          // bucket(20)
+        $this->assertSame(1, $metrics['site_count']);
+
+        foreach ($metrics as $key => $value) {
+            $this->assertIsScalar($value, "metric '$key' must be scalar");
+        }
+    }
+
+    public function testBundleFlagsReflectActiveBundles(): void
+    {
+        $metrics = $this->collector([
+            new PillarStubEcommerceFrameworkBundle(),
+            new PillarStubDataHubBundle(),
+        ])->collect();
+
+        $this->assertTrue($metrics['commerce_bundle_active']);
+        $this->assertTrue($metrics['datahub_bundle_active']);
+        $this->assertFalse($metrics['seo_bundle_active']);
+        $this->assertFalse($metrics['portal_engine_bundle_active']);
+    }
+
+    /**
+     * @param list<object> $activeBundles
+     */
+    private function collector(array $activeBundles): PillarUsageCollector
+    {
+        $statistics = $this->createMock(ElementStatisticsProviderInterface::class);
+        $statistics->method('typeCounts')->willReturnCallback(
+            static fn (ElementKind $kind): ElementTypeCounts => match ($kind) {
+                ElementKind::Asset => new ElementTypeCounts(['image' => 30, 'video' => 5, 'document' => 4, 'audio' => 0, 'folder' => 3]),
+                ElementKind::DataObject => new ElementTypeCounts(['object' => 40, 'variant' => 0, 'folder' => 2]),
+                ElementKind::Document => new ElementTypeCounts(['page' => 60, 'email' => 5, 'link' => 5]),
+            }
+        );
+
+        // Runner still serves the tiny classes/sites COUNT(*)s.
+        $connection = $this->createMock(Connection::class);
+        $connection->method('quoteIdentifier')->willReturnArgument(0);
+        $connection->method('fetchOne')->willReturnCallback(
+            static fn (string $sql): int => match (true) {
+                str_contains($sql, 'classes') => 20,
+                str_contains($sql, 'sites') => 1,
+                default => 0,
+            }
+        );
+
+        $bundleManager = $this->createMock(PimcoreBundleManager::class);
+        $bundleManager->method('getActiveBundles')->willReturn($activeBundles);
+
+        return new PillarUsageCollector(
+            new ActiveBundles($bundleManager),
+            new SnapshotQueryRunner($connection, 0),
+            $statistics,
+            new Bucketizer(),
+        );
+    }
+}

--- a/tests/Unit/Telemetry/SnapshotBuilderTest.php
+++ b/tests/Unit/Telemetry/SnapshotBuilderTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Telemetry;
+
+use Doctrine\DBAL\Connection;
+use Pimcore\Telemetry\Snapshot\SnapshotBuilder;
+use Pimcore\Telemetry\Snapshot\SnapshotCollectorInterface;
+use Pimcore\Telemetry\Snapshot\StatementCounter;
+use Pimcore\Tests\Support\Test\TestCase;
+
+class SnapshotBuilderTest extends TestCase
+{
+    public function testCollectorsAreMergedUnderTheirNamespace(): void
+    {
+        $snapshot = (new SnapshotBuilder([
+            $this->collector('core', ['asset_count_bucket' => '11-50', 'php_version' => '8.4.0']),
+            $this->collector('datahub', ['graphql_configs' => '1-10', 'rest_enabled' => true]),
+        ]))->build();
+
+        unset($snapshot['meta.duration_ms']); // self-reporting, covered separately
+
+        $this->assertSame(
+            [
+                'core.asset_count_bucket' => '11-50',
+                'core.php_version' => '8.4.0',
+                'datahub.graphql_configs' => '1-10',
+                'datahub.rest_enabled' => true,
+            ],
+            $snapshot
+        );
+    }
+
+    public function testWithoutCollectorsOnlyTheSelfReportRemains(): void
+    {
+        $this->assertSame(['meta.duration_ms'], array_keys((new SnapshotBuilder([]))->build()));
+    }
+
+    public function testReportsItsOwnDuration(): void
+    {
+        $snapshot = (new SnapshotBuilder([]))->build();
+
+        $this->assertArrayHasKey('meta.duration_ms', $snapshot);
+        $this->assertIsInt($snapshot['meta.duration_ms']);
+        $this->assertGreaterThanOrEqual(0, $snapshot['meta.duration_ms']);
+    }
+
+    public function testDbStatementsIsOmittedWhenNoCounterIsWired(): void
+    {
+        $this->assertArrayNotHasKey('meta.db_statements', (new SnapshotBuilder([]))->build());
+    }
+
+    public function testDbStatementsDiscountsTheClosingProbe(): void
+    {
+        // Session counter reads 100 before and 111 after; the closing read is one of those
+        // statements, so the work in between is 10.
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchAssociative')->willReturnOnConsecutiveCalls(
+            ['Value' => '100'],
+            ['Value' => '111'],
+        );
+
+        $snapshot = (new SnapshotBuilder([], new StatementCounter($connection)))->build();
+
+        $this->assertSame(10, $snapshot['meta.db_statements']);
+    }
+
+    public function testDbStatementsIsOmittedWhenTheCounterIsUnavailable(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchAssociative')->willReturn(false);
+
+        $snapshot = (new SnapshotBuilder([], new StatementCounter($connection)))->build();
+
+        $this->assertArrayNotHasKey('meta.db_statements', $snapshot);
+    }
+
+    /**
+     * @param array<string, mixed> $metrics
+     */
+    private function collector(string $namespace, array $metrics): SnapshotCollectorInterface
+    {
+        return new class($namespace, $metrics) implements SnapshotCollectorInterface {
+            /**
+             * @param array<string, mixed> $metrics
+             */
+            public function __construct(
+                private readonly string $namespace,
+                private readonly array $metrics,
+            ) {
+            }
+
+            public function getNamespace(): string
+            {
+                return $this->namespace;
+            }
+
+            public function collect(): array
+            {
+                return $this->metrics;
+            }
+        };
+    }
+}

--- a/tests/Unit/Telemetry/SnapshotBuilderTest.php
+++ b/tests/Unit/Telemetry/SnapshotBuilderTest.php
@@ -19,6 +19,7 @@ use Pimcore\Telemetry\Snapshot\SnapshotBuilder;
 use Pimcore\Telemetry\Snapshot\SnapshotCollectorInterface;
 use Pimcore\Telemetry\Snapshot\StatementCounter;
 use Pimcore\Tests\Support\Test\TestCase;
+use TypeError;
 
 class SnapshotBuilderTest extends TestCase
 {
@@ -74,6 +75,36 @@ class SnapshotBuilderTest extends TestCase
         $snapshot = (new SnapshotBuilder([], new StatementCounter($connection)))->build();
 
         $this->assertSame(10, $snapshot['meta.db_statements']);
+    }
+
+    /**
+     * Collectors are a public extension point, and Maintenance\Executor only catches Exception - so
+     * an Error escaping a collector would abort the whole maintenance run, not just telemetry. The
+     * builder is the isolation boundary: a broken collector is logged and skipped, the healthy ones
+     * still report.
+     */
+    public function testOneFailingCollectorDoesNotLoseTheOthers(): void
+    {
+        $exploding = new class implements SnapshotCollectorInterface {
+            public function getNamespace(): string
+            {
+                return 'boom';
+            }
+
+            public function collect(): array
+            {
+                throw new TypeError('a defect inside a third-party collector');
+            }
+        };
+
+        $snapshot = (new SnapshotBuilder([
+            $exploding,
+            $this->collector('core', ['php_version' => '8.4.0']),
+        ]))->build();
+
+        $this->assertSame('8.4.0', $snapshot['core.php_version'], 'healthy collectors must still report');
+        $this->assertArrayNotHasKey('boom.anything', $snapshot);
+        $this->assertArrayHasKey('meta.duration_ms', $snapshot, 'the snapshot itself must still complete');
     }
 
     public function testDbStatementsIsOmittedWhenTheCounterIsUnavailable(): void

--- a/tests/Unit/Telemetry/SnapshotQueryRunnerTest.php
+++ b/tests/Unit/Telemetry/SnapshotQueryRunnerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Telemetry;
+
+use Pimcore\Telemetry\Snapshot\SnapshotQueryRunner;
+use Pimcore\Tests\Support\Test\TestCase;
+
+class SnapshotQueryRunnerTest extends TestCase
+{
+    public function testMariaDbWrapsWithSetStatementInSeconds(): void
+    {
+        $this->assertSame(
+            'SET STATEMENT max_statement_time=5 FOR SELECT COUNT(*) FROM objects',
+            SnapshotQueryRunner::buildTimeoutSql('SELECT COUNT(*) FROM objects', true, 5)
+        );
+    }
+
+    public function testMySqlInjectsMaxExecutionTimeHintInMilliseconds(): void
+    {
+        $this->assertSame(
+            'SELECT /*+ MAX_EXECUTION_TIME(5000) */ COUNT(*) FROM objects',
+            SnapshotQueryRunner::buildTimeoutSql('SELECT COUNT(*) FROM objects', false, 5)
+        );
+    }
+
+    public function testMySqlHintIsInjectedOnlyOnTheOutermostSelect(): void
+    {
+        // Only the leading SELECT is bounded; the subquery SELECT must stay untouched.
+        $this->assertSame(
+            'SELECT /*+ MAX_EXECUTION_TIME(2000) */ MAX(c) FROM (SELECT COUNT(*) c FROM objects GROUP BY parentId) t',
+            SnapshotQueryRunner::buildTimeoutSql(
+                'SELECT MAX(c) FROM (SELECT COUNT(*) c FROM objects GROUP BY parentId) t',
+                false,
+                2
+            )
+        );
+    }
+
+    public function testNonSelectStatementIsPassedThroughUnchanged(): void
+    {
+        $this->assertSame('UPDATE t SET x = 1', SnapshotQueryRunner::buildTimeoutSql('UPDATE t SET x = 1', true, 5));
+        $this->assertSame('UPDATE t SET x = 1', SnapshotQueryRunner::buildTimeoutSql('UPDATE t SET x = 1', false, 5));
+    }
+
+    public function testNonPositiveTimeoutDisablesTheCap(): void
+    {
+        $this->assertSame('SELECT 1', SnapshotQueryRunner::buildTimeoutSql('SELECT 1', true, 0));
+        $this->assertSame('SELECT 1', SnapshotQueryRunner::buildTimeoutSql('SELECT 1', false, -3));
+    }
+}

--- a/tests/Unit/Telemetry/SqlElementStatisticsProviderTest.php
+++ b/tests/Unit/Telemetry/SqlElementStatisticsProviderTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Telemetry;
+
+use Doctrine\DBAL\Connection;
+use Pimcore\Telemetry\Snapshot\SnapshotQueryRunner;
+use Pimcore\Telemetry\Snapshot\Statistics\ElementKind;
+use Pimcore\Telemetry\Snapshot\Statistics\SqlElementStatisticsProvider;
+use Pimcore\Tests\Support\Test\TestCase;
+use function str_contains;
+
+class SqlElementStatisticsProviderTest extends TestCase
+{
+    public function testTypeCountsAggregatesTheGroupByResult(): void
+    {
+        $counts = $this->provider()->typeCounts(ElementKind::Asset);
+
+        $this->assertSame(4, $counts->total());
+        $this->assertSame(3, $counts->ofType('image'));
+        $this->assertSame(0, $counts->ofType('video'));
+        $this->assertSame(2, $counts->distinctTypes());
+    }
+
+    public function testTreeDepthReadsTheCombinedMaxAvgScan(): void
+    {
+        $depth = $this->provider()->treeDepth(ElementKind::DataObject);
+
+        $this->assertSame(4, $depth->max);
+        $this->assertSame(2, $depth->avg); // round(2.0)
+    }
+
+    public function testVariantAndFanoutShape(): void
+    {
+        $provider = $this->provider();
+
+        $this->assertSame(2, $provider->objectsWithVariants());
+        $this->assertSame(3, $provider->maxVariantsPerObject());
+        $this->assertSame(50, $provider->maxObjectFanout());
+    }
+
+    private function provider(): SqlElementStatisticsProvider
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('quoteIdentifier')->willReturnArgument(0);
+        $connection->method('fetchAllKeyValue')->willReturn(['image' => 3, 'folder' => 1]);
+        $connection->method('fetchAssociative')->willReturn(['max_d' => 4, 'avg_d' => 2.0]);
+        $connection->method('fetchOne')->willReturnCallback(
+            static fn (string $sql): int => match (true) {
+                str_contains($sql, 'DISTINCT') => 2,                                  // objectsWithVariants
+                str_contains($sql, 'MAX(c)') && str_contains($sql, "'variant'") => 3, // maxVariantsPerObject
+                str_contains($sql, 'MAX(c)') => 50,                                   // maxObjectFanout
+                default => 0,
+            }
+        );
+
+        return new SqlElementStatisticsProvider(new SnapshotQueryRunner($connection, 0));
+    }
+}

--- a/tests/Unit/Telemetry/TelemetryOutboxServiceTest.php
+++ b/tests/Unit/Telemetry/TelemetryOutboxServiceTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Telemetry;
+
+use Pimcore\Telemetry\Crypto\EnvelopeCipher;
+use Pimcore\Telemetry\Spool\EncryptedBatch;
+use Pimcore\Telemetry\Spool\SpooledBatch;
+use Pimcore\Telemetry\Spool\TelemetrySpoolReaderInterface;
+use Pimcore\Telemetry\Spool\TelemetryOutboxService;
+use Pimcore\Tests\Support\Test\TestCase;
+
+class TelemetryOutboxServiceTest extends TestCase
+{
+    private const PRODUCT_KEY = 'product-key-outbox';
+
+    private const INSTANCE = 'inst-xyz';
+
+    /**
+     * @param list<array<string, mixed>> $events
+     */
+    private function reader(?SpooledBatch $batch, array &$acked = [], array &$released = []): TelemetrySpoolReaderInterface
+    {
+        return new class($batch, $acked, $released) implements TelemetrySpoolReaderInterface {
+            /**
+             * @param array<int, string> $acked
+             * @param array<int, string> $released
+             */
+            public function __construct(
+                private readonly ?SpooledBatch $batch,
+                private array &$acked,
+                private array &$released,
+            ) {
+            }
+
+            public function claim(int $limit = 500): ?SpooledBatch
+            {
+                return $this->batch;
+            }
+
+            public function ack(string $nonce): int
+            {
+                $this->acked[] = $nonce;
+
+                return 1;
+            }
+
+            public function release(string $nonce): int
+            {
+                $this->released[] = $nonce;
+
+                return 1;
+            }
+        };
+    }
+
+    public function testIsReadyRequiresInstanceIdAndProductKey(): void
+    {
+        $cipher = new EnvelopeCipher();
+        $this->assertTrue((new TelemetryOutboxService($this->reader(null), $cipher, self::INSTANCE, self::PRODUCT_KEY))->isReady());
+        $this->assertFalse((new TelemetryOutboxService($this->reader(null), $cipher, '', self::PRODUCT_KEY))->isReady());
+        $this->assertFalse((new TelemetryOutboxService($this->reader(null), $cipher, self::INSTANCE, ''))->isReady());
+    }
+
+    public function testNextBatchEncryptsClaimedEventsForTheRelay(): void
+    {
+        $cipher = new EnvelopeCipher();
+        $events = [
+            ['type' => 'capture', 'event' => 'object.created', 'properties' => ['element_type' => 'object'], 'eventUid' => 'u1'],
+        ];
+        $service = new TelemetryOutboxService($this->reader(new SpooledBatch('nonce-abc', $events)), $cipher, self::INSTANCE, self::PRODUCT_KEY);
+
+        $batch = $service->nextBatch();
+
+        $this->assertInstanceOf(EncryptedBatch::class, $batch);
+        $this->assertSame('nonce-abc', $batch->nonce);
+        $this->assertSame(self::INSTANCE, $batch->instanceIdentifier);
+        $this->assertSame(1, $batch->count);
+
+        $inner = $cipher->decrypt($batch->ciphertext, self::PRODUCT_KEY);
+        $this->assertSame(self::INSTANCE, $inner['instanceIdentifier']);
+        $this->assertIsInt($inner['ts']);
+        $this->assertSame($events, $inner['events']);
+    }
+
+    public function testNextBatchReturnsNullWhenSpoolEmpty(): void
+    {
+        $service = new TelemetryOutboxService($this->reader(null), new EnvelopeCipher(), self::INSTANCE, self::PRODUCT_KEY);
+
+        $this->assertNull($service->nextBatch());
+    }
+
+    public function testAckAndReleaseDelegateToTheSpool(): void
+    {
+        $acked = [];
+        $released = [];
+        $service = new TelemetryOutboxService(
+            $this->reader(new SpooledBatch('n', []), $acked, $released),
+            new EnvelopeCipher(),
+            self::INSTANCE,
+            self::PRODUCT_KEY,
+        );
+
+        $service->ack('nonce-1');
+        $service->release('nonce-2');
+
+        $this->assertSame(['nonce-1'], $acked);
+        $this->assertSame(['nonce-2'], $released);
+    }
+}

--- a/tests/Unit/Telemetry/TelemetrySnapshotTaskTest.php
+++ b/tests/Unit/Telemetry/TelemetrySnapshotTaskTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Telemetry;
+
+use Pimcore\Maintenance\Tasks\TelemetrySnapshotTask;
+use Pimcore\Telemetry\Snapshot\SnapshotBuilder;
+use Pimcore\Telemetry\Snapshot\TelemetrySnapshotStateInterface;
+use Pimcore\Telemetry\TelemetryInterface;
+use Pimcore\Tests\Support\Test\TestCase;
+
+class TelemetrySnapshotTaskTest extends TestCase
+{
+    private const INTERVAL = 3600;
+
+    private function telemetry(bool $enabled): TelemetryInterface
+    {
+        return new class($enabled) implements TelemetryInterface {
+            public int $flushes = 0;
+
+            /** @var list<string> */
+            public array $events = [];
+
+            public function __construct(private readonly bool $enabled)
+            {
+            }
+
+            public function isEnabled(): bool
+            {
+                return $this->enabled;
+            }
+
+            public function capture(string $event, array $properties = [], array $groups = []): void
+            {
+                $this->events[] = $event;
+            }
+
+            public function groupIdentify(string $type, string $key, array $properties): void
+            {
+            }
+
+            public function flush(): void
+            {
+                $this->flushes++;
+            }
+        };
+    }
+
+    private function state(?int $lastAt): TelemetrySnapshotStateInterface
+    {
+        return new class($lastAt) implements TelemetrySnapshotStateInterface {
+            public ?int $marked = null;
+
+            public function __construct(private readonly ?int $lastAt)
+            {
+            }
+
+            public function getLastSnapshotAt(): ?int
+            {
+                return $this->lastAt;
+            }
+
+            public function markSnapshotTaken(int $timestamp): void
+            {
+                $this->marked = $timestamp;
+            }
+        };
+    }
+
+    private function task(TelemetryInterface $telemetry, TelemetrySnapshotStateInterface $state): TelemetrySnapshotTask
+    {
+        return new TelemetrySnapshotTask($telemetry, new SnapshotBuilder([]), $state, 'inst-1', self::INTERVAL);
+    }
+
+    public function testProducesWhenNeverTakenBefore(): void
+    {
+        $telemetry = $this->telemetry(true);
+        $state = $this->state(null);
+
+        $this->task($telemetry, $state)->execute();
+
+        $this->assertSame(1, $telemetry->flushes);
+        $this->assertNotNull($state->marked);
+        $this->assertContains('instance.snapshot', $telemetry->events);
+    }
+
+    public function testThrottledWithinInterval(): void
+    {
+        $telemetry = $this->telemetry(true);
+        $state = $this->state(time() - 100);
+
+        $this->task($telemetry, $state)->execute();
+
+        $this->assertSame(0, $telemetry->flushes);
+        $this->assertNull($state->marked);
+    }
+
+    public function testProducesWhenStale(): void
+    {
+        $telemetry = $this->telemetry(true);
+        $state = $this->state(time() - (self::INTERVAL + 400));
+
+        $this->task($telemetry, $state)->execute();
+
+        $this->assertSame(1, $telemetry->flushes);
+        $this->assertNotNull($state->marked);
+    }
+
+    public function testNoOpWhenDisabled(): void
+    {
+        $telemetry = $this->telemetry(false);
+        $state = $this->state(null);
+
+        $this->task($telemetry, $state)->execute();
+
+        $this->assertSame(0, $telemetry->flushes);
+        $this->assertNull($state->marked);
+    }
+}

--- a/tests/Unit/Telemetry/TelemetrySpoolDrainTaskTest.php
+++ b/tests/Unit/Telemetry/TelemetrySpoolDrainTaskTest.php
@@ -49,8 +49,9 @@ class TelemetrySpoolDrainTaskTest extends TestCase
     public function testNoOpWhenOutboxNotReadyOrRelayNotConfigured(): void
     {
         $notReady = $this->outbox([$this->batch('n1', 'c1')], ready: false);
-        (new TelemetrySpoolDrainTask($notReady, $this->relay()))->execute();
-        $this->assertCount(0, $this->relay()->sent);
+        $relay = $this->relay();
+        (new TelemetrySpoolDrainTask($notReady, $relay))->execute();
+        $this->assertCount(0, $relay->sent, 'a not-ready outbox must not send anything');
         $this->assertSame([], $notReady->acked);
 
         $outbox = $this->outbox([$this->batch('n1', 'c1')]);

--- a/tests/Unit/Telemetry/TelemetrySpoolDrainTaskTest.php
+++ b/tests/Unit/Telemetry/TelemetrySpoolDrainTaskTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Telemetry;
+
+use Pimcore\Maintenance\Tasks\TelemetrySpoolDrainTask;
+use Pimcore\Telemetry\Relay\RelayClientInterface;
+use Pimcore\Telemetry\Spool\EncryptedBatch;
+use Pimcore\Telemetry\Spool\TelemetryOutboxInterface;
+use Pimcore\Tests\Support\Test\TestCase;
+
+class TelemetrySpoolDrainTaskTest extends TestCase
+{
+    public function testDrainsAllBatchesOnSuccessAndAcksEach(): void
+    {
+        $outbox = $this->outbox([$this->batch('n1', 'c1'), $this->batch('n2', 'c2')]);
+        $relay = $this->relay();
+
+        (new TelemetrySpoolDrainTask($outbox, $relay))->execute();
+
+        $this->assertSame(['n1', 'n2'], $outbox->acked);
+        $this->assertSame([], $outbox->released);
+        $this->assertCount(2, $relay->sent);
+    }
+
+    public function testReleasesFailedBatchAndStops(): void
+    {
+        $outbox = $this->outbox([$this->batch('n1', 'c1'), $this->batch('n2', 'FAIL'), $this->batch('n3', 'c3')]);
+        $relay = $this->relay('FAIL');
+
+        (new TelemetrySpoolDrainTask($outbox, $relay))->execute();
+
+        $this->assertSame(['n1'], $outbox->acked, 'only the first batch is acked');
+        $this->assertSame(['n2'], $outbox->released, 'the failed batch is released');
+        $this->assertCount(2, $relay->sent, 'drain stops after the failure and never reaches n3');
+    }
+
+    public function testNoOpWhenOutboxNotReadyOrRelayNotConfigured(): void
+    {
+        $notReady = $this->outbox([$this->batch('n1', 'c1')], ready: false);
+        (new TelemetrySpoolDrainTask($notReady, $this->relay()))->execute();
+        $this->assertCount(0, $this->relay()->sent);
+        $this->assertSame([], $notReady->acked);
+
+        $outbox = $this->outbox([$this->batch('n1', 'c1')]);
+        $unconfigured = $this->relay(configured: false);
+        (new TelemetrySpoolDrainTask($outbox, $unconfigured))->execute();
+        $this->assertSame([], $outbox->acked);
+    }
+
+    private function batch(string $nonce, string $ciphertext): EncryptedBatch
+    {
+        return new EncryptedBatch($nonce, 'inst', $ciphertext, 1);
+    }
+
+    /**
+     * @param list<EncryptedBatch> $batches
+     */
+    private function outbox(array $batches, bool $ready = true): TelemetryOutboxInterface
+    {
+        return new class($batches, $ready) implements TelemetryOutboxInterface {
+            /** @var array<int, string> */
+            public array $acked = [];
+
+            /** @var array<int, string> */
+            public array $released = [];
+
+            /** @param list<EncryptedBatch> $batches */
+            public function __construct(private array $batches, private readonly bool $ready)
+            {
+            }
+
+            public function isReady(): bool
+            {
+                return $this->ready;
+            }
+
+            public function nextBatch(): ?EncryptedBatch
+            {
+                return array_shift($this->batches);
+            }
+
+            public function ack(string $nonce): int
+            {
+                $this->acked[] = $nonce;
+
+                return 1;
+            }
+
+            public function release(string $nonce): int
+            {
+                $this->released[] = $nonce;
+
+                return 1;
+            }
+        };
+    }
+
+    private function relay(?string $failOnCiphertext = null, bool $configured = true): RelayClientInterface
+    {
+        return new class($failOnCiphertext, $configured) implements RelayClientInterface {
+            /** @var array<int, string> */
+            public array $sent = [];
+
+            public function __construct(private readonly ?string $failOnCiphertext, private readonly bool $configured)
+            {
+            }
+
+            public function isConfigured(): bool
+            {
+                return $this->configured;
+            }
+
+            public function send(string $instanceIdentifier, string $ciphertext): bool
+            {
+                $this->sent[] = $ciphertext;
+
+                return $ciphertext !== $this->failOnCiphertext;
+            }
+        };
+    }
+}

--- a/tests/Unit/Telemetry/TelemetryTest.php
+++ b/tests/Unit/Telemetry/TelemetryTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Telemetry;
+
+use Pimcore\Telemetry\EventSanitizer;
+use Pimcore\Telemetry\Spool\TelemetrySpoolWriterInterface;
+use Pimcore\Telemetry\Telemetry;
+use Pimcore\Tests\Support\Test\TestCase;
+use Psr\Log\NullLogger;
+use stdClass;
+
+// Records the events handed to the spool instead of persisting them.
+final class RecordingSpoolWriter implements TelemetrySpoolWriterInterface
+{
+    /** @var list<array<string, mixed>> */
+    public array $enqueued = [];
+
+    public function enqueue(array $events, ?int $cap = null): void
+    {
+        foreach ($events as $event) {
+            $this->enqueued[] = $event;
+        }
+    }
+}
+
+class TelemetryTest extends TestCase
+{
+    private const INSTANCE = 'instance-1';
+
+    private const PRODUCT_KEY = 'product-key-1';
+
+    public function testFlushPersistsBufferedEventsToTheSpool(): void
+    {
+        $spool = new RecordingSpoolWriter();
+        $telemetry = $this->telemetry($spool);
+
+        $telemetry->capture('object.created', ['element_type' => 'object']);
+        $this->assertSame([], $spool->enqueued, 'nothing is spooled before flush');
+
+        $telemetry->flush();
+
+        $this->assertCount(1, $spool->enqueued);
+        $this->assertSame('object.created', $spool->enqueued[0]['event']);
+        $this->assertSame(self::INSTANCE, $spool->enqueued[0]['groups']['instance']);
+    }
+
+    public function testFlushClearsTheBuffer(): void
+    {
+        $spool = new RecordingSpoolWriter();
+        $telemetry = $this->telemetry($spool);
+
+        $telemetry->capture('object.created');
+        $telemetry->flush();
+        $telemetry->flush();
+
+        $this->assertCount(1, $spool->enqueued);
+    }
+
+    public function testUnidentifiedInstanceSpoolsNothing(): void
+    {
+        $spool = new RecordingSpoolWriter();
+        $telemetry = new Telemetry('', self::PRODUCT_KEY, $spool, new NullLogger(), $this->sanitizer());
+
+        $this->assertFalse($telemetry->isEnabled());
+
+        $telemetry->capture('object.created');
+        $telemetry->flush();
+
+        $this->assertSame([], $spool->enqueued);
+    }
+
+    public function testMissingProductKeyDisablesTelemetry(): void
+    {
+        $spool = new RecordingSpoolWriter();
+        $telemetry = new Telemetry(self::INSTANCE, '', $spool, new NullLogger(), $this->sanitizer());
+
+        $this->assertFalse($telemetry->isEnabled());
+
+        $telemetry->capture('object.created');
+        $telemetry->flush();
+
+        $this->assertSame([], $spool->enqueued);
+    }
+
+    public function testObjectPropertiesNeverReachTheSpoolButScalarArraysDo(): void
+    {
+        $spool = new RecordingSpoolWriter();
+        $telemetry = $this->telemetry($spool);
+
+        $telemetry->capture('object.created', [
+            'element_type' => 'object',
+            'bundles' => ['PimcoreCoreBundle', 'PimcoreDataHubBundle'], // scalar array -> kept
+            'leaked_object' => new stdClass(),                          // object -> dropped
+        ]);
+        $telemetry->flush();
+
+        $this->assertSame(
+            ['element_type' => 'object', 'bundles' => ['PimcoreCoreBundle', 'PimcoreDataHubBundle']],
+            $spool->enqueued[0]['properties']
+        );
+    }
+
+    private function telemetry(TelemetrySpoolWriterInterface $spool): Telemetry
+    {
+        return new Telemetry(self::INSTANCE, self::PRODUCT_KEY, $spool, new NullLogger(), $this->sanitizer());
+    }
+
+    private function sanitizer(): EventSanitizer
+    {
+        return new EventSanitizer(new NullLogger());
+    }
+}


### PR DESCRIPTION
Part of https://github.com/pimcore/product-management/issues/1243

Adds server-side product telemetry: a content-never picture of how an installation is used, delivered to the first-party relay on the license server.

## Two collector types

**Snapshot (Layer 1)** — a structural census produced at most once per 24 h from tagged `SnapshotCollectorInterface` services: `core.*`, `pillars.*`, `datamodel.*`, `catalog.*`, `usage.*`, `meta.*`. Bundles contribute their own metrics without touching CoreBundle; `BundleUsageProviderInterface` lets a bundle report whether it is genuinely *used* rather than merely installed.

**Event (Layer 2)** — discrete actions captured via `TelemetryInterface::capture()` and buffered, never sent inline.

## Delivery

Transactional outbox. Events are spooled to `telemetry_spool`, encrypted per batch with the instance product key (AES-256-GCM, HKDF-SHA256), and forwarded by the maintenance job — or, for instances with no outbound access, by the Studio UI after login. A batch is deleted only once the relay confirms it; repeated failures are counted and dead-lettered so one undeliverable batch cannot block the outbox.

## Privacy

Everything emitted is behavior, structure, a count, a coarse bucket, a boolean, or Pimcore's own type identifiers — never names, paths, field values or customer content. `EventSanitizer` enforces it. The instance holds no PostHog key, and the browser that may carry a batch cannot read it. Reporting requires an identified instance **with a product key**, so unlicensed checkouts and CI runs are silent by construction.

There is no configuration node — the relay address, cadence and outbox bounds are fixed in `TelemetrySettings`.

## Performance

Collector queries are time-boxed per statement, so a structural aggregate on a large table degrades that one metric instead of stalling maintenance. Element sizes come from optimizer estimates rather than full scans, and the active-bundle list is resolved once per snapshot. On the demo instance a snapshot is ~100 ms / 59 statements.

## Schema

`telemetry_spool` is provisioned by `install.sql` (new installs) and by `Version20260720120000` (existing ones). It is never created at runtime.

## Review notes

- Depends on nothing else to merge, but the companion PRs in `studio-backend-bundle` and `studio-ui-bundle` build on the interfaces added here, so **merge this first**.
- Branch name still says `poc` — happy to rename before this leaves draft.