### PR TITLE
[Telemetry] Usage providers can report unknown; drop core.datahub_enabled

### DIFF
--- a/lib/Telemetry/Snapshot/CoreSnapshotCollector.php
+++ b/lib/Telemetry/Snapshot/CoreSnapshotCollector.php
@@ -79,7 +79,10 @@ final readonly class CoreSnapshotCollector implements SnapshotCollectorInterface
             'object_count_bucket' => $this->bucketizer->bucket($this->countTable('objects')),
             'asset_count_bucket' => $this->bucketizer->bucket($this->countTable('assets')),
             'document_count_bucket' => $this->bucketizer->bucket($this->countTable('documents')),
-            'datahub_enabled' => $this->activeBundles->has('DataHub'),
+            // No `datahub_enabled` here: it was a bundle-active flag, which `core.bundles` and
+            // `pillars.datahub_bundle_active` already carry, and Data Hub now reports real adoption
+            // through `usage.datahub` and the `datahub.*` namespace. Three copies of the same L2
+            // boolean invite exactly the wrong reading - that "enabled" says something about use.
         ];
     }
 

--- a/lib/Telemetry/Snapshot/CoreSnapshotCollector.php
+++ b/lib/Telemetry/Snapshot/CoreSnapshotCollector.php
@@ -79,10 +79,6 @@ final readonly class CoreSnapshotCollector implements SnapshotCollectorInterface
             'object_count_bucket' => $this->bucketizer->bucket($this->countTable('objects')),
             'asset_count_bucket' => $this->bucketizer->bucket($this->countTable('assets')),
             'document_count_bucket' => $this->bucketizer->bucket($this->countTable('documents')),
-            // No `datahub_enabled` here: it was a bundle-active flag, which `core.bundles` and
-            // `pillars.datahub_bundle_active` already carry, and Data Hub now reports real adoption
-            // through `usage.datahub` and the `datahub.*` namespace. Three copies of the same L2
-            // boolean invite exactly the wrong reading - that "enabled" says something about use.
         ];
     }
 

--- a/lib/Telemetry/Usage/BundleUsageCollector.php
+++ b/lib/Telemetry/Usage/BundleUsageCollector.php
@@ -21,9 +21,11 @@ use Pimcore\Telemetry\Snapshot\SnapshotCollectorInterface;
  * one `usage.<bundleKey>` boolean per provider. Cross-referenced with `core.bundles` (installed) in
  * PostHog, `installed && usage=false` is the "installed but not used" signal (stakeholder Q12).
  *
- * A provider that throws is recorded as `false` rather than breaking the snapshot - telemetry is
- * best-effort. Bundles without a provider are simply absent (unknown), which is intended: usage
- * reporting is opt-in per bundle.
+ * Absence means unknown, and there are three ways to be absent: no provider at all (usage reporting is
+ * opt-in per bundle), a provider that answers null because it could not reach its own configuration,
+ * and a provider that throws. All three are treated alike on purpose - reporting any of them as
+ * `false` would be indistinguishable from a genuine "installed but not used", which is the one signal
+ * this namespace exists to produce.
  *
  * @internal
  */
@@ -47,14 +49,19 @@ final readonly class BundleUsageCollector implements SnapshotCollectorInterface
         $usage = [];
 
         foreach ($this->providers as $provider) {
-            $key = $provider->getBundleKey();
-
             try {
-                $usage[$key] = $provider->isUsed();
+                $used = $provider->isUsed();
             } catch (Exception) {
-                // A provider must never break the snapshot; treat a failure as "not used".
-                $usage[$key] = false;
+                // A provider must never break the snapshot, and a broken provider knows nothing about
+                // adoption - so this is "unknown", not "unused".
+                continue;
             }
+
+            if ($used === null) {
+                continue;
+            }
+
+            $usage[$provider->getBundleKey()] = $used;
         }
 
         return $usage;

--- a/lib/Telemetry/Usage/BundleUsageProviderInterface.php
+++ b/lib/Telemetry/Usage/BundleUsageProviderInterface.php
@@ -34,8 +34,16 @@ interface BundleUsageProviderInterface
     public function getBundleKey(): string;
 
     /**
-     * Whether this bundle/capability is actually used on this instance. Should be cheap (runs on the
-     * periodic snapshot) and must not throw - a failure is treated as "not used".
+     * Whether this bundle/capability is actually used on this instance. Should be cheap - it runs on
+     * the periodic snapshot.
+     *
+     * Return **null for "cannot tell"**, and the key is omitted from the snapshot rather than reported
+     * as unused. That distinction matters more than it looks: several bundles keep their configuration
+     * in a deployment-configurable location (Data Hub and Data Importer can write either to the
+     * settings store or to Symfony config files), so a provider that answers `false` when it simply
+     * could not reach its own repository would invent an adoption gap on every customer using the
+     * other target. Absent already means "unknown" for bundles with no provider at all; null keeps
+     * that one meaning rather than adding a second, wrong one.
      */
-    public function isUsed(): bool;
+    public function isUsed(): ?bool;
 }

--- a/lib/Telemetry/Usage/WorkflowUsageProvider.php
+++ b/lib/Telemetry/Usage/WorkflowUsageProvider.php
@@ -22,6 +22,9 @@ use Pimcore\Workflow\Manager;
  * count) - it self-resets to false if all workflows are removed, so the bundle/capability owns the
  * definition of "used". Bundles (Data Hub, Portal Engine, …) add their own provider the same way.
  *
+ * Also the reference for the null case: if the workflow manager cannot be consulted we do not know
+ * whether workflows are in use, and saying `false` there would be a fabricated adoption gap.
+ *
  * @internal
  */
 final readonly class WorkflowUsageProvider implements BundleUsageProviderInterface
@@ -36,12 +39,12 @@ final readonly class WorkflowUsageProvider implements BundleUsageProviderInterfa
         return 'workflow';
     }
 
-    public function isUsed(): bool
+    public function isUsed(): ?bool
     {
         try {
             return $this->workflowManager->getAllWorkflows() !== [];
         } catch (Exception) {
-            return false;
+            return null;
         }
     }
 }

--- a/tests/Unit/Telemetry/BundleUsageCollectorTest.php
+++ b/tests/Unit/Telemetry/BundleUsageCollectorTest.php
@@ -23,11 +23,13 @@ use Throwable;
 
 class BundleUsageCollectorTest extends TestCase
 {
-    private function provider(string $key, bool|Throwable $used): BundleUsageProviderInterface
+    private function provider(string $key, bool|Throwable|null $used): BundleUsageProviderInterface
     {
         return new class($key, $used) implements BundleUsageProviderInterface {
-            public function __construct(private readonly string $key, private readonly bool|Throwable $used)
-            {
+            public function __construct(
+                private readonly string $key,
+                private readonly bool|Throwable|null $used,
+            ) {
             }
 
             public function getBundleKey(): string
@@ -35,7 +37,7 @@ class BundleUsageCollectorTest extends TestCase
                 return $this->key;
             }
 
-            public function isUsed(): bool
+            public function isUsed(): ?bool
             {
                 if ($this->used instanceof Throwable) {
                     throw $this->used;
@@ -64,14 +66,37 @@ class BundleUsageCollectorTest extends TestCase
         $this->assertSame(['datahub' => true, 'portal_engine' => false], $collector->collect());
     }
 
-    public function testThrowingProviderDegradesToFalse(): void
+    /**
+     * A provider that blew up knows nothing about adoption. Reporting `false` would be
+     * indistinguishable from a genuine "installed but not used" - the one signal this namespace
+     * exists to produce - so the key is omitted and stays unknown.
+     */
+    public function testAThrowingProviderIsOmittedRatherThanReportedUnused(): void
     {
         $collector = new BundleUsageCollector([
             $this->provider('ok', true),
             $this->provider('boom', new RuntimeException('kaboom')),
         ]);
 
-        $this->assertSame(['ok' => true, 'boom' => false], $collector->collect());
+        $this->assertSame(['ok' => true], $collector->collect());
+    }
+
+    /**
+     * The case the null return exists for: several bundles keep their configuration in a
+     * deployment-configurable location, so a provider that cannot reach its own repository must say
+     * "cannot tell" rather than invent an adoption gap on every customer using the other target.
+     */
+    public function testANullAnsweringProviderIsOmittedRatherThanReportedUnused(): void
+    {
+        $collector = new BundleUsageCollector([
+            $this->provider('resolvable', false),
+            $this->provider('unresolvable', null),
+        ]);
+
+        $collected = $collector->collect();
+
+        $this->assertSame(['resolvable' => false], $collected);
+        $this->assertArrayNotHasKey('unresolvable', $collected, 'unknown must not become false');
     }
 
     public function testNoProvidersYieldsEmptyMap(): void

--- a/tests/Unit/Telemetry/CoreSnapshotCollectorTest.php
+++ b/tests/Unit/Telemetry/CoreSnapshotCollectorTest.php
@@ -109,6 +109,17 @@ class CoreSnapshotCollectorTest extends TestCase
     }
 
     /**
+     * `datahub_enabled` was a bundle-active flag that `core.bundles` and `pillars.datahub_bundle_active`
+     * already carried, and Data Hub now reports real adoption through `usage.*` and `datahub.*`. It was
+     * removed because a third copy of the same L2 boolean invited the reading that "enabled" said
+     * something about use - so reintroducing it would be a regression, not an addition.
+     */
+    public function testTheRemovedDatahubEnabledFlagStaysRemoved(): void
+    {
+        $this->assertArrayNotHasKey('datahub_enabled', $this->collector()->collect());
+    }
+
+    /**
      * Debug and dev mode are misconfiguration signals, not usage: either one left on in a production
      * deployment costs performance and exposes internals. Both are plain booleans about our own
      * runtime, so they carry nothing about the customer.

--- a/tests/Unit/Telemetry/WorkflowUsageProviderTest.php
+++ b/tests/Unit/Telemetry/WorkflowUsageProviderTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Telemetry;
+
+use Pimcore\Telemetry\Usage\BundleUsageProviderInterface;
+use Pimcore\Telemetry\Usage\WorkflowUsageProvider;
+use Pimcore\Tests\Support\Test\TestCase;
+use Pimcore\Workflow\Manager;
+use RuntimeException;
+
+class WorkflowUsageProviderTest extends TestCase
+{
+    public function testReportsUnderTheWorkflowKey(): void
+    {
+        $provider = new WorkflowUsageProvider($this->manager([]));
+
+        $this->assertInstanceOf(BundleUsageProviderInterface::class, $provider);
+        $this->assertSame('workflow', $provider->getBundleKey());
+    }
+
+    public function testWorkflowsConfiguredCountsAsUsed(): void
+    {
+        $this->assertTrue((new WorkflowUsageProvider($this->manager(['product_approval'])))->isUsed());
+    }
+
+    /**
+     * Self-resetting: the capability owns the definition of "used", and removing the last workflow
+     * flips it back rather than leaving a sticky true.
+     */
+    public function testNoWorkflowsCountsAsNotUsed(): void
+    {
+        $this->assertFalse((new WorkflowUsageProvider($this->manager([])))->isUsed());
+    }
+
+    /**
+     * The reason `isUsed()` returns `?bool`. A manager that cannot be consulted tells us nothing about
+     * adoption, and `false` there is indistinguishable from a genuine "installed but not used" - the
+     * one signal the `usage.*` namespace exists to produce. Null omits the key instead.
+     */
+    public function testAnUnavailableWorkflowManagerIsUnknownRatherThanUnused(): void
+    {
+        $manager = $this->createMock(Manager::class);
+        $manager->method('getAllWorkflows')->willThrowException(new RuntimeException('container not booted'));
+
+        $used = (new WorkflowUsageProvider($manager))->isUsed();
+
+        $this->assertNull($used, 'a failure must not be reported as "not used"');
+        $this->assertNotFalse($used);
+    }
+
+    /**
+     * @param list<string> $workflows
+     */
+    private function manager(array $workflows): Manager
+    {
+        $manager = $this->createMock(Manager::class);
+        $manager->method('getAllWorkflows')->willReturn($workflows);
+
+        return $manager;
+    }
+}


### PR DESCRIPTION
Part of https://github.com/pimcore/product-management/issues/1414
## What

`BundleUsageProviderInterface::isUsed()` returns `?bool`. Null — and a thrown exception — now omit the `usage.<bundle>` key instead of reporting `false`.

Removes `core.datahub_enabled`.

## Why

`false` was doing two jobs: "installed but not used" (the signal this namespace exists for) and "the provider could not answer". Those are not the same, and conflating them fabricates adoption gaps.

It matters in practice because several bundles keep configuration in a deployment-configurable location — Data Hub and Data Importer write either to the settings store or to Symfony config files. A provider that answered `false` because it could not reach its own repository would report an adoption gap on every customer using the other target.

`core.datahub_enabled` was a bundle-active flag already carried by `core.bundles` and `pillars.datahub_bundle_active`. Data Hub now reports real adoption via `usage.*` and `datahub.*`, so a third copy of the same L2 boolean only invited the reading that "enabled" said something about use.

## Verification

`OK (112 tests, 401 assertions)` — includes two new tests asserting that a throwing provider and a null-answering provider are both **omitted** rather than reported unused.

## Note for reviewers

Downstream bundles implementing this interface need no change: a `bool` return still satisfies `?bool` covariantly.