### PR TITLE
Speed up getLatestVersion by avoiding a redundant query

### DIFF
--- a/models/Element/Traits/VersionDaoTrait.php
+++ b/models/Element/Traits/VersionDaoTrait.php
@@ -27,19 +27,19 @@ trait VersionDaoTrait
     public function getLatestVersion(?int $userId = null, bool $includingPublished = false): ?Version
     {
         $operator = $includingPublished ? '>=' : '>';
-        $versionId = $this->db->fetchOne('SELECT id FROM versions WHERE cid = :cid AND ctype = :ctype AND (`date` ' . $operator . ' :mdate OR versionCount ' . $operator . ' :versionCount) AND ((autoSave = 1 AND userId = :userId) OR autoSave = 0) ORDER BY `versionCount` DESC LIMIT 1', [
+
+        $list = new Version\Listing();
+        // load the auto-save versions as well, the condition below restricts them to the given user
+        $list->setLoadAutoSave(true);
+        $list->setCondition('cid = :cid AND ctype = :ctype AND (`date` ' . $operator . ' :mdate OR versionCount ' . $operator . ' :versionCount) AND ((autoSave = 1 AND userId = :userId) OR autoSave = 0)', [
             'cid' => $this->model->getId(),
             'ctype' => Element\Service::getElementType($this->model),
             'userId' => $userId,
             'mdate' => $this->model->getModificationDate(),
             'versionCount' => $this->model->getVersionCount(),
-        ]);
+        ])->setOrderKey('versionCount')->setOrder('DESC')->setLimit(1);
 
-        if ($versionId) {
-            return Version::getById($versionId);
-        }
-
-        return null;
+        return $list->load()[0] ?? null;
     }
 
     /**

--- a/tests/Service/Element/VersionTest.php
+++ b/tests/Service/Element/VersionTest.php
@@ -17,6 +17,7 @@ use Exception;
 use Pimcore;
 use Pimcore\Db;
 use Pimcore\Model\DataObject\Unittest;
+use Pimcore\Model\User;
 use Pimcore\Model\Version;
 use Pimcore\Model\Version\Adapter\DatabaseVersionStorageAdapter;
 use Pimcore\Model\Version\Adapter\FileSystemVersionStorageAdapter;
@@ -143,6 +144,81 @@ class VersionTest extends TestCase
 
         $multihref = $sourceObjectFromDb->getMultihref();
         $this->assertCount(1, $multihref, 'expected 1 target element');
+    }
+
+    /**
+     * getLatestVersion() must only report versions that are newer than the element itself, and the
+     * returned version must be hydrated exactly like a directly loaded one.
+     */
+    public function testGetLatestVersion(): void
+    {
+        $this->setStorageAdapter($this->mockFileSystemStorageAdapter());
+        $object = TestHelper::createEmptyObject();
+
+        // the version written by save() represents the published state, so it is only reported
+        // when $includingPublished is set
+        $this->assertNull($object->getLatestVersion(), 'expected no version newer than the object itself');
+
+        $publishedVersion = $object->getLatestVersion(null, true);
+        $this->assertNotNull($publishedVersion, 'expected the published version to be returned');
+        $this->assertSame($object->getId(), $publishedVersion->getCid(), 'version belongs to another element');
+        $this->assertSame('object', $publishedVersion->getCtype(), 'unexpected element type');
+        $this->assertSame($object->getVersionCount(), $publishedVersion->getVersionCount(), 'unexpected version count');
+        $this->assertFalse($publishedVersion->isAutoSave(), 'the published version must not be an auto-save one');
+
+        $directlyLoadedVersion = Version::getById((int) $publishedVersion->getId());
+        $this->assertNotNull($directlyLoadedVersion, 'the returned version must exist in the database');
+        $this->assertSame($directlyLoadedVersion->getDate(), $publishedVersion->getDate(), 'date not hydrated');
+        $this->assertSame($directlyLoadedVersion->getVersionCount(), $publishedVersion->getVersionCount(), 'versionCount not hydrated');
+        $this->assertSame($directlyLoadedVersion->isAutoSave(), $publishedVersion->isAutoSave(), 'autoSave not hydrated');
+        $this->assertSame($directlyLoadedVersion->getSerialized(), $publishedVersion->getSerialized(), 'serialized not hydrated');
+
+        // a version newer than the element wins, regardless of $includingPublished
+        $newerVersion = $object->saveVersion();
+        $this->assertNotNull($newerVersion, 'expected a new version to be saved');
+        $latestVersion = $object->getLatestVersion();
+        $this->assertNotNull($latestVersion, 'expected the newly saved version to be returned');
+        $this->assertSame($newerVersion->getId(), $latestVersion->getId(), 'expected the newest version');
+        $this->assertGreaterThan($object->getVersionCount(), $latestVersion->getVersionCount(), 'expected a newer version count');
+    }
+
+    /**
+     * Auto-save versions are private to their author: getLatestVersion() must return the caller's
+     * own auto-save version, and must never leak somebody else's.
+     */
+    public function testGetLatestVersionOnlyReturnsOwnAutoSaveVersion(): void
+    {
+        $this->setStorageAdapter($this->mockFileSystemStorageAdapter());
+
+        $author = $this->createUser('test-version-author');
+        $otherUser = $this->createUser('test-version-other-user');
+
+        $object = TestHelper::createEmptyObject();
+        $object->setUserModification($author->getId());
+        $autoSaveVersion = $object->saveVersion(true, true, null, true);
+        $this->assertNotNull($autoSaveVersion, 'expected an auto-save version to be saved');
+        $this->assertTrue($autoSaveVersion->isAutoSave(), 'expected an auto-save version');
+
+        $latestVersion = $object->getLatestVersion($author->getId());
+        $this->assertNotNull($latestVersion, 'the author must see their own auto-save version');
+        $this->assertSame($autoSaveVersion->getId(), $latestVersion->getId(), 'expected the auto-save version');
+        $this->assertSame($author->getId(), $latestVersion->getUserId(), 'unexpected auto-save author');
+        $this->assertTrue($latestVersion->isAutoSave(), 'autoSave not hydrated');
+
+        $this->assertNull(
+            $object->getLatestVersion($otherUser->getId()),
+            'an auto-save version must not be visible to another user'
+        );
+    }
+
+    protected function createUser(string $name): User
+    {
+        if (!$user = User::getByName($name)) {
+            $user = new User();
+            $user->setName($name)->save();
+        }
+
+        return $user;
     }
 
     // Save a new object and check if the storagetype is set to fs


### PR DESCRIPTION
## Changes in this pull request

Resolves pimcore/platform-version#334

`getLatestVersion()` selected the version id and then loaded the full record again via `Version::getById()`, resulting in two queries against the `versions` table for the same row.

Use a `Version\Listing` with the existing filter clause and `LIMIT 1` to load the version in a single query. `setLoadAutoSave(true)` is required so the listing does not append its own `AND autoSave = 0` clause, which would override the per-user auto-save condition already expressed in the condition.

## Additional info

Behaviour is unchanged: same filter, same `versionCount DESC` ordering, same `null` when no newer version exists. Targeting `2026.x` as an improvement per the contributing guidelines.

Originally reported as pimcore/pimcore#17728 (labelled `PR Welcome`), which was auto-closed for inactivity; re-filed in `platform-version` per the issue-link guardrail.
