### PR TITLE
[DataObject] Add searchPath option to Image, Hotspotimage & ImageGallery

### DIFF
--- a/doc/03_Objects/01_Object_Classes/01_Data_Types/45_Image_Types.md
+++ b/doc/03_Objects/01_Object_Classes/01_Data_Types/45_Image_Types.md
@@ -30,6 +30,18 @@ in the class settings as follows:
 
 ![Image Configuration](../../../img/classes-datatypes-image2.jpg)
 
+#### Upload Path & Search Path
+
+Two optional asset folder paths can be configured in the class settings (available for the Image, Image Advanced and
+Image Gallery data types):
+
+- **Upload Path**: the target folder for images uploaded directly via the field (e.g. inline upload or drag & drop from
+  the file system).
+- **Search Path**: the asset folder the search dialog of the field is scoped to by default. The path is applied as a
+  pre-filled filter when the asset search is opened from the field, so users start off seeing only assets below the
+  configured folder. It is a convenience default, not a restriction — the filter is visible in the search dialog and can
+  be adjusted or removed there.
+
 
 #### Working with images in frontend
 To get a thumbnail of an image field, call `getThumbnail()` on the returned asset object.

--- a/models/DataObject/ClassDefinition/Data/Image.php
+++ b/models/DataObject/ClassDefinition/Data/Image.php
@@ -227,6 +227,7 @@ class Image extends Data implements ResourcePersistenceAwareInterface, QueryReso
     public function synchronizeWithMainDefinition(Model\DataObject\ClassDefinition\Data $mainDefinition): void
     {
         $this->uploadPath = $mainDefinition->uploadPath;
+        $this->searchPath = $mainDefinition->searchPath;
     }
 
     public function isFilterable(): bool

--- a/models/DataObject/ClassDefinition/Data/ImageGallery.php
+++ b/models/DataObject/ClassDefinition/Data/ImageGallery.php
@@ -35,6 +35,11 @@ class ImageGallery extends Data implements ResourcePersistenceAwareInterface, Qu
     /**
      * @internal
      */
+    public string $searchPath = '';
+
+    /**
+     * @internal
+     */
     public ?int $ratioX = null;
 
     /**
@@ -86,6 +91,16 @@ class ImageGallery extends Data implements ResourcePersistenceAwareInterface, Qu
     public function setUploadPath(string $uploadPath): void
     {
         $this->uploadPath = $uploadPath;
+    }
+
+    public function getSearchPath(): string
+    {
+        return $this->searchPath;
+    }
+
+    public function setSearchPath(string $searchPath): void
+    {
+        $this->searchPath = $searchPath;
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/ImageTrait.php
+++ b/models/DataObject/ClassDefinition/Data/ImageTrait.php
@@ -30,6 +30,11 @@ trait ImageTrait
     public string $uploadPath;
 
     /**
+     * @internal
+     */
+    public string $searchPath = '';
+
+    /**
      * @return $this
      */
     public function setUploadPath(string $uploadPath): static
@@ -42,5 +47,20 @@ trait ImageTrait
     public function getUploadPath(): string
     {
         return $this->uploadPath;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setSearchPath(string $searchPath): static
+    {
+        $this->searchPath = $searchPath;
+
+        return $this;
+    }
+
+    public function getSearchPath(): string
+    {
+        return $this->searchPath;
     }
 }


### PR DESCRIPTION
Adds a new "searchPath" class-definition setting next to "uploadPath" for the image-flavored data types. While uploadPath only targets inline uploads, searchPath lets the asset search dialog of the field open pre-scoped to a configured asset folder (as a visible, user-clearable filter — a soft default, not a restriction).

The property is serialized to the UI automatically via the public-props JSON serialization, so the admin UIs (Studio / classic) can consume it from the field configuration.


<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `12.3`
- Feature/Improvement: choose `2026.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`2026.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `12.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #17157
Tracking issue: pimcore/platform-version#433

## Additional info
Additional info: UI support implemented in https://github.com/pimcore/studio-ui-bundle/pull/3993, the property is inert without it.