### PR TITLE
[Bug] Imagick: preserve the source colorspace when compositing onto a new canvas

### DIFF
--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -629,8 +629,30 @@ class Imagick extends Adapter
         $newImage = new \Imagick();
         $newImage->newimage($width, $height, $color);
         $newImage->setImageFormat($this->resource->getImageFormat());
+        $this->inheritColorspace($newImage);
 
         return $newImage;
+    }
+
+    /**
+     * A canvas created by \Imagick::newImage() is always sRGB. Compositing a source image with a
+     * different colorspace (eg. CMYK) onto it copies the raw channel data without any conversion,
+     * which results in an sRGB image containing CMYK data - the colors appear inverted.
+     * Transferring the colorspace and the embedded ICC profile of the source image to the canvas
+     * keeps both images in the same color space. For images that were already converted to sRGB
+     * during loading (preserveColor = false) this is a no-op.
+     */
+    private function inheritColorspace(\Imagick $newImage): void
+    {
+        $colorspace = $this->resource->getImageColorspace();
+        if ($colorspace !== \Imagick::COLORSPACE_UNDEFINED && $colorspace !== $newImage->getImageColorspace()) {
+            $newImage->setImageColorspace($colorspace);
+        }
+
+        $profiles = $this->resource->getImageProfiles('icc', true);
+        if (isset($profiles['icc'])) {
+            $newImage->setImageProfile('icc', $profiles['icc']);
+        }
     }
 
     /**

--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -638,16 +638,26 @@ class Imagick extends Adapter
      * A canvas created by \Imagick::newImage() is always sRGB. Compositing a source image with a
      * different colorspace (eg. CMYK) onto it copies the raw channel data without any conversion,
      * which results in an sRGB image containing CMYK data - the colors appear inverted.
-     * Transferring the colorspace and the embedded ICC profile of the source image to the canvas
-     * keeps both images in the same color space. For images that were already converted to sRGB
-     * during loading (preserveColor = false) this is a no-op.
+     * Converting the canvas to the colorspace of the source image and transferring its embedded
+     * ICC profile keeps both images in the same color space. For images that were already
+     * converted to sRGB while loading (preserveColor = false) this is a no-op.
      */
     private function inheritColorspace(\Imagick $newImage): void
     {
         $colorspace = $this->resource->getImageColorspace();
-        if ($colorspace !== \Imagick::COLORSPACE_UNDEFINED && $colorspace !== $newImage->getImageColorspace()) {
-            $newImage->setImageColorspace($colorspace);
+        if ($colorspace === \Imagick::COLORSPACE_UNDEFINED || $colorspace === $newImage->getImageColorspace()) {
+            return;
         }
+
+        if ($newImage->getImageAlphaChannel()) {
+            // A canvas that is (partly) transparent has to be flattened onto the background color
+            // when the thumbnail is written, and save() does that with \Imagick::ALPHACHANNEL_REMOVE,
+            // which applies the background color as raw channel data. That only yields the intended
+            // result in an RGB colorspace, so such a canvas is left untouched.
+            return;
+        }
+
+        $newImage->transformImageColorspace($colorspace);
 
         $profiles = $this->resource->getImageProfiles('icc', true);
         if (isset($profiles['icc'])) {

--- a/tests/Unit/Image/Adapter/ImagickTest.php
+++ b/tests/Unit/Image/Adapter/ImagickTest.php
@@ -20,15 +20,35 @@ use Pimcore\Tests\Support\Test\TestCase;
 /**
  * Regression tests for the Imagick adapter (#14543).
  *
- * Transformations that composite the image onto a freshly created canvas
- * (setBackgroundColor(), frame()) used to drop the colorspace of the source
- * image, because \Imagick::newImage() always produces an sRGB canvas. With
- * preserveColor = true the CMYK channel data of the source was therefore
- * written into an sRGB image, which made the thumbnail come out with inverted
- * colors.
+ * setBackgroundColor() composites the image onto a freshly created canvas, and
+ * \Imagick::newImage() always produces an sRGB canvas. With preserveColor = true
+ * the CMYK channel data of the source was therefore written into an sRGB image,
+ * which made the thumbnail come out with inverted colors.
  */
-class ImagickTest extends TestCase
+final class ImagickTest extends TestCase
 {
+    /**
+     * The color the test fixtures are built from.
+     */
+    private const SOURCE_RGB = [220, 30, 40];
+
+    private const WHITE_RGB = [255, 255, 255];
+
+    /**
+     * Tolerance per channel for a color that stayed in its colorspace. Only the
+     * JPEG compression is lossy here.
+     */
+    private const DELTA = 12;
+
+    /**
+     * Tolerance per channel for a color that went through an ICC based CMYK to
+     * sRGB conversion, which is considerably lossy - but nowhere near enough to
+     * turn red into the cyan the regression produced.
+     */
+    private const DELTA_CONVERTED = 45;
+
+    private const FIXTURE_SIZE = 40;
+
     /**
      * @var string[]
      */
@@ -55,67 +75,117 @@ class ImagickTest extends TestCase
 
     public function testSetBackgroundColorPreservesCmykColorspace(): void
     {
-        $source = $this->createCmykImage();
-
-        $adapter = new Imagick();
-        $adapter->load($source, ['preserveColor' => true]);
+        $adapter = $this->adapter($this->createCmykImage(), true);
         $adapter->setBackgroundColor('#ffffff');
 
-        $this->assertSame(\Imagick::COLORSPACE_CMYK, $this->saveAndGetColorspace($adapter));
-    }
+        $result = $this->saveAndReload($adapter);
 
-    public function testFramePreservesCmykColorspace(): void
-    {
-        $source = $this->createCmykImage();
-
-        $adapter = new Imagick();
-        $adapter->load($source, ['preserveColor' => true]);
-        $adapter->frame(80, 80);
-
-        $this->assertSame(\Imagick::COLORSPACE_CMYK, $this->saveAndGetColorspace($adapter));
+        $this->assertSame(\Imagick::COLORSPACE_CMYK, $result->getImageColorspace());
+        $this->assertArrayHasKey('icc', $result->getImageProfiles('icc', true));
+        $this->assertPixelColor(self::SOURCE_RGB, $result, 20, 20, self::DELTA);
     }
 
     /**
      * Without preserveColor the image is converted to sRGB while loading, so the
-     * canvas must stay sRGB as well.
+     * canvas has to stay sRGB as well.
      */
     public function testSetBackgroundColorConvertsCmykToSrgbWithoutPreserveColor(): void
     {
-        $source = $this->createCmykImage();
-
-        $adapter = new Imagick();
-        $adapter->load($source, ['preserveColor' => false]);
+        $adapter = $this->adapter($this->createCmykImage(), false);
         $adapter->setBackgroundColor('#ffffff');
 
-        $this->assertSame(\Imagick::COLORSPACE_SRGB, $this->saveAndGetColorspace($adapter));
+        $result = $this->saveAndReload($adapter);
+
+        $this->assertSame(\Imagick::COLORSPACE_SRGB, $result->getImageColorspace());
+        $this->assertPixelColor(self::SOURCE_RGB, $result, 20, 20, self::DELTA_CONVERTED);
     }
 
+    /**
+     * frame() builds a transparent canvas, which has to be flattened onto the
+     * background color when the JPEG is written - and that only works in an RGB
+     * colorspace. The canvas therefore deliberately keeps its colorspace, and
+     * the border around the image has to stay white instead of turning black.
+     */
+    public function testFrameKeepsAWhiteBorderForACmykImage(): void
+    {
+        $adapter = $this->adapter($this->createCmykImage(), true);
+        // the fixture is smaller than the frame, so it is centered on the canvas
+        // and the canvas stays visible as a border around it
+        $adapter->frame(80, 80);
+
+        $result = $this->saveAndReload($adapter);
+
+        $this->assertPixelColor(self::WHITE_RGB, $result, 5, 5, self::DELTA);
+    }
+
+    private function adapter(string $path, bool $preserveColor): Imagick
+    {
+        $adapter = new Imagick();
+        $adapter->load($path, ['preserveColor' => $preserveColor]);
+        // mirrors the thumbnail configuration of #14543
+        $adapter->setPreserveMetaData(true);
+
+        return $adapter;
+    }
+
+    /**
+     * Creates an opaque CMYK JPEG with an embedded CMYK ICC profile.
+     */
     private function createCmykImage(): string
     {
         $image = new \Imagick();
-        $image->newImage(40, 40, new ImagickPixel('rgb(220,30,40)'));
+        $image->newImage(
+            self::FIXTURE_SIZE,
+            self::FIXTURE_SIZE,
+            new ImagickPixel(sprintf('rgb(%d,%d,%d)', ...self::SOURCE_RGB))
+        );
         $image->setImageFormat('jpeg');
         $image->transformImageColorspace(\Imagick::COLORSPACE_CMYK);
+        $image->profileImage('icc', Imagick::getCMYKColorProfile());
 
         $path = $this->tmpFile('jpg');
         $image->writeImage($path);
 
-        $written = new \Imagick($path);
+        $fixture = new \Imagick($path);
         $this->assertSame(
             \Imagick::COLORSPACE_CMYK,
-            $written->getImageColorspace(),
+            $fixture->getImageColorspace(),
             'The test fixture could not be created as a CMYK image.'
+        );
+        $this->assertArrayHasKey(
+            'icc',
+            $fixture->getImageProfiles('icc', true),
+            'The test fixture was created without an ICC profile.'
         );
 
         return $path;
     }
 
-    private function saveAndGetColorspace(Imagick $adapter): int
+    private function saveAndReload(Imagick $adapter): \Imagick
     {
         $path = $this->tmpFile('jpg');
         $adapter->save($path, 'jpeg');
 
-        return (new \Imagick($path))->getImageColorspace();
+        return new \Imagick($path);
+    }
+
+    /**
+     * @param int[] $expectedRgb
+     */
+    private function assertPixelColor(array $expectedRgb, \Imagick $image, int $x, int $y, float $delta): void
+    {
+        $probe = clone $image;
+        $probe->transformImageColorspace(\Imagick::COLORSPACE_SRGB);
+        $color = $probe->getImagePixelColor($x, $y)->getColor();
+
+        foreach (['r', 'g', 'b'] as $index => $channel) {
+            $this->assertEqualsWithDelta(
+                $expectedRgb[$index],
+                $color[$channel],
+                $delta,
+                sprintf('Unexpected color at %d,%d: rgb(%d,%d,%d)', $x, $y, $color['r'], $color['g'], $color['b'])
+            );
+        }
     }
 
     private function tmpFile(string $extension): string

--- a/tests/Unit/Image/Adapter/ImagickTest.php
+++ b/tests/Unit/Image/Adapter/ImagickTest.php
@@ -1,0 +1,128 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Image\Adapter;
+
+use ImagickPixel;
+use Pimcore\Image\Adapter\Imagick;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * Regression tests for the Imagick adapter (#14543).
+ *
+ * Transformations that composite the image onto a freshly created canvas
+ * (setBackgroundColor(), frame()) used to drop the colorspace of the source
+ * image, because \Imagick::newImage() always produces an sRGB canvas. With
+ * preserveColor = true the CMYK channel data of the source was therefore
+ * written into an sRGB image, which made the thumbnail come out with inverted
+ * colors.
+ */
+class ImagickTest extends TestCase
+{
+    /**
+     * @var string[]
+     */
+    private array $tmpFiles = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!extension_loaded('imagick')) {
+            $this->markTestSkipped('The imagick extension is not available.');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tmpFiles as $file) {
+            @unlink($file);
+        }
+        $this->tmpFiles = [];
+
+        parent::tearDown();
+    }
+
+    public function testSetBackgroundColorPreservesCmykColorspace(): void
+    {
+        $source = $this->createCmykImage();
+
+        $adapter = new Imagick();
+        $adapter->load($source, ['preserveColor' => true]);
+        $adapter->setBackgroundColor('#ffffff');
+
+        $this->assertSame(\Imagick::COLORSPACE_CMYK, $this->saveAndGetColorspace($adapter));
+    }
+
+    public function testFramePreservesCmykColorspace(): void
+    {
+        $source = $this->createCmykImage();
+
+        $adapter = new Imagick();
+        $adapter->load($source, ['preserveColor' => true]);
+        $adapter->frame(80, 80);
+
+        $this->assertSame(\Imagick::COLORSPACE_CMYK, $this->saveAndGetColorspace($adapter));
+    }
+
+    /**
+     * Without preserveColor the image is converted to sRGB while loading, so the
+     * canvas must stay sRGB as well.
+     */
+    public function testSetBackgroundColorConvertsCmykToSrgbWithoutPreserveColor(): void
+    {
+        $source = $this->createCmykImage();
+
+        $adapter = new Imagick();
+        $adapter->load($source, ['preserveColor' => false]);
+        $adapter->setBackgroundColor('#ffffff');
+
+        $this->assertSame(\Imagick::COLORSPACE_SRGB, $this->saveAndGetColorspace($adapter));
+    }
+
+    private function createCmykImage(): string
+    {
+        $image = new \Imagick();
+        $image->newImage(40, 40, new ImagickPixel('rgb(220,30,40)'));
+        $image->setImageFormat('jpeg');
+        $image->transformImageColorspace(\Imagick::COLORSPACE_CMYK);
+
+        $path = $this->tmpFile('jpg');
+        $image->writeImage($path);
+
+        $written = new \Imagick($path);
+        $this->assertSame(
+            \Imagick::COLORSPACE_CMYK,
+            $written->getImageColorspace(),
+            'The test fixture could not be created as a CMYK image.'
+        );
+
+        return $path;
+    }
+
+    private function saveAndGetColorspace(Imagick $adapter): int
+    {
+        $path = $this->tmpFile('jpg');
+        $adapter->save($path, 'jpeg');
+
+        return (new \Imagick($path))->getImageColorspace();
+    }
+
+    private function tmpFile(string $extension): string
+    {
+        $path = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/imagick-adapter-test-' . uniqid() . '.' . $extension;
+        $this->tmpFiles[] = $path;
+
+        return $path;
+    }
+}


### PR DESCRIPTION
## Changes in this pull request

Fixes #14543.

`Imagick::createImage()` builds the canvas with `\Imagick::newImage()`, which always produces an **sRGB** image. `createCompositeImageFromResource()` then composites the source onto that canvas — and Imagick copies the raw channel data without any conversion. With `preserveColor: true` a CMYK source therefore ends up as an sRGB file that still contains CMYK data, so the thumbnail comes out with inverted colors.

The canvas is now converted to the colorspace of the source image (`transformImageColorspace()`, so the background color itself is converted too, not just relabelled) and the source's embedded ICC profile is transferred to it before the composite. For images that were already converted to sRGB while loading (`preserveColor: false`, the default) it is a no-op, since source and canvas colorspace are then identical.

### Reproduction

With ImageMagick 7.1.2, compositing a CMYK JPEG onto the sRGB canvas:

| | colorspace | ICC | pixel rendered as sRGB |
|---|---|---|---|
| source | CMYK | yes | `srgb(86.3%, 11.8%, 15.2%)` — red |
| before | sRGB | no | `srgb(0, 220, 210)` — cyan |
| after | CMYK | yes | `srgb(86.3%, 11.8%, 15.2%)` — red |

### Scope: opaque canvases only

A canvas that is still (partly) transparent — which is what `frame()` creates — is deliberately left in sRGB. Such a canvas has to be flattened onto the background color when the JPEG is written, and `save()` does that with `\Imagick::ALPHACHANNEL_REMOVE`, which applies the background color as **raw channel data**. In a CMYK image that turns the white background into `CMYK(100%,100%,100%)`, i.e. black. Fixing that means replacing the alpha removal in `save()` with a real flatten, which changes the write path for *every* JPEG thumbnail that has an alpha channel — too broad for this PR.

So `setBackgroundColor()` (the case reported in #14543) is fixed, and `frame()` keeps behaving exactly as it does today. `testFrameKeepsAWhiteBorderForACmykImage` pins that boundary.

### Tests

`tests/Unit/Image/Adapter/ImagickTest.php`, run against a CMYK JPEG fixture with an embedded ICC profile (`ISOcoated_v2_eci.icc`, the profile Pimcore ships):

| test | verified against baseline |
|---|---|
| `testSetBackgroundColorPreservesCmykColorspace` | fails on `2026.2` — `Failed asserting that 23 is identical to 2` (sRGB instead of CMYK) |
| `testFrameKeepsAWhiteBorderForACmykImage` | fails against the first revision of this PR — `rgb(0,0,0)` at the border |
| `testSetBackgroundColorConvertsCmykToSrgbWithoutPreserveColor` | pins the `preserveColor: false` path |

Each one asserts the rendered pixel color (converted to sRGB) on top of the colorspace tag, so a canvas that is merely relabelled cannot pass. The test skips itself when `ext-imagick` is unavailable.

Full `Unit` suite is green locally (914 tests, 1842 assertions), php-cs-fixer clean.

### Not covered here

- The `save()` alpha-flatten defect described above.
- `setBackgroundImage()` has a related but distinct problem: it composites the resource onto a background image loaded from disk, which brings its own colorspace. Deciding which of the two colorspaces should win is a separate call.

## Additional info

- Base branch: `2026.2`
