### PR TITLE
[Bug] Make the dateRange block assertion independent of the Carbon major

### DIFF
--- a/tests/Model/DataType/BlockTest.php
+++ b/tests/Model/DataType/BlockTest.php
@@ -253,10 +253,15 @@ class BlockTest extends ModelTestCase
         $reloaded = DataObject::getById($object->getId(), ['force' => true]);
         $loaded = $reloaded->getTestblock()[0]['blockdateRange']->getData();
 
-        // DatePeriod, not CarbonPeriod: the deep copy on the load path runs myclabs/deep-copy's
-        // DatePeriodFilter, which rebuilds any DatePeriod subclass as a plain DatePeriod. That
-        // downgrade is pre-existing and unrelated to the unserialize behaviour asserted here.
-        $this->assertInstanceOf(DatePeriod::class, $loaded);
+        // The concrete class depends on the Carbon major, which is not pinned (^2.72 || ^3.10):
+        // Carbon 3's CarbonPeriod extends DatePeriod, so the deep copy on the load path runs
+        // myclabs/deep-copy's DatePeriodFilter and rebuilds it as a plain DatePeriod; Carbon 2's
+        // CarbonPeriod does not, so it stays a CarbonPeriod. Both are fine and neither is what this
+        // test is about - assert the period survived with its bounds instead.
+        $this->assertTrue(
+            $loaded instanceof DatePeriod || $loaded instanceof CarbonPeriod,
+            'expected a date period, got ' . get_debug_type($loaded)
+        );
         $this->assertSame($dateRange->getStartDate()->getTimestamp(), $loaded->getStartDate()->getTimestamp());
         $this->assertSame($dateRange->getEndDate()->getTimestamp(), $loaded->getEndDate()->getTimestamp());
     }


### PR DESCRIPTION
Follow-up to #19345, test-only.

`BlockTest::testDateRangeInsideBlock` asserted the loaded value is a `DatePeriod`. That only holds on
**Carbon 3**, whose `CarbonPeriod` extends `DatePeriod` — so the deep copy on the load path runs
`myclabs/deep-copy`'s `DatePeriodFilter` and rebuilds it as a plain `DatePeriod`. **Carbon 2**'s
`CarbonPeriod` does not extend `DatePeriod`, so it stays a `CarbonPeriod` and the assertion fails.

`nesbot/carbon` is constrained to `^2.72 || ^3.10.0` on this line, so both majors are legitimate
installs. CI happened to resolve 3.x, so the fragility was latent. It surfaced on the 11.5 LTS
backport (pimcore/ee-pimcore#1051), which pins `^2.72`:

```
Failed asserting that Carbon\CarbonPeriod Object (...) is an instance of class "DatePeriod".
```

The concrete class is not what the test is about. It now accepts either period type and asserts the
bounds survived — which is the behaviour the regression test exists to guard (before #19345 this case
threw `InvalidPeriodParameterException` during `save()`).

Verified on both majors: green with Carbon 3.13.1 (this line and ee-pimcore 12.3) and with Carbon
2.73.0 (ee-pimcore 11.5).

Co-Authored-By: Claude <noreply@anthropic.com>
