### PR TITLE
[Document Editor] Deprecate height option of the multiselect editable

### DIFF
--- a/doc/01_Documents/02_Templates/03_Editables/22_Multiselect.md
+++ b/doc/01_Documents/02_Templates/03_Editables/22_Multiselect.md
@@ -11,12 +11,12 @@ The Multiselect editable generates a **multiselect** box component in editmode.
 
 ## Configuration
 
-| Name     | Type    | Description                                                                        |
-|----------|---------|------------------------------------------------------------------------------------|
-| `store`  | array   | Key/Value pairs for the available options.                                         |
-| `width`  | integer | Width of a generated block in editmode                                             |
-| `height` | integer | Height of a generated block in editmode                                            |
-| `class`  | string  | A CSS class that is added to the surrounding container of this element in editmode |
+| Name     | Type    | Description                                                                                                                         |
+|----------|---------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `store`  | array   | Key/Value pairs for the available options.                                                                                          |
+| `width`  | integer | Width of a generated block in editmode                                                                                              |
+| `height` | integer | **Deprecated since 2026.2.9, no longer has any effect.** Height of a generated block in editmode. Not interpreted by the Studio UI. |
+| `class`  | string  | A CSS class that is added to the surrounding container of this element in editmode                                                  |
 
 ## Methods
 
@@ -34,7 +34,6 @@ Also, it shows the list of chosen elements in the frontend.
 {% if editmode %}
     {{ pimcore_multiselect("categories", {
         "width": 200,
-        "height": 100,
         "store": [
             ["cars", "Cars"],
             ["motorcycles", "Motorcycles"],

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,5 +1,14 @@
 # Upgrade Notes
 
+## Pimcore 2026.2.9
+
+### Deprecations
+
+#### [Document Editor]
+
+The `height` option of the `multiselect` document editable is deprecated and no longer has any effect.
+The Studio UI does not interpret it — the field is sized via `width` only.
+
 ## Pimcore 2026.2.7
 
 ### Possible data loss on 11.5.21, 12.3.12, 12.3.13, 2026.2.5 and 2026.2.6


### PR DESCRIPTION
## Changes in this pull request

Deprecates the `height` configuration option of the `multiselect` document editable.

The option has no effect. No core code reads it — `Multiselect` never calls `getConfig()`, and the only config key core interprets generically is `class`, in `Editable::getEditmodeElementClasses()` (`models/Document/Editable.php:245`); everything else is passed through verbatim to the frontend via `getEditmodeDefinition()` (`models/Document/Editable.php:164`). On the Studio side, `MultiSelectEditableDefinition` accepts `store`, `width` and `class` only. It was an ExtJS-era option that became inert with the classic admin UI removal.

Two files, documentation only:

- `doc/01_Documents/02_Templates/03_Editables/22_Multiselect.md` — `height` marked deprecated in the config table; removed from the Twig example so it stops being copied.
- `doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md` — new `## Pimcore 2026.2.9` → `### Deprecations` → `#### [Document Editor]` note.

## Additional info

**No runtime deprecation is triggered, deliberately.** For this option there is no method, property or signature to attach `trigger_deprecation()` to — `height` is only ever an array key in a template-supplied config array that nothing reads. Warning about it would mean adding a `setConfig()` override to `Multiselect` purely to announce the absence of code, firing on every render, with no migration available beyond deleting a key whose removal changes nothing. This differs from #19187, where `EditableDialogBoxConfiguration::$width/$height` are real properties with setters slated for actual removal.

For the same reason the note does not promise a removal version — there is nothing to remove.

**Scope:** `multiselect` only. Every other editable that documents `height` (textarea, wysiwyg, embed, relations, video, image, pdf, snippet, renderlet) does declare it in its Studio config type, so those options are not dead. Issue #1654's title says "options" plural while its body lists only this one; if more are added, the docs-only approach is worth revisiting.

**Verification:** documentation change with nothing executable, so no suite was run — the diff is the verification. The code claims above were checked by reading the files cited.

**Target branch:** opened against `2026.2` per request; a `2026.2` → `2026.x` forward-merge is still outstanding. Worth confirming `2026.2.9` is the right version — the newest tag is `v2026.2.6` and the upgrade-notes file has no `2026.2.8` section, so this note now sits above `2026.2.7`.

Refs pimcore/studio-ui-bundle#1654

🤖 Generated with [Claude Code](https://claude.com/claude-code)