### PR TITLE
[Bug]: Default Select field "options" to [] instead of null in the class-definition API

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -422,7 +422,14 @@ class Select extends Data implements
             $this->options = null;
         }
 
-        return parent::jsonSerialize();
+        $data = parent::jsonSerialize();
+
+        // Consumers of this API (e.g. the Studio class editor) expect "options" to always be an
+        // array. Internally, null still means "not configured / not yet resolved" (see getOptions(),
+        // checkValidity()), so only the serialized representation is normalized here.
+        $data['options'] ??= [];
+
+        return $data;
     }
 
     public function resolveBlockedVars(): array

--- a/tests/Unit/Models/DataObject/ClassDefinition/Data/SelectTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/Data/SelectTest.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\DataObject\ClassDefinition\Data;
+
+use Pimcore\Model\DataObject\ClassDefinition\Data\Select;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * @group unit.model.datatype.select
+ */
+class SelectTest extends TestCase
+{
+    /**
+     * Regression test for platform-version#260: a select field whose "options" were never
+     * configured serialized "options" as null. The Studio class editor feeds this value
+     * straight into a grid that spreads/iterates it (`[...options, newRow]`), which throws
+     * "TypeError: e is not iterable" as soon as the first option row is added.
+     */
+    public function testJsonSerializeDefaultsOptionsToEmptyArrayWhenUnconfigured(): void
+    {
+        $select = new Select();
+        $select->setName('status');
+
+        $this->assertNull($select->getOptions(), 'internal state must stay null (used as an "unresolved" sentinel elsewhere)');
+
+        $serialized = $select->jsonSerialize();
+
+        $this->assertSame([], $serialized['options']);
+    }
+
+    public function testJsonSerializeKeepsConfiguredOptionsAsIs(): void
+    {
+        $select = new Select();
+        $select->setName('status');
+        $select->setOptions([
+            ['key' => 'Open', 'value' => 'open'],
+            ['key' => 'Closed', 'value' => 'closed'],
+        ]);
+
+        $serialized = $select->jsonSerialize();
+
+        $this->assertSame([
+            ['key' => 'Open', 'value' => 'open'],
+            ['key' => 'Closed', 'value' => 'closed'],
+        ], $serialized['options']);
+    }
+}


### PR DESCRIPTION
## Root cause

The class-definition layout API (`GET /pimcore-studio/api/class/definition/configuration-view/detail/{id}/layout`) serializes a `select` field's `options` as `null`, not `[]`, when the field has never had any options configured — e.g. `{"name":"status", ..., "options":null, ...}`.

The underlying model, `Pimcore\Model\DataObject\ClassDefinition\Data\Select`, defaults the `options` property to `null` and `jsonSerialize()` (inherited from `Data::jsonSerialize()`, which does `get_object_vars($this)`) passes that straight through into the API response.

The Studio class editor's "Select Options" grid feeds this value directly into a shared grid component whose `addRow` handler does `[...value, data]`. `null` is not iterable, so clicking **Add** on a select field with no configured options throws `TypeError: e is not iterable` in the browser and no row is added. See pimcore/studio-ui-bundle#4004 for the UI-side fix (the actual crash), which is independent of this change.

## Fix

`Select::jsonSerialize()` now normalizes the serialized `"options"` key to `[]` when it is `null`.

The internal `null` default itself is intentionally left untouched — it is used elsewhere (`getOptions() === null` in `checkValidity()`) as a sentinel meaning "not yet resolved", which triggers `enrichFieldDefinition()` for fields backed by a dynamic options provider. Changing the property default itself would have broken that resolution path for dynamic-options fields with `enforceValidation` enabled. Only the JSON *output* is normalized, which is what every other consumer of this API already assumes "options" to be (an array).

## Testing

Added `tests/Unit/Models/DataObject/ClassDefinition/Data/SelectTest.php`:
- asserts `jsonSerialize()` returns `[]` for `options` when unconfigured, while the internal `getOptions()` stays `null`
- asserts already-configured options are serialized unchanged

Ran locally (PHP 8.3 + Codeception, per `.github/ci/scripts/setup-pimcore-environment.sh`):
```
tests/Unit/Models/DataObject/ClassDefinition/Data/          41 tests, 103 assertions — OK
```
(includes the existing `UserTest`, since `User` extends `Select` — no regression.)

Refs pimcore/platform-version#260