### PR TITLE
[Bug] Fix TypeError in ClassDefinition::getLinkGenerator() when no link generator reference is set

### DIFF
--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -930,8 +930,12 @@ final class ClassDefinition extends Model\AbstractModel implements ClassDefiniti
 
     public function getLinkGenerator(): ?ClassDefinition\LinkGeneratorInterface
     {
-        /** @var ClassDefinition\LinkGeneratorInterface|null $interface */
-        $interface = DataObject\ClassDefinition\Helper\LinkGeneratorResolver::resolveGenerator($this->getLinkGeneratorReference());
+        $interface = null;
+
+        if ($this->getLinkGeneratorReference()) {
+            /** @var ClassDefinition\LinkGeneratorInterface|null $interface */
+            $interface = DataObject\ClassDefinition\Helper\LinkGeneratorResolver::resolveGenerator($this->getLinkGeneratorReference());
+        }
 
         return $interface;
     }

--- a/tests/Unit/Models/DataObject/ClassDefinition/GetLinkGeneratorTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/GetLinkGeneratorTest.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\DataObject\ClassDefinition;
+
+use PHPUnit\Framework\TestCase;
+use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\ClassDefinition\LinkGeneratorInterface;
+
+class GetLinkGeneratorTest extends TestCase
+{
+    public function testNullLinkGeneratorReferenceReturnsNull(): void
+    {
+        $classDefinition = new ClassDefinition();
+
+        $this->assertNull($classDefinition->getLinkGenerator());
+    }
+
+    public function testLinkGeneratorReferenceIsResolvedToInstance(): void
+    {
+        $classDefinition = new ClassDefinition();
+        $classDefinition->setLinkGeneratorReference(TestLinkGenerator::class);
+
+        $this->assertInstanceOf(TestLinkGenerator::class, $classDefinition->getLinkGenerator());
+    }
+}
+
+class TestLinkGenerator implements LinkGeneratorInterface
+{
+    public function generate(object $object, array $params = []): string
+    {
+        return '/test-link';
+    }
+}

--- a/tests/Unit/Models/DataObject/ClassDefinition/GetLinkGeneratorTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/GetLinkGeneratorTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\DataObject\ClassDefinition\LinkGeneratorInterface;
 
-class GetLinkGeneratorTest extends TestCase
+final class GetLinkGeneratorTest extends TestCase
 {
     public function testNullLinkGeneratorReferenceReturnsNull(): void
     {
@@ -35,7 +35,7 @@ class GetLinkGeneratorTest extends TestCase
     }
 }
 
-class TestLinkGenerator implements LinkGeneratorInterface
+final class TestLinkGenerator implements LinkGeneratorInterface
 {
     public function generate(object $object, array $params = []): string
     {


### PR DESCRIPTION
## Changes in this pull request
Resolves pimcore/platform-version#211

Supersedes #19360 (same fix, rebased onto `2026.2`).

`ClassDefinition::getLinkGeneratorReference()` may return `null`, but `LinkGeneratorResolver::resolveGenerator()` only accepts `string`, so opening a data object whose class has a Link field but no link generator configured fails with:

```
Pimcore\Model\DataObject\ClassDefinition\Helper\LinkGeneratorResolver::resolveGenerator(): Argument #1 ($generatorClass) must be of type string, null given, called in .../models/DataObject/ClassDefinition.php on line 934
```

`getLinkGenerator()` now guards the resolver call the same way the sibling `getPreviewGenerator()` already does, returning `null` when no reference is set. Includes a regression test covering both the null and the resolved case.

## Additional info
- How to reproduce: create a data object class with a Link field, don't configure a link generator, open a data object of that class.
- The 12 line is handled separately in ee-pimcore (pimcore/ee-pimcore#1083).
- Forward-merge to `2026.x` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)