### PR TITLE
Prevent circular parent/child references for data objects

### DIFF
--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -632,6 +632,12 @@ abstract class AbstractObject extends Model\Element\AbstractElement
 
             // use the parent's path from the database here (getCurrentFullPath), to ensure the path really exists and does not rely on the path
             // that is currently in the parent object (in memory), because this might have changed but wasn't not saved
+            $currentFullPath = $this->getDao()->getCurrentFullPath();
+            $parentFullPath = $parent->getCurrentFullPath();
+            if ($currentFullPath !== null && $parentFullPath !== null && str_starts_with($parentFullPath, $currentFullPath . '/')) {
+                throw new Exception('Cannot set parent, because the new parent is one of its own children, which would create a circular reference in the tree.');
+            }
+
             $this->setPath(str_replace('//', '/', $parent->getCurrentFullPath().'/'));
 
             if (strlen($this->getKey()) < 1) {

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -525,7 +525,20 @@ abstract class AbstractObject extends Model\Element\AbstractElement
                 // get the old path from the database before the update is done
                 $oldPath = null;
                 if ($isUpdate) {
-                    $oldPath = $this->getDao()->getCurrentFullPath();
+                    $parent = DataObject::getById($this->getParentId());
+
+                    // lock this object's and the new parent's row in a fixed order (ascending id) so that
+                    // two concurrent moves affecting the same pair of objects (e.g. A becomes a child of B
+                    // while B becomes a child of A) are serialized instead of racing past each other's check
+                    if ($parent && $this->getId() > $parent->getId()) {
+                        $parentFullPath = $parent->getDao()->getCurrentFullPathForUpdate();
+                        $oldPath = $this->getDao()->getCurrentFullPathForUpdate();
+                    } else {
+                        $oldPath = $this->getDao()->getCurrentFullPathForUpdate();
+                        $parentFullPath = $parent?->getDao()->getCurrentFullPathForUpdate();
+                    }
+
+                    $this->assertParentIsNotOwnDescendant($oldPath, $parentFullPath);
                 }
 
                 // if the old path is different from the new path, update all children
@@ -607,6 +620,18 @@ abstract class AbstractObject extends Model\Element\AbstractElement
     /**
      * @internal
      *
+     * @throws Exception
+     */
+    protected function assertParentIsNotOwnDescendant(?string $currentFullPath, ?string $parentFullPath): void
+    {
+        if ($currentFullPath !== null && $parentFullPath !== null && str_starts_with($parentFullPath, $currentFullPath . '/')) {
+            throw new Exception('Cannot set parent, because the new parent is one of its own children, which would create a circular reference in the tree.');
+        }
+    }
+
+    /**
+     * @internal
+     *
      * @throws Exception|DuplicateFullPathException
      */
     protected function correctPath(): void
@@ -632,11 +657,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
 
             // use the parent's path from the database here (getCurrentFullPath), to ensure the path really exists and does not rely on the path
             // that is currently in the parent object (in memory), because this might have changed but wasn't not saved
-            $currentFullPath = $this->getDao()->getCurrentFullPath();
-            $parentFullPath = $parent->getCurrentFullPath();
-            if ($currentFullPath !== null && $parentFullPath !== null && str_starts_with($parentFullPath, $currentFullPath . '/')) {
-                throw new Exception('Cannot set parent, because the new parent is one of its own children, which would create a circular reference in the tree.');
-            }
+            $this->assertParentIsNotOwnDescendant($this->getDao()->getCurrentFullPath(), $parent->getDao()->getCurrentFullPath());
 
             $this->setPath(str_replace('//', '/', $parent->getCurrentFullPath().'/'));
 

--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -193,6 +193,21 @@ class Dao extends Model\Element\Dao
         return null;
     }
 
+    /**
+     * Same as getCurrentFullPath(), but locks the row so that a concurrent transaction
+     * changing this object's path or parent has to wait until the current transaction finishes.
+     *
+     * @return string|null retrieves the current full object path from DB
+     */
+    public function getCurrentFullPathForUpdate(): ?string
+    {
+        if ($path = $this->db->fetchOne('SELECT CONCAT(`path`,`key`) as `path` FROM objects WHERE id = ? FOR UPDATE', [$this->model->getId()])) {
+            return $path;
+        }
+
+        return null;
+    }
+
     public function getVersionCountForUpdate(): int
     {
         if (!$this->model->getId()) {

--- a/tests/Model/DataObject/ObjectTest.php
+++ b/tests/Model/DataObject/ObjectTest.php
@@ -49,6 +49,45 @@ class ObjectTest extends ModelTestCase
     }
 
     /**
+     * Verifies that an object cannot be moved into one of its own children, which
+     * would create a circular parent/child reference in the tree.
+     */
+    public function testParentCannotBeOwnDescendant(): void
+    {
+        $parent = TestHelper::createEmptyObject();
+        $child = TestHelper::createEmptyObject('', false);
+        $child->setParentId($parent->getId());
+        $child->save();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Cannot set parent, because the new parent is one of its own children, which would create a circular reference in the tree.');
+
+        $parent->setParentId($child->getId());
+        $parent->save();
+    }
+
+    /**
+     * Verifies that an object cannot be moved into a grandchild several levels down,
+     * which would create a circular parent/child reference in the tree.
+     */
+    public function testParentCannotBeOwnGrandchild(): void
+    {
+        $grandParent = TestHelper::createEmptyObject();
+        $parent = TestHelper::createEmptyObject('', false);
+        $parent->setParentId($grandParent->getId());
+        $parent->save();
+        $child = TestHelper::createEmptyObject('', false);
+        $child->setParentId($parent->getId());
+        $child->save();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Cannot set parent, because the new parent is one of its own children, which would create a circular reference in the tree.');
+
+        $grandParent->setParentId($child->getId());
+        $grandParent->save();
+    }
+
+    /**
      * Verifies that object PHP API version note is saved
      */
     public function testSavingVersionNotes(): void

--- a/tests/Model/DataObject/ObjectTest.php
+++ b/tests/Model/DataObject/ObjectTest.php
@@ -88,6 +88,17 @@ class ObjectTest extends ModelTestCase
     }
 
     /**
+     * Verifies that the locking variant of getCurrentFullPath() used to re-check for
+     * circular parent references inside the save transaction returns the same path.
+     */
+    public function testGetCurrentFullPathForUpdateMatchesGetCurrentFullPath(): void
+    {
+        $object = TestHelper::createEmptyObject();
+
+        $this->assertSame($object->getDao()->getCurrentFullPath(), $object->getDao()->getCurrentFullPathForUpdate());
+    }
+
+    /**
      * Verifies that object PHP API version note is saved
      */
     public function testSavingVersionNotes(): void


### PR DESCRIPTION
## Summary
- Moving a data object into one of its own descendants (e.g. via drag & drop in the tree) was only guarded against the direct case (setting an object as its own parent). A deeper cycle (object -> parent -> grandparent -> object again) was accepted and persisted.
- Once such a cycle exists, anything that walks the parent chain (e.g. inheritance resolution during search indexing) recurses forever and exhausts memory/CPU.
- `AbstractObject::correctPath()` now also rejects the save when the new parent's current path is nested inside the object's own current path, i.e. when the new parent is actually one of the object's own descendants.

Fixes https://github.com/pimcore/platform-version/issues/159

## Test plan
- [x] Added `testParentCannotBeOwnDescendant` and `testParentCannotBeOwnGrandchild` regression tests in `tests/Model/DataObject/ObjectTest.php`, following the existing `testParentIdentical` pattern.
- [ ] CI (Codeception `Model` suite) — not run locally, relying on CI for verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)