### PR TITLE
Fix grid column configuration for workspaces allowing the main layout

### DIFF
--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -817,6 +817,13 @@ class Service extends Model\Element\Service
         foreach ($permissionList as $permissionSet) {
             $allowedLayoutIds = self::getLayoutPermissions($classId, $permissionSet);
             if (is_array($allowedLayoutIds)) {
+                // layout id 0 is the class' main layout, i.e. the user is not restricted to custom
+                // layouts - same as in getValidLayouts(). The grid must not be reduced to the
+                // intersection of the remaining custom layouts then.
+                if (isset($allowedLayoutIds[0])) {
+                    return null;
+                }
+
                 foreach ($allowedLayoutIds as $allowedLayoutId) {
                     if ($allowedLayoutId) {
                         if (!isset($layoutDefinitions[$allowedLayoutId])) {

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -821,7 +821,7 @@ class Service extends Model\Element\Service
                 // layouts - same as in getValidLayouts(). The grid must not be reduced to the
                 // intersection of the remaining custom layouts then.
                 if (isset($allowedLayoutIds[0])) {
-                    return null;
+                    continue;
                 }
 
                 foreach ($allowedLayoutIds as $allowedLayoutId) {


### PR DESCRIPTION
Fixes pimcore/platform-version#312

## Problem

`DataObject\Service::getCustomGridFieldDefinitions()` reduces the grid columns to the intersection of the custom layouts a workspace allows. Layout id `0` denotes the class' main layout, i.e. "not restricted to a custom layout" — `getValidLayouts()` treats it exactly that way (`models/DataObject/Service.php:617`):

```php
if (!$layoutPermissions || isset($layoutPermissions[0])) {
    $isMainAllowed = true;
}
```

`getCustomGridFieldDefinitions()` never reaches that case. `getLayoutPermissions()` stores the layout id as the value (`$layoutPermissions[$l] = $l`), and the loop guards on truthiness, so `"0"` is skipped:

```php
foreach ($allowedLayoutIds as $allowedLayoutId) {
    if ($allowedLayoutId) {   // <-- "0" never gets here
```

For a workspace that grants the main layout **plus** N per-department custom layouts, the column set therefore becomes the intersection of those N layouts. With non-overlapping layouts that intersection is empty, so `$mergedFieldDefinition` ends up with zero fields and non-admin users get system columns only in the grid and filter configuration — while edit mode renders the full main layout for the same objects.

## Fix

Return `null` (unrestricted, same as for admins) as soon as layout id `0` is among the allowed ids, before the intersection is built. This aligns `getCustomGridFieldDefinitions()` with `getValidLayouts()`.

The change is strictly narrowing in scope: it only affects permission sets that contain layout id `0`, which previously produced a wrong (too small) column set. Workspaces that allow only custom layouts are unaffected.

## Verification

Verified on an instance with a class whose main layout is granted as `<class>_0` alongside 24 per-department custom layouts on one workspace, for a non-admin role:

```
before: mergedFieldDefinition: 0 fields   ->  0 grid columns from class fields
after:  mergedFieldDefinition: null       ->  196 grid columns from class fields
```

Admins are unaffected (early return above), and a workspace granting only custom layouts still yields the intersection of those layouts.

## Notes

- No test added: `getCustomGridFieldDefinitions()` needs a persisted object, class definition and workspace rows, and there is currently no test covering `getCustomGridFieldDefinitions()` / `getValidLayouts()` / `getLayoutPermissions()` to extend. Happy to add one if you point me at the preferred place.
- Related but deliberately out of scope: when a workspace allows several custom layouts but *not* the main layout, the columns remain the intersection of those layouts, which is usually near-empty. A union would arguably be the expected behaviour — separate topic, can be a separate issue.
