### PR TITLE
Docs: correct NoteEvents summary after #19287

### DIFF
--- a/doc/10_Extending_Pimcore/01_Events/01_Core_Framework_Events.md
+++ b/doc/10_Extending_Pimcore/01_Events/01_Core_Framework_Events.md
@@ -56,7 +56,7 @@ of the event's purpose and the event object it dispatches.
 - [TagEvents](https://github.com/pimcore/pimcore/blob/2026.x/lib/Event/TagEvents.php) -
   tag assignment and management
 - [NoteEvents](https://github.com/pimcore/pimcore/blob/2026.x/lib/Event/NoteEvents.php) -
-  note create, update, and delete
+  note create and delete
 - [NotificationEvents](https://github.com/pimcore/pimcore/blob/2026.x/lib/Event/NotificationEvents.php) -
   notification lifecycle events
 - [UserRoleEvents](https://github.com/pimcore/pimcore/blob/2026.x/lib/Event/UserRoleEvents.php) -


### PR DESCRIPTION
## Summary

Follow-up to #19287 (merged), which added `NoteEvents::POST_DELETE`.

- Fixes `doc/10_Extending_Pimcore/01_Events/01_Core_Framework_Events.md`, which described `NoteEvents` as covering "note create, update, and delete". In reality `NoteEvents` only ever had `POST_ADD` (dispatched on create only); there has never been an update event for notes. This line was already inaccurate before #19287 (introduced by the doc refactor in #19037) and is now updated to "note create and delete" to match what #19287 actually shipped.

## Upgrade notes

No upgrade-notes entry added. `POST_DELETE` is a purely additive lifecycle event with no behavior change for existing installs, consistent with how prior additive-event PRs (e.g. #17547, #19200) were handled — upgrade notes are reserved for breaking changes and deprecations.

## Test plan

- [x] Doc-only change, verified by rendering the diff.
- [x] Confirmed via `grep`/`git log` that no update event exists anywhere in the codebase, and that the upgrade-notes file has no other outstanding reference needing a change for this PR.