### PR TITLE
[DataObject] classes-rebuild: regenerate node-local PHP class files even when the database is already up-to-date

### DIFF
--- a/doc/11_Deployment_Recommendations/02_Deployment_Tools.md
+++ b/doc/11_Deployment_Recommendations/02_Deployment_Tools.md
@@ -82,6 +82,10 @@ Run `pimcore:deployment:classes-rebuild` after every code update to push changes
 bin/console pimcore:deployment:classes-rebuild
 ```
 
+When multiple nodes share the same database, run the command on every node: even if another node
+already updated the database, the command still regenerates missing or outdated PHP class files
+on the local filesystem without performing additional database writes.
+
 To update only the database structure without dumping classes to the file system:
 
 ```bash

--- a/doc/13_Upgrade_Notes/README.md
+++ b/doc/13_Upgrade_Notes/README.md
@@ -9,6 +9,7 @@
 - [Thumbnails] The cache lifetime used for the `Cache-Control` and `Expires` HTTP headers when a thumbnail is delivered on-the-fly through the thumbnail service is now configurable via `pimcore.assets.thumbnails.cache_lifetime` (in seconds). It defaults to `604800` (one week), which preserves the previous hard-coded behavior.
 
 ### [DataObject]
+- [Deployment] `pimcore:deployment:classes-rebuild` now regenerates missing or outdated node-local PHP class files (`var/classes/DataObject/<Class>.php` and the corresponding `Listing.php`) even when the database is already up-to-date, so secondary nodes in a shared-database cluster no longer require `--force`. Affected classes are reported as `saved` instead of `skipped` in verbose output. `Pimcore\Model\DataObject\ClassDefinition\ClassDefinitionManager` gained the public method `hasStalePhpClassFiles()`.
 - [Relations] The `ownername` column has been widened from `VARCHAR(70)` to `VARCHAR(190)` in the per-class relation tables (`object_relations_*`), the advanced-relation metadata tables (`object_metadata_*`) and `object_url_slugs`. The generated `ownername` for a localized field nested inside an object brick or field collection (e.g. `/objectbrick~<field>/<brickKey>/localizedfield~localizedfield`) can exceed 70 characters, which caused "Data too long for column 'ownername'" on save under strict SQL mode. Existing installations are updated automatically by the migration `Version20260721000000`; no code or configuration changes are required.
 
 

--- a/lib/Model/DataObject/ClassDefinition/ClassDefinitionManager.php
+++ b/lib/Model/DataObject/ClassDefinition/ClassDefinitionManager.php
@@ -144,6 +144,8 @@ class ClassDefinitionManager
      * Additional method that gives more control over the saving process. Added as a separate method to avoid compatibility issues.
      * TODO: Should be refactored in Pimcore 13 to avoid duplication with saveClass.
      *
+     * @return bool whether the class was saved (or its PHP class files were regenerated) or not
+     *
      * @throws Exception
      * @throws DefinitionWriteException
      */

--- a/lib/Model/DataObject/ClassDefinition/ClassDefinitionManager.php
+++ b/lib/Model/DataObject/ClassDefinition/ClassDefinitionManager.php
@@ -130,7 +130,7 @@ class ClassDefinitionManager
     }
 
     /**
-     * @return bool whether the class was saved or not
+     * @return bool whether the class was saved (or its PHP class files were regenerated) or not
      *
      * @throws DefinitionWriteException     *
      * @throws Exception
@@ -169,6 +169,35 @@ class ClassDefinitionManager
     }
 
     /**
+     * Checks whether the generated PHP class files of a class definition are missing or outdated
+     * on the local filesystem. This can be the case even if the database is already up-to-date,
+     * e.g. when another node sharing the same database has performed a rebuild, while this
+     * node's filesystem was never updated.
+     */
+    public function hasStalePhpClassFiles(ClassDefinitionInterface $class): bool
+    {
+        $definitionModificationTime = (int) $class->getModificationDate();
+
+        $definitionFile = $class->getDefinitionFile();
+        if (is_file($definitionFile) && ($definitionFileModificationTime = filemtime($definitionFile)) !== false) {
+            $definitionModificationTime = max($definitionModificationTime, $definitionFileModificationTime);
+        }
+
+        foreach ([$class->getPhpClassFile(), $class->getPhpListingClassFile()] as $phpClassFile) {
+            if (!is_file($phpClassFile)) {
+                return true;
+            }
+
+            $phpClassFileModificationTime = filemtime($phpClassFile);
+            if ($phpClassFileModificationTime === false || $phpClassFileModificationTime < $definitionModificationTime) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @throws Exception
      * @throws DefinitionWriteException
      */
@@ -190,8 +219,19 @@ class ClassDefinitionManager
             } else {
                 $class->save($saveDefinitionFile);
             }
+
+            return true;
         }
 
-        return $shouldSave;
+        // the shared database may already be up-to-date (e.g. another node performed the rebuild first),
+        // while the PHP class files on this node are still missing or outdated - regenerate them
+        // locally without touching the database
+        if ($dumpPHPClasses && $this->hasStalePhpClassFiles($class)) {
+            $class->generateClassFiles(false);
+
+            return true;
+        }
+
+        return false;
     }
 }

--- a/tests/Model/DataObject/ClassDefinitionManagerTest.php
+++ b/tests/Model/DataObject/ClassDefinitionManagerTest.php
@@ -72,20 +72,49 @@ class ClassDefinitionManagerTest extends ModelTestCase
         $this->assertFileDoesNotExist($phpClassFile, 'PHP classes must not be dumped when $dumpPHPClasses is false');
     }
 
-    public function testDumpClassDefinitionsWithForceRestoresPhpClasses(): void
+    public function testDumpClassDefinitionsRestoresMissingPhpClassesWithoutForce(): void
     {
         $class = $this->createTestClassDefinition();
         $phpClassFile = $class->getPhpClassFile();
+        $phpListingClassFile = $class->getPhpListingClassFile();
 
         $this->simulateEmptyDatabase($class);
 
         $this->getClassDefinitionManager()->dumpClassDefinitions(dumpPHPClasses: false);
         $this->assertFileDoesNotExist($phpClassFile);
 
-        // a subsequent run with PHP class dumping enabled needs force, as the definition did not change
-        $this->getClassDefinitionManager()->dumpClassDefinitions(force: true);
+        // even without force, missing PHP classes must be restored: the database being up-to-date
+        // (e.g. because another node sharing the same database already ran the rebuild)
+        // says nothing about the state of the generated files on this node
+        RuntimeCache::clear();
+        $changes = $this->getClassDefinitionManager()->dumpClassDefinitions();
 
-        $this->assertFileExists($phpClassFile, 'PHP classes must be dumped again when $dumpPHPClasses is true');
+        $this->assertContains(
+            [self::CLASS_NAME, self::CLASS_NAME, ClassDefinitionManager::SAVED],
+            $changes,
+            'Class must be reported as saved when its PHP classes were regenerated'
+        );
+        $this->assertFileExists($phpClassFile, 'PHP classes must be restored even if the database did not change');
+        $this->assertFileExists($phpListingClassFile, 'PHP listing class must be restored even if the database did not change');
+    }
+
+    public function testDumpClassDefinitionsSkipsClassesWithUpToDatePhpClasses(): void
+    {
+        $this->createTestClassDefinition();
+
+        // a first run may regenerate the PHP classes in case their modification time
+        // is older than the one of the definition file
+        RuntimeCache::clear();
+        $this->getClassDefinitionManager()->dumpClassDefinitions();
+
+        RuntimeCache::clear();
+        $changes = $this->getClassDefinitionManager()->dumpClassDefinitions();
+
+        $this->assertContains(
+            [self::CLASS_NAME, self::CLASS_NAME, ClassDefinitionManager::SKIPPED],
+            $changes,
+            'Class must be skipped when neither the database nor the generated PHP classes are outdated'
+        );
     }
 
     private function createTestClassDefinition(): ClassDefinition

--- a/tests/Model/DataObject/ClassDefinitionManagerTest.php
+++ b/tests/Model/DataObject/ClassDefinitionManagerTest.php
@@ -82,6 +82,7 @@ class ClassDefinitionManagerTest extends ModelTestCase
 
         $this->getClassDefinitionManager()->dumpClassDefinitions(dumpPHPClasses: false);
         $this->assertFileDoesNotExist($phpClassFile);
+        $this->assertFileDoesNotExist($phpListingClassFile);
 
         // even without force, missing PHP classes must be restored: the database being up-to-date
         // (e.g. because another node sharing the same database already ran the rebuild)
@@ -96,6 +97,76 @@ class ClassDefinitionManagerTest extends ModelTestCase
         );
         $this->assertFileExists($phpClassFile, 'PHP classes must be restored even if the database did not change');
         $this->assertFileExists($phpListingClassFile, 'PHP listing class must be restored even if the database did not change');
+    }
+
+    public function testHasStalePhpClassFilesDetectsMissingAndOutdatedFiles(): void
+    {
+        $class = $this->createTestClassDefinition();
+        $manager = $this->getClassDefinitionManager();
+
+        $definitionFile = $class->getDefinitionFile();
+        $phpClassFile = $class->getPhpClassFile();
+        $phpListingClassFile = $class->getPhpListingClassFile();
+        $modificationDate = $class->getModificationDate();
+
+        // all files in sync with the definition -> up-to-date
+        touch($definitionFile, $modificationDate);
+        touch($phpClassFile, $modificationDate);
+        touch($phpListingClassFile, $modificationDate);
+        clearstatcache();
+        $this->assertFalse($manager->hasStalePhpClassFiles($class), 'Files in sync with the definition must not be considered stale');
+
+        // generated class file older than the modification date embedded in the definition -> stale
+        touch($phpClassFile, $modificationDate - 1);
+        clearstatcache();
+        $this->assertTrue($manager->hasStalePhpClassFiles($class), 'A class file older than the definition modification date must be considered stale');
+
+        // generated listing class file older than the modification date embedded in the definition -> stale
+        touch($phpClassFile, $modificationDate);
+        touch($phpListingClassFile, $modificationDate - 1);
+        clearstatcache();
+        $this->assertTrue($manager->hasStalePhpClassFiles($class), 'A listing class file older than the definition modification date must be considered stale');
+
+        // generated files older than the definition file on disk (e.g. freshly deployed) -> stale
+        touch($phpListingClassFile, $modificationDate);
+        touch($definitionFile, $modificationDate + 1);
+        clearstatcache();
+        $this->assertTrue($manager->hasStalePhpClassFiles($class), 'Class files older than the definition file on disk must be considered stale');
+
+        // missing listing class file, while the class file itself exists -> stale
+        touch($definitionFile, $modificationDate);
+        (new Filesystem())->remove($phpListingClassFile);
+        clearstatcache();
+        $this->assertTrue($manager->hasStalePhpClassFiles($class), 'A missing listing class file must be considered stale');
+    }
+
+    public function testDumpClassDefinitionsRegeneratesOutdatedPhpClassesWithoutForce(): void
+    {
+        $class = $this->createTestClassDefinition();
+        $phpClassFile = $class->getPhpClassFile();
+
+        // settle the generated files, so only the outdated class file triggers the regeneration below
+        RuntimeCache::clear();
+        $this->getClassDefinitionManager()->dumpClassDefinitions();
+
+        touch($phpClassFile, $class->getModificationDate() - 1);
+        clearstatcache();
+
+        RuntimeCache::clear();
+        $changes = $this->getClassDefinitionManager()->dumpClassDefinitions();
+
+        $this->assertContains(
+            [self::CLASS_NAME, self::CLASS_NAME, ClassDefinitionManager::SAVED],
+            $changes,
+            'Class must be reported as saved when its outdated PHP classes were regenerated'
+        );
+
+        clearstatcache();
+        $this->assertGreaterThanOrEqual(
+            $class->getModificationDate(),
+            filemtime($phpClassFile),
+            'An outdated PHP class file must be regenerated even if the database did not change'
+        );
     }
 
     public function testDumpClassDefinitionsSkipsClassesWithUpToDatePhpClasses(): void
@@ -135,7 +206,7 @@ class ClassDefinitionManagerTest extends ModelTestCase
     private function simulateEmptyDatabase(ClassDefinition $class): void
     {
         Db::get()->executeStatement('DELETE FROM classes WHERE id = ?', [$class->getId()]);
-        (new Filesystem())->remove($class->getPhpClassFile());
+        (new Filesystem())->remove([$class->getPhpClassFile(), $class->getPhpListingClassFile()]);
         RuntimeCache::clear();
 
         $this->assertNull(ClassDefinition::getByName(self::CLASS_NAME));


### PR DESCRIPTION
## Changes in this pull request
Resolves pimcore/platform-version#333 (originally reported as pimcore/pimcore#19296)

In multi-node deployments sharing one database, the node that runs
`pimcore:deployment:classes-rebuild` first updates the shared
`classes.definitionModificationDate`. Subsequent nodes then saw "no changes" and
skipped regenerating their own node-local PHP class files entirely, leaving stale
or missing generated classes on those nodes — unless `--force` was used, which
causes redundant database writes from every node on every deploy.

This PR decouples the two concerns in `ClassDefinitionManager::saveClassDefinition()`:

- **Database writes** remain gated by the existing database-based change detection
  (`hasChanges()`), so there is no additional cross-node write contention.
- **PHP class file generation** is additionally gated by a new node-local staleness
  check (`hasStalePhpClassFiles()`): when the database is already up-to-date, the
  generated class and listing files are considered stale if either is missing, or
  older than both the class's modification date and the definition file's mtime
  (covering both mtime-preserving and mtime-resetting deploy tooling). Stale files
  are regenerated via `generateClassFiles(false)` without touching the database,
  and the class is reported as `saved` instead of `skipped`.

`--db-only` and `--force` behave as before. Each node can now self-heal its
generated files regardless of deployment order.

Tests: the existing test asserting that `--force` was required to restore missing
PHP classes now asserts they are restored without force (including the listing
class), and a new test verifies fully up-to-date classes are still reported as
`skipped`. A short note about multi-node behavior was added to the deployment docs.

## Additional info
The branch is based on `2026.x`, so the PR targets `2026.x`; the underlying bug
also exists on the maintenance branches (the issue reports it for 11.x/12.x), so
a backport may be desirable.
