### PR TITLE
[Bug]: Write notification dates in UTC

### DIFF
--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -32,6 +32,11 @@ WHERE id > <last id created before the upgrade>;
 Take a backup first, and note that a single named-zone conversion is only exact if all the rows
 you convert fall on the same side of a DST boundary.
 
+Directly after the upgrade, unread notifications created shortly before it may be re-announced by
+the Classic UI popup for up to the zone-offset duration - their local-time `creationDate` sits
+"in the future" relative to the corrected UTC polling bound. This resolves itself once that
+offset has elapsed (or once the rows are converted / marked as read).
+
 ## Pimcore 2026.2.9
 
 ### Deprecations

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,5 +1,37 @@
 # Upgrade Notes
 
+## Pimcore 2026.2.10
+
+### [Notifications]
+
+Notification `creationDate` / `modificationDate` are now written in UTC, which is the convention
+these columns have used since the `Version20230321133700` migration converted the existing rows,
+and which every reader already assumes. Previously they were written in the local timezone, so with
+a non-UTC `general.timezone` the notification date shown in Studio and in the Classic UI was shifted
+by the zone offset (for example two hours ahead for `Europe/Berlin` during DST).
+
+Rows written before this fix remain in local time and will still be displayed with that offset.
+They cannot be corrected automatically, because a local-time row is indistinguishable from a
+correctly stored UTC row. If the skew on historical entries matters for your instance, convert the
+affected rows manually, for example:
+
+```sql
+-- 1. Preflight. This must return a datetime, not NULL. NULL means the named time-zone
+--    tables are not loaded (see mysql_tzinfo_to_sql) and CONVERT_TZ() cannot be used -
+--    load them first, or convert with a fixed INTERVAL instead.
+SELECT CONVERT_TZ('2000-01-01 00:00:00', 'Europe/Berlin', 'UTC');
+
+-- 2. Convert. COALESCE keeps the original value if the conversion yields NULL, so a
+--    missing time-zone table makes this a no-op rather than erasing the dates.
+UPDATE notifications
+SET creationDate = COALESCE(CONVERT_TZ(creationDate, 'Europe/Berlin', 'UTC'), creationDate),
+    modificationDate = COALESCE(CONVERT_TZ(modificationDate, 'Europe/Berlin', 'UTC'), modificationDate)
+WHERE id > <last id created before the upgrade>;
+```
+
+Take a backup first, and note that a single named-zone conversion is only exact if all the rows
+you convert fall on the same side of a DST boundary.
+
 ## Pimcore 2026.2.9
 
 ### Deprecations

--- a/models/Notification/Dao.php
+++ b/models/Notification/Dao.php
@@ -52,11 +52,16 @@ class Dao extends AbstractDao
     /**
      * Save notification
      *
+     * `creationDate` / `modificationDate` are stored in UTC (see migration
+     * Version20230321133700, which converted the existing rows), so they must be
+     * written in UTC too - otherwise readers parsing them as UTC shift the value
+     * by the configured `general.timezone` offset.
+     *
      * @throws Exception
      */
     public function save(): void
     {
-        $this->model->setModificationDate(date('Y-m-d H:i:s'));
+        $this->model->setModificationDate(gmdate('Y-m-d H:i:s'));
 
         if ($this->model->getId() === null || !$this->model->getCreationDate()) {
             $this->model->setCreationDate($this->model->getModificationDate());

--- a/models/Notification/Service/NotificationService.php
+++ b/models/Notification/Service/NotificationService.php
@@ -217,7 +217,8 @@ class NotificationService
             'recipient = ? AND `read` = 0 AND `isStudio` = 0 AND creationDate >= ?',
             [
                 $user,
-                date('Y-m-d H:i:s', $lastUpdate),
+                // creationDate is stored in UTC, so the bound must be rendered in UTC too
+                gmdate('Y-m-d H:i:s', $lastUpdate),
             ]
         );
         $listing->setOrderKey('creationDate');

--- a/models/Notification/Service/NotificationServiceFilterParser.php
+++ b/models/Notification/Service/NotificationServiceFilterParser.php
@@ -132,7 +132,9 @@ class NotificationServiceFilterParser
     {
         $result = null;
         $property = $this->getDbProperty($item);
-        $value = new Carbon($item[self::KEY_VALUE]);
+        // The filter value is a wall-clock date in the application timezone, but
+        // creationDate is stored in UTC - convert so the day window lines up.
+        $value = (new Carbon($item[self::KEY_VALUE]))->setTimezone('UTC');
 
         switch ($item[self::KEY_OPERATOR]) {
             case self::OPERATOR_EQ:

--- a/models/Notification/Service/NotificationServiceFilterParser.php
+++ b/models/Notification/Service/NotificationServiceFilterParser.php
@@ -132,9 +132,7 @@ class NotificationServiceFilterParser
     {
         $result = null;
         $property = $this->getDbProperty($item);
-        // The filter value is a wall-clock date in the application timezone, but
-        // creationDate is stored in UTC - convert so the day window lines up.
-        $value = (new Carbon($item[self::KEY_VALUE]))->setTimezone('UTC');
+        $value = new Carbon($item[self::KEY_VALUE]);
 
         switch ($item[self::KEY_OPERATOR]) {
             case self::OPERATOR_EQ:
@@ -143,8 +141,8 @@ class NotificationServiceFilterParser
                     $key,
                     "{$property} BETWEEN :{$key}_start AND :{$key}_end",
                     [
-                        $key . '_start' => $value->toDateTimeString(),
-                        $key . '_end' => $value->addDay()->subSecond()->toDateTimeString(),
+                        $key . '_start' => $this->toUtcBound($value),
+                        $key . '_end' => $this->toUtcBound($value->copy()->addDay()->subSecond()),
                     ],
                 ];
 
@@ -154,7 +152,7 @@ class NotificationServiceFilterParser
                 $result = [
                     $key,
                     "{$property} > :{$key}",
-                    [$key => $value->toDateTimeString()],
+                    [$key => $this->toUtcBound($value)],
                 ];
 
                 break;
@@ -163,7 +161,7 @@ class NotificationServiceFilterParser
                 $result = [
                     $key,
                     "{$property} < :{$key}",
-                    [$key => $value->addDay()->subSecond()->toDateTimeString()],
+                    [$key => $this->toUtcBound($value->copy()->addDay()->subSecond())],
                 ];
 
                 break;
@@ -174,6 +172,17 @@ class NotificationServiceFilterParser
         }
 
         return $result;
+    }
+
+    /**
+     * creationDate is stored in UTC while the filter value is a wall-clock date in the
+     * application timezone. Day boundaries are derived in the application timezone -
+     * so DST-length local days (23h/25h) stay intact - and each finished boundary is
+     * converted to UTC only when binding.
+     */
+    private function toUtcBound(Carbon $value): string
+    {
+        return $value->copy()->setTimezone('UTC')->toDateTimeString();
     }
 
     private function getDbProperty(array $item): string

--- a/tests/Unit/Notification/NotificationTimezoneTest.php
+++ b/tests/Unit/Notification/NotificationTimezoneTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Notification;
+
+use Carbon\Carbon;
+use DateTimeImmutable;
+use DateTimeZone;
+use Pimcore;
+use Pimcore\Cache\RuntimeCache;
+use Pimcore\Model\Notification;
+use Pimcore\Model\Notification\Service\NotificationService;
+use Pimcore\Model\User;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * `notifications.creationDate` / `modificationDate` are stored in UTC - see migration
+ * Version20230321133700, which converted the pre-existing rows - and every reader
+ * (NotificationService::format(), Studio's NotificationHydrator) parses them as UTC.
+ * Dao::save() has to honour that convention, otherwise the displayed time is shifted
+ * by the configured `general.timezone` offset.
+ */
+class NotificationTimezoneTest extends TestCase
+{
+    private const TEST_TIMEZONE = 'Europe/Berlin';
+
+    private string $originalTimezone;
+
+    protected function needsDb(): bool
+    {
+        return true;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalTimezone = date_default_timezone_get();
+        date_default_timezone_set(self::TEST_TIMEZONE);
+    }
+
+    public function _after(): void
+    {
+        date_default_timezone_set($this->originalTimezone);
+
+        $user = User::getByName('notification-timezone-user');
+        if ($user instanceof User) {
+            Pimcore::getContainer()->get(NotificationService::class)->deleteAll($user->getId());
+            $user->delete();
+        }
+    }
+
+    public function testSaveStoresDatesInUtc(): void
+    {
+        $before = time();
+        $notification = $this->createNotification();
+        $after = time();
+
+        $dates = [
+            'creationDate' => $notification->getCreationDate(),
+            'modificationDate' => $notification->getModificationDate(),
+        ];
+
+        foreach ($dates as $field => $stored) {
+            $this->assertNotNull($stored, $field . ' was not set');
+
+            $utc = new DateTimeImmutable($stored, new DateTimeZone('UTC'));
+            $this->assertGreaterThanOrEqual($before, $utc->getTimestamp(), $field . ' is not UTC');
+            $this->assertLessThanOrEqual($after, $utc->getTimestamp(), $field . ' is not UTC');
+        }
+    }
+
+    /**
+     * The value also has to survive the database round trip as UTC. These are `TIMESTAMP`
+     * columns, which MySQL renders in its own session timezone on read, so the stored
+     * string is only usable if the writer and the readers agree on the convention.
+     */
+    public function testCreationDateSurvivesTheDatabaseRoundTripAsUtc(): void
+    {
+        $before = time();
+        $notification = $this->createNotification();
+        $after = time();
+
+        // The expression used by both NotificationService::format() and Studio's
+        // NotificationHydrator.
+        $timestamp = (new Carbon($this->reRead($notification)->getCreationDate(), 'UTC'))
+            ->getTimestamp();
+
+        $this->assertGreaterThanOrEqual($before, $timestamp);
+        $this->assertLessThanOrEqual($after, $timestamp);
+    }
+
+    public function testFormattedTimestampMatchesTheRealEventTime(): void
+    {
+        $before = time();
+        $notification = $this->createNotification();
+        $after = time();
+
+        $formatted = Pimcore::getContainer()
+            ->get(NotificationService::class)
+            ->format($this->reRead($notification));
+
+        $this->assertGreaterThanOrEqual($before, $formatted['timestamp']);
+        $this->assertLessThanOrEqual($after, $formatted['timestamp']);
+    }
+
+    public function testStoredDateIsNotLocalWallClockTime(): void
+    {
+        $notification = $this->createNotification();
+
+        // Guard against the regression: writing local time made readers - which parse the
+        // value as UTC - report a timestamp shifted by the zone offset (+2h during DST).
+        $localOffset = (new DateTimeZone(self::TEST_TIMEZONE))
+            ->getOffset(new DateTimeImmutable('@' . time()));
+        $this->assertNotSame(0, $localOffset, 'test timezone must have a non-zero UTC offset');
+
+        $stored = new DateTimeImmutable($notification->getCreationDate(), new DateTimeZone('UTC'));
+        $this->assertLessThan(
+            abs($localOffset),
+            abs($stored->getTimestamp() - time()),
+            'creationDate was stored as local wall-clock time instead of UTC'
+        );
+    }
+
+    /**
+     * Re-read from the database, bypassing the runtime cache.
+     */
+    private function reRead(Notification $notification): Notification
+    {
+        RuntimeCache::clear();
+
+        $reRead = Notification::getById((int) $notification->getId());
+        $this->assertInstanceOf(Notification::class, $reRead);
+
+        return $reRead;
+    }
+
+    private function createNotification(): Notification
+    {
+        $user = User::getByName('notification-timezone-user');
+
+        if (!$user instanceof User) {
+            $user = new User();
+            $user->setName('notification-timezone-user');
+            $user->save();
+        }
+
+        $notification = new Notification();
+        $notification->setRecipient($user);
+        $notification->setTitle('Test title');
+        $notification->setMessage('Test message');
+        $notification->save();
+
+        return $notification;
+    }
+}

--- a/tests/Unit/Notification/NotificationTimezoneTest.php
+++ b/tests/Unit/Notification/NotificationTimezoneTest.php
@@ -115,6 +115,27 @@ class NotificationTimezoneTest extends TestCase
         $this->assertLessThanOrEqual($after, $formatted['timestamp']);
     }
 
+    /**
+     * The Classic UI polls findLastUnread() with a unix epoch to show live popups.
+     * The bound derived from that epoch has to be rendered in UTC like the stored
+     * values - a local-time bound sits ahead of every fresh row by the zone offset,
+     * silently suppressing the popups.
+     */
+    public function testFindLastUnreadFindsAFreshNotification(): void
+    {
+        $notification = $this->createNotification();
+        $recipientId = (int) $notification->getRecipient()->getId();
+
+        $service = Pimcore::getContainer()->get(NotificationService::class);
+
+        $result = $service->findLastUnread($recipientId, time() - 60);
+        $this->assertSame(1, $result['total'], 'fresh notification not found by the unread poller');
+
+        // Negative control: a bound in the future must not match.
+        $result = $service->findLastUnread($recipientId, time() + 3600);
+        $this->assertSame(0, $result['total']);
+    }
+
     public function testStoredDateIsNotLocalWallClockTime(): void
     {
         $notification = $this->createNotification();

--- a/tests/Unit/Notification/Service/NotificationServiceFilterParserTest.php
+++ b/tests/Unit/Notification/Service/NotificationServiceFilterParserTest.php
@@ -77,6 +77,37 @@ final class NotificationServiceFilterParserTest extends TestCase
         }
     }
 
+    /**
+     * The day window must cover exactly the local calendar day even across DST
+     * transitions, where a local day is 23 or 25 hours long. Boundaries are derived in
+     * the application timezone and only converted to UTC when binding - converting
+     * first and adding 24h would bleed an hour into the neighbouring day.
+     */
+    public function testDateFilterKeepsLocalDayLengthAcrossDstTransition(): void
+    {
+        $originalTimezone = date_default_timezone_get();
+        date_default_timezone_set('Europe/Berlin');
+
+        try {
+            // 2026-03-29 is a 23-hour day in Europe/Berlin (CET +01:00 -> CEST +02:00)
+            $parser = new NotificationServiceFilterParser($this->buildRequest([
+                ['type' => 'date', 'property' => 'timestamp', 'operator' => 'eq', 'value' => '2026-03-29'],
+            ]));
+
+            $result = $parser->parse();
+
+            $this->assertSame(
+                [
+                    'creationDate_eq_start' => '2026-03-28 23:00:00',
+                    'creationDate_eq_end' => '2026-03-29 21:59:59',
+                ],
+                $result['creationDate_eq']['conditionVariables']
+            );
+        } finally {
+            date_default_timezone_set($originalTimezone);
+        }
+    }
+
     public function testUnknownStringPropertyIsRejected(): void
     {
         // Not a whitelisted property: previously fell through to being used

--- a/tests/Unit/Notification/Service/NotificationServiceFilterParserTest.php
+++ b/tests/Unit/Notification/Service/NotificationServiceFilterParserTest.php
@@ -51,6 +51,32 @@ final class NotificationServiceFilterParserTest extends TestCase
         $this->assertSame('creationDate > :creationDate_gt', $result['creationDate_gt']['condition']);
     }
 
+    /**
+     * creationDate is stored in UTC; a filter entered as a local-timezone day has to be
+     * converted, otherwise the day window is shifted by the zone offset.
+     */
+    public function testDateFilterValueIsConvertedToUtc(): void
+    {
+        $originalTimezone = date_default_timezone_get();
+        date_default_timezone_set('Europe/Berlin');
+
+        try {
+            $parser = new NotificationServiceFilterParser($this->buildRequest([
+                ['type' => 'date', 'property' => 'timestamp', 'operator' => 'gt', 'value' => '2026-07-01'],
+            ]));
+
+            $result = $parser->parse();
+
+            // 2026-07-01 00:00 Europe/Berlin (CEST, UTC+2) is 2026-06-30 22:00 UTC
+            $this->assertSame(
+                '2026-06-30 22:00:00',
+                $result['creationDate_gt']['conditionVariables']['creationDate_gt']
+            );
+        } finally {
+            date_default_timezone_set($originalTimezone);
+        }
+    }
+
     public function testUnknownStringPropertyIsRejected(): void
     {
         // Not a whitelisted property: previously fell through to being used


### PR DESCRIPTION
Fixes pimcore/platform-version#335

### Problem

`notifications.creationDate` / `modificationDate` **are stored in UTC**. That convention was established in #14741, which shipped migration `Version20230321133700`, described as:

> Converts datetime/timestamp values to UTC for application logs and notifications.

Its `up()` converts `application_logs.timestamp`, `notifications.creationDate` and `notifications.modificationDate` from the local timezone to UTC, and it's documented in the upgrade notes. Every reader assumes it — both `NotificationService::format()` (Classic UI) and `NotificationHydrator` (Studio) parse the value with `new Carbon($date, 'UTC')`.

That change fixed the readers and made `ApplicationLoggerDb` write UTC, but **never updated the writer**. `Notification\Dao::save()` has used `date('Y-m-d H:i:s')` — local time — since the feature landed in #3401; `git log -S UTC -- models/Notification/Dao.php` returns nothing.

So since March 2023 the table has held a mix:

| rows | stored as | displays |
|---|---|---|
| written before the migration | UTC (converted) | correct |
| written after | local wall-clock | **shifted by the `general.timezone` offset** |

Reported from a `Europe/Berlin` instance:

```
notifications table: id=221189, creationDate = 2026-07-29 09:57:48
Application Logger (same event):               29.07.26, 09:57:48    (correct)
Studio notification panel (same event):        29.07.26, 11:57:48    (wrong, +2h)
```

+2h during DST, +1h outside it. The Classic UI notification panel is affected identically — this is not Studio-specific.

### Fix

Write UTC via `gmdate()`, so the writer matches the migrated convention and the existing readers. `save()` already derives `creationDate` from `modificationDate`, so one line covers both.

**No reader changes are needed** — the Classic UI and Studio both become correct at once, and notifications stay consistent with `application_logs`, which genuinely is UTC.

A consumer audit then surfaced two comparison paths that were self-consistent with the old local-time writer and had to move to UTC bounds along with it (second commit, details in the audit comment below):

- `NotificationService::findLastUnread()` — the Classic UI's live-popup polling bound (`date()` → `gmdate()`); without this the UTC writer would have suppressed new-notification popups for the zone-offset duration.
- `NotificationServiceFilterParser::parseDate()` — the Classic grid's date-filter day window, now converted to UTC like Studio's `LogRepository` already does for application logs.

I first went at this from the read side (studio-backend-bundle#2003) before finding the migration; that approach is wrong and has been closed — it would have matched the reader to the buggy writer, broken the correctly-migrated pre-2023 rows, left the Classic UI wrong, and made the two UIs disagree.

### Regression test

`tests/Unit/Notification/NotificationTimezoneTest.php`, running under `Europe/Berlin`:

- saved `creationDate` / `modificationDate` parse as UTC to the real event time
- `NotificationService::format()['timestamp']` — the reader — agrees with the real event time
- the stored value is not local wall-clock

Reverting `gmdate()` to `date()` fails all three with exactly the reported shift (`Failed asserting that 7200 is less than 7200`).

### Verification

- Full `Unit` suite: `OK (917 tests, 1858 assertions)`
- PHPStan level 6 on the changed files: `No errors`

### Note on existing rows

Rows written before this fix stay in local time and will still display with the offset. They can't be corrected automatically — a local-time row is indistinguishable from a correctly stored UTC one. Documented in the upgrade notes with a manual `CONVERT_TZ` snippet for anyone who needs it.

### Follow-ups (not in this PR)

- The DBAL session `time_zone` is never pinned, and these are `TIMESTAMP` columns, so MySQL converts using its own session zone. The PHP round-trip is self-consistent either way, but the physically stored instant is only right when MySQL's zone matches `general.timezone`. Pinning it to UTC would make this airtight and also fix the column's `DEFAULT CURRENT_TIMESTAMP`, which inserts session-local time (harmless today — only this Dao writes the table).
- `NotificationHydrator::hydrate()` / `hydrateDetail()` pass a nullable `getType()` into schema constructors declaring `string $type`, unlike `hydrateMinimal()` which defaults to `'info'`.
