### PR TITLE
Fix workflow support strategy crashing on a blank expression

### DIFF
--- a/lib/Workflow/SupportStrategy/ExpressionSupportStrategy.php
+++ b/lib/Workflow/SupportStrategy/ExpressionSupportStrategy.php
@@ -49,6 +49,10 @@ class ExpressionSupportStrategy implements WorkflowSupportStrategyInterface
             return false;
         }
 
+        if ($this->expression === '') {
+            return true;
+        }
+
         $ret = $this->expressionService->evaluateExpression($workflow, $subject, $this->expression);
 
         return filter_var($ret, FILTER_VALIDATE_BOOL) ? (bool)$ret : false;

--- a/tests/Unit/Models/Workflow/SupportStrategy/ExpressionSupportStrategyTest.php
+++ b/tests/Unit/Models/Workflow/SupportStrategy/ExpressionSupportStrategyTest.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\Workflow\SupportStrategy;
+
+use Pimcore\Tests\Support\Test\TestCase;
+use Pimcore\Workflow\ExpressionService;
+use Pimcore\Workflow\SupportStrategy\ExpressionSupportStrategy;
+use stdClass;
+use Symfony\Component\Workflow\WorkflowInterface;
+
+class ExpressionSupportStrategyTest extends TestCase
+{
+    /**
+     * Regression: supports() unconditionally evaluated the configured expression, even when
+     * it was blank. Symfony's ExpressionLanguage throws a syntax error when parsing an empty
+     * string, which propagated out of the workflow registry lookup and broke every action on
+     * the workflow instead of the support strategy simply falling back to matching on class
+     * alone.
+     */
+    public function testSupportsDoesNotEvaluateBlankExpression(): void
+    {
+        $expressionService = $this->createMock(ExpressionService::class);
+        $expressionService->expects($this->never())->method('evaluateExpression');
+
+        $strategy = new ExpressionSupportStrategy($expressionService, stdClass::class, '');
+
+        $result = $strategy->supports($this->createStub(WorkflowInterface::class), new stdClass());
+
+        $this->assertTrue($result);
+    }
+
+    public function testSupportsReturnsFalseForUnsupportedClassEvenWithBlankExpression(): void
+    {
+        $expressionService = $this->createMock(ExpressionService::class);
+        $expressionService->expects($this->never())->method('evaluateExpression');
+
+        $strategy = new ExpressionSupportStrategy($expressionService, self::class, '');
+
+        $result = $strategy->supports($this->createStub(WorkflowInterface::class), new stdClass());
+
+        $this->assertFalse($result);
+    }
+
+    public function testSupportsStillEvaluatesNonBlankExpression(): void
+    {
+        $expressionService = $this->createMock(ExpressionService::class);
+        $expressionService->expects($this->once())
+            ->method('evaluateExpression')
+            ->willReturn(false);
+
+        $strategy = new ExpressionSupportStrategy($expressionService, stdClass::class, 'subject.foo == "bar"');
+
+        $result = $strategy->supports($this->createStub(WorkflowInterface::class), new stdClass());
+
+        $this->assertFalse($result);
+    }
+}


### PR DESCRIPTION
## Summary
- Applying (or even just listing) actions on a workflow configured with a `support_strategy` of type `expression` whose expression argument is blank fails with an error such as `Submitting action <transition> failed: Unexpected token "end of expression" of value "" around position 1.`
- Root cause: `ExpressionSupportStrategy::supports()` always forwards the configured expression straight to the `ExpressionLanguage` evaluator. Evaluating an empty string throws a syntax error, which surfaces out of the workflow registry lookup and breaks every action on the workflow — not just the one being submitted.
- Every other guard/condition check in this subsystem (`PlaceConfig`, `NotesSubscriber`'s sibling `NotificationSubscriber`, and `GlobalAction::isGuardValid()`) already treats a blank expression as "no restriction" and skips evaluation. `ExpressionSupportStrategy` was the one holdout.
- Fix: when the expression is an empty string, `supports()` now returns `true` (i.e. defers to the class check alone) instead of evaluating it.

## Test plan
- [x] Added `tests/Unit/Models/Workflow/SupportStrategy/ExpressionSupportStrategyTest.php`: asserts a blank expression is never passed to the expression evaluator and the strategy still matches on class, asserts an unsupported class is still rejected without evaluating, and asserts a non-blank expression is still evaluated as before.
- [ ] CI (Codeception) — not run locally, relying on CI for full validation.

Co-Authored-By: Claude <noreply@anthropic.com>