### PR TITLE
Drop the composer-check matrix leg for the non-existent 11.5 branch

### DIFF
--- a/.github/workflows/composer-checks-outdated-monthly.yaml
+++ b/.github/workflows/composer-checks-outdated-monthly.yaml
@@ -17,6 +17,7 @@ jobs:
             matrix:
                 include:
                     - { php-version: 8.5, branch: 2026.x }
+                    - { php-version: 8.5, branch: 2026.2 }
                     - { php-version: 8.4, branch: 12.3 }
         with:
             php-version: ${{ matrix.php-version }}

--- a/.github/workflows/composer-checks-outdated-monthly.yaml
+++ b/.github/workflows/composer-checks-outdated-monthly.yaml
@@ -18,7 +18,6 @@ jobs:
                 include:
                     - { php-version: 8.5, branch: 2026.x }
                     - { php-version: 8.4, branch: 12.3 }
-                    - { php-version: 8.3, branch: 11.5 }
         with:
             php-version: ${{ matrix.php-version }}
             branch: ${{ matrix.branch }}

--- a/.github/workflows/composer-checks-outdated-monthly.yaml
+++ b/.github/workflows/composer-checks-outdated-monthly.yaml
@@ -17,7 +17,9 @@ jobs:
             matrix:
                 include:
                     - { php-version: 8.5, branch: 2026.x }
+                    - { php-version: 8.4, branch: 2026.x }
                     - { php-version: 8.5, branch: 2026.2 }
+                    - { php-version: 8.4, branch: 2026.2 }
                     - { php-version: 8.4, branch: 12.3 }
         with:
             php-version: ${{ matrix.php-version }}

--- a/.github/workflows/composer-checks-outdated.yaml
+++ b/.github/workflows/composer-checks-outdated.yaml
@@ -21,7 +21,6 @@ jobs:
                     - { php-version: 8.5, branch: 2026.2 }
                     - { php-version: 8.4, branch: 2026.2 }
                     - { php-version: 8.4, branch: 12.3 }
-                    - { php-version: 8.3, branch: 11.5 }
         with:
             php-version: ${{ matrix.php-version }}
             branch: ${{ matrix.branch }}

--- a/.github/workflows/static-analyisis-12x.yaml
+++ b/.github/workflows/static-analyisis-12x.yaml
@@ -47,7 +47,7 @@ jobs:
               with:
                 ref: "refs/pull/${{ github.event.pull_request.number }}/merge"
 
-            - name: Checkout 11.5 branch for scheduled runs
+            - name: Checkout 12.3 branch for scheduled runs
               if: github.event_name == 'schedule'
               uses: "actions/checkout@v5.0.1"
               with:


### PR DESCRIPTION
Both composer-outdated workflows include a matrix leg for branch `11.5`, which does not exist in this
repository (branches: `12.3`, `2026.2`, `2026.x`). The leg fails at checkout before any composer step
runs. That line is covered in `pimcore/ee-pimcore`, which has the branch.

- Remove `{ php-version: 8.3, branch: 11.5 }` from `composer-checks-outdated.yaml` and
  `composer-checks-outdated-monthly.yaml`
- Add `{ php-version: 8.5, branch: 2026.2 }` to the monthly minor check, which did not cover the current
  stable line
- Rename a step in `static-analyisis-12x.yaml` titled "Checkout 11.5 branch" that checks out `12.3`

Refs pimcore/DevOps-Tasks#30
