### PR TITLE
[security] GHSA-8v44-m977-ph86: ImageGallery still deserializes __hotspots with allowed_classes=true

### DIFF
--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,5 +1,35 @@
 # Upgrade Notes
 
+## Pimcore 2026.2.7
+
+### Possible data loss on 11.5.21, 12.3.12, 12.3.13, 2026.2.5 and 2026.2.6
+
+Those releases restricted object deserialization for two stores that legitimately contain PHP
+objects, so affected values were read back empty:
+
+- **`block` fields** — the child types `externalImage`, `consent`, `date`, `datetime`,
+  `structuredTable`, `hotspotimage`, `imageGallery` and `dateRange`, including inside a block
+  nested in `localizedfields`. A `dateRange` child raised
+  `Carbon\Exceptions\InvalidPeriodParameterException` on save.
+- **Document `image` editables** — hotspot and marker metadata, which made rendering a page with
+  such an editable fail with `Cannot use object of type __PHP_Incomplete_Class as array`.
+
+Reading was affected, so **saving an object or document while running one of those versions
+persisted the empty value**. A field marked mandatory blocked the save instead, which left the
+stored value intact.
+
+If you ran any of those versions, check the affected fields after upgrading. Versioning was not
+affected, so earlier values can be recovered from the element's version history.
+
+### WebDAV move failed on 12.3.7 and later
+
+Independently of the above, and over a wider range of releases (**12.3.7** and later, **2026.1.3**
+and later), replacing an asset over WebDAV failed when the client deleted the file and then moved
+the new one into place — the pattern used by several desktop applications, Photoshop among them.
+The move aborted with `The script tried to call a method on an incomplete object`.
+
+No data was lost in this case; the operation simply did not complete.
+
 ## Pimcore 12.3.12
 
 ### Deprecations

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,6 +1,6 @@
 # Upgrade Notes
 
-## Pimcore 2026.2.7
+## Pimcore 12.3.12.1
 
 ### Possible data loss on 11.5.21, 12.3.12, 12.3.13, 2026.2.5 and 2026.2.6
 

--- a/models/Asset/WebDAV/Service.php
+++ b/models/Asset/WebDAV/Service.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Model\Asset\WebDAV;
 
 use Pimcore\Model\Asset;
+use Pimcore\Tool\Serialize;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -26,13 +27,41 @@ class Service
         return PIMCORE_SYSTEM_TEMP_DIRECTORY . '/webdav-delete.dat';
     }
 
+    /**
+     * Rebuilds the asset that File::delete() stored in a delete-log entry, so Tree::move() can turn
+     * a third-party "delete then move" back into an overwrite of the existing asset.
+     *
+     * Object deserialization has to stay enabled here: the payload is a whole serialized Asset.
+     * Forbidding it yielded an __PHP_Incomplete_Class, which is truthy, so the caller's setData()
+     * call became fatal - see pimcore/platform-version#298 for the same defect in document
+     * editables.
+     *
+     * An allowlist is not viable either. The asset is serialized in dump state, where
+     * Asset::getBlockedVars() keeps `properties` and `children`, so the graph also holds Property
+     * objects (a `date` property carries a Carbon), further Asset objects, and the free-form
+     * `customSettings` array that bundles write into. Scoping this is tracked with the other
+     * permissive readers in pimcore/internal-improvements#24.
+     *
+     * Returns null when the payload does not rebuild into an Asset, so the caller can fall back
+     * instead of operating on an unusable value.
+     */
+    public static function restoreDeletedAsset(string $payload): ?Asset
+    {
+        $asset = Serialize::unserialize($payload, true);
+
+        return $asset instanceof Asset ? $asset : null;
+    }
+
     public static function getDeleteLog(): array
     {
         $log = [];
         if (file_exists(self::getDeleteLogFile())) {
             $raw = file_get_contents(self::getDeleteLogFile());
             if (is_string($raw)) {
-                $log = unserialize($raw, ['allowed_classes' => [Asset::class]]);
+                // The log itself is a plain array of scalars: each entry holds an id, a timestamp
+                // and the already-serialized asset as a string. The asset object is reconstructed
+                // one level down, in Tree::move(), against getDeleteLogAllowedClasses().
+                $log = unserialize($raw, ['allowed_classes' => false]);
             }
 
             if (!is_array($log)) {

--- a/models/Asset/WebDAV/Tree.php
+++ b/models/Asset/WebDAV/Tree.php
@@ -18,7 +18,6 @@ use Pimcore\Logger;
 use Pimcore\Model\Asset;
 use Pimcore\Model\Element;
 use Pimcore\Tool\Admin;
-use Pimcore\Tool\Serialize;
 use Sabre\DAV;
 use Sabre\DAV\Exception\Forbidden;
 
@@ -68,8 +67,12 @@ class Tree extends DAV\Tree
                 // see: Asset\WebDAV\File::delete() why this is necessary
                 $log = Asset\WebDAV\Service::getDeleteLog();
                 if (!$asset && array_key_exists('/' .$destinationPath, $log)) {
-                    $asset = Serialize::unserialize($log['/' . $destinationPath]['data'], false);
-                    if ($asset) {
+                    // Returns null when the payload does not rebuild into an Asset, so the fallback
+                    // below still resolves the source asset. See restoreDeletedAsset() for why the
+                    // payload needs object deserialization.
+                    $restored = Asset\WebDAV\Service::restoreDeletedAsset($log['/' . $destinationPath]['data']);
+                    if ($restored !== null) {
+                        $asset = $restored;
                         $sourceAsset = Asset::getByPath('/' . $sourcePath);
                         $asset->setData($sourceAsset->getData());
                     }

--- a/models/DataObject/ClassDefinition/Data/Block.php
+++ b/models/DataObject/ClassDefinition/Data/Block.php
@@ -170,7 +170,18 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
                 }, $data);
             }
 
-            $unserializedData = Serialize::unserialize($data, false);
+            // A block's resource blob legitimately contains PHP objects, so object deserialization
+            // must stay enabled here. Child values are written by getDataForResource() through the
+            // per-fieldtype block marshallers, several of which rebuild a value object before
+            // serializing (externalImage, consent, date/datetime, structuredTable), while types
+            // without a marshaller store their raw normalize() output, which can keep objects too
+            // (hotspotimage/imageGallery -> MarkerHotspotItem, dateRange -> Carbon). The set is not
+            // enumerable: bundles may register further block marshallers and field definitions.
+            // Restricting this to `false` silently dropped those values to null and corrupted
+            // hotspot metadata - see pimcore/platform-version#262.
+            // Tightening this is tracked in pimcore/internal-improvements#24 and needs the write
+            // side to stop storing live objects first.
+            $unserializedData = Serialize::unserialize($data, true);
             $result = [];
 
             foreach ($unserializedData as $blockElements) {

--- a/models/DataObject/ClassDefinition/Data/ImageGallery.php
+++ b/models/DataObject/ClassDefinition/Data/ImageGallery.php
@@ -139,7 +139,7 @@ class ImageGallery extends Data implements ResourcePersistenceAwareInterface, Qu
 
         $images = $data[$this->getName() . '__images'];
         $hotspots = $data[$this->getName() . '__hotspots'];
-        $hotspots = $hotspots ? Serialize::unserialize($hotspots, true) : [];
+        $hotspots = $hotspots ? Serialize::unserialize($hotspots, false) : [];
 
         if (!$images) {
             return $this->createEmptyImageGallery($params);

--- a/models/Document/Editable.php
+++ b/models/Document/Editable.php
@@ -722,7 +722,15 @@ abstract class Editable extends Model\AbstractModel implements Model\Document\Ed
             return $data;
         }
         if (is_string($data)) {
-            $unserializedData = Serialize::unserialize($data, false);
+            // An editable's resource blob legitimately contains PHP objects, so object
+            // deserialization must stay enabled here: Image::getDataForResource() persists its
+            // hotspot/marker metadata as Element\Data\MarkerHotspotItem instances, and bundle
+            // editables may store value objects of their own. Restricting this to `false` left
+            // __PHP_Incomplete_Class instances in the metadata, which made
+            // Image::getCacheTags() fatal - see pimcore/platform-version#298.
+            // Tightening this is tracked in pimcore/internal-improvements#24 and needs the write
+            // side to stop storing live objects first.
+            $unserializedData = Serialize::unserialize($data, true);
             if (!is_array($unserializedData) && !is_null($unserializedData)) {
                 throw new InvalidArgumentException('Unserialized data must be an array or null.');
             }

--- a/tests/Model/Asset/WebDavDeleteLogTest.php
+++ b/tests/Model/Asset/WebDavDeleteLogTest.php
@@ -1,0 +1,104 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\Asset;
+
+use Pimcore\Model\Asset;
+use Pimcore\Model\Asset\WebDAV\Service as WebDavService;
+use Pimcore\Model\Property;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+use Pimcore\Tests\Support\Util\TestHelper;
+use Pimcore\Tool\Serialize;
+
+/**
+ * Regression coverage for the WebDAV delete log, which Asset\WebDAV\File::delete() writes and
+ * Asset\WebDAV\Tree::move() reads to turn a third-party "delete then move" (how e.g. Photoshop
+ * saves) back into an overwrite of the existing asset.
+ *
+ * The entry's payload is a whole serialized Asset, so reading it needs object deserialization. With
+ * it forbidden the payload came back as __PHP_Incomplete_Class - which is truthy, so Tree::move()
+ * went on to call setData() on it and died with "The script tried to call a method on an incomplete
+ * object".
+ *
+ * @group model.asset.webdav
+ */
+class WebDavDeleteLogTest extends ModelTestCase
+{
+    public function tearDown(): void
+    {
+        $file = WebDavService::getDeleteLogFile();
+        if (file_exists($file)) {
+            unlink($file);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * The log array itself only ever holds scalars - the asset lives in it as an already-serialized
+     * string - which is why the outer read can forbid object deserialization.
+     */
+    public function testDeleteLogItselfHoldsThePayloadAsAString(): void
+    {
+        $asset = TestHelper::createImageAsset();
+        $path = $asset->getRealFullPath();
+
+        WebDavService::saveDeleteLog([
+            $path => ['id' => $asset->getId(), 'timestamp' => time(), 'data' => Serialize::serialize($asset)],
+        ]);
+
+        $log = WebDavService::getDeleteLog();
+
+        $this->assertArrayHasKey($path, $log);
+        $this->assertIsString($log[$path]['data']);
+        $this->assertSame($asset->getId(), $log[$path]['id']);
+    }
+
+    /**
+     * Writes the log the way File::delete() does, reads it back the way Tree::move() does, and
+     * checks the nested graph too: in dump state Asset::getBlockedVars() keeps `properties`, so the
+     * payload contains Property objects as well as the Asset itself.
+     */
+    public function testDeletedAssetSurvivesTheDeleteLogRoundTrip(): void
+    {
+        $asset = TestHelper::createImageAsset();
+        $asset->setProperty('webdavProbe', 'text', 'probeValue');
+        $asset->save();
+
+        $path = $asset->getRealFullPath();
+
+        // exactly what File::delete() persists
+        $asset->setInDumpState(true);
+        WebDavService::saveDeleteLog([
+            $path => ['id' => $asset->getId(), 'timestamp' => time(), 'data' => Serialize::serialize($asset)],
+        ]);
+        $asset->setInDumpState(false);
+
+        $log = WebDavService::getDeleteLog();
+        // the same call Tree::move() makes
+        $restored = WebDavService::restoreDeletedAsset($log[$path]['data']);
+
+        $this->assertInstanceOf(Asset\Image::class, $restored);
+        $this->assertSame($asset->getId(), $restored->getId());
+
+        // The nested Property objects must be intact - Asset::__wakeup() calls methods on them, so a
+        // neutralised Property is an immediate fatal rather than a silent loss.
+        $property = $restored->getProperties()['webdavProbe'] ?? null;
+        $this->assertInstanceOf(Property::class, $property);
+        $this->assertSame('probeValue', $property->getData());
+
+        // The frame that was fatal in Tree::move().
+        $restored->setData('some new binary content');
+        $this->assertSame('some new binary content', $restored->getData());
+    }
+}

--- a/tests/Model/DataType/BlockTest.php
+++ b/tests/Model/DataType/BlockTest.php
@@ -13,18 +13,26 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Model\DataType;
 
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
+use Carbon\CarbonPeriod;
+use DatePeriod;
 use Exception;
 use Pimcore\Cache;
 use Pimcore\Model\Asset\Image;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\Data\BlockElement;
+use Pimcore\Model\DataObject\Data\Consent;
+use Pimcore\Model\DataObject\Data\ExternalImage;
 use Pimcore\Model\DataObject\Data\Geobounds;
 use Pimcore\Model\DataObject\Data\GeoCoordinates;
 use Pimcore\Model\DataObject\Data\Hotspotimage;
 use Pimcore\Model\DataObject\Data\Link;
+use Pimcore\Model\DataObject\Data\StructuredTable;
 use Pimcore\Model\DataObject\Service;
 use Pimcore\Model\DataObject\unittestBlock;
 use Pimcore\Model\Document\Page;
+use Pimcore\Model\Element\Data\MarkerHotspotItem;
 use Pimcore\Tests\Support\Test\ModelTestCase;
 use Pimcore\Tests\Support\Util\TestHelper;
 
@@ -99,10 +107,9 @@ class BlockTest extends ModelTestCase
     }
 
     /**
-     * Every geo datatype must round-trip inside a Block. The block resource blob is read back via
-     * Block::getDataFromResource() -> Serialize::unserialize($data, false); this guards that the
-     * safe `false` there does not neutralise geo values (they are stored normalized, then rebuilt
-     * by each sub-field's denormalize()).
+     * Every geo datatype must round-trip inside a Block. Geo values are stored fully normalized
+     * (plain arrays / JSON) and rebuilt by each sub-field's denormalize(), so they are the subset
+     * of block child types that survives even a restricted unserialize().
      *
      * @throws Exception
      */
@@ -156,6 +163,195 @@ class BlockTest extends ModelTestCase
         $this->assertCount(2, $loadedPolyline);
         $this->assertContainsOnlyInstancesOf(GeoCoordinates::class, $loadedPolyline);
         $this->assertEqualsWithDelta(15.5, $loadedPolyline[1]->getLongitude(), 1e-6);
+    }
+
+    /**
+     * Regression test for pimcore/platform-version#262.
+     *
+     * Unlike geo values, several block child types are stored as *live PHP objects* inside the
+     * block's serialized resource blob: their block marshaller rebuilds a value object before
+     * Serialize::serialize() (externalImage, consent, date, datetime, structuredTable), or their
+     * normalize() keeps one (dateRange -> Carbon, via CarbonPeriod::toArray()).
+     *
+     * Block::getDataFromResource() must therefore allow object deserialization. Restricting it
+     * silently dropped every value below to null, and the next save persisted that loss.
+     *
+     * @throws Exception
+     */
+    public function testObjectValueTypesInsideBlock(): void
+    {
+        $externalImage = new ExternalImage('https://example.com/image.png');
+        $consent = new Consent(true, null);
+        $date = new Carbon('2026-03-04 00:00:00');
+        $dateTime = new Carbon('2026-05-06 07:08:09');
+
+        $structuredTable = new StructuredTable();
+        $structuredTable->setData([
+            'row1' => ['col1' => 42, 'col2' => 'first'],
+            'row2' => ['col1' => 43, 'col2' => 'second'],
+        ]);
+
+        $object = $this->createBlockObject();
+        $object->setTestblock([
+            [
+                'blockexternalImage' => new BlockElement('blockexternalImage', 'externalImage', $externalImage),
+                'blockconsent' => new BlockElement('blockconsent', 'consent', $consent),
+                'blockdate' => new BlockElement('blockdate', 'date', $date),
+                'blockdatetime' => new BlockElement('blockdatetime', 'datetime', $dateTime),
+                'blockstructuredTable' => new BlockElement('blockstructuredTable', 'structuredTable', $structuredTable),
+            ],
+        ]);
+        $object->save();
+
+        // Force-reload from the database so the block goes through the resource unserialize path.
+        $reloaded = DataObject::getById($object->getId(), ['force' => true]);
+        $data = $reloaded->getTestblock()[0];
+
+        $loadedExternalImage = $data['blockexternalImage']->getData();
+        $this->assertInstanceOf(ExternalImage::class, $loadedExternalImage);
+        $this->assertSame('https://example.com/image.png', $loadedExternalImage->getUrl());
+
+        $loadedConsent = $data['blockconsent']->getData();
+        $this->assertInstanceOf(Consent::class, $loadedConsent);
+        $this->assertTrue($loadedConsent->getConsent());
+
+        $loadedDate = $data['blockdate']->getData();
+        $this->assertInstanceOf(CarbonInterface::class, $loadedDate);
+        $this->assertSame($date->getTimestamp(), $loadedDate->getTimestamp());
+
+        $loadedDateTime = $data['blockdatetime']->getData();
+        $this->assertInstanceOf(CarbonInterface::class, $loadedDateTime);
+        $this->assertSame($dateTime->getTimestamp(), $loadedDateTime->getTimestamp());
+
+        $loadedStructuredTable = $data['blockstructuredTable']->getData();
+        $this->assertInstanceOf(StructuredTable::class, $loadedStructuredTable);
+        $this->assertSame('first', $loadedStructuredTable->getData()['row1']['col2']);
+    }
+
+    /**
+     * Regression test for pimcore/platform-version#262, kept separate because a dateRange fails
+     * louder than the rest: DateRange::normalize() returns CarbonPeriod::toArray(), i.e. an array
+     * of Carbon objects, and denormalize() feeds them straight back into CarbonPeriod::create().
+     * With object deserialization restricted, that threw InvalidPeriodParameterException during
+     * save instead of merely losing the value.
+     *
+     * @throws Exception
+     */
+    public function testDateRangeInsideBlock(): void
+    {
+        $dateRange = CarbonPeriod::create('2026-01-01', '2026-01-05');
+
+        $object = $this->createBlockObject();
+        $object->setTestblock([
+            [
+                'blockdateRange' => new BlockElement('blockdateRange', 'dateRange', $dateRange),
+            ],
+        ]);
+        $object->save();
+
+        $reloaded = DataObject::getById($object->getId(), ['force' => true]);
+        $loaded = $reloaded->getTestblock()[0]['blockdateRange']->getData();
+
+        // DatePeriod, not CarbonPeriod: the deep copy on the load path runs myclabs/deep-copy's
+        // DatePeriodFilter, which rebuilds any DatePeriod subclass as a plain DatePeriod. That
+        // downgrade is pre-existing and unrelated to the unserialize behaviour asserted here.
+        $this->assertInstanceOf(DatePeriod::class, $loaded);
+        $this->assertSame($dateRange->getStartDate()->getTimestamp(), $loaded->getStartDate()->getTimestamp());
+        $this->assertSame($dateRange->getEndDate()->getTimestamp(), $loaded->getEndDate()->getTimestamp());
+    }
+
+    /**
+     * Regression test for pimcore/platform-version#262, one nesting level deeper: a block inside
+     * localizedfields routes its children through BlockDataMarshaller\Localizedfields, which
+     * delegates to the same per-type block marshallers and therefore stores the same objects.
+     *
+     * @throws Exception
+     */
+    public function testObjectValueTypesInsideLocalizedBlock(): void
+    {
+        $externalImage = new ExternalImage('https://example.com/localized.png');
+        $date = new Carbon('2026-07-08 00:00:00');
+
+        $object = $this->createBlockObject();
+        $object->setLtestblock([
+            [
+                'lblockexternalImage' => new BlockElement('lblockexternalImage', 'externalImage', $externalImage),
+                'lblockdate' => new BlockElement('lblockdate', 'date', $date),
+            ],
+        ], 'en');
+        $object->save();
+
+        $reloaded = DataObject::getById($object->getId(), ['force' => true]);
+        $data = $reloaded->getLtestblock('en')[0];
+
+        $loadedExternalImage = $data['lblockexternalImage']->getData();
+        $this->assertInstanceOf(ExternalImage::class, $loadedExternalImage);
+        $this->assertSame('https://example.com/localized.png', $loadedExternalImage->getUrl());
+
+        $loadedDate = $data['lblockdate']->getData();
+        $this->assertInstanceOf(CarbonInterface::class, $loadedDate);
+        $this->assertSame($date->getTimestamp(), $loadedDate->getTimestamp());
+    }
+
+    /**
+     * Regression test for pimcore/platform-version#262 / #298.
+     *
+     * A hotspotimage has no block marshaller, so Block stores the raw normalize() output — which
+     * keeps the MarkerHotspotItem objects of its hotspot/marker metadata. Restricting the block
+     * unserialize left __PHP_Incomplete_Class instances buried inside the reconstructed value:
+     * denormalize() still returned a Hotspotimage, so the corruption stayed invisible until
+     * something accessed the metadata (see Document\Editable\Image::getCacheTags()).
+     *
+     * @throws Exception
+     */
+    public function testHotspotImageMetaDataInsideBlock(): void
+    {
+        $image = TestHelper::createImageAsset();
+
+        // Build it the way the editmode does: getDataFromEditmode() wraps each metadata entry in a
+        // MarkerHotspotItem, and those objects are what end up in the block's serialized blob.
+        $fieldDefinition = new DataObject\ClassDefinition\Data\Hotspotimage();
+        $fieldDefinition->setName('blockhotspotimage');
+        $hotspotImage = $fieldDefinition->getDataFromEditmode([
+            'id' => $image->getId(),
+            'hotspots' => [
+                [
+                    'name' => 'hotspot1',
+                    'width' => 10,
+                    'height' => 20,
+                    'top' => 30,
+                    'left' => 40,
+                    'data' => [
+                        ['name' => 'metaName', 'type' => 'text', 'value' => 'metaValue'],
+                    ],
+                ],
+            ],
+        ]);
+        $this->assertInstanceOf(Hotspotimage::class, $hotspotImage);
+        $this->assertInstanceOf(MarkerHotspotItem::class, $hotspotImage->getHotspots()[0]['data'][0]);
+
+        $object = $this->createBlockObject();
+        $object->setTestblock([
+            [
+                'blockhotspotimage' => new BlockElement('blockhotspotimage', 'hotspotimage', $hotspotImage),
+            ],
+        ]);
+        $object->save();
+
+        $reloaded = DataObject::getById($object->getId(), ['force' => true]);
+        $loaded = $reloaded->getTestblock()[0]['blockhotspotimage']->getData();
+
+        $this->assertInstanceOf(Hotspotimage::class, $loaded);
+
+        $metaData = $loaded->getHotspots()[0]['data'][0];
+        $this->assertNotInstanceOf(
+            '__PHP_Incomplete_Class',
+            $metaData,
+            'hotspot metadata must not be neutralised by the block resource unserialize()'
+        );
+        // MarkerHotspotItem is ArrayAccess; array access is exactly what broke on the stripped object.
+        $this->assertSame('metaName', $metaData['name']);
+        $this->assertSame('metaValue', $metaData['value']);
     }
 
     /**

--- a/tests/Model/DataType/BlockTest.php
+++ b/tests/Model/DataType/BlockTest.php
@@ -252,10 +252,15 @@ class BlockTest extends ModelTestCase
         $reloaded = DataObject::getById($object->getId(), ['force' => true]);
         $loaded = $reloaded->getTestblock()[0]['blockdateRange']->getData();
 
-        // DatePeriod, not CarbonPeriod: the deep copy on the load path runs myclabs/deep-copy's
-        // DatePeriodFilter, which rebuilds any DatePeriod subclass as a plain DatePeriod. That
-        // downgrade is pre-existing and unrelated to the unserialize behaviour asserted here.
-        $this->assertInstanceOf(DatePeriod::class, $loaded);
+        // The concrete class depends on the Carbon major, which is not pinned (^2.72 || ^3.10):
+        // Carbon 3's CarbonPeriod extends DatePeriod, so the deep copy on the load path runs
+        // myclabs/deep-copy's DatePeriodFilter and rebuilds it as a plain DatePeriod; Carbon 2's
+        // CarbonPeriod does not, so it stays a CarbonPeriod. Both are fine and neither is what this
+        // test is about - assert the period survived with its bounds instead.
+        $this->assertTrue(
+            $loaded instanceof DatePeriod || $loaded instanceof CarbonPeriod,
+            'expected a date period, got ' . get_debug_type($loaded)
+        );
         $this->assertSame($dateRange->getStartDate()->getTimestamp(), $loaded->getStartDate()->getTimestamp());
         $this->assertSame($dateRange->getEndDate()->getTimestamp(), $loaded->getEndDate()->getTimestamp());
     }

--- a/tests/Support/Helper/Document/TestDataHelper.php
+++ b/tests/Support/Helper/Document/TestDataHelper.php
@@ -38,6 +38,7 @@ use Pimcore\Model\Document\Editable\Video;
 use Pimcore\Model\Document\Editable\Wysiwyg;
 use Pimcore\Model\Document\Page;
 use Pimcore\Model\Document\PageSnippet;
+use Pimcore\Model\Element\Data\MarkerHotspotItem;
 use Pimcore\Tests\Support\Helper\AbstractTestDataHelper;
 use Pimcore\Tests\Support\Util\TestHelper;
 
@@ -114,6 +115,39 @@ class TestDataHelper extends AbstractTestDataHelper
 
         $expectedImage = $params['asset'];
         $this->assertEquals($expectedImage->getId(), $value->getId());
+
+        // Regression guard for pimcore/platform-version#298: hotspot/marker metadata is persisted
+        // as MarkerHotspotItem objects inside the editable's serialized data. A restricted
+        // unserialize() turned them into __PHP_Incomplete_Class, which then made
+        // Image::getCacheTags() fatal on `$metaData['value']`.
+        foreach (['hotspots' => $editable->getHotspots(), 'marker' => $editable->getMarker()] as $what => $entries) {
+            $this->assertNotEmpty($entries, sprintf('expected %s to be persisted', $what));
+            $metaData = $entries[0]['data'][0];
+            $this->assertInstanceOf(
+                MarkerHotspotItem::class,
+                $metaData,
+                sprintf('%s metadata must survive the editable resource unserialize()', $what)
+            );
+            $this->assertSame($what . 'MetaName' . $seed, $metaData['name']);
+            $this->assertSame($what . 'MetaValue' . $seed, $metaData['value']);
+        }
+
+        // The element-typed hotspot entry must still resolve to its Asset through MarkerHotspotItem's
+        // ArrayAccess, which only works while the object is intact.
+        $referenced = $params['referencedAsset'];
+        $metaAsset = $editable->getHotspots()[0]['data'][1];
+        $this->assertInstanceOf(MarkerHotspotItem::class, $metaAsset);
+        $this->assertSame('asset', $metaAsset['type']);
+        $this->assertInstanceOf(Asset::class, $metaAsset['value']);
+        $this->assertEquals($referenced->getId(), $metaAsset['value']->getId());
+
+        // getCacheTags() is the frame that crashed in #298. Note it does NOT collect tags from
+        // element-typed metadata: it calls get_object_vars() on the MarkerHotspotItem first, which
+        // bypasses the lazy id->element resolution in offsetGet(), so `$metaData['value']` is the
+        // raw id and the ElementInterface branch never fires. That gap predates this test (added in
+        // 0338170bb2, 2022) and is deliberately not asserted here.
+        $tags = $editable->getCacheTags($pagesnippet, []);
+        $this->assertArrayHasKey($params['asset']->getCacheTag(), $tags);
     }
 
     public function assertInput(PageSnippet $pagesnippet, string $field, int $seed = 1): void
@@ -407,11 +441,40 @@ class TestDataHelper extends AbstractTestDataHelper
     public function fillImage(Page $page, string $field, int $seed = 1, ?array &$returnData): void
     {
         $asset = TestHelper::createImageAsset();
+        // A second, unrelated asset referenced only from hotspot metadata. It is the sole source of
+        // its own cache tag, so assertImage() can prove the metadata was really traversed.
+        $referenced = TestHelper::createImageAsset();
         $editable = new Image();
         $editable->setName($field);
-        $editable->setDataFromEditmode(['id' => $asset->getId()]);
+        // Hotspot and marker metadata is what makes this editable store PHP objects
+        // (MarkerHotspotItem) in its resource blob - see assertImage(). The element-typed entry
+        // matters as well: Image::getCacheTags() only reaches into the metadata to collect tags
+        // from element-typed values, so a text-only fixture would not exercise that branch.
+        $editable->setDataFromEditmode([
+            'id' => $asset->getId(),
+            'hotspots' => [
+                [
+                    'name' => 'hotspot' . $seed,
+                    'top' => 10, 'left' => 20, 'width' => 30, 'height' => 40,
+                    'data' => [
+                        ['name' => 'hotspotsMetaName' . $seed, 'type' => 'text', 'value' => 'hotspotsMetaValue' . $seed],
+                        ['name' => 'hotspotsMetaAsset' . $seed, 'type' => 'asset', 'value' => $referenced->getFullPath()],
+                    ],
+                ],
+            ],
+            'marker' => [
+                [
+                    'name' => 'marker' . $seed,
+                    'top' => 50, 'left' => 60,
+                    'data' => [
+                        ['name' => 'markerMetaName' . $seed, 'type' => 'text', 'value' => 'markerMetaValue' . $seed],
+                    ],
+                ],
+            ],
+        ]);
         $returnData = [
             'asset' => $asset,
+            'referencedAsset' => $referenced,
         ];
         $page->setEditable($editable);
     }

--- a/tests/Support/Helper/Model.php
+++ b/tests/Support/Helper/Model.php
@@ -319,6 +319,25 @@ class Model extends AbstractDefinitionHelper
             $block->addChild($this->createDataChild('geopolygon', 'blockgeopolygon'));
             $block->addChild($this->createDataChild('geopolyline', 'blockgeopolyline'));
 
+            // Child types whose block representation legitimately contains PHP objects, either
+            // because their block marshaller rebuilds a value object or because normalize() keeps
+            // one. Covered by BlockTest::testObjectValueTypesInsideBlock().
+            $block->addChild($this->createDataChild('externalImage', 'blockexternalImage'));
+            $block->addChild($this->createDataChild('consent', 'blockconsent'));
+            $block->addChild($this->createDataChild('date', 'blockdate'));
+            $block->addChild($this->createDataChild('datetime', 'blockdatetime'));
+            $block->addChild($this->createDataChild('dateRange', 'blockdateRange'));
+            $block->addChild($this->createDataChild('structuredTable', 'blockstructuredTable')
+                ->setCols([
+                    ['position' => 1, 'key' => 'col1', 'type' => 'number', 'label' => 'collabel1'],
+                    ['position' => 2, 'key' => 'col2', 'type' => 'text', 'label' => 'collabel2'],
+                ])
+                ->setRows([
+                    ['position' => 1, 'key' => 'row1', 'label' => 'rowlabel1'],
+                    ['position' => 2, 'key' => 'row2', 'label' => 'rowlabel2'],
+                ])
+            );
+
             $block->addChild($this->createDataChild('advancedManyToManyRelation', 'blockadvancedRelations')
                 ->setAllowMultipleAssignments(false)
                 ->setDocumentTypes([])->setAssetTypes([])->setClasses(['RelationTest'])
@@ -335,6 +354,11 @@ class Model extends AbstractDefinitionHelper
             $lblock->addChild($this->createDataChild('input', 'lblockinput'));
             $lblock->addChild($this->createDataChild('link', 'lblocklink'));
             $lblock->addChild($this->createDataChild('hotspotimage', 'lblockhotspotimage'));
+
+            // Same object-carrying child types, nested one level deeper (block inside
+            // localizedfields), which routes through BlockDataMarshaller\Localizedfields.
+            $lblock->addChild($this->createDataChild('externalImage', 'lblockexternalImage'));
+            $lblock->addChild($this->createDataChild('date', 'lblockdate'));
 
             $lblock->addChild($this->createDataChild('advancedManyToManyRelation', 'lblockadvancedRelations')
                 ->setAllowMultipleAssignments(false)

--- a/tests/Unit/Models/DataObject/ClassDefinition/Data/ImageGalleryTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/Data/ImageGalleryTest.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\DataObject\ClassDefinition\Data;
+
+use Pimcore\Model\DataObject\ClassDefinition\Data\ImageGallery;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * Probe class used to detect whether __wakeup is invoked during a restricted unserialize.
+ * It must NOT be in the allowlist (here: none at all) passed to getDataFromResource.
+ */
+class ImageGalleryObjectInjectionProbe
+{
+    public static bool $wakeupCalled = false;
+
+    public function __wakeup(): void
+    {
+        self::$wakeupCalled = true;
+    }
+}
+
+/**
+ * @group unit.model.datatype.imagegallery
+ */
+class ImageGalleryTest extends TestCase
+{
+    /**
+     * Regression test for GHSA-8v44-m977-ph86.
+     *
+     * ImageGallery::getDataFromResource() unserialized the `__hotspots` column with
+     * allowed_classes=true, even though the column only ever legitimately holds a serialized
+     * array of strings (Hotspotimage::getDataForResource stringifies each entry before it is
+     * collected). A stored payload whose top-level bytes decode to an object was therefore
+     * instantiated - and any object with a dangerous __wakeup/__destruct became a PHP Object
+     * Injection / RCE gadget. The unserialize runs before the `$images` guard, so a crafted
+     * `__hotspots` value alone is enough to trigger it.
+     */
+    public function testGetDataFromResourceDoesNotInstantiateObjectsFromHotspots(): void
+    {
+        ImageGalleryObjectInjectionProbe::$wakeupCalled = false;
+
+        $payload = serialize(new ImageGalleryObjectInjectionProbe());
+
+        (new ImageGallery())->getDataFromResource([
+            '__images' => null,
+            '__hotspots' => $payload,
+        ]);
+
+        $this->assertFalse(
+            ImageGalleryObjectInjectionProbe::$wakeupCalled,
+            '__wakeup() must not be called when deserializing the __hotspots column - it must never instantiate objects'
+        );
+    }
+}


### PR DESCRIPTION
## Vulnerability

The hardening commit for CVE-2026-55220 (GHSA-w23p-wrp7-ch38, `c5b2917c03` / #19293) set an explicit `allowed_classes` value on `Video::getDataFromResource()` (`false`) and left `Block::getDataFromResource()` at `true` deliberately (Block's blob legitimately carries live PHP objects, per its own comment referencing `pimcore/internal-improvements#24`). It missed `ImageGallery::getDataFromResource()`, which still called:

```php
$hotspots = $hotspots ? Serialize::unserialize($hotspots, true) : [];
```

`ImageGallery`'s `<field>__hotspots` column only ever legitimately holds `Serialize::serialize([<hotspot strings>])` — an array of strings, since `Hotspotimage::getDataForResource()` stringifies each hotspot entry before `ImageGallery::getDataForResource()` collects them. No object ever legitimately appears in that column, unlike Block. So `allowed_classes=true` here was gratuitous and let a crafted stored value (e.g. `O:31:"GuzzleHttp\Cookie\FileCookieJar":...`) be instantiated directly by `unserialize()`, achieving PHP Object Injection / RCE via a destructor gadget chain — bundled `guzzlehttp/guzzle` ships a working one. The call happens before the `if (!$images)` guard, so a non-empty `__hotspots` value alone is sufficient to trigger it, independent of the `__images` value.

## Fix

Change the call to `Serialize::unserialize($hotspots, false)`, matching the already-fixed `Video.php` call site and consistent with the data shape ImageGallery actually stores. No other code path reads `ImageGallery`'s raw resource data or relies on object deserialization there.

## Backward compatibility

Checked against the BC promise (`pimcore-backward-compatibility` skill): this changes an *internal call site's* argument to a helper, not `getDataFromResource()`'s own signature, default arguments, return type/shape, or visibility — the method continues to return a `DataObject\Data\ImageGallery` built from the same `Hotspotimage` items for all legitimate data. Since the column never legitimately contains anything but stringified hotspot data (established above), no real stored data changes behavior; only a stored payload that decodes to a PHP object (never produced by `getDataForResource()`) is affected, and only by having that object safely become `__PHP_Incomplete_Class` instead of being instantiated as the intended class. This mirrors the accepted `Video.php` fix already on this branch and is not a BC break.

## Testing

Tests added: `tests/Unit/Models/DataObject/ClassDefinition/Data/ImageGalleryTest.php`

This is a lightweight unit test (no DB/container needed), following the existing precedent in `tests/Unit/Models/DataObject/ClassDefinition/Data/LinkTest.php` for the same class of fix. It builds a probe class with a `__wakeup()` that flips a static flag, serializes an instance of it as the `__hotspots` payload, calls `ImageGallery::getDataFromResource()` with it, and asserts `__wakeup()` was never invoked — i.e. the object is never instantiated. Against the vulnerable code (`allowed_classes = true`) this assertion fails (the probe's `__wakeup()` fires); against the fix it passes.

I don't have Composer/network access in this sandbox to run the Codeception suite, so this could not be executed here; `php -l` passes on both changed files, and I independently verified the underlying PHP semantics (`unserialize($s, ['allowed_classes' => false])` on a serialized object returns `__PHP_Incomplete_Class` without calling `__wakeup()`) with a standalone script using the host PHP binary.

Security-Advisory: pimcore/pimcore/GHSA-8v44-m977-ph86




> Generated by [Draft a security-advisory fix](https://github.com/pimcore/workflows-centralized/actions/runs/31558743508) · sonnet50 · 79.2 AIC · ⌖ 18.9 AIC · ⊞ 6.2K · [◷](https://github.com/search?q=repo%3Apimcore%2Fpimcore+%22gh-aw-workflow-id%3A+advisory-fix%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Draft a security-advisory fix, engine: claude, model: claude-sonnet-5, id: 31558743508, workflow_id: advisory-fix, run: https://github.com/pimcore/workflows-centralized/actions/runs/31558743508 -->

<!-- gh-aw-workflow-id: advisory-fix -->
<!-- gh-aw-workflow-call-id: pimcore/workflows-centralized/advisory-fix -->