### PR TITLE
[Asset] Fix thumbnail status cache for ORIGINAL format thumbnails

### DIFF
--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -356,16 +356,16 @@ class Processor
                     $format = $image->getContentOptimizedFormat();
                 }
 
-                $tmpFsPath = File::getLocalTempFilePath($fileExtension);
-
-                $fileHandle = null;
-
                 if ($format === 'original') {
-                    $fileHandle = fopen($asset->getLocalFile(), 'rb');
+                    // the source file is streamed to the storage as-is, so it is also
+                    // the file the status cache entry below has to be built from
+                    $tmpFsPath = $asset->getLocalFile();
                 } else {
+                    $tmpFsPath = File::getLocalTempFilePath($fileExtension);
                     $image->save($tmpFsPath, $format, $config->getQuality());
-                    $fileHandle = fopen($tmpFsPath, 'rb');
                 }
+
+                $fileHandle = fopen($tmpFsPath, 'rb');
 
                 $storage->writeStream($storagePath, $fileHandle);
 
@@ -375,12 +375,7 @@ class Processor
 
                 if ($statusCacheEnabled && $asset instanceof Asset\Image) {
                     //update thumbnail dimensions to cache
-                    // for the 'original' format $tmpFsPath is never written, use the source file instead
-                    $asset->addThumbnailFileToCache(
-                        $format === 'original' ? $asset->getLocalFile() : $tmpFsPath,
-                        $filename,
-                        $config
-                    );
+                    $asset->addThumbnailFileToCache($tmpFsPath, $filename, $config);
                 }
 
                 if (!Config::exists($config->getName())) {

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -375,7 +375,12 @@ class Processor
 
                 if ($statusCacheEnabled && $asset instanceof Asset\Image) {
                     //update thumbnail dimensions to cache
-                    $asset->addThumbnailFileToCache($tmpFsPath, $filename, $config);
+                    // for the 'original' format $tmpFsPath is never written, use the source file instead
+                    $asset->addThumbnailFileToCache(
+                        $format === 'original' ? $asset->getLocalFile() : $tmpFsPath,
+                        $filename,
+                        $config
+                    );
                 }
 
                 if (!Config::exists($config->getName())) {

--- a/tests/Model/Asset/AssetThumbnailCacheTest.php
+++ b/tests/Model/Asset/AssetThumbnailCacheTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Tests\Model\Asset;
 
 use Pimcore\Bundle\CoreBundle\Controller\PublicServicesController;
+use Pimcore\Db;
 use Pimcore\Model\Asset;
 use Pimcore\Tests\Support\Test\TestCase;
 use Pimcore\Tests\Support\Util\TestHelper;
@@ -123,6 +124,42 @@ class AssetThumbnailCacheTest extends TestCase
         $thumbnailStorage->delete($pathReference['storagePath']);
         $this->assertNotNull($asset->getDao()->getCachedThumbnailModificationDate($thumbnailName, $thumbConfig->getFilename()));
         $this->assertFalse($thumbnailStorage->fileExists($pathReference['storagePath']));
+    }
+
+    /**
+     * Regression test for the ORIGINAL format: the processor streams the source
+     * file to the storage without writing the local temp path, but used to pass
+     * that never-written temp path to addThumbnailFileToCache(), so the status
+     * cache row was never created and every generation logged an error.
+     */
+    public function testOriginalFormatThumbnailWritesStatusCache(): void
+    {
+        /** @var Asset\Image $asset */
+        $asset = $this->testAsset;
+
+        $thumbConfig = TestHelper::createThumbnailConfigurationOriginalFormat();
+        $thumbnailName = $thumbConfig->getName();
+
+        $thumb = $asset->getThumbnail($thumbnailName);
+        $asset->clearThumbnails(true);
+        $this->assertNull($asset->getDao()->getCachedThumbnailModificationDate($thumbnailName, $thumb->getFilename()));
+
+        //create thumbnail
+        $thumb->getPath(['deferredAllowed' => false]);
+
+        $this->assertTrue(Storage::get('thumbnail')->fileExists($thumb->getPathReference(true)['storagePath']));
+        $this->assertNotNull($asset->getDao()->getCachedThumbnailModificationDate($thumbnailName, $thumb->getFilename()));
+
+        //ORIGINAL is a passthrough of the source file, so the cached dimensions
+        //and file size must be those of the source
+        $cacheRow = Db::get()->fetchAssociative(
+            'SELECT filesize, width, height FROM assets_image_thumbnail_cache WHERE cid = ? AND name = ? AND filename = ?',
+            [$asset->getId(), $thumbnailName, $thumb->getFilename()]
+        );
+        $this->assertNotFalse($cacheRow);
+        $this->assertSame($asset->getFileSize(), (int) $cacheRow['filesize']);
+        $this->assertSame($asset->getWidth(), (int) $cacheRow['width']);
+        $this->assertSame($asset->getHeight(), (int) $cacheRow['height']);
     }
 
     /**

--- a/tests/Support/Util/TestHelper.php
+++ b/tests/Support/Util/TestHelper.php
@@ -873,6 +873,24 @@ class TestHelper
     /**
      * @throws Exception
      */
+    public static function createThumbnailConfigurationOriginalFormat(): Asset\Image\Thumbnail\Config
+    {
+        $name = 'assettest_original_format';
+        $pipe = Asset\Image\Thumbnail\Config::getByName($name);
+        if (!$pipe) {
+            $pipe = new Asset\Image\Thumbnail\Config();
+            $pipe->setName($name);
+            $pipe->setFormat('ORIGINAL');
+            $pipe->save(true);
+            self::$thumbnail_configs[] = $name;
+        }
+
+        return $pipe;
+    }
+
+    /**
+     * @throws Exception
+     */
     public static function createThumbnailConfigurationRotate(int $angle = 90): Asset\Image\Thumbnail\Config
     {
         $name = 'assettest_rotate_' . $angle;


### PR DESCRIPTION
## Changes in this pull request
Resolves pimcore/platform-version#300

For thumbnail configs with format **ORIGINAL**, `Processor::process()` streams the source file directly to the thumbnail storage and never writes the temp path composed by `File::getLocalTempFilePath()` (which only builds a path, it creates no file). That non-existent path was still passed to `Asset::addThumbnailFileToCache()`, so:

- every generation logged `pimcore.ERROR: Unable to load image /…/var/tmp/temp-file-…: … No such file or directory` (from the Imagick fallback in `addThumbnailFileToCache()`), and
- the `assets_image_thumbnail_cache` row was never written, so every deferred path lookup for such thumbnails falls back to a storage `lastModified()` round-trip instead of the status cache — noticeable with remote (e.g. S3) thumbnail storage.

This PR passes the asset's local file to `addThumbnailFileToCache()` in the `'original'` case. Since the `original` format is a passthrough of the source file, the source file has exactly the dimensions and file size that belong in the cache entry.

### How to reproduce

1. Create an image thumbnail definition with **Format: ORIGINAL** (an empty transformation pipeline reproduces it too).
2. Generate it non-deferred for any image asset: `bin/console pimcore:thumbnails:image --id=<assetId> --thumbnails=<configName> --force`.
3. Before this fix: the ERROR above is logged and `assets_image_thumbnail_cache` gets no row for the config. After: no error, and the row is written with the source file's dimensions/size.

## Additional info
Full analysis in pimcore/platform-version#300.
