### PR TITLE
[Bug] Fix TypeError when a video image thumbnail cannot be generated

### DIFF
--- a/models/Asset/Document/ImageThumbnail.php
+++ b/models/Asset/Document/ImageThumbnail.php
@@ -111,10 +111,7 @@ final class ImageThumbnail implements ImageThumbnailInterface
         }
 
         if (empty($this->pathReference)) {
-            $this->pathReference = [
-                'type' => 'error',
-                'src' => '/bundles/pimcoreadmin/img/filetype-not-supported.svg',
-            ];
+            $this->pathReference = $this->getErrorPathReference();
         }
 
         $event = new GenericEvent($this, [

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -143,10 +143,7 @@ final class Thumbnail implements ThumbnailInterface
                     'src' => $this->asset->getRealFullPath(),
                 ];
             } else {
-                $this->pathReference = [
-                    'type' => 'error',
-                    'src' => '/bundles/pimcoreadmin/img/filetype-not-supported.svg',
-                ];
+                $this->pathReference = $this->getErrorPathReference();
             }
         }
 

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -287,10 +287,34 @@ trait ImageThumbnailTrait
         return pathinfo($this->getPath(), PATHINFO_EXTENSION);
     }
 
+    /**
+     * Path reference used whenever no thumbnail can be provided at all, so that the path getters
+     * always resolve to a valid (placeholder) path instead of null.
+     *
+     * @internal
+     *
+     * @return array{type: string, src: string}
+     */
+    protected function getErrorPathReference(): array
+    {
+        return [
+            'type' => 'error',
+            'src' => '/bundles/pimcoreadmin/img/filetype-not-supported.svg',
+        ];
+    }
+
     protected function convertToWebPath(array $pathReference, bool $frontend): ?string
     {
         $type = $pathReference['type'] ?? null;
         $path = $pathReference['src'] ?? null;
+
+        if ($path === null) {
+            // an incomplete path reference must not result in a null path, as the path getters are
+            // contracted to return a string - use the placeholder instead
+            $pathReference = $this->getErrorPathReference();
+            $type = $pathReference['type'];
+            $path = $pathReference['src'];
+        }
 
         if ($frontend) {
             if ($type === 'data-uri') {

--- a/models/Asset/Video/ImageThumbnail.php
+++ b/models/Asset/Video/ImageThumbnail.php
@@ -154,13 +154,15 @@ final class ImageThumbnail implements ImageThumbnailInterface
                 // if the original image could not be extracted from the video (e.g. no video adapter available or a
                 // broken/missing video file), don't bail out here, so that the error path reference below is used
                 if ($imageAvailable && $this->getConfig()) {
+                    $cacheFileStream = $storage->readStream($cacheFilePath);
+
                     $this->getConfig()->setFilenameSuffix('time-' . $timeOffset);
 
                     try {
                         $this->pathReference = Image\Thumbnail\Processor::process(
                             $this->asset,
                             $this->getConfig(),
-                            $storage->readStream($cacheFilePath),
+                            $cacheFileStream,
                             $deferred,
                             $generated
                         );

--- a/models/Asset/Video/ImageThumbnail.php
+++ b/models/Asset/Video/ImageThumbnail.php
@@ -195,6 +195,7 @@ final class ImageThumbnail implements ImageThumbnailInterface
         string $cacheFilePath,
         int $timeOffset
     ): bool {
+        $tempFile = File::getLocalTempFilePath('png');
         $converter = Video::newInstance();
         if ($converter === null) {
             Logger::error('No video adapter available to create image thumbnail for video ' . $asset->getRealFullPath() . '.');
@@ -202,7 +203,6 @@ final class ImageThumbnail implements ImageThumbnailInterface
             return false;
         }
 
-        $tempFile = File::getLocalTempFilePath('png');
         $converter->load($asset->getLocalFile());
         if (false === $converter->saveImage($tempFile, $timeOffset)) {
             Logger::info('Creation of image thumbnail for video ' . $asset->getRealFullPath() . ' failed.');

--- a/models/Asset/Video/ImageThumbnail.php
+++ b/models/Asset/Video/ImageThumbnail.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Pimcore\Model\Asset\Video;
 
 use Exception;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
 use Pimcore;
 use Pimcore\Event\AssetEvents;
 use Pimcore\Event\FrontendEvents;
@@ -76,7 +78,7 @@ final class ImageThumbnail implements ImageThumbnailInterface
     }
 
     /**
-     * @throws Exception|\League\Flysystem\FilesystemException|ThumbnailFormatNotSupportedException
+     * @throws Exception|FilesystemException|ThumbnailFormatNotSupportedException
      *
      * @internal
      */
@@ -127,48 +129,38 @@ final class ImageThumbnail implements ImageThumbnailInterface
                     $timeOffset
                 );
 
-                if (!$storage->fileExists($cacheFilePath)) {
+                $imageAvailable = $storage->fileExists($cacheFilePath);
+                if (!$imageAvailable) {
                     $lock = Pimcore::getContainer()->get(LockFactory::class)->createLock($cacheFilePath);
                     $lock->acquire(true);
 
-                    // after we got the lock, check again if the image exists in the meantime - if not - generate it
-                    if (!$storage->fileExists($cacheFilePath)) {
-                        $tempFile = File::getLocalTempFilePath('png');
-                        $converter = Video::newInstance();
-                        if ($converter === null) {
-                            Logger::error('No video adapter available to create image thumbnail for video ' . $this->asset->getRealFullPath() . '.');
-
-                            return;
+                    try {
+                        // after we got the lock, check again if the image exists in the meantime - if not - generate it
+                        $imageAvailable = $storage->fileExists($cacheFilePath);
+                        if (!$imageAvailable) {
+                            $generated = $this->writeOriginalImage(
+                                $this->asset,
+                                $storage,
+                                $cacheFilePath,
+                                (int) $timeOffset
+                            );
+                            $imageAvailable = $generated;
                         }
-                        $converter->load($this->asset->getLocalFile());
-                        if (false === $converter->saveImage($tempFile, (int) $timeOffset)) {
-                            Logger::info('Creation of image thumbnail for video ' . $this->asset->getRealFullPath() . ' failed.');
-
-                            return;
-                        }
-                        $tempFileContent = file_get_contents($tempFile);
-                        if (false === $tempFileContent) {
-                            Logger::info('Could not read temporary image thumbnail file for video ' . $this->asset->getRealFullPath() . '.');
-
-                            return;
-                        }
-                        $storage->write($cacheFilePath, $tempFileContent);
-                        $generated = true;
+                    } finally {
+                        $lock->release();
                     }
-
-                    $lock->release();
                 }
 
-                $cacheFileStream = $storage->readStream($cacheFilePath);
-
-                if ($this->getConfig()) {
+                // if the original image could not be extracted from the video (e.g. no video adapter available or a
+                // broken/missing video file), don't bail out here, so that the error path reference below is used
+                if ($imageAvailable && $this->getConfig()) {
                     $this->getConfig()->setFilenameSuffix('time-' . $timeOffset);
 
                     try {
                         $this->pathReference = Image\Thumbnail\Processor::process(
                             $this->asset,
                             $this->getConfig(),
-                            $cacheFileStream,
+                            $storage->readStream($cacheFilePath),
                             $deferred,
                             $generated
                         );
@@ -180,10 +172,7 @@ final class ImageThumbnail implements ImageThumbnailInterface
         }
 
         if (empty($this->pathReference)) {
-            $this->pathReference = [
-                'type' => 'error',
-                'src' => '/bundles/pimcoreadmin/img/filetype-not-supported.svg',
-            ];
+            $this->pathReference = $this->getErrorPathReference();
         }
 
         $event = new GenericEvent($this, [
@@ -191,6 +180,46 @@ final class ImageThumbnail implements ImageThumbnailInterface
             'generated' => $generated,
         ]);
         Pimcore::getEventDispatcher()->dispatch($event, AssetEvents::VIDEO_IMAGE_THUMBNAIL);
+    }
+
+    /**
+     * Extracts the frame at the given time offset from the video and writes it to the asset cache storage.
+     *
+     * @return bool whether the image has been written to the asset cache storage
+     *
+     * @throws Exception|FilesystemException
+     */
+    private function writeOriginalImage(
+        Model\Asset\Video $asset,
+        FilesystemOperator $storage,
+        string $cacheFilePath,
+        int $timeOffset
+    ): bool {
+        $converter = Video::newInstance();
+        if ($converter === null) {
+            Logger::error('No video adapter available to create image thumbnail for video ' . $asset->getRealFullPath() . '.');
+
+            return false;
+        }
+
+        $tempFile = File::getLocalTempFilePath('png');
+        $converter->load($asset->getLocalFile());
+        if (false === $converter->saveImage($tempFile, $timeOffset)) {
+            Logger::info('Creation of image thumbnail for video ' . $asset->getRealFullPath() . ' failed.');
+
+            return false;
+        }
+
+        $tempFileContent = file_get_contents($tempFile);
+        if (false === $tempFileContent) {
+            Logger::info('Could not read temporary image thumbnail file for video ' . $asset->getRealFullPath() . '.');
+
+            return false;
+        }
+
+        $storage->write($cacheFilePath, $tempFileContent);
+
+        return true;
     }
 
     /**

--- a/tests/Model/Asset/VideoImageThumbnailTest.php
+++ b/tests/Model/Asset/VideoImageThumbnailTest.php
@@ -1,0 +1,98 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\Asset;
+
+use Pimcore\Model\Asset;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+use Pimcore\Tests\Support\Util\TestHelper;
+use Pimcore\Tool\Storage;
+
+/**
+ * Regression tests for pimcore/platform-version#246.
+ *
+ * When the original image could not be extracted from a video - because the video file is gone from
+ * storage or because no video adapter is available - generate() used to bail out early, leaving an
+ * empty path reference behind. getPath() then returned null, violating its `string` return type and
+ * crashing with a TypeError instead of degrading to the "filetype not supported" placeholder.
+ *
+ * @group model.asset.video-image-thumbnail
+ */
+class VideoImageThumbnailTest extends ModelTestCase
+{
+    private const PLACEHOLDER = '/bundles/pimcoreadmin/img/filetype-not-supported.svg';
+
+    protected function tearDown(): void
+    {
+        TestHelper::clearThumbnailConfigurations();
+
+        parent::tearDown();
+    }
+
+    /**
+     * A time offset is passed explicitly so that the test does not depend on getDuration(), which
+     * would itself require a readable video file.
+     */
+    private function thumbnailOfVideoMissingOnStorage(): Asset\Video\ImageThumbnail
+    {
+        $asset = TestHelper::createVideoAsset();
+        $config = TestHelper::createThumbnailConfigurationScaleByWidth();
+
+        Storage::get('asset')->delete($asset->getRealFullPath());
+
+        return new Asset\Video\ImageThumbnail($asset, $config, 1, null, false);
+    }
+
+    public function testGetPathReturnsPlaceholderWhenVideoIsMissingOnStorage(): void
+    {
+        $path = $this->thumbnailOfVideoMissingOnStorage()->getPath(['deferredAllowed' => false, 'frontend' => false]);
+
+        $this->assertSame(self::PLACEHOLDER, $path);
+    }
+
+    public function testGetPathReturnsPlaceholderForFrontendWhenVideoIsMissingOnStorage(): void
+    {
+        $path = $this->thumbnailOfVideoMissingOnStorage()->getPath(['deferredAllowed' => false, 'frontend' => true]);
+
+        $this->assertSame(self::PLACEHOLDER, $path);
+    }
+
+    /**
+     * The rest of the API built on top of the path reference has to stay usable as well - this is
+     * what indexing (e.g. the generic data index) relies on.
+     */
+    public function testThumbnailStaysUsableWhenVideoIsMissingOnStorage(): void
+    {
+        $thumbnail = $this->thumbnailOfVideoMissingOnStorage();
+
+        $this->assertFalse($thumbnail->exists());
+        $this->assertSame('svg', $thumbnail->getFileExtension());
+        $this->assertStringStartsWith('image/svg', $thumbnail->getMimeType());
+        $this->assertNull($thumbnail->getFileSize());
+    }
+
+    /**
+     * An incomplete path reference must never resolve to null either, no matter how it came to be.
+     */
+    public function testConvertToWebPathFallsBackToPlaceholderForEmptyPathReference(): void
+    {
+        $thumbnail = new Asset\Video\ImageThumbnail(null);
+
+        foreach ([true, false] as $frontend) {
+            $this->assertSame(
+                self::PLACEHOLDER,
+                TestHelper::callMethod($thumbnail, 'convertToWebPath', [[], $frontend])
+            );
+        }
+    }
+}

--- a/tests/Model/Asset/VideoImageThumbnailTest.php
+++ b/tests/Model/Asset/VideoImageThumbnailTest.php
@@ -28,7 +28,7 @@ use Pimcore\Tool\Storage;
  *
  * @group model.asset.video-image-thumbnail
  */
-class VideoImageThumbnailTest extends ModelTestCase
+final class VideoImageThumbnailTest extends ModelTestCase
 {
     private const PLACEHOLDER = '/bundles/pimcoreadmin/img/filetype-not-supported.svg';
 


### PR DESCRIPTION
Fixes https://github.com/pimcore/platform-version/issues/246

### Problem

`Video\ImageThumbnail::generate()` returned early — without ever setting a path reference — whenever the original image could not be extracted from the video:

* no video adapter is available,
* `Video\Adapter::saveImage()` fails (e.g. the video file has been deleted from storage, as in the reported reproduction),
* or the temporary PNG cannot be read back.

Because of the early `return;`, the `type => error` fallback at the end of `generate()` was skipped. `getPathReference()` then handed back an empty array and `convertToWebPath()` resolved to `null`, so the `string`-typed getter blew up:

```
Pimcore\Model\Asset\Video\ImageThumbnail::getPath(): Return value must be of type string, null returned
```

…or, in a frontend context, with a TypeError out of `urlencode_ignore_slash()`. This broke anything that only wants a path, e.g. `generic-index` over an asset whose file is missing on storage.

Two further consequences of the early returns:

* the lock on the cache file was **never released** (`$lock->release()` was unreachable),
* `$storage->readStream($cacheFilePath)` was called unconditionally on a cache file that may not exist.

### Fix

* The extraction is moved into a private `writeOriginalImage()` that reports failure via its return value instead of aborting `generate()`. The "filetype not supported" placeholder is used instead — the same degradation `Document\ImageThumbnail` already applies.
* The lock is released in a `finally` block.
* `readStream()` is only called when the cache file actually exists.
* As a safety net, `ImageThumbnailTrait::convertToWebPath()` also falls back to the placeholder for an incomplete path reference, so the path getters can no longer return `null` no matter how the path reference came to be.
* The placeholder definition, previously duplicated in all three `generate()` implementations, is shared via `ImageThumbnailTrait::getErrorPathReference()`.

No signature or behaviour change for the success path — the number of storage calls is unchanged.

### About the second error in the issue

The issue also mentions `Pimcore\Model\Asset\Image::getWidth(): Return value must be of type int, string returned`. That one is already fixed on 2026.2 by "Ensure that dimensions are integers" (#18890, released in 2026.2.0) — `Image::getWidth()/getHeight()` now cast the dimension to `int`. Nothing left to do there.

### Tests

New `tests/Model/Asset/VideoImageThumbnailTest.php` reproduces the issue: a video asset is created, its file is deleted from the `asset` storage, and the image thumbnail is requested. Verified that all 4 tests fail on the unpatched code with exactly the reported errors…

```
[TypeError] Pimcore\Model\Asset\Video\ImageThumbnail::getPath(): Return value must be of type string, null returned
[TypeError] urlencode_ignore_slash(): Argument #1 ($var) must be of type string, null given
Tests: 4, Assertions: 0, Errors: 4.
```

…and pass with it. Full `tests/Model/Asset` suite green locally (54 tests, 213 assertions), php-cs-fixer and PHPStan (level 6, CI paths) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
