### PR TITLE
Run Codeception and PHPStan on 11.x pull requests

### DIFF
--- a/.github/workflows/codeception-11x.yaml
+++ b/.github/workflows/codeception-11x.yaml
@@ -1,0 +1,54 @@
+name: "Codeception Tests centralised 11.x"
+
+on:
+    workflow_dispatch:
+    pull_request_target:
+        types: [opened, synchronize, reopened]
+        branches:
+            - "11.*"
+        paths-ignore:
+            - 'doc/**'
+            - 'bundles/**/public/**'
+    push:
+        branches:
+            - "11.*"
+        paths-ignore:
+            - 'doc/**'
+            - 'bundles/**/public/**'
+permissions:
+  contents: read
+jobs:
+    codeception-tests:
+        uses: pimcore/workflows-collection-public/.github/workflows/reusable-codeception-public.yaml@main
+        strategy:
+            matrix:
+                include:
+                    - { php-version: 8.3, database: "mariadb:11.2", dependencies: highest, experimental: false, storage: local, symfony: "", composer-options: "" }
+                    - { php-version: 8.3, database: "mariadb:10.3", dependencies: lowest, experimental: false, storage: local, symfony: "", composer-options: "" }
+                    - { php-version: 8.2, database: "mariadb:10.5", dependencies: highest, experimental: false, storage: local, symfony: "", composer-options: "" }
+                    - { php-version: 8.2, database: "mariadb:10.11", dependencies: highest, experimental: false, storage: local, symfony: "", composer-options: "" }
+                    - { php-version: 8.2, database: "mariadb:10.11", dependencies: highest, experimental: true, storage: local, symfony: "6.4.x-dev", composer-options: "" }
+                    - { php-version: 8.1, database: "mariadb:10.7", dependencies: highest, experimental: false, storage: local, symfony: "", composer-options: "" }
+                    - { php-version: 8.1, database: "mysql:8.0", dependencies: lowest, experimental: false, storage: local, symfony: "", composer-options: "" }
+                    - { php-version: 8.1, database: "percona:8.0", dependencies: lowest, experimental: false, storage: minio, symfony: "", composer-options: "" }
+        with:
+            php-version: ${{ matrix.php-version }}
+            database: ${{ matrix.database }}
+            dependencies: ${{ matrix.dependencies }}
+            experimental: ${{ matrix.experimental }}
+            storage: ${{ matrix.storage }}
+            symfony: ${{ matrix.symfony }}
+            composer-options: ${{ matrix.composer-options }}
+            repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+            PIMCORE_PROJECT_ROOT: ${{ github.workspace }}
+            APP_ENV: "test"
+            PIMCORE_TEST: 1
+            PIMCORE_TEST_DB_DSN: "mysql://root@127.0.0.1:33006/pimcore_test"
+            PIMCORE_TEST_REDIS_DSN: "redis://127.0.0.1:63379"
+            MINIO_ACCESS_KEY: "PIMCORE_OBJECT_STORAGE_ACCESS_KEY"
+            MINIO_SECRET_KEY: "PIMCORE_OBJECT_STORAGE_SECRET_KEY"
+            BRANCH_NAME: ${{ github.head_ref || github.ref }}
+        secrets:
+            PIMCORE_INSTANCE_IDENTIFIER: ${{ secrets.PIMCORE_CI_INSTANCE_IDENTIFIER }}
+            PIMCORE_ENCRYPTION_SECRET: ${{ secrets.PIMCORE_CI_ENCRYPTION_SECRET }}
+            PIMCORE_PRODUCT_KEY: ${{ secrets.PIMCORE_CI_PRODUCT_KEY }}

--- a/.github/workflows/static-analysis-11x.yaml
+++ b/.github/workflows/static-analysis-11x.yaml
@@ -1,0 +1,99 @@
+
+name: "PHPStan Static Analysis 11.x"
+
+on:
+    workflow_dispatch:
+    pull_request_target:
+        branches:
+            - "11.*"
+        paths-ignore:
+            - 'doc/**'
+            - 'bundles/**/public/**'
+    push:
+        branches:
+            - "11.*"
+        paths-ignore:
+            - 'doc/**'
+            - 'bundles/**/public/**'
+
+env:
+    PIMCORE_INSTANCE_IDENTIFIER: ${{ secrets.PIMCORE_CI_INSTANCE_IDENTIFIER }}
+    PIMCORE_ENCRYPTION_SECRET: ${{ secrets.PIMCORE_CI_ENCRYPTION_SECRET }}
+    PIMCORE_PRODUCT_KEY: ${{ secrets.PIMCORE_CI_PRODUCT_KEY }}
+    PIMCORE_PROJECT_ROOT: ${{ github.workspace }}
+    APP_ENV: test
+    PIMCORE_TEST: 1
+    PIMCORE_STORAGE: 'local'
+
+permissions:
+  contents: read
+
+jobs:
+    static-analysis-phpstan:
+        name: "Static Analysis with PHPStan"
+        runs-on: "ubuntu-22.04"
+        continue-on-error: ${{ matrix.experimental }}
+        strategy:
+            matrix:
+                include:
+                    - { php-version: "8.3", dependencies: "lowest", experimental: false, symfony: "", composer-options: "" }
+                    - { php-version: "8.3", dependencies: "highest", experimental: false, symfony: "", composer-options: "" }
+                    - { php-version: "8.2", dependencies: "lowest", experimental: false, symfony: "", composer-options: "" }
+                    - { php-version: "8.2", dependencies: "highest", experimental: false, symfony: "", composer-options: "" }
+                    - { php-version: "8.2", dependencies: "highest", experimental: true, symfony: "6.4.x-dev", composer-options: "" }
+                    - { php-version: "8.1", dependencies: "lowest", experimental: false, symfony: "", composer-options: "" }
+                    - { php-version: "8.1", dependencies: "highest", experimental: false, symfony: "", composer-options: "" }
+
+        steps:
+            - name: Checkout PR head (only for pull_request_target)
+              if: github.event_name == 'pull_request_target'
+              uses: "actions/checkout@v5.0.1"
+              with:
+                ref: "refs/pull/${{ github.event.pull_request.number }}/merge"
+
+            - name: Checkout PR head (for push or workflow_dispatch)
+              if: github.event_name != 'pull_request_target'
+              uses: "actions/checkout@v5.0.1"
+
+            - name: "Install PHP"
+              uses: "shivammathur/setup-php@v2"
+              with:
+                  coverage: "none"
+                  php-version: "${{ matrix.php-version }}"
+
+            - name: "Setup Pimcore environment"
+              run: |
+                  .github/ci/scripts/setup-pimcore-environment.sh
+
+            - name: "Set Symfony version constraint in composer.json"
+              env:
+                  SYMFONY_VERSION: "${{ matrix.symfony }}"
+              run: |
+                  if [ ! -z "$SYMFONY_VERSION" ]; then
+                    .github/ci/scripts/symfony-require-dev.sh
+                  fi
+
+            - name: "Install dependencies with Composer"
+              uses: "ramsey/composer-install@v2"
+              with:
+                  dependency-versions: "${{ matrix.dependencies }}"
+                  composer-options: "${{ matrix.composer-options }}"
+
+            - name: "Run a static analysis with phpstan/phpstan (highest)"
+              if: ${{ matrix.dependencies == 'highest' }}
+              run: "vendor/bin/phpstan analyse --memory-limit=-1"
+
+            - name: "Run a static analysis with phpstan/phpstan (lowest)"
+              if: ${{ matrix.dependencies == 'lowest' }}
+              run: "vendor/bin/phpstan analyse --memory-limit=-1 -c phpstan-lowest.neon"
+
+            - name: "Generate baseline file"
+              if: ${{ failure() }}
+              run: "vendor/bin/phpstan analyse --memory-limit=-1 --generate-baseline"
+
+            - name: "Upload baseline file"
+              if: ${{ failure() }}
+              uses: actions/upload-artifact@v4
+              with:
+                  name: phpstan-baseline.neon
+                  path: phpstan-baseline.neon


### PR DESCRIPTION
## Changes in this pull request

Adds `11.*`-filtered Codeception and PHPStan workflows, so pull requests targeting the `11.5` branch get pre-merge CI. Mirrors the existing `codeception-12x.yaml` / `static-analyisis-12x.yaml` pattern.

- `.github/workflows/codeception-11x.yaml`
- `.github/workflows/static-analysis-11x.yaml`

### Why

GitHub resolves `pull_request_target` workflow files from the repository's **default branch** (`2026.x`), not from the PR's base branch. On `2026.x` both `codeception.yaml` and `static-analysis.yaml` are filtered to `branches: ["2026.*"]`, so a PR with base `11.5` matches no trigger and gets neither Codeception nor PHPStan.

The `11.5` branch does carry its own correctly `11.*`-filtered copies, but those are only ever reached by `push` events, which *do* resolve from the pushed branch. Net effect: 11.5 backports — including security backports — are reviewed and merged on Psalm alone, and the test suite first runs only *after* merge.

Evidence from `pimcore/ee-pimcore`, `.github/workflows/codeception.yaml` (workflow id `73688748`):

| event | runs named `Codeception Tests centralised` (the `2026.x` copy) | runs named `Codeception Tests centralised 11.x` (the `11.5` copy) |
|---|---|---|
| `push` | 43 | **7** |
| `pull_request_target` | 39 | **0** |

`pull_request_target` has never once resolved the 11.5 copy, despite 134 merged PRs against `11.5` (0 currently open). On [ee-pimcore#1069](https://github.com/pimcore/ee-pimcore/pull/1069) (base `11.5`) only `cla-workflow`, `guardrails`, `Psalm` and `comment` ran; a developer worked around it by manually `workflow_dispatch`-ing the 11.x Codeception workflow against the PR head branch.

### Notes on the two files

Both are derived from the `11.5` branch's own working copies, so the PR matrix is identical to what already runs on `push` to 11.5 — a green PR then means a green merge. `codeception-11x.yaml` matches the 11.5 file exactly (8 legs, PHP 8.1–8.3). `static-analysis-11x.yaml` keeps its 7 legs and all steps, with four deliberate deltas:

1. **`schedule:` removed.** The 11.5 copy declares `cron '0 3 * * *'`, which is inert on a non-default branch. Carried onto `2026.x` it *would* fire daily, check out 2026.x code and run it under PHP 8.1–8.3 against a tree requiring `~8.4.0 || ~8.5.0` — guaranteed daily red. `static-analyisis-12x.yaml` likewise has no `schedule:`.
2. Added the three `PIMCORE_CI_*` values to `env:`, for parity with the 12.x variant (the 11.5 copy predates them).
3. `actions/checkout@v4` → `@v5.0.1`, matching the current 12.x and 2026.x files.
4. Dropped the dead `schedule`-guarded checkout step that `-12x` still carries.

These files are **inert in CE**, which has no `11.*` branch — they take effect once the normal CE → EE sync lands them on `ee-pimcore`'s default branch, which is the repo whose `11.5` branch and PRs are affected.

**No duplicate runs:** on `push` to `11.5` only the 11.5 branch's own `codeception.yaml` fires (the `-11x` file does not exist there); on PRs only the `-11x` file fires (the default-branch `codeception.yaml` is `2026.*`-filtered).

Resolves pimcore/DevOps-Tasks#31

## Additional info

- Trigger resolution only reads the default branch, so this **cannot be validated from this PR**. After the CE → EE sync lands it on EE `2026.x`: the next PR against `11.5` should show `Static Analysis with PHPStan` (7 legs) and `codeception-tests … / Codeception tests` (8 legs). Note there is **no** dispatch-based interim check — `workflow_dispatch` executes the file from the selected ref, and the `-11x` files exist only on `2026.x`.
- 11.5 CI is currently green (last `push` run 2026-08-11). There are currently **0 open** PRs against `11.5` (135 closed, 134 merged), so nothing picks up the new check legs until the next 11.5 backport is opened — no queue burst.
- `runs-on: ubuntu-22.04` is retained (as in the 12.x variant) because the PHP 8.1 legs depend on it. That image is on GitHub's deprecation path — worth a separate follow-up, out of scope here.
- New file uses the correct spelling `static-analysis-11x.yaml`; the 12.x equivalent is misspelled `static-analyisis-12x.yaml`. Filenames do not affect check names, so there is no check-name drift.
- No docs change: CI-only, no user-facing functionality. No test added: the artifacts *are* CI config, and it cannot be exercised until it is on a default branch (see above).

