### PR TITLE
Fix TypeError in Link::isEqual() for empty localized values

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Link.php
+++ b/models/DataObject/ClassDefinition/Data/Link.php
@@ -349,6 +349,10 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
             unset($oldValue['_owner']);
             unset($oldValue['_fieldname']);
             unset($oldValue['_language']);
+        } elseif ($this->isEmpty($oldValue)) {
+            // e.g. version-diff templates fall back to an empty string for an unset
+            // localized value, which is not a valid `?array` for isEqualArray()
+            $oldValue = null;
         }
 
         if ($newValue instanceof DataObject\Data\Link) {
@@ -357,6 +361,8 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
             unset($newValue['_owner']);
             unset($newValue['_fieldname']);
             unset($newValue['_language']);
+        } elseif ($this->isEmpty($newValue)) {
+            $newValue = null;
         }
 
         return $this->isEqualArray($oldValue, $newValue);

--- a/tests/Unit/Models/DataObject/ClassDefinition/Data/LinkTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/Data/LinkTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Tests\Unit\Model\DataObject\ClassDefinition\Data;
 
 use Pimcore\Model\DataObject\ClassDefinition\Data\Link;
+use Pimcore\Model\DataObject\Data\Link as LinkData;
 use Pimcore\Tests\Support\Test\TestCase;
 
 /**
@@ -56,5 +57,53 @@ class LinkTest extends TestCase
             ObjectInjectionProbe::$wakeupCalled,
             '__wakeup() must not be called when the class is excluded by the deserialization allowlist'
         );
+    }
+
+    private function buildLink(string $direct): LinkData
+    {
+        $link = new LinkData();
+        $link->setLinktype('direct');
+        $link->setDirect($direct);
+
+        return $link;
+    }
+
+    /**
+     * Regression test for https://github.com/pimcore/platform-version/issues/318.
+     *
+     * The version-comparison template (diff_versions.html.twig) falls back to an empty
+     * string for a localized value that is not set in a given language. That empty string
+     * used to be passed straight into isEqualArray(?array $array1, ...), which threw a
+     * TypeError instead of the intended "no diff" / "diff" result.
+     */
+    public function testIsEqualDoesNotThrowForEmptyStringOperands(): void
+    {
+        $definition = new Link();
+
+        $this->assertTrue($definition->isEqual('', null), 'empty string vs null must be treated as equal (both "no link")');
+        $this->assertTrue($definition->isEqual(null, ''), 'null vs empty string must be treated as equal (both "no link")');
+        $this->assertTrue($definition->isEqual('', ''), 'empty string vs empty string must be treated as equal');
+    }
+
+    public function testIsEqualDetectsDiffBetweenEmptyAndRealLink(): void
+    {
+        $definition = new Link();
+        $link = $this->buildLink('https://www.pimcore.com');
+
+        $this->assertFalse($definition->isEqual('', $link), 'empty string vs a real link must be reported as a diff');
+        $this->assertFalse($definition->isEqual($link, ''), 'a real link vs empty string must be reported as a diff');
+        $this->assertFalse($definition->isEqual(null, $link), 'null vs a real link must be reported as a diff');
+    }
+
+    public function testIsEqualStillComparesTwoRealLinksCorrectly(): void
+    {
+        $definition = new Link();
+
+        $linkA = $this->buildLink('https://www.pimcore.com');
+        $linkB = $this->buildLink('https://www.pimcore.com');
+        $linkC = $this->buildLink('https://www.pimcore.org');
+
+        $this->assertTrue($definition->isEqual($linkA, $linkB), 'two links with identical data must be equal');
+        $this->assertFalse($definition->isEqual($linkA, $linkC), 'two links with different data must not be equal');
     }
 }


### PR DESCRIPTION
## Root cause

Version comparison crashes with

```
TypeError: Pimcore\Model\DataObject\ClassDefinition\Data\Link::isEqualArray():
Argument #1 ($array1) must be of type ?array, string given
```

when comparing two versions of a `DataObject` that has a `Link` field inside a
localized-fields container, if the field is left empty in at least one enabled
language.

`admin-ui-classic-bundle`'s `diff_versions.html.twig` calls
`EqualComparisonInterface::isEqual($keyData1, $keyData2)` on the field
definition, and for a localized value that is unset in a given language it
substitutes an empty string (`getLocalizedValue(...) ?? ''`) rather than
passing through `null`.

`Link::isEqual()` only special-cased `null` and `DataObject\Data\Link`
instances:

```php
public function isEqual(mixed $oldValue, mixed $newValue): bool
{
    if ($oldValue === null && $newValue === null) {
        return true;
    }

    if ($oldValue instanceof DataObject\Data\Link) {
        $oldValue = $oldValue->getObjectVars();
        // ...
    }
    // ... same for $newValue

    return $this->isEqualArray($oldValue, $newValue);
}
```

An empty string falls through both checks unchanged and is passed straight
into `SimpleComparisonTrait::isEqualArray(?array $array1, ?array $array2)`,
whose strict `?array` parameter type rejects a `string` at the call boundary
and throws the `TypeError` before the method body's own
`is_array(...) ? ... : []` defensive check ever runs.

## Fix

`models/DataObject/ClassDefinition/Data/Link.php`: normalize any operand that
is neither a `DataObject\Data\Link` instance nor already "empty" (per this
class's own `isEmpty()` convention, inherited from `Data::isEmpty()` =
`empty($data)`, so `''`, `null`, `[]`, etc. all qualify) to `null` before
delegating to `isEqualArray()`. This mirrors the coercion-to-empty-state
pattern `StructuredTable::isEqual()` already uses for its non-instance
operands, so the fix is consistent with an existing convention in this file
family rather than a one-off special case.

Comparisons between two real `Link` values are unaffected: the `instanceof`
branch and the resulting array diff are unchanged.

## Test plan

Added regression tests to the existing
`tests/Unit/Models/DataObject/ClassDefinition/Data/LinkTest.php`:

- `testIsEqualDoesNotThrowForEmptyStringOperands` — `isEqual('', null)`,
  `isEqual(null, '')`, `isEqual('', '')` no longer throw and are reported as
  equal ("no link" vs "no link").
- `testIsEqualDetectsDiffBetweenEmptyAndRealLink` — an empty string/`null`
  compared against a real `Link` is still correctly reported as a diff.
- `testIsEqualStillComparesTwoRealLinksCorrectly` — two real `Link` values
  with identical vs. different data still compare exactly as before (proves
  the fix doesn't change behavior for the non-buggy case).

Verified locally (host PHP 8.3, `vendor/bin/codecept run Unit`, per this
repo's own `.github/ci/scripts/setup-pimcore-environment.sh` + a throwaway
MariaDB container):

- Confirmed **red**: reverting only the `Link.php` change reproduces the
  exact reported `TypeError` (`Argument #1 ($array1) must be of type ?array,
  string given`) in the two new tests.
- Confirmed **green** with the fix applied: all tests in
  `tests/Unit/Models/DataObject/ClassDefinition` pass (74 tests, 143
  assertions), including the 3 new ones.
- `php-cs-fixer --dry-run --diff` on both changed files: clean.
- `phpstan analyse --memory-limit=-1` on `Link.php`: no errors.

Fixes pimcore/platform-version#318