### PR TITLE
docs(upgrade-notes): note Custom Reports enabled_adapters config option

### DIFF
--- a/doc/13_Upgrade_Notes/README.md
+++ b/doc/13_Upgrade_Notes/README.md
@@ -1,5 +1,16 @@
 # Upgrade Notes
 
+## Pimcore 2026.2.5
+
+### [Custom Reports]
+- Added a `pimcore_custom_reports.enabled_adapters` config option to enable/disable individual Custom Report data-source adapters (e.g. the built-in `sql` adapter) per project. Adapters not listed default to enabled; a disabled adapter is removed from the shared `pimcore.custom_report.adapter.factories` service locator, so it becomes unavailable to every consumer (the classic admin controller and the Studio backend bundle alike).
+    ```yaml
+    pimcore_custom_reports:
+        enabled_adapters:
+            sql: false
+    ```
+  We recommend disabling the built-in `sql` adapter unless specifically needed: any user with the `reports_config` permission can otherwise define arbitrary `SELECT` statements against the application's database, including tables never intended to be exposed. See `doc/06_Reporting/01_Custom_Reports.md` for details.
+
 ## Pimcore 2026.2.0
 
 ### [General]
@@ -31,15 +42,6 @@
 ### [Translations]
 - `Translation::DOMAIN_ADMIN` constant is deprecated since 2026.2 and will be removed in a future release. Avoid referencing the `admin` translation domain directly.
 - `Translator::$adminPath` and `Translator::$adminTranslationMapping` properties are deprecated since 2026.2.
-
-### [Custom Reports]
-- Added a `pimcore_custom_reports.enabled_adapters` config option to enable/disable individual Custom Report data-source adapters (e.g. the built-in `sql` adapter) per project. Adapters not listed default to enabled; a disabled adapter is removed from the shared `pimcore.custom_report.adapter.factories` service locator, so it becomes unavailable to every consumer (the classic admin controller and the Studio backend bundle alike).
-    ```yaml
-    pimcore_custom_reports:
-        enabled_adapters:
-            sql: false
-    ```
-  We recommend disabling the built-in `sql` adapter unless specifically needed: any user with the `reports_config` permission can otherwise define arbitrary `SELECT` statements against the application's database, including tables never intended to be exposed. See `doc/06_Reporting/01_Custom_Reports.md` for details.
 
 ## Pimcore 2026.1.0
 

--- a/doc/13_Upgrade_Notes/README.md
+++ b/doc/13_Upgrade_Notes/README.md
@@ -9,7 +9,7 @@
         enabled_adapters:
             sql: false
     ```
-  We recommend disabling the built-in `sql` adapter unless specifically needed: any user with the `reports_config` permission can otherwise define arbitrary `SELECT` statements against the application's database, including tables never intended to be exposed. See `doc/06_Reporting/01_Custom_Reports.md` for details.
+  We recommend disabling the built-in `sql` adapter unless specifically needed: any user with the `reports_config` permission can otherwise define arbitrary `SELECT` statements against the application's database, including tables never intended to be exposed. See [Custom Reports](../06_Reporting/01_Custom_Reports.md)  for details.
 
 ## Pimcore 2026.2.0
 
@@ -116,13 +116,13 @@ The following bundles have been removed:
 
 
 ### [Database]
-- All `utf8mb4` tables now use `utf8mb4_unicode_520_ci` as their default collation to match Doctrine's `default_table_options` 
-  configuration. Columns inherit this collation unless a different one is explicitly defined (for example `utf8mb4_bin` 
-  for case-sensitive keys). Previously, `install.sql` and Dao `CREATE TABLE` statements specified `DEFAULT CHARSET=utf8mb4` 
-  without an explicit `COLLATE` clause, which caused MySQL/MariaDB to assign the charset's built-in default collation 
-  (`utf8mb4_general_ci`) instead of the intended `utf8mb4_unicode_520_ci`. 
-  Existing installations need to update the collation of their tables and columns manually, details see 
-  'Tasks to Do Prior the Update' chapter above. 
+- All `utf8mb4` tables now use `utf8mb4_unicode_520_ci` as their default collation to match Doctrine's `default_table_options`
+  configuration. Columns inherit this collation unless a different one is explicitly defined (for example `utf8mb4_bin`
+  for case-sensitive keys). Previously, `install.sql` and Dao `CREATE TABLE` statements specified `DEFAULT CHARSET=utf8mb4`
+  without an explicit `COLLATE` clause, which caused MySQL/MariaDB to assign the charset's built-in default collation
+  (`utf8mb4_general_ci`) instead of the intended `utf8mb4_unicode_520_ci`.
+  Existing installations need to update the collation of their tables and columns manually, details see
+  'Tasks to Do Prior the Update' chapter above.
 
 ### [Models]
 - Added a new optional `$parameters` argument to `AbstractUser::save()` and `AbstractUser::delete()`, as well as their interface methods, to allow passing of arguments to `UserRoleEvent`.

--- a/doc/13_Upgrade_Notes/README.md
+++ b/doc/13_Upgrade_Notes/README.md
@@ -32,6 +32,15 @@
 - `Translation::DOMAIN_ADMIN` constant is deprecated since 2026.2 and will be removed in a future release. Avoid referencing the `admin` translation domain directly.
 - `Translator::$adminPath` and `Translator::$adminTranslationMapping` properties are deprecated since 2026.2.
 
+### [Custom Reports]
+- Added a `pimcore_custom_reports.enabled_adapters` config option to enable/disable individual Custom Report data-source adapters (e.g. the built-in `sql` adapter) per project. Adapters not listed default to enabled; a disabled adapter is removed from the shared `pimcore.custom_report.adapter.factories` service locator, so it becomes unavailable to every consumer (the classic admin controller and the Studio backend bundle alike).
+    ```yaml
+    pimcore_custom_reports:
+        enabled_adapters:
+            sql: false
+    ```
+  We recommend disabling the built-in `sql` adapter unless specifically needed: any user with the `reports_config` permission can otherwise define arbitrary `SELECT` statements against the application's database, including tables never intended to be exposed. See `doc/06_Reporting/01_Custom_Reports.md` for details.
+
 ## Pimcore 2026.1.0
 
 ### Tasks to Do Prior the Update


### PR DESCRIPTION
## Summary
- Adds an upgrade-notes entry for #19304, which introduces the `pimcore_custom_reports.enabled_adapters` config option to enable/disable individual Custom Report data-source adapters (e.g. the built-in `sql` adapter) per project.
- Notes that a disabled adapter is removed from the shared `pimcore.custom_report.adapter.factories` service locator and is therefore unavailable to every consumer, and repeats the security recommendation to disable the `sql` adapter unless explicitly needed.

## Test plan
- [x] Doc-only change; verified rendering of the new section in `doc/13_Upgrade_Notes/README.md`.