### PR TITLE
[Asset] Fix PDF JavaScript scan false positives (#16955)

### DIFF
--- a/models/Asset/Document.php
+++ b/models/Asset/Document.php
@@ -18,6 +18,7 @@ use Pimcore\Cache;
 use Pimcore\Config;
 use Pimcore\Logger;
 use Pimcore\Model;
+use Pimcore\Model\Asset\Document\PdfScanner;
 
 /**
  * @method Dao getDao()
@@ -151,26 +152,13 @@ class Document extends Model\Asset
             Model\Asset\Enum\PdfScanStatus::IN_PROGRESS->value
         );
 
-        $chunkSize = 1024;
-        $filePointer = $this->getStream();
+        if ((new PdfScanner())->containsJavaScript($this->getStream())) {
+            $this->setCustomSetting(
+                self::CUSTOM_SETTING_PDF_SCAN_STATUS,
+                Model\Asset\Enum\PdfScanStatus::UNSAFE->value
+            );
 
-        $tagLength = strlen('/JS');
-
-        while ($chunk = fread($filePointer, $chunkSize)) {
-            if (strlen($chunk) <= $tagLength) {
-                break;
-            }
-
-            // NOTE: raw string matching produces false positives (see #16955) — /JS can appear
-            // in font names, operator sequences, or other non-JavaScript PDF structures.
-            if (str_contains($chunk, '/JS') || str_contains($chunk, '/JavaScript')) {
-                $this->setCustomSetting(
-                    self::CUSTOM_SETTING_PDF_SCAN_STATUS,
-                    Model\Asset\Enum\PdfScanStatus::UNSAFE->value
-                );
-
-                return true;
-            }
+            return true;
         }
 
         $this->setCustomSetting(

--- a/models/Asset/Document/PdfScanner.php
+++ b/models/Asset/Document/PdfScanner.php
@@ -1,0 +1,160 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Model\Asset\Document;
+
+/**
+ * Scans a PDF for JavaScript by matching /JS and /JavaScript as proper PDF name
+ * tokens outside of stream payloads, instead of raw byte matching which flags
+ * binary (compressed) stream data by chance (see #16955).
+ *
+ * This is a heuristic pre-check for the admin preview, not a sanitizer: names
+ * hidden inside compressed object streams are not decompressed.
+ *
+ * @internal
+ */
+final class PdfScanner
+{
+    private const STREAM_KEYWORD = 'stream';
+
+    private const ENDSTREAM_KEYWORD = 'endstream';
+
+    /**
+     * Longest byte sequence that may straddle a chunk boundary: a fully
+     * hex-escaped /JavaScript name (1 + 10 * 3 bytes) plus a terminating
+     * delimiter, or the stream keyword with its EOL marker.
+     */
+    private const BOUNDARY_OVERLAP = 64;
+
+    public function __construct(private readonly int $chunkSize = 65536)
+    {
+    }
+
+    /**
+     * @param resource $stream seekable or non-seekable readable stream positioned at the start of the PDF
+     */
+    public function containsJavaScript($stream): bool
+    {
+        $buffer = '';
+        $inStreamPayload = false;
+
+        do {
+            $chunk = feof($stream) ? '' : fread($stream, $this->chunkSize);
+            if (is_string($chunk)) {
+                $buffer .= $chunk;
+            }
+            $atEof = $chunk === false || $chunk === '' || feof($stream);
+
+            if ($this->scanBuffer($buffer, $inStreamPayload, $atEof)) {
+                return true;
+            }
+        } while (!$atEof);
+
+        return false;
+    }
+
+    /**
+     * Consumes the buffer, retaining an unconsumed tail so tokens and keywords
+     * split across chunk boundaries are seen once completed by the next read.
+     */
+    private function scanBuffer(string &$buffer, bool &$inStreamPayload, bool $atEof): bool
+    {
+        $position = 0;
+        $length = strlen($buffer);
+
+        while (true) {
+            if ($inStreamPayload) {
+                $endstream = strpos($buffer, self::ENDSTREAM_KEYWORD, $position);
+                if ($endstream === false) {
+                    // everything so far is payload — keep only enough bytes to
+                    // recognize a split endstream keyword on the next read
+                    $keep = $atEof ? 0 : strlen(self::ENDSTREAM_KEYWORD) - 1;
+                    $buffer = $keep > 0 ? substr($buffer, max($position, $length - $keep)) : '';
+
+                    return false;
+                }
+
+                $position = $endstream + strlen(self::ENDSTREAM_KEYWORD);
+                $inStreamPayload = false;
+
+                continue;
+            }
+
+            $streamKeywordStart = $this->findStreamKeyword($buffer, $position);
+            $regionEnd = $streamKeywordStart ?? $length;
+            $regionIsFinal = $streamKeywordStart === null && $atEof;
+
+            if ($this->regionContainsJsName(substr($buffer, $position, $regionEnd - $position), $regionIsFinal)) {
+                return true;
+            }
+
+            if ($streamKeywordStart === null) {
+                // keep a tail: it may hold the start of a stream keyword or an
+                // incomplete name token continued by the next read
+                $keep = $atEof ? 0 : self::BOUNDARY_OVERLAP;
+                $buffer = $keep > 0 ? substr($buffer, max($position, $length - $keep)) : '';
+
+                return false;
+            }
+
+            $position = $streamKeywordStart + strlen(self::STREAM_KEYWORD);
+            $inStreamPayload = true;
+        }
+    }
+
+    /**
+     * Finds the stream keyword: not part of a longer token such as endstream
+     * or a name, and followed by an end-of-line marker (PDF 32000-1 §7.3.8.1).
+     */
+    private function findStreamKeyword(string $buffer, int $offset): ?int
+    {
+        if (preg_match('/(?<![A-Za-z0-9#\/])stream(?=\r\n|\n|\r)/', $buffer, $match, PREG_OFFSET_CAPTURE, $offset)) {
+            return $match[0][1];
+        }
+
+        return null;
+    }
+
+    /**
+     * Matches /JS and /JavaScript as complete name tokens (PDF 32000-1 §7.3.5):
+     * terminated by whitespace or a delimiter, with #xx hex escapes decoded.
+     */
+    private function regionContainsJsName(string $region, bool $regionIsFinal): bool
+    {
+        if (!preg_match_all('/\/([^\x00\t\n\f\r ()<>\[\]{}\/%]*)/', $region, $matches, PREG_OFFSET_CAPTURE)) {
+            return false;
+        }
+
+        $regionLength = strlen($region);
+
+        foreach ($matches[1] as [$rawName, $nameOffset]) {
+            if (!$regionIsFinal && $nameOffset + strlen($rawName) === $regionLength) {
+                // the token may continue in the next chunk — it stays in the
+                // retained tail and is re-examined once completed
+                continue;
+            }
+
+            $name = preg_replace_callback(
+                '/#([0-9a-fA-F]{2})/',
+                static fn (array $hex): string => chr((int) hexdec($hex[1])),
+                $rawName
+            );
+
+            if ($name === 'JS' || $name === 'JavaScript') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Unit/Asset/Document/PdfScannerTest.php
+++ b/tests/Unit/Asset/Document/PdfScannerTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Asset\Document;
+
+use Pimcore\Model\Asset\Document\PdfScanner;
+use Pimcore\Tests\Support\Test\TestCase;
+
+class PdfScannerTest extends TestCase
+{
+    public function testJsActionNameIsDetected(): void
+    {
+        $pdf = $this->wrapPdf(
+            "1 0 obj\n<< /Type /Action /S /JavaScript /JS (app.alert(1);) >>\nendobj\n"
+        );
+
+        $this->assertTrue($this->scan($pdf));
+    }
+
+    public function testJavaScriptNameTreeIsDetected(): void
+    {
+        $pdf = $this->wrapPdf(
+            "1 0 obj\n<< /Names << /JavaScript 2 0 R >> >>\nendobj\n"
+        );
+
+        $this->assertTrue($this->scan($pdf));
+    }
+
+    public function testHexEscapedJsNameIsDetected(): void
+    {
+        // /J#53 and /#4a#53 both decode to the name /JS (PDF 32000-1 §7.3.5)
+        $this->assertTrue($this->scan($this->wrapPdf("<< /S /JavaScript /J#53 (x) >>\n")));
+        $this->assertTrue($this->scan($this->wrapPdf("<< /S /JavaScript /#4a#53 (x) >>\n")));
+    }
+
+    public function testJsNameAtEndOfFileIsDetected(): void
+    {
+        // name token terminated by EOF instead of a delimiter
+        $this->assertTrue($this->scan("%PDF-1.7\n<< /JS"));
+    }
+
+    public function testJsBytesInsideStreamPayloadAreIgnored(): void
+    {
+        // the reported false positive (#16955): /JS occurring as raw bytes
+        // inside a (compressed) stream payload is not JavaScript
+        $payload = "\x12\x88/JS\x99binary/JavaScript\x00garbage";
+        $pdf = $this->wrapPdf(
+            '2 0 obj<< /Length ' . strlen($payload) . " >>stream\n" . $payload . "\nendstream\nendobj\n"
+        );
+
+        $this->assertFalse($this->scan($pdf));
+    }
+
+    public function testJsNameAfterStreamPayloadIsDetected(): void
+    {
+        $pdf = $this->wrapPdf(
+            "2 0 obj\n<< /Length 10 >>\nstream\n0123456789\nendstream\nendobj\n" .
+            "3 0 obj\n<< /S /JavaScript /JS (app.alert(1);) >>\nendobj\n"
+        );
+
+        $this->assertTrue($this->scan($pdf));
+    }
+
+    public function testNameWithJsPrefixIsNotDetected(): void
+    {
+        // /JSXTransform and /JavaScripted are different name tokens than /JS and /JavaScript
+        $this->assertFalse($this->scan($this->wrapPdf("<< /Filter /JSXTransform >>\n")));
+        $this->assertFalse($this->scan($this->wrapPdf("<< /Producer /JavaScripted >>\n")));
+    }
+
+    public function testStreamLikeNameDoesNotStartPayloadSkipping(): void
+    {
+        // "stream" as part of a name token is not the stream keyword — the
+        // /JS after it must still be found
+        $pdf = $this->wrapPdf("<< /Type /mystream\n/JS (app.alert(1);) >>\n");
+
+        $this->assertTrue($this->scan($pdf));
+    }
+
+    public function testDetectionAcrossChunkBoundaries(): void
+    {
+        // tokens and keywords split across read-chunk boundaries must still be handled
+        $pdf = $this->wrapPdf(
+            "2 0 obj\n<< /Length 30 >>\nstream\nbinary/JS...../JavaScript....\nendstream\nendobj\n" .
+            "3 0 obj\n<< /S /JavaScript /JS (app.alert(1);) >>\nendobj\n"
+        );
+
+        foreach ([1, 2, 3, 7] as $chunkSize) {
+            $this->assertTrue(
+                $this->scan($pdf, $chunkSize),
+                sprintf('real /JS missed with chunk size %d', $chunkSize)
+            );
+        }
+
+        $cleanPdf = $this->wrapPdf(
+            "2 0 obj\n<< /Length 30 >>\nstream\nbinary/JS...../JavaScript....\nendstream\nendobj\n"
+        );
+
+        foreach ([1, 2, 3, 7] as $chunkSize) {
+            $this->assertFalse(
+                $this->scan($cleanPdf, $chunkSize),
+                sprintf('false positive with chunk size %d', $chunkSize)
+            );
+        }
+    }
+
+    public function testShortReadsDoNotAbortTheScan(): void
+    {
+        // fread() may return less than the requested chunk size (e.g. remote
+        // Flysystem streams) — the scan must keep reading until EOF
+        ShortReadStream::$content = $this->wrapPdf(
+            str_repeat('x', 512) . "\n<< /S /JavaScript /JS (app.alert(1);) >>\n"
+        );
+
+        stream_wrapper_register('pimcore-shortread', ShortReadStream::class);
+
+        try {
+            $stream = fopen('pimcore-shortread://test', 'r');
+            $this->assertTrue((new PdfScanner())->containsJavaScript($stream));
+            fclose($stream);
+        } finally {
+            stream_wrapper_unregister('pimcore-shortread');
+        }
+    }
+
+    public function testCleanPdfIsNotFlagged(): void
+    {
+        $pdf = $this->wrapPdf(
+            "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n" .
+            "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n"
+        );
+
+        $this->assertFalse($this->scan($pdf));
+    }
+
+    private function scan(string $content, ?int $chunkSize = null): bool
+    {
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, $content);
+        rewind($stream);
+
+        $scanner = $chunkSize !== null ? new PdfScanner($chunkSize) : new PdfScanner();
+        $result = $scanner->containsJavaScript($stream);
+
+        fclose($stream);
+
+        return $result;
+    }
+
+    private function wrapPdf(string $body): string
+    {
+        return "%PDF-1.7\n" . $body . "trailer\n<< /Root 1 0 R >>\n%%EOF\n";
+    }
+}
+
+/**
+ * Stream wrapper that returns at most one byte per read to simulate short reads.
+ */
+class ShortReadStream
+{
+    public static string $content = '';
+
+    public mixed $context = null;
+
+    private int $position = 0;
+
+    public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
+    {
+        $this->position = 0;
+
+        return true;
+    }
+
+    public function stream_read(int $count): string
+    {
+        $chunk = substr(self::$content, $this->position, 1);
+        $this->position += strlen($chunk);
+
+        return $chunk;
+    }
+
+    public function stream_eof(): bool
+    {
+        return $this->position >= strlen(self::$content);
+    }
+
+    public function stream_stat(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
## Changes in this pull request
Resolves #16955

The PDF pre-check in `Asset\Document::checkIfPdfContainsJS()` used raw byte matching (`str_contains($chunk, '/JS')`) over the entire file, including Flate-compressed binary stream payloads (images, fonts, ICC profiles). In compressed data any 3-byte sequence occurs by chance (~once per 17 MB), so large image-heavy print-ready PDFs were regularly flagged as containing JavaScript and their preview blocked — the false positive reported in #16955.

This PR extracts the scan into a new `@internal` `Pimcore\Model\Asset\Document\PdfScanner`, which matches `/JS` and `/JavaScript` only as **complete PDF name tokens** (terminated by whitespace or a delimiter per PDF 32000-1 §7.3.5, with `#xx` hex escapes decoded) and **skips `stream…endstream` payloads**. `checkIfPdfContainsJS()` keeps its signature, return semantics, and the `PdfScanStatus` custom-setting flow — no BC surface is touched.

It also fixes three false negatives of the previous loop:
- name tokens split across the 1024-byte read-chunk boundary were never matched (no overlap between chunks),
- a short `fread()` return (e.g. remote Flysystem streams) silently aborted the whole scan and marked the asset safe,
- hex-escaped names such as `/J#53` (= `/JS`) were not recognized.

## How to reproduce
1. Upload a large print-ready PDF whose compressed image streams happen to contain the raw bytes `/JS` (statistically near-certain for multi-MB print PDFs; the regression test constructs one deterministically).
2. Open the asset preview: it is blocked with "This PDF file contains JavaScript…" although the file contains none.

## Additional info
- Regression tests in `tests/Unit/Asset/Document/PdfScannerTest.php` cover the false-positive case, token boundaries (chunk sizes down to 1 byte), short reads, hex escapes, and real `/JS` / `/JavaScript` action dictionaries.
- The scanner is streaming and memory-bounded (64 KB chunks, small carry-over tail); no new dependencies.
- Known pre-existing limitation (unchanged by this PR): names hidden inside Flate-compressed object streams are not detected — this was already the case before (verified with the JS sample attached to #16955, which the previous scan also did not flag). Scanning decompressed streams incrementally would be a possible follow-up.
- Note: authored per request against `2026.2`; the same code exists unchanged on `12.3`, so it can be cherry-picked there if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)