### PR TITLE
[Improvement] Don't read the localized query tables when inheritance is disabled

### DIFF
--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -135,6 +135,8 @@ class Dao extends Model\Dao\AbstractDao
             DataObject\Localizedfield::setGetFallbackValues(true);
         }
 
+        $inheritanceEnabled = $object->getClass()->getAllowInherit();
+
         foreach ($validLanguages as $language) {
             if (empty($params['newParent'])
                 && !empty($params['isUpdate'])
@@ -226,17 +228,7 @@ class Dao extends Model\Dao\AbstractDao
                     }
                 } catch (TableNotFoundException $e) {
                     // if the table doesn't exist -> create it! deferred creation for object bricks ...
-                    try {
-                        $this->db->rollBack();
-                    } catch (Exception $er) {
-                        // PDO adapter throws exceptions if rollback fails
-                        Logger::info((string) $er);
-                    }
-
-                    $this->createUpdateTable();
-
-                    // throw exception which gets caught in AbstractObject::save() -> retry saving
-                    throw new LanguageTableDoesNotExistException('missing table created, start next run ... ;-)');
+                    $this->createMissingTableAndRetry();
                 }
 
                 if ($container instanceof DataObject\ClassDefinition || $container instanceof DataObject\Objectbrick\Definition) {
@@ -252,43 +244,31 @@ class Dao extends Model\Dao\AbstractDao
                         $queryTable
                     );
                     $this->inheritanceHelper->resetFieldsToCheck();
-                    $sql = 'SELECT * FROM '.$queryTable.' WHERE ooo_id = '.$object->getId(
-                    )." AND language = '".$language."'";
-
-                    $oldData = [];
-
-                    try {
-                        $oldData = $this->db->fetchAssociative($sql);
-                    } catch (TableNotFoundException $e) {
-                        // if the table doesn't exist -> create it!
-
-                        // the following is to ensure consistent data and atomic transactions, while having the flexibility
-                        // to add new languages on the fly without saving all classes having localized fields
-
-                        // first we need to roll back all modifications, because otherwise they would be implicitly committed
-                        // by the following DDL
-                        try {
-                            $this->db->rollBack();
-                        } catch (Exception $er) {
-                            // PDO adapter throws exceptions if rollback fails
-                            Logger::info((string) $er);
-                        }
-
-                        // this creates the missing table
-                        $this->createUpdateTable();
-
-                        // at this point we throw an exception so that the transaction gets repeated in DataObject::save()
-                        throw new LanguageTableDoesNotExistException('missing table created, start next run ... ;-)');
-                    }
 
                     // get fields which shouldn't be updated
                     $untouchable = [];
 
                     // @TODO: currently we do not support lazyloading in localized fields
 
-                    $inheritanceEnabled = $object->getClass()->getAllowInherit();
+                    $oldData = [];
                     $parentData = null;
+
+                    // both the currently stored data and the data of the parent object are only needed to
+                    // determine which fields have to be propagated to the child objects, so there is no point
+                    // in reading the query table at all if inheritance is disabled. this saves one SELECT per
+                    // language and object on every save.
                     if ($inheritanceEnabled) {
+                        $sql = 'SELECT * FROM '.$queryTable.' WHERE ooo_id = '.$object->getId(
+                        )." AND language = '".$language."'";
+
+                        try {
+                            $oldData = $this->db->fetchAssociative($sql);
+                        } catch (TableNotFoundException $e) {
+                            // if the table doesn't exist -> create it! this gives us the flexibility to add new
+                            // languages on the fly without saving all classes having localized fields
+                            $this->createMissingTableAndRetry();
+                        }
+
                         // get the next suitable parent for inheritance
                         $parentForInheritance = $object->getNextParentForInheritance();
                         if ($parentForInheritance) {
@@ -403,8 +383,14 @@ class Dao extends Model\Dao\AbstractDao
                         }
                     }
 
-                    $queryTable = $this->getQueryTableName().'_'.$language;
-                    Helper::upsert($this->db, $queryTable, $data, $this->getPrimaryKey($queryTable));
+                    try {
+                        Helper::upsert($this->db, $queryTable, $data, $this->getPrimaryKey($queryTable));
+                    } catch (TableNotFoundException $e) {
+                        // with inheritance disabled this is the first statement touching the query table,
+                        // so the deferred creation of a missing language table has to be handled here as well
+                        $this->createMissingTableAndRetry();
+                    }
+
                     if ($inheritanceEnabled) {
                         $context = isset($params['context']) ? $params['context'] : [];
                         if ($context['containerType'] === 'objectbrick') {
@@ -435,6 +421,29 @@ class Dao extends Model\Dao\AbstractDao
         }
         DataObject\Concrete\Dao\InheritanceHelper::setUseRuntimeCache(false);
         DataObject\Concrete\Dao\InheritanceHelper::clearRuntimeCache();
+    }
+
+    /**
+     * Creates a query/store table that does not exist yet (deferred creation, e.g. when a new language
+     * was added or for object bricks) and signals DataObject::save() to retry the whole save.
+     *
+     * The current transaction has to be rolled back first, otherwise the modifications made so far would
+     * be committed implicitly by the following DDL.
+     *
+     * @throws LanguageTableDoesNotExistException
+     */
+    private function createMissingTableAndRetry(): never
+    {
+        try {
+            $this->db->rollBack();
+        } catch (Exception $er) {
+            // PDO adapter throws exceptions if rollback fails
+            Logger::info((string) $er);
+        }
+
+        $this->createUpdateTable();
+
+        throw new LanguageTableDoesNotExistException('missing table created, start next run ... ;-)');
     }
 
     /**
@@ -500,17 +509,7 @@ class Dao extends Model\Dao\AbstractDao
             Logger::error((string) $e);
 
             if ($isUpdate && $e instanceof TableNotFoundException) {
-                try {
-                    $this->db->rollBack();
-                } catch (Exception $er) {
-                    // PDO adapter throws exceptions if rollback fails
-                    Logger::info((string) $er);
-                }
-
-                $this->createUpdateTable();
-
-                // throw exception which gets caught in AbstractObject::save() -> retry saving
-                throw new LanguageTableDoesNotExistException('missing table created, start next run ... ;-)');
+                $this->createMissingTableAndRetry();
             }
         }
 

--- a/tests/Model/DataType/LocalizedFieldQueryTableTest.php
+++ b/tests/Model/DataType/LocalizedFieldQueryTableTest.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Model\DataType;
 
+use Pimcore\Cache;
+use Pimcore\Cache\RuntimeCache;
 use Pimcore\Db;
+use Pimcore\Model;
 use Pimcore\Model\DataObject\Inheritance;
 use Pimcore\Tests\Support\Helper\Pimcore;
 use Pimcore\Tests\Support\Test\ModelTestCase;
@@ -104,6 +107,48 @@ class LocalizedFieldQueryTableTest extends ModelTestCase
             $this->grabQueryTableReads(),
             'saving an object of a class with inheritance still has to read the localized query tables'
         );
+    }
+
+    /**
+     * The skipped read used to be the first statement touching the per-language query table and
+     * therefore triggered the deferred creation of a missing language table. With inheritance
+     * disabled that role is taken over by the upsert, so a language table that does not exist yet
+     * still has to be created and the save has to be retried.
+     */
+    public function testMissingLanguageQueryTableIsRecreatedWhenInheritanceIsDisabled(): void
+    {
+        $object = TestHelper::createEmptyObject();
+        $this->assertFalse($object->getClass()->getAllowInherit(), 'precondition: test class must not allow inheritance');
+        $object->save();
+
+        $languages = Tool::getValidLanguages();
+        $language = (string)end($languages);
+        $queryTable = 'object_localized_query_'.$object->getClassId().'_'.$language;
+
+        $db = Db::get();
+        $db->executeStatement('DROP TABLE '.$queryTable);
+
+        // a language table that was never written to also has no cached column information, so drop it
+        // here as well to end up in the same state as after adding a language to the system settings
+        RuntimeCache::getInstance()->offsetUnset(Model\Dao\AbstractDao::CACHEKEY.$queryTable);
+        Cache::clearTags(['system', 'resource']);
+
+        $this->assertFalse($this->tableExists($queryTable), 'precondition: the language query table has to be gone');
+
+        $object->setLinput('recreated-'.$language, $language);
+        $object->save();
+
+        $this->assertTrue($this->tableExists($queryTable), 'the missing language query table has to be created again');
+        $this->assertSame(
+            'recreated-'.$language,
+            $db->fetchOne('SELECT `linput` FROM '.$queryTable.' WHERE ooo_id = ?', [$object->getId()]),
+            'the retried save has to persist the value into the recreated table'
+        );
+    }
+
+    private function tableExists(string $table): bool
+    {
+        return (bool)Db::get()->fetchOne('SHOW TABLES LIKE '.Db::get()->quote($table));
     }
 
     /**

--- a/tests/Model/DataType/LocalizedFieldQueryTableTest.php
+++ b/tests/Model/DataType/LocalizedFieldQueryTableTest.php
@@ -1,0 +1,126 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\DataType;
+
+use Pimcore\Db;
+use Pimcore\Model\DataObject\Inheritance;
+use Pimcore\Tests\Support\Helper\Pimcore;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+use Pimcore\Tests\Support\Util\TestHelper;
+use Pimcore\Tool;
+use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
+
+/**
+ * Covers the number of statements the localized field DAO issues against the per-language query
+ * tables. Every additional statement in there is executed once per language, so it directly
+ * multiplies the cost of saving an object on installations with many languages.
+ *
+ * @see https://github.com/pimcore/pimcore/issues/11757
+ */
+class LocalizedFieldQueryTableTest extends ModelTestCase
+{
+    private DebugDataHolder $debugDataHolder;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        TestHelper::cleanUp();
+
+        $container = $this->getModule('\\'.Pimcore::class)->_getContainer();
+        if (!$container->has('doctrine.debug_data_holder')) {
+            $this->markTestSkipped('The Doctrine debug data holder is only registered when the kernel runs in debug mode.');
+        }
+
+        $this->debugDataHolder = $container->get('doctrine.debug_data_holder');
+    }
+
+    /**
+     * The stored query table data is only used to decide which fields have to be propagated to the
+     * child objects, so it must not be read at all when the class does not allow inheritance.
+     */
+    public function testQueryTableIsNotReadWhenInheritanceIsDisabled(): void
+    {
+        $object = TestHelper::createEmptyObject();
+        $this->assertFalse($object->getClass()->getAllowInherit(), 'precondition: test class must not allow inheritance');
+        $object->save();
+
+        $languages = Tool::getValidLanguages();
+        $this->assertGreaterThan(1, count($languages), 'precondition: more than one language has to be configured');
+
+        foreach ($languages as $language) {
+            $object->setLinput('value-'.$language, $language);
+        }
+
+        $this->debugDataHolder->reset();
+        $object->save();
+
+        $this->assertSame(
+            [],
+            $this->grabQueryTableReads(),
+            'saving an object of a class without inheritance must not read the localized query tables'
+        );
+
+        // the data still has to end up in the query tables
+        $db = Db::get();
+        foreach ($languages as $language) {
+            $value = $db->fetchOne(
+                'SELECT `linput` FROM object_localized_query_'.$object->getClassId().'_'.$language.' WHERE ooo_id = ?',
+                [$object->getId()]
+            );
+            $this->assertSame('value-'.$language, $value, 'query table of language '.$language);
+        }
+    }
+
+    /**
+     * Counterpart of the test above: with inheritance enabled the stored data is needed to detect
+     * the changed fields, so it still has to be read.
+     */
+    public function testQueryTableIsReadWhenInheritanceIsEnabled(): void
+    {
+        $object = new Inheritance();
+        $object->setKey('inheritance-query-table');
+        $object->setParentId(1);
+        $object->setPublished(true);
+        $this->assertTrue($object->getClass()->getAllowInherit(), 'precondition: test class must allow inheritance');
+        $object->save();
+
+        $object->setInput('some value', 'en');
+
+        $this->debugDataHolder->reset();
+        $object->save();
+
+        $this->assertNotEmpty(
+            $this->grabQueryTableReads(),
+            'saving an object of a class with inheritance still has to read the localized query tables'
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    private function grabQueryTableReads(): array
+    {
+        $reads = [];
+        foreach ($this->debugDataHolder->getData() as $queries) {
+            foreach ($queries as $query) {
+                $sql = preg_replace('/\s+/', ' ', (string)$query['sql']);
+                if (preg_match('/^SELECT \* FROM object_localized_query_/i', $sql)) {
+                    $reads[] = $sql;
+                }
+            }
+        }
+
+        return $reads;
+    }
+}


### PR DESCRIPTION
## Changes in this pull request

Partially addresses the second half of #11757. The root cause originally reported there (`insertOrUpdate()` querying `information_schema` for the primary keys of every table on every insert) is gone since 11.0 — `Helper::upsert()` takes the key columns from the caller and `AbstractDao::getValidTableColumns()` uses a cached `SHOW COLUMNS`. What was never addressed is the follow-up complaint in the thread: the number of statements a save issues grows with the number of configured languages.

This removes one of those per-language statements.

### The wasted read

`Localizedfield\Dao::save()` iterates over all valid languages and, for every iteration, ran:

```sql
SELECT * FROM object_localized_query_<classId>_<language> WHERE ooo_id = … AND language = '…'
```

The result (`$oldData`) is only ever evaluated inside the `if ($inheritanceEnabled && !$fd instanceof CalculatedValue)` branches, where it is compared against the new value to feed `InheritanceHelper::addFieldToCheck()` / `addRelationToCheck()` — i.e. it exists purely to decide which fields have to be propagated to the child objects. For a class with `allowInherit = false` there is nothing to propagate, so the row was fetched from a potentially very wide table and thrown away, once per language and per save.

The read is now gated on inheritance, in the same block as the parent-object lookup that was already gated.

### Deferred language-table creation

That `SELECT` used to be the first statement touching the per-language query table, so it doubled as the trigger for the deferred creation of a missing language table (add a language, save an object of a class that has not been re-saved yet → table is created and the save is retried). With the read skipped, that role moves to the query-table `upsert()`, which is now wrapped in the same handling.

The rollback / `createUpdateTable()` / `LanguageTableDoesNotExistException` block that was duplicated three times is extracted into `createMissingTableAndRetry()`.

### Effect

Measured on the test class (`unittest`, inheritance disabled), varying the number of configured languages. Numbers are per `$object->save()` on the update path, averaged over 5 saves after a warm-up save, counted with the Doctrine debug middleware:

| languages | statements before | statements after | removed | share |
|---|---|---|---|---|
| 4  | 140  | 136  | 4  | 2.9 % |
| 20 | 556  | 536  | 20 | 3.6 % |
| 50 | 1336 | 1286 | 50 | 3.7 % |

Exactly one removed statement per configured language, as expected. The remaining slope is ~25 statements per language, so this is roughly a **4 % reduction** — worth having, but the per-language cost is dominated by the other ~24.

Measured query time for the removed statements alone was ~82 ms per save at 50 languages (out of ~2.0 s total DB time in that instrumented run — absolute values are inflated by the debug middleware, so treat the ratio rather than the absolute as meaningful).

The gain is proportionally larger when the database is not on the same host as PHP, which is the setup in the issue: every removed statement is one fewer network round trip, so at 50 languages this saves 50 × RTT per save regardless of how cheap the query itself is.

To be explicit about the scope: this does **not** remove the `O(languages)` scaling itself. That is inherent to the "one query table per language" schema — the remaining per-language statements go to different tables and cannot be batched without a schema change. This removes one of the statements executed per language, for classes without inheritance.

Behaviour for classes with inheritance enabled is unchanged.

### Also in here

- the loop-invariant `getAllowInherit()` call is hoisted out of the language loop
- a redundant recomputation of `$queryTable` right before the upsert is removed

### Tests

New `tests/Model/DataType/LocalizedFieldQueryTableTest.php`:

- `testQueryTableIsNotReadWhenInheritanceIsDisabled()` — asserts no query table is read during the save, and that the values still land in every language's query table. Fails on `2026.x` without this change.
- `testQueryTableIsReadWhenInheritanceIsEnabled()` — the counterpart, so the optimisation stays scoped and inheritance change detection keeps its input.

Full `Model` and `Unit` suites were run locally against this branch and against unmodified `2026.x`; the failure sets are identical (2 pre-existing environment-only errors in the encrypted-field tests, caused by the local setup not having a real encryption key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

