### PR TITLE
Fix workflow checkbox additional-field value always evaluating to false

### DIFF
--- a/lib/Workflow/EventSubscriber/NotesSubscriber.php
+++ b/lib/Workflow/EventSubscriber/NotesSubscriber.php
@@ -210,7 +210,7 @@ class NotesSubscriber implements EventSubscriberInterface
         $data = $additional[$fieldConfig['name']];
 
         if ($fieldConfig['fieldType'] === 'checkbox') {
-            return $data === 'true';
+            return is_bool($data) ? $data : $data === 'true';
         }
 
         return $data;

--- a/tests/Unit/Models/Workflow/EventSubscriber/NotesSubscriberTest.php
+++ b/tests/Unit/Models/Workflow/EventSubscriber/NotesSubscriberTest.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\Workflow\EventSubscriber;
+
+use Pimcore\Tests\Support\Test\TestCase;
+use Pimcore\Workflow\EventSubscriber\NotesSubscriber;
+use ReflectionMethod;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class NotesSubscriberTest extends TestCase
+{
+    /**
+     * Regression: getAdditionalDataForField() compared checkbox values with a strict
+     * `=== 'true'` string check. Callers that hydrate additional-field values as native
+     * booleans (rather than the legacy form-encoded strings) send a real `true`, which never
+     * matched the string comparison, so a checked "required" checkbox was always read back
+     * as false and the transition could never be submitted.
+     */
+    public function testCheckboxFieldAcceptsNativeBooleanTrue(): void
+    {
+        $result = $this->getAdditionalDataForCheckbox(true);
+
+        $this->assertTrue($result);
+    }
+
+    public function testCheckboxFieldAcceptsNativeBooleanFalse(): void
+    {
+        $result = $this->getAdditionalDataForCheckbox(false);
+
+        $this->assertFalse($result);
+    }
+
+    public function testCheckboxFieldStillAcceptsLegacyStringTrue(): void
+    {
+        $result = $this->getAdditionalDataForCheckbox('true');
+
+        $this->assertTrue($result);
+    }
+
+    public function testCheckboxFieldStillAcceptsLegacyStringFalse(): void
+    {
+        $result = $this->getAdditionalDataForCheckbox('false');
+
+        $this->assertFalse($result);
+    }
+
+    private function getAdditionalDataForCheckbox(mixed $rawValue): mixed
+    {
+        $subscriber = new NotesSubscriber($this->createStub(TranslatorInterface::class));
+        $subscriber->setAdditionalData([
+            'additional' => [
+                'marketingInvolved' => $rawValue,
+            ],
+        ]);
+
+        $method = new ReflectionMethod($subscriber, 'getAdditionalDataForField');
+        $method->setAccessible(true);
+
+        return $method->invoke($subscriber, [
+            'name' => 'marketingInvolved',
+            'fieldType' => 'checkbox',
+            'title' => 'Please confirm that Marketing was sufficiently involved',
+            'required' => true,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- `NotesSubscriber::getAdditionalDataForField()` compared workflow-transition "additional field" checkbox values with a strict `=== 'true'` string check.
- Callers that hydrate additional-field values as native PHP booleans send a real `true`/`false`, which never matches the string comparison, so a checked, `required: true` checkbox was always read back as `false` and the transition could never be submitted (`empty($data)` was always true).
- Fix: when the raw value is already a boolean, return it as-is; otherwise keep the existing string comparison for legacy form-encoded submissions.

resolves https://github.com/pimcore/platform-version/issues/175

## Test plan
- [x] Added `tests/Unit/Models/Workflow/EventSubscriber/NotesSubscriberTest.php` covering native boolean `true`/`false` and legacy string `'true'`/`'false'` checkbox values via the existing reflection-based private-method test pattern used elsewhere in this suite.
- [ ] CI (Codeception) — not run locally, relying on CI for full validation.

Co-Authored-By: Claude <noreply@anthropic.com>