### PR TITLE
Fix pretty URL resolution matching documents of nested sites

### DIFF
--- a/models/Document/Dao.php
+++ b/models/Document/Dao.php
@@ -96,7 +96,7 @@ class Dao extends Model\Element\Dao
      */
     public function getByPrettyUrl(string $path): void
     {
-        $data = $this->db->fetchAssociative('SELECT id FROM documents_page WHERE prettyUrl = :prettyUrl', [
+        $data = $this->db->fetchAssociative('SELECT id FROM documents_page WHERE prettyUrl = :prettyUrl ORDER BY id LIMIT 1', [
             'prettyUrl' => $path,
         ]);
 

--- a/models/Document/Service/Dao.php
+++ b/models/Document/Service/Dao.php
@@ -26,12 +26,65 @@ class Dao extends Model\Dao\AbstractDao
 {
     public function getDocumentIdByPrettyUrlInSite(Site $site, string $path): int
     {
-        return (int) $this->db->fetchOne(
-            'SELECT documents.id FROM documents
+        $candidates = $this->db->fetchAllAssociative(
+            'SELECT documents.id, CONCAT(documents.`path`, documents.`key`) AS fullPath FROM documents
             LEFT JOIN documents_page ON documents.id = documents_page.id
-            WHERE documents.path LIKE ? AND documents_page.prettyUrl = ?',
-            [Helper::escapeLike($site->getRootPath()) . '/%', rtrim($path, '/')]
+            WHERE documents.path LIKE :sitePath AND documents_page.prettyUrl = :prettyUrl
+            ORDER BY documents.id',
+            [
+                'sitePath' => Helper::escapeLike($site->getRootPath()) . '/%',
+                'prettyUrl' => rtrim($path, '/'),
+            ]
         );
+
+        if ($candidates === []) {
+            return 0;
+        }
+
+        // documents living below the root of another site nested inside the given site belong
+        // to that nested site (nearest site root wins, see Tool\Frontend::getSiteIdForDocument())
+        // and must not be matched when resolving a pretty URL within the given site
+        $nestedSiteRootPaths = $this->getNestedSiteRootPaths($site);
+
+        foreach ($candidates as $candidate) {
+            if (!$this->isPathBelowAnyPath((string) $candidate['fullPath'], $nestedSiteRootPaths)) {
+                return (int) $candidate['id'];
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * Returns the root paths of all sites whose root document is located within the given site.
+     *
+     * @return string[]
+     */
+    private function getNestedSiteRootPaths(Site $site): array
+    {
+        return $this->db->fetchFirstColumn(
+            'SELECT CONCAT(documents.`path`, documents.`key`) FROM sites
+            INNER JOIN documents ON sites.rootId = documents.id
+            WHERE sites.id != :siteId AND documents.path LIKE :sitePath',
+            [
+                'siteId' => $site->getId(),
+                'sitePath' => Helper::escapeLike($site->getRootPath()) . '/%',
+            ]
+        );
+    }
+
+    /**
+     * @param string[] $parentPaths
+     */
+    private function isPathBelowAnyPath(string $path, array $parentPaths): bool
+    {
+        foreach ($parentPaths as $parentPath) {
+            if (str_starts_with($path . '/', $parentPath . '/')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function getTranslationSourceId(Document $document): mixed

--- a/tests/Model/Document/ServiceTest.php
+++ b/tests/Model/Document/ServiceTest.php
@@ -83,6 +83,41 @@ class ServiceTest extends ModelTestCase
         );
     }
 
+    /**
+     * Regression test: two published pages share the same pretty URL and neither belongs to a
+     * site. The global pretty URL lookup has to pick the same document on every request
+     * instead of whichever row the storage engine happens to return first.
+     *
+     * @see \Pimcore\Model\Document\Dao::getByPrettyUrl()
+     */
+    public function testPrettyUrlWithoutSiteResolvesDeterministically(): void
+    {
+        $prettyUrl = '/imprint-' . uniqid();
+
+        $firstPage = $this->createPage('imprint-a-' . uniqid(), 1, $prettyUrl);
+        $secondPage = $this->createPage('imprint-b-' . uniqid(), 1, $prettyUrl);
+
+        $this->assertLessThan(
+            $secondPage->getId(),
+            $firstPage->getId(),
+            'The document created first is expected to carry the lower id.'
+        );
+
+        foreach ([1, 2] as $attempt) {
+            $document = new Document();
+            $document->getDao()->getByPrettyUrl($prettyUrl);
+
+            $this->assertSame(
+                $firstPage->getId(),
+                $document->getId(),
+                sprintf(
+                    'A pretty URL shared by several documents must always resolve to the same document (attempt %d).',
+                    $attempt
+                )
+            );
+        }
+    }
+
     private function createPage(string $key, int $parentId, ?string $prettyUrl = null): Page
     {
         $page = new Page();

--- a/tests/Model/Document/ServiceTest.php
+++ b/tests/Model/Document/ServiceTest.php
@@ -1,0 +1,132 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\Document;
+
+use Pimcore\Model\Document;
+use Pimcore\Model\Document\Page;
+use Pimcore\Model\Document\Service;
+use Pimcore\Model\Site;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+
+/**
+ * Class ServiceTest
+ *
+ * @package Pimcore\Tests\Model\Document
+ *
+ * @group model.document.service
+ */
+class ServiceTest extends ModelTestCase
+{
+    protected function needsDb(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Regression test: two published pages share the same pretty URL - one belongs to a site,
+     * the other to a second site whose root document is nested inside the first site. Both
+     * pages live below the first site's root path, so a plain path-prefix match finds both.
+     * Resolving the pretty URL within the enclosing site must return the document that
+     * actually belongs to it (nearest site root wins, consistent with
+     * Tool\Frontend::getSiteIdForDocument()) - never the nested site's document.
+     *
+     * @see \Pimcore\Model\Document\Service\Dao::getDocumentIdByPrettyUrlInSite()
+     */
+    public function testPrettyUrlInSiteDoesNotResolveToDocumentOfNestedSite(): void
+    {
+        $prettyUrl = '/impressum-' . uniqid();
+
+        $parentSiteRoot = $this->createPage('section-' . uniqid(), 1);
+        $parentSite = $this->createSite($parentSiteRoot, 'parent-site-' . uniqid() . '.example.com');
+
+        // the nested site root sorts alphabetically before "footer" and its pretty URL page is
+        // created (and therefore id-ordered) before the parent site's page, so an
+        // unfixed, unordered path-prefix lookup would pick the nested site's document
+        $nestedSiteRoot = $this->createPage('aaa-sub-site-' . uniqid(), $parentSiteRoot->getId());
+        $nestedSite = $this->createSite($nestedSiteRoot, 'nested-site-' . uniqid() . '.example.com');
+
+        $nestedSitePage = $this->createPage(
+            'impressum',
+            $this->createFolderPath($nestedSiteRoot, ['footer', 'sockel'])->getId(),
+            $prettyUrl
+        );
+
+        $parentSitePage = $this->createPage(
+            'impressum',
+            $this->createFolderPath($parentSiteRoot, ['footer', 'sockel'])->getId(),
+            $prettyUrl
+        );
+
+        $dao = (new Service())->getDao();
+
+        $this->assertSame(
+            $parentSitePage->getId(),
+            $dao->getDocumentIdByPrettyUrlInSite($parentSite, $prettyUrl),
+            'The pretty URL requested within the parent site must resolve to the parent site\'s own document, not to the document of a site nested inside it.'
+        );
+
+        $this->assertSame(
+            $nestedSitePage->getId(),
+            $dao->getDocumentIdByPrettyUrlInSite($nestedSite, $prettyUrl),
+            'The pretty URL requested within the nested site must resolve to the nested site\'s document.'
+        );
+    }
+
+    private function createPage(string $key, int $parentId, ?string $prettyUrl = null): Page
+    {
+        $page = new Page();
+        $page->setKey($key);
+        $page->setParentId($parentId);
+        $page->setPublished(true);
+        $page->setUserOwner(1);
+        $page->setUserModification(1);
+        $page->setCreationDate(time());
+        if ($prettyUrl !== null) {
+            $page->setPrettyUrl($prettyUrl);
+        }
+        $page->save();
+
+        return $page;
+    }
+
+    /**
+     * @param string[] $folderKeys
+     */
+    private function createFolderPath(Document $parent, array $folderKeys): Document
+    {
+        foreach ($folderKeys as $folderKey) {
+            $folder = new Document\Folder();
+            $folder->setKey($folderKey);
+            $folder->setParentId($parent->getId());
+            $folder->setUserOwner(1);
+            $folder->setUserModification(1);
+            $folder->setCreationDate(time());
+            $folder->save();
+
+            $parent = $folder;
+        }
+
+        return $parent;
+    }
+
+    private function createSite(Page $rootDocument, string $mainDomain): Site
+    {
+        $site = new Site();
+        $site->setRootDocument($rootDocument);
+        $site->setMainDomain($mainDomain);
+        $site->save();
+
+        return $site;
+    }
+}


### PR DESCRIPTION
### Issue
Fixes https://github.com/pimcore/platform-version/issues/202

### Problem
When a Site B has its root document nested inside another Site A (e.g. `/section-a/sub-site` inside `/section-a`), and two published pages share the same `prettyUrl`, requesting that pretty URL on Site A's domain could serve Site B's document.

`Document\Service\Dao::getDocumentIdByPrettyUrlInSite()` scoped candidates only by a path prefix:

```sql
WHERE documents.path LIKE ? AND documents_page.prettyUrl = ?
```

Documents of a site nested inside the requesting site also satisfy that prefix condition, and the query had no `ORDER BY`. MySQL's index range scan returns rows in ascending `path` order, so whichever full path sorted first won — which is why renaming a folder flips the outcome, as described in the issue.

Both call sites go through this one method (`Routing\Dynamic\DocumentRouteHandler::matchRequest()` and `Document\Service::getNearestDocumentByPath()`), so the fix applies to both.

### Fix
- Candidates located at or below the root of a **different site nested inside** the requesting site are excluded — they belong to that nested site. This mirrors the established "nearest site root wins" semantics of `Tool\Frontend::getSiteIdForDocument()`, which the router already relies on for the inverse check (serving a 404 for site content on the main domain).
- The candidate lookup gains a deterministic `ORDER BY`, and the global fallback `Document\Dao::getByPrettyUrl()` was made deterministic as well.
- Queries stay sargable (prefix `LIKE` on the indexed `path` column, no wrapping of the column in functions) and all values are bound parameters. The nested-site roots are fetched with one small query; the boundary check is done in PHP so that a sibling like `/aaa-sub-site-2` is not mistaken for a child of `/aaa-sub-site`.

Both Dao classes are `@internal` and no public signature changed.

### Tests
`tests/Model/Document/ServiceTest::testPrettyUrlInSiteDoesNotResolveToDocumentOfNestedSite` builds the exact scenario from the issue: a parent site, a second site rooted inside it, and two published pages sharing one `prettyUrl`. The fixture is arranged so the unfixed query returns the wrong document under both plausible row orders. It asserts each site's request resolves to its own page.

### Verification
- `php -l` clean on all changed files; the exclusion/boundary logic was verified with a standalone simulation (parent picks its own document, nested site picks its own, the nested root document is excluded, a similar-prefix sibling is not).
- **Not run locally** (no vendor/DB in this environment) — CI validates the Codeception Model suite including the new regression test, PHPStan, php-cs-fixer, and the actual MySQL execution plan of the two adjusted queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)