### PR TITLE
[Bug] Imagick: only clip images that actually have a clipping path

### DIFF
--- a/doc/13_Upgrade_Notes/README.md
+++ b/doc/13_Upgrade_Notes/README.md
@@ -11,6 +11,9 @@
     ```
   We recommend disabling the built-in `sql` adapter unless specifically needed: any user with the `reports_config` permission can otherwise define arbitrary `SELECT` statements against the application's database, including tables never intended to be exposed. See [Custom Reports](../06_Reporting/01_Custom_Reports.md)  for details.
 
+### [Assets]
+- [Thumbnails] Automatic clipping (`pimcore.assets.image.thumbnails.clip_auto_support`) is only applied again when the image actually carries a clipping path, i.e. the Photoshop image resource `8BIM 2999` ('Name of clipping path'). Images that only contain saved Photoshop paths (`8BIM 2000` - `2998`) are no longer clipped, since clipping them by an arbitrary path removed their whole content and resulted in empty thumbnails. Existing thumbnails of such images have to be cleared to be re-generated.
+
 ## Pimcore 2026.2.0
 
 ### [General]

--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -138,14 +138,26 @@ class Imagick extends Adapter
                 //$identifyRaw = $i->identifyImage(true)['rawOutput'];
                 //if (strpos($identifyRaw, 'Clipping path') && strpos($identifyRaw, '<svg')) {
                 // if there's a clipping path embedded, apply the first one
+                // clipping overwrites the alpha channel of the image, so keep a copy of the unclipped image
+                // around: it is the only way to still deliver the image when the clipping fails
+                $unclipped = clone $i;
+
                 try {
                     $i->setImageAlphaChannel(\Imagick::ALPHACHANNEL_TRANSPARENT);
                     $i->clipImage();
                     $i->setImageAlphaChannel(\Imagick::ALPHACHANNEL_OPAQUE);
+                    $unclipped->clear();
                 } catch (Exception $e) {
-                    // the alpha channel was already set to transparent above, so it has to be reset here -
-                    // otherwise the image would be entirely transparent instead of just being left unclipped
-                    $i->setImageAlphaChannel(\Imagick::ALPHACHANNEL_OPAQUE);
+                    // the image is entirely transparent at this point, so restore the copy instead of
+                    // just resetting the alpha channel, which would drop any pre-existing transparency
+                    if ($this->resource === $i) {
+                        $this->resource = $unclipped;
+                    } else {
+                        // the animation handling above replaced the resource with a different image,
+                        // which was never clipped in the first place
+                        $unclipped->clear();
+                    }
+
                     Logger::info(sprintf('Although automatic clipping support is enabled, your current ImageMagick / Imagick version does not support this operation on the image %s', $imagePath));
                 }
                 //}

--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -143,6 +143,9 @@ class Imagick extends Adapter
                     $i->clipImage();
                     $i->setImageAlphaChannel(\Imagick::ALPHACHANNEL_OPAQUE);
                 } catch (Exception $e) {
+                    // the alpha channel was already set to transparent above, so it has to be reset here -
+                    // otherwise the image would be entirely transparent instead of just being left unclipped
+                    $i->setImageAlphaChannel(\Imagick::ALPHACHANNEL_OPAQUE);
                     Logger::info(sprintf('Although automatic clipping support is enabled, your current ImageMagick / Imagick version does not support this operation on the image %s', $imagePath));
                 }
                 //}
@@ -165,13 +168,12 @@ class Imagick extends Adapter
         fclose($handle);
 
         // according to 8BIM format: https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#50577409_pgfId-1037504
-        // we're looking for the resource id 'Name of clipping path' which is 8BIM 2999 (decimal) or 0x0BB7 in hex
-        // and the first path information which is 8BIM 2000 (decimal) or 0x07D0 in hex
-        if (preg_match('/8BIM\x0b\xb7/', $chunk) || preg_match('/8BIM\x07\xd0/', $chunk)) {
-            return true;
-        }
-
-        return false;
+        // we're looking for the resource id 'Name of clipping path' which is 8BIM 2999 (decimal) or 0x0BB7 in hex.
+        // The path information resources (8BIM 2000 - 2998 / 0x07D0 - 0x0BB6) must not be taken into account here:
+        // they hold every path saved with the image, no matter whether it was designated as the clipping path or
+        // not. Clipping an image by an arbitrary Photoshop path (e.g. a guide or an unrelated shape) removes the
+        // entire image content, which resulted in empty thumbnails.
+        return (bool) preg_match('/8BIM\x0b\xb7/', $chunk);
     }
 
     public function getContentOptimizedFormat(): string

--- a/tests/Unit/Image/Adapter/ImagickTest.php
+++ b/tests/Unit/Image/Adapter/ImagickTest.php
@@ -18,12 +18,15 @@ use Pimcore\Image\Adapter\Imagick;
 use Pimcore\Tests\Support\Test\TestCase;
 
 /**
- * Regression tests for the Imagick adapter (#14543).
+ * Regression tests for the Imagick adapter.
  *
- * setBackgroundColor() composites the image onto a freshly created canvas, and
- * \Imagick::newImage() always produces an sRGB canvas. With preserveColor = true
+ * #14543: setBackgroundColor() composites the image onto a freshly created canvas,
+ * and \Imagick::newImage() always produces an sRGB canvas. With preserveColor = true
  * the CMYK channel data of the source was therefore written into an sRGB image,
  * which made the thumbnail come out with inverted colors.
+ *
+ * #184 (platform-version): images carrying a plain Photoshop path were clipped as
+ * if that path was a clipping path, which left the thumbnails empty.
  */
 final class ImagickTest extends TestCase
 {
@@ -118,6 +121,25 @@ final class ImagickTest extends TestCase
         $this->assertPixelColor(self::WHITE_RGB, $result, 5, 5, self::DELTA);
     }
 
+    /**
+     * Photoshop keeps every saved path in an image resource of its own (8BIM 2000 - 2998),
+     * no matter whether the path was designated as the clipping path (8BIM 2999) or not.
+     * Clipping the image by such an arbitrary path removes all of its content, so an image
+     * that has no clipping path must be loaded as it is.
+     */
+    public function testImageWithSavedPathButWithoutClippingPathIsNotClipped(): void
+    {
+        $adapter = $this->adapter($this->createImageWithPhotoshopPath(), false);
+
+        $result = $this->saveAndReload($adapter, 'png32', 'png');
+
+        // the whole image has to be left intact, both inside and outside of the saved path
+        $this->assertPixelOpaque($result, 20, 20);
+        $this->assertPixelOpaque($result, 2, 2);
+        $this->assertPixelColor(self::SOURCE_RGB, $result, 20, 20, self::DELTA);
+        $this->assertPixelColor(self::SOURCE_RGB, $result, 2, 2, self::DELTA);
+    }
+
     private function adapter(string $path, bool $preserveColor): Imagick
     {
         $adapter = new Imagick();
@@ -161,12 +183,74 @@ final class ImagickTest extends TestCase
         return $path;
     }
 
-    private function saveAndReload(Imagick $adapter): \Imagick
+    /**
+     * Creates an image with a single saved Photoshop path (8BIM 2000) covering the center of
+     * the image, but without the 'Name of clipping path' resource (8BIM 2999) - the same
+     * metadata Photoshop writes for an image that has a path, but no clipping path.
+     */
+    private function createImageWithPhotoshopPath(): string
     {
-        $path = $this->tmpFile('jpg');
-        $adapter->save($path, 'jpeg');
+        $image = new \Imagick();
+        $image->newImage(
+            self::FIXTURE_SIZE,
+            self::FIXTURE_SIZE,
+            new ImagickPixel(sprintf('rgb(%d,%d,%d)', ...self::SOURCE_RGB))
+        );
+        $image->setImageFormat('tiff');
+        $image->profileImage('8bim', $this->pathImageResource());
+
+        $path = $this->tmpFile('tif');
+        $image->writeImage($path);
+
+        $fixture = new \Imagick($path);
+        $this->assertNotEmpty(
+            $fixture->getImageProperty('8BIM:1999,2998:#1'),
+            'The test fixture was created without a Photoshop path.'
+        );
+
+        return $path;
+    }
+
+    /**
+     * Builds an 8BIM image resource block holding one closed path, see
+     * https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#50577409_pgfId-1037504
+     */
+    private function pathImageResource(): string
+    {
+        // 'Closed subpath length record': selector 0, followed by the number of knots
+        $data = pack('nn', 0, 4) . str_repeat("\x00", 22);
+
+        // one 'Closed subpath Bezier knot' record per corner of a centered square, each holding
+        // the preceding control point, the anchor point and the leaving control point as pairs of
+        // 8.24 fixed point numbers relative to the image dimensions (vertical before horizontal)
+        foreach ([[0.25, 0.25], [0.25, 0.75], [0.75, 0.75], [0.75, 0.25]] as [$vertical, $horizontal]) {
+            $point = pack('NN', (int) ($vertical * (1 << 24)), (int) ($horizontal * (1 << 24)));
+            $data .= pack('n', 2) . str_repeat($point, 3);
+        }
+
+        // the resource name is a pascal string padded to an even length
+        $name = "\x06" . 'Path 1' . "\x00";
+
+        return '8BIM' . pack('n', 2000) . $name . pack('N', strlen($data)) . $data;
+    }
+
+    private function saveAndReload(Imagick $adapter, string $format = 'jpeg', string $extension = 'jpg'): \Imagick
+    {
+        $path = $this->tmpFile($extension);
+        $adapter->save($path, $format);
 
         return new \Imagick($path);
+    }
+
+    private function assertPixelOpaque(\Imagick $image, int $x, int $y): void
+    {
+        // 1 = normalized color values, so a fully opaque pixel has an alpha value of 1.0
+        $this->assertEqualsWithDelta(
+            1.0,
+            $image->getImagePixelColor($x, $y)->getColor(1)['a'],
+            0.001,
+            sprintf('The pixel at %d,%d is not opaque.', $x, $y)
+        );
     }
 
     /**

--- a/tests/Unit/Image/Adapter/ImagickTest.php
+++ b/tests/Unit/Image/Adapter/ImagickTest.php
@@ -140,6 +140,22 @@ final class ImagickTest extends TestCase
         $this->assertPixelColor(self::SOURCE_RGB, $result, 2, 2, self::DELTA);
     }
 
+    /**
+     * When the clipping itself fails - e.g. because the clipping path cannot be resolved or the
+     * ImageMagick installation cannot render it - the image has to be delivered unclipped, which
+     * includes the transparency it already had before the clipping was attempted.
+     */
+    public function testFailingClippingKeepsTheUnclippedImage(): void
+    {
+        $adapter = $this->adapter($this->createImageWithUnresolvableClippingPath(), false);
+
+        $result = $this->saveAndReload($adapter, 'png32', 'png');
+
+        $this->assertPixelOpaque($result, 20, 20);
+        $this->assertPixelColor(self::SOURCE_RGB, $result, 20, 20, self::DELTA);
+        $this->assertPixelTransparent($result, 2, 2);
+    }
+
     private function adapter(string $path, bool $preserveColor): Imagick
     {
         $adapter = new Imagick();
@@ -234,6 +250,54 @@ final class ImagickTest extends TestCase
         return '8BIM' . pack('n', 2000) . $name . pack('N', strlen($data)) . $data;
     }
 
+    /**
+     * Creates a partly transparent image that carries the 'Name of clipping path' resource
+     * (8BIM 2999) without any path information, so that \Imagick::clipImage() fails with
+     * 'no clip path defined'.
+     */
+    private function createImageWithUnresolvableClippingPath(): string
+    {
+        $square = new \Imagick();
+        $square->newImage(
+            (int) (self::FIXTURE_SIZE / 2),
+            (int) (self::FIXTURE_SIZE / 2),
+            new ImagickPixel(sprintf('rgb(%d,%d,%d)', ...self::SOURCE_RGB))
+        );
+
+        $image = new \Imagick();
+        $image->newImage(self::FIXTURE_SIZE, self::FIXTURE_SIZE, new ImagickPixel('transparent'));
+        $image->setImageFormat('tiff');
+        // leaves a transparent border around the opaque center of the image
+        $image->compositeImage($square, \Imagick::COMPOSITE_OVER, (int) (self::FIXTURE_SIZE / 4), (int) (self::FIXTURE_SIZE / 4));
+        $image->profileImage('8bim', $this->clippingPathNameImageResource());
+
+        $path = $this->tmpFile('tif');
+        $image->writeImage($path);
+
+        $fixture = new \Imagick($path);
+        $this->assertTrue(
+            (bool) $fixture->getImageAlphaChannel(),
+            'The test fixture was created without an alpha channel.'
+        );
+        $this->assertFalse(
+            $fixture->getImageProperty('8BIM:1999,2998:#1'),
+            'The test fixture was created with a resolvable clipping path.'
+        );
+
+        return $path;
+    }
+
+    /**
+     * Builds an 8BIM image resource block naming the clipping path of the image, holding the
+     * name of the path as a pascal string followed by the flatness as an 8.24 fixed point number.
+     */
+    private function clippingPathNameImageResource(): string
+    {
+        $data = "\x06" . 'Path 1' . pack('N', 1 << 24);
+
+        return '8BIM' . pack('n', 2999) . "\x00\x00" . pack('N', strlen($data)) . $data;
+    }
+
     private function saveAndReload(Imagick $adapter, string $format = 'jpeg', string $extension = 'jpg'): \Imagick
     {
         $path = $this->tmpFile($extension);
@@ -250,6 +314,16 @@ final class ImagickTest extends TestCase
             $image->getImagePixelColor($x, $y)->getColor(1)['a'],
             0.001,
             sprintf('The pixel at %d,%d is not opaque.', $x, $y)
+        );
+    }
+
+    private function assertPixelTransparent(\Imagick $image, int $x, int $y): void
+    {
+        $this->assertEqualsWithDelta(
+            0.0,
+            $image->getImagePixelColor($x, $y)->getColor(1)['a'],
+            0.001,
+            sprintf('The pixel at %d,%d is not transparent.', $x, $y)
         );
     }
 


### PR DESCRIPTION
## Changes in this pull request

Fixes pimcore/platform-version#184: images that carry a Photoshop path but no clipping path produce empty (fully transparent) thumbnails.

### Root cause

`Imagick::has8BIMClippingPath()` returned `true` for two different Photoshop image resources:

* `8BIM 2999` / `0x0BB7` — *Name of clipping path*, i.e. the path the image was actually designated to be clipped by
* `8BIM 2000` / `0x07D0` — the first *Path Information* resource, which holds any path saved with the image (a guide, an unrelated shape, a leftover pen path, …)

The second check was added in #17362 for TIFFs that have a clipping path but no clipping path *name*. Unfortunately the two cases cannot be told apart at metadata level, so every image that merely contains a saved Photoshop path was clipped by an arbitrary shape as well — which removes the whole image content and leaves the thumbnail empty.

Reproduced with hand-built 8BIM profiles (ImageMagick 7.1.2): a file whose only path resource is `8BIM 2000` goes through `clipImage()` and ends up with alpha `0.0` everywhere.

### Fix

* Automatic clipping is only triggered by the *Name of clipping path* resource (`8BIM 2999`) again. Saved paths (`8BIM 2000` - `2998`) are ignored.
* If `clipImage()` throws, the alpha channel is reset to opaque. It is set to transparent right before the clipping and was never reset in the error path, so the "deliver the unclipped image" fallback from #7437 actually delivered a blank image.
* Regression test in `tests/Unit/Image/Adapter/ImagickTest.php` building a TIFF with a saved path (and no clipping path) and asserting the loaded image is left intact. It fails on the current code (`The pixel at 20,20 is not opaque. Failed asserting that 0.0 matches expected 1.0.`) and passes with this change.
* Upgrade note for the behavior change.

### Note on #17362

This intentionally reverts the heuristic introduced there: images with saved paths but without the clipping path name are not auto-clipped anymore. There is no way to distinguish a path that was meant as a clipping path from an ordinary saved path, so the heuristic clips images that must not be clipped. If the old behavior is still wanted for such files, it should become an explicit opt-in option instead of the default.