### PR TITLE
Make schema changing migrations non transactional

### DIFF
--- a/bundles/CoreBundle/src/Migrations/Version20201007000000.php
+++ b/bundles/CoreBundle/src/Migrations/Version20201007000000.php
@@ -23,6 +23,11 @@ use Symfony\Component\Cache\Adapter\DoctrineDbalAdapter;
  */
 final class Version20201007000000 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $db = Db::get();

--- a/bundles/CoreBundle/src/Migrations/Version20201008082752.php
+++ b/bundles/CoreBundle/src/Migrations/Version20201008082752.php
@@ -21,6 +21,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20201008082752 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if ($schema->hasTable('tracking_events')) {

--- a/bundles/CoreBundle/src/Migrations/Version20201008101817.php
+++ b/bundles/CoreBundle/src/Migrations/Version20201008101817.php
@@ -21,6 +21,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20201008101817 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->addSql('DROP VIEW IF EXISTS documents_editables;');

--- a/bundles/CoreBundle/src/Migrations/Version20201008132324.php
+++ b/bundles/CoreBundle/src/Migrations/Version20201008132324.php
@@ -21,6 +21,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20201008132324 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if ($schema->hasTable('locks')) {

--- a/bundles/CoreBundle/src/Migrations/Version20201009095924.php
+++ b/bundles/CoreBundle/src/Migrations/Version20201009095924.php
@@ -21,6 +21,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20201009095924 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if ($schema->getTable('users')->hasColumn('apiKey')) {

--- a/bundles/CoreBundle/src/Migrations/Version20201012154224.php
+++ b/bundles/CoreBundle/src/Migrations/Version20201012154224.php
@@ -21,6 +21,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20201012154224 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if ($schema->getTable('glossary')->hasColumn('acronym')) {

--- a/bundles/CoreBundle/src/Migrations/Version20201113143914.php
+++ b/bundles/CoreBundle/src/Migrations/Version20201113143914.php
@@ -24,6 +24,11 @@ final class Version20201113143914 extends AbstractMigration
     private array $tables = ['documents_email', 'documents_newsletter', 'documents_page',
         'documents_snippet', 'documents_printpage', ];
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         foreach ($this->tables as $table) {

--- a/bundles/CoreBundle/src/Migrations/Version20201201084201.php
+++ b/bundles/CoreBundle/src/Migrations/Version20201201084201.php
@@ -22,6 +22,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20201201084201 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         foreach (['cache', 'cache_tags'] as $tableName) {

--- a/bundles/CoreBundle/src/Migrations/Version20210323082921.php
+++ b/bundles/CoreBundle/src/Migrations/Version20210323082921.php
@@ -40,6 +40,11 @@ final class Version20210323082921 extends AbstractMigration
         return '';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $db = \Pimcore\Db::get();

--- a/bundles/CoreBundle/src/Migrations/Version20210324152822.php
+++ b/bundles/CoreBundle/src/Migrations/Version20210324152822.php
@@ -23,6 +23,11 @@ use Pimcore\Db;
  */
 final class Version20210324152822 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $db = Db::get();

--- a/bundles/CoreBundle/src/Migrations/Version20210330132354.php
+++ b/bundles/CoreBundle/src/Migrations/Version20210330132354.php
@@ -27,6 +27,11 @@ final class Version20210330132354 extends AbstractMigration
         return '';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->addSql("ALTER TABLE `users_workspaces_asset` CHANGE `cpath` `cpath` varchar(765) COLLATE 'utf8_bin' NULL AFTER `cid`;");

--- a/bundles/CoreBundle/src/Migrations/Version20210408153226.php
+++ b/bundles/CoreBundle/src/Migrations/Version20210408153226.php
@@ -22,6 +22,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 class Version20210408153226 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $versionsTable = $schema->getTable('versions');

--- a/bundles/CoreBundle/src/Migrations/Version20210412112812.php
+++ b/bundles/CoreBundle/src/Migrations/Version20210412112812.php
@@ -27,6 +27,11 @@ final class Version20210412112812 extends AbstractMigration
         return '';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $notesTable = $schema->getTable('notes_data');

--- a/bundles/CoreBundle/src/Migrations/Version20210428145320.php
+++ b/bundles/CoreBundle/src/Migrations/Version20210428145320.php
@@ -27,6 +27,11 @@ final class Version20210428145320 extends AbstractMigration
         return 'Increases prettyUrl field size to 255';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->addSql('ALTER TABLE `documents_page` CHANGE `prettyUrl` `prettyUrl` varchar(255) NULL AFTER `metaData`;');

--- a/bundles/CoreBundle/src/Migrations/Version20210505093841.php
+++ b/bundles/CoreBundle/src/Migrations/Version20210505093841.php
@@ -27,6 +27,11 @@ final class Version20210505093841 extends AbstractMigration
         return 'WebDAV locks with database backend instead of file-based';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->addSql(

--- a/bundles/CoreBundle/src/Migrations/Version20210531125102.php
+++ b/bundles/CoreBundle/src/Migrations/Version20210531125102.php
@@ -27,6 +27,11 @@ final class Version20210531125102 extends AbstractMigration
         return 'Added LocalizedErrorDocuments to sites table.';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if (!$schema->getTable('sites')->hasColumn('localizedErrorDocuments')) {

--- a/bundles/CoreBundle/src/Migrations/Version20210616114744.php
+++ b/bundles/CoreBundle/src/Migrations/Version20210616114744.php
@@ -24,6 +24,11 @@ final class Version20210616114744 extends AbstractMigration
         return 'Add columns staticGeneratorEnabled & staticGeneratorLifetime to documents_page table';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if (!$schema->getTable('documents_page')->hasColumn('staticGeneratorEnabled')) {

--- a/bundles/CoreBundle/src/Migrations/Version20210624085031.php
+++ b/bundles/CoreBundle/src/Migrations/Version20210624085031.php
@@ -27,6 +27,11 @@ final class Version20210624085031 extends AbstractMigration
         return 'Support saving error message for sent mails';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if (!$schema->getTable('email_log')->hasColumn('error')) {

--- a/bundles/CoreBundle/src/Migrations/Version20210928135248.php
+++ b/bundles/CoreBundle/src/Migrations/Version20210928135248.php
@@ -24,6 +24,11 @@ final class Version20210928135248 extends AbstractMigration
         return '';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if ($schema->hasTable('sanitycheck')) {

--- a/bundles/CoreBundle/src/Migrations/Version20211016084043.php
+++ b/bundles/CoreBundle/src/Migrations/Version20211016084043.php
@@ -24,6 +24,11 @@ final class Version20211016084043 extends AbstractMigration
         return 'Add setAsFavourite to gridconfigs to allow admins to set gridconfig as favorite for users';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if (!$schema->getTable('gridconfigs')->hasColumn('setAsFavourite')) {

--- a/bundles/CoreBundle/src/Migrations/Version20211028155535.php
+++ b/bundles/CoreBundle/src/Migrations/Version20211028155535.php
@@ -21,6 +21,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20211028155535 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->addSql('ALTER TABLE object_url_slugs MODIFY slug VARCHAR(765) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci;');

--- a/bundles/CoreBundle/src/Migrations/Version20211103055110.php
+++ b/bundles/CoreBundle/src/Migrations/Version20211103055110.php
@@ -22,6 +22,11 @@ use Doctrine\Migrations\AbstractMigration;
  */
 class Version20211103055110 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $db = \Pimcore\Db::get();

--- a/bundles/CoreBundle/src/Migrations/Version20211221152344.php
+++ b/bundles/CoreBundle/src/Migrations/Version20211221152344.php
@@ -24,6 +24,11 @@ final class Version20211221152344 extends AbstractMigration
         return '';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         //disable foreign key checks

--- a/bundles/CoreBundle/src/Migrations/Version20220119082511.php
+++ b/bundles/CoreBundle/src/Migrations/Version20220119082511.php
@@ -24,6 +24,11 @@ final class Version20220119082511 extends AbstractMigration
         return 'Use foreign key for delete cascade on gridconfig_favourites & gridconfig_shares';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         //disable foreign key checks

--- a/bundles/CoreBundle/src/Migrations/Version20220120121803.php
+++ b/bundles/CoreBundle/src/Migrations/Version20220120121803.php
@@ -24,6 +24,11 @@ final class Version20220120121803 extends AbstractMigration
         return 'Use foreign key for delete cascade on documents references';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         //disable foreign key checks

--- a/bundles/CoreBundle/src/Migrations/Version20220120162621.php
+++ b/bundles/CoreBundle/src/Migrations/Version20220120162621.php
@@ -24,6 +24,11 @@ final class Version20220120162621 extends AbstractMigration
         return '';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         //disable foreign key checks

--- a/bundles/CoreBundle/src/Migrations/Version20220214110000.php
+++ b/bundles/CoreBundle/src/Migrations/Version20220214110000.php
@@ -24,6 +24,11 @@ final class Version20220214110000 extends AbstractMigration
         return 'Add `storageType` column to `version` database table';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if ($schema->getTable('versions')->hasColumn('storageType') === false) {

--- a/bundles/CoreBundle/src/Migrations/Version20220317125711.php
+++ b/bundles/CoreBundle/src/Migrations/Version20220317125711.php
@@ -24,6 +24,11 @@ final class Version20220317125711 extends AbstractMigration
         return '';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if (!$schema->hasTable('assets_image_thumbnail_cache')) {

--- a/bundles/CoreBundle/src/Migrations/Version20220402104849.php
+++ b/bundles/CoreBundle/src/Migrations/Version20220402104849.php
@@ -24,6 +24,11 @@ final class Version20220402104849 extends AbstractMigration
         return 'Change docTypes column of user table to text';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->addSql('ALTER TABLE `users` CHANGE `docTypes` `docTypes` text DEFAULT NULL');

--- a/bundles/CoreBundle/src/Migrations/Version20220419120333.php
+++ b/bundles/CoreBundle/src/Migrations/Version20220419120333.php
@@ -24,6 +24,11 @@ final class Version20220419120333 extends AbstractMigration
         return 'Add index to versions.stackTrace to accelerate maintenance task "VersionsCleanupStackTraceDbTask"';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $versionsTable = $schema->getTable('versions');

--- a/bundles/CoreBundle/src/Migrations/Version20220425082914.php
+++ b/bundles/CoreBundle/src/Migrations/Version20220425082914.php
@@ -24,6 +24,11 @@ final class Version20220425082914 extends AbstractMigration
         return 'Improve data object grid loading performance';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if ($schema->getTable('objects')->hasIndex('type')) {

--- a/bundles/CoreBundle/src/Migrations/Version20220502104200.php
+++ b/bundles/CoreBundle/src/Migrations/Version20220502104200.php
@@ -27,6 +27,11 @@ final class Version20220502104200 extends AbstractMigration
         return 'Change targetGroupIds field to NOT NULL DEFAULT \'\'';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->addSql('ALTER TABLE `documents_page` CHANGE `targetGroupIds` `targetGroupIds` varchar(255) NOT NULL DEFAULT \'\';');

--- a/bundles/CoreBundle/src/Migrations/Version20220506103100.php
+++ b/bundles/CoreBundle/src/Migrations/Version20220506103100.php
@@ -24,6 +24,11 @@ final class Version20220506103100 extends AbstractMigration
         return 'Modify `storageType` column in `version` database table';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if ($schema->getTable('versions')->hasColumn('storageType') === true) {

--- a/bundles/CoreBundle/src/Migrations/Version20220511085800.php
+++ b/bundles/CoreBundle/src/Migrations/Version20220511085800.php
@@ -24,6 +24,11 @@ final class Version20220511085800 extends AbstractMigration
         return 'Add key and index to search_backend_data table';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if (!$schema->getTable('search_backend_data')->hasColumn('key')) {

--- a/bundles/CoreBundle/src/Migrations/Version20220614115124.php
+++ b/bundles/CoreBundle/src/Migrations/Version20220614115124.php
@@ -24,6 +24,11 @@ final class Version20220614115124 extends AbstractMigration
         return 'Add filesize, width and height to assets_image_thumbnail_cache';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         // Delete old Version Name

--- a/bundles/CoreBundle/src/Migrations/Version20220617145524.php
+++ b/bundles/CoreBundle/src/Migrations/Version20220617145524.php
@@ -24,6 +24,11 @@ final class Version20220617145524 extends AbstractMigration
         return 'Drop custom_layouts table in favor of LocationAwareConfigRepository';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->addSql('DROP TABLE IF EXISTS custom_layouts');

--- a/bundles/CoreBundle/src/Migrations/Version20220718162200.php
+++ b/bundles/CoreBundle/src/Migrations/Version20220718162200.php
@@ -24,6 +24,11 @@ final class Version20220718162200 extends AbstractMigration
         return 'Improve object url slugs loading performance';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if (!$schema->getTable('object_url_slugs')->hasIndex('fieldname_ownertype_position_objectId')) {

--- a/bundles/CoreBundle/src/Migrations/Version20220725154615.php
+++ b/bundles/CoreBundle/src/Migrations/Version20220725154615.php
@@ -28,6 +28,11 @@ final class Version20220725154615 extends AbstractMigration
         return '';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $db = Db::get();

--- a/bundles/CoreBundle/src/Migrations/Version20220906111031.php
+++ b/bundles/CoreBundle/src/Migrations/Version20220906111031.php
@@ -24,6 +24,11 @@ final class Version20220906111031 extends AbstractMigration
         return 'Add date index to recyclebin table';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->addSql('ALTER TABLE `recyclebin` ADD INDEX `recyclebin_date` (`date`)');

--- a/bundles/CoreBundle/src/Migrations/Version20220908113752.php
+++ b/bundles/CoreBundle/src/Migrations/Version20220908113752.php
@@ -25,6 +25,11 @@ final class Version20220908113752 extends AbstractMigration
         return 'Renames Application Logger DB tables from prefix_MM_YYYY to prefix_YYYY_MM';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $tableList = $this->connection->fetchAllAssociative("SHOW TABLES LIKE '" . ApplicationLoggerDb::TABLE_ARCHIVE_PREFIX . "%'");

--- a/bundles/CoreBundle/src/Migrations/Version20221003115124.php
+++ b/bundles/CoreBundle/src/Migrations/Version20221003115124.php
@@ -24,6 +24,11 @@ final class Version20221003115124 extends AbstractMigration
         return 'Rename o_id columns to id.';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->addSql('ALTER TABLE objects CHANGE o_id id int(11) unsigned auto_increment NOT NULL;');

--- a/bundles/CoreBundle/src/Migrations/Version20221005090000.php
+++ b/bundles/CoreBundle/src/Migrations/Version20221005090000.php
@@ -24,6 +24,11 @@ final class Version20221005090000 extends AbstractMigration
         return 'Add locked column to notes table';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if ($schema->getTable('notes')->hasColumn('locked') === false) {

--- a/bundles/CoreBundle/src/Migrations/Version20221107084519.php
+++ b/bundles/CoreBundle/src/Migrations/Version20221107084519.php
@@ -24,6 +24,11 @@ final class Version20221107084519 extends AbstractMigration
         return 'Remove index column from object_url_slugs table.';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->addSql('ALTER TABLE object_url_slugs DROP INDEX `index`;');

--- a/bundles/CoreBundle/src/Migrations/Version20221222181745.php
+++ b/bundles/CoreBundle/src/Migrations/Version20221222181745.php
@@ -24,6 +24,11 @@ final class Version20221222181745 extends AbstractMigration
         return 'Add CONSTRAINT of classificationstore_groups in object_classificationstore_groups';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $tableList = $this->connection->fetchAllAssociative("show tables like 'object_classificationstore_groups_%'");

--- a/bundles/CoreBundle/src/Migrations/Version20230124120641.php
+++ b/bundles/CoreBundle/src/Migrations/Version20230124120641.php
@@ -24,6 +24,11 @@ final class Version20230124120641 extends AbstractMigration
         return 'Covert column types to JSON for columns containing only JSON data';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if ($schema->getTable('classificationstore_keys')->hasColumn('definition') === true) {

--- a/bundles/CoreBundle/src/Migrations/Version20230222174636.php
+++ b/bundles/CoreBundle/src/Migrations/Version20230222174636.php
@@ -24,6 +24,11 @@ final class Version20230222174636 extends AbstractMigration
         return '';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if ($schema->getTable('documents_page')->hasColumn('metaData')) {

--- a/bundles/CoreBundle/src/Migrations/Version20230223101848.php
+++ b/bundles/CoreBundle/src/Migrations/Version20230223101848.php
@@ -19,6 +19,11 @@ use Doctrine\Migrations\AbstractMigration;
 
 final class Version20230223101848 extends AbstractMigration
 {
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if (!$schema->getTable('users')->hasColumn('provider')) {

--- a/bundles/CoreBundle/src/Migrations/Version20230322114936.php
+++ b/bundles/CoreBundle/src/Migrations/Version20230322114936.php
@@ -30,6 +30,11 @@ final class Version20230322114936 extends AbstractMigration
         return 'rename master to main';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->addSql('ALTER TABLE email_blacklist RENAME email_blocklist;');

--- a/bundles/CoreBundle/src/Migrations/Version20230615103905.php
+++ b/bundles/CoreBundle/src/Migrations/Version20230615103905.php
@@ -24,6 +24,11 @@ final class Version20230615103905 extends AbstractMigration
         return 'Add definitionModificationDate to classes table for optimizing rebuild command performance.';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if (!$schema->getTable('classes')->hasColumn('definitionModificationDate')) {

--- a/bundles/CoreBundle/src/Migrations/Version20230616085142.php
+++ b/bundles/CoreBundle/src/Migrations/Version20230616085142.php
@@ -36,6 +36,11 @@ final class Version20230616085142 extends AbstractMigration
         return 'Migrate object_metadata schema to have a auto increment column';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->addSql('SET foreign_key_checks = 0');

--- a/bundles/CoreBundle/src/Migrations/Version20230913173812.php
+++ b/bundles/CoreBundle/src/Migrations/Version20230913173812.php
@@ -24,6 +24,11 @@ final class Version20230913173812 extends AbstractMigration
         return 'Adds passwordRecoveryToken column to users table';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if (!$schema->getTable('users')->hasColumn('passwordRecoveryToken')) {

--- a/bundles/CoreBundle/src/Migrations/Version20240131080600.php
+++ b/bundles/CoreBundle/src/Migrations/Version20240131080600.php
@@ -24,6 +24,11 @@ final class Version20240131080600 extends AbstractMigration
         return 'Increase passwordRecoveryToken column length on users table';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if ($schema->getTable('users')->hasColumn('passwordRecoveryToken')) {

--- a/bundles/CoreBundle/src/Migrations/Version20240222143211.php
+++ b/bundles/CoreBundle/src/Migrations/Version20240222143211.php
@@ -29,6 +29,11 @@ final class Version20240222143211 extends AbstractMigration
         return 'Dynamically rename _o_id foreign keys to _id.';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->addSql('SET foreign_key_checks = 0');

--- a/bundles/CoreBundle/src/Migrations/Version20240229152000.php
+++ b/bundles/CoreBundle/src/Migrations/Version20240229152000.php
@@ -24,6 +24,11 @@ final class Version20240229152000 extends AbstractMigration
         return 'Add language default value on users table';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->addSql(

--- a/bundles/CoreBundle/src/Migrations/Version20240606165618.php
+++ b/bundles/CoreBundle/src/Migrations/Version20240606165618.php
@@ -28,6 +28,11 @@ final class Version20240606165618 extends AbstractMigration
         return 'Adds the Date Time Locale column to the Users table.';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if (!$schema->getTable('users')->hasColumn('datetimeLocale')) {

--- a/bundles/CoreBundle/src/Migrations/Version20240916105500.php
+++ b/bundles/CoreBundle/src/Migrations/Version20240916105500.php
@@ -24,6 +24,11 @@ final class Version20240916105500 extends AbstractMigration
         return 'Set default value 0 for creationDate and modificationDate columns';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->addSql('UPDATE `assets` SET `creationDate` = 0 WHERE `creationDate` IS NULL');

--- a/bundles/CoreBundle/src/Migrations/Version20241025101923.php
+++ b/bundles/CoreBundle/src/Migrations/Version20241025101923.php
@@ -36,6 +36,11 @@ final class Version20241025101923 extends AbstractMigration
         return 'Follow up migrating object_metadata schema to have a auto increment column';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->addSql('SET foreign_key_checks = 0');

--- a/bundles/CoreBundle/src/Migrations/Version20250312132759.php
+++ b/bundles/CoreBundle/src/Migrations/Version20250312132759.php
@@ -39,6 +39,11 @@ final class Version20250312132759 extends AbstractMigration
      * @throws JsonException
      * @throws Exception
      */
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->migrateAssets();

--- a/bundles/CoreBundle/src/Migrations/Version20250416120333.php
+++ b/bundles/CoreBundle/src/Migrations/Version20250416120333.php
@@ -24,6 +24,11 @@ final class Version20250416120333 extends AbstractMigration
         return 'Add index to versions.public"';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $versionsTable = $schema->getTable('versions');

--- a/bundles/CoreBundle/src/Migrations/Version20250908143245.php
+++ b/bundles/CoreBundle/src/Migrations/Version20250908143245.php
@@ -27,6 +27,11 @@ final class Version20250908143245 extends AbstractMigration
         return 'Add lastPasswordReset column with default CURRENT_TIMESTAMP to users table';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->addSql('ALTER TABLE users ADD lastPasswordReset INT(11) UNSIGNED NULL');

--- a/bundles/CoreBundle/src/Migrations/Version20251217000100.php
+++ b/bundles/CoreBundle/src/Migrations/Version20251217000100.php
@@ -23,6 +23,11 @@ final class Version20251217000100 extends AbstractMigration
         return 'Remove parametersPost, cookies and serverVars from http_error_log';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if (!$schema->hasTable('http_error_log')) {

--- a/bundles/CoreBundle/src/Migrations/Version20260319134454.php
+++ b/bundles/CoreBundle/src/Migrations/Version20260319134454.php
@@ -24,6 +24,11 @@ final class Version20260319134454 extends AbstractMigration
         return 'Remove http_error_log (irreversible; table must be recreated manually if needed)';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if (!$schema->hasTable('http_error_log')) {

--- a/bundles/CoreBundle/src/Migrations/Version20260623090000.php
+++ b/bundles/CoreBundle/src/Migrations/Version20260623090000.php
@@ -27,6 +27,11 @@ final class Version20260623090000 extends AbstractMigration
         return 'Add theme column to users table';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if (!$schema->getTable('users')->hasColumn('theme')) {

--- a/bundles/CoreBundle/src/Migrations/Version20260701100000.php
+++ b/bundles/CoreBundle/src/Migrations/Version20260701100000.php
@@ -27,6 +27,11 @@ final class Version20260701100000 extends AbstractMigration
         return 'Add coauthorType and coauthor columns to versions table';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if (!$schema->getTable('versions')->hasColumn('coauthorType')) {

--- a/bundles/CoreBundle/src/Migrations/Version20260720120000.php
+++ b/bundles/CoreBundle/src/Migrations/Version20260720120000.php
@@ -31,6 +31,11 @@ final class Version20260720120000 extends AbstractMigration
         return 'Create the telemetry_spool outbox table';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->addSql(

--- a/bundles/CoreBundle/src/Migrations/Version20260721000000.php
+++ b/bundles/CoreBundle/src/Migrations/Version20260721000000.php
@@ -39,6 +39,11 @@ final class Version20260721000000 extends AbstractMigration
         );
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         foreach ($this->getPerClassTables() as $tableName) {

--- a/bundles/CoreBundle/src/Migrations/Version20260729120000.php
+++ b/bundles/CoreBundle/src/Migrations/Version20260729120000.php
@@ -64,6 +64,11 @@ final class Version20260729120000 extends AbstractMigration
         return 'Modernize deprecated utf8/utf8_bin/utf8_general_ci charset and collation usage across the core schema';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->modifyColumnIfStockLegacy($schema, 'assets', 'filename', 'utf8_bin', 255, "ALTER TABLE `assets` MODIFY `filename` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin DEFAULT '';");

--- a/bundles/UuidBundle/src/Migrations/Version20230203160742.php
+++ b/bundles/UuidBundle/src/Migrations/Version20230203160742.php
@@ -22,6 +22,11 @@ final class Version20230203160742 extends AbstractMigration
         return 'Modify `itemId` column type in `uuids` db table';
     }
 
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->addSql('ALTER TABLE `uuids` MODIFY COLUMN `itemId` VARCHAR(50) NOT NULL;');


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `12.3`
- Feature/Improvement: choose `2026.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`2026.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [x] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `12.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
 

## Additional info

When a Migration changes the database schema (adding tables, changing columns ...) any running transaction will be terminated:

https://mariadb.com/kb/en/sql-statements-that-cause-an-implicit-commit/

When a migration is transactional, a new transaction will be started in the DBAL connection before the migration is executed. When the migration now executes a schema change, the transaction is terminated in the database but the transaction counter in the Connection class will not be reduced.

This can lead to errors when migrations also make changes using data objects, that use transactions in their save logic (observed error was that a Savepoint no longer exists).

To fix this, all migrations making schema changes are marked as non transactional (as already correctly done in `Pimcore\Bundle\CoreBundle\Migrations\Version20260331112000`

## How to reproduce

<details>

<summary>Instructions to reproduced based on UuidBundle</summary>

## Assumptions

**Assumes:** a fresh Pimcore install with `UuidBundle` installed — i.e. `uuids` exists and `Version20230203160742` is already marked as applied.

## Setup

Revert the fix (remove the `isTransactional()` override, so it defaults back to `true`), then use the migration's own `down()` to get back to its pre-migration state — no manual schema/data changes needed:

```
$ bin/console doctrine:migrations:migrate 0 --prefix="Pimcore\Bundle\UuidBundle"
```

Add one throwaway migration, timestamped to run immediately after it, that does nothing but a self-contained nested transaction — no DDL, no table dependency. On its own, in any migration, at any time, this would always succeed:

```php
namespace Pimcore\Bundle\CoreBundle\Migrations;

use Doctrine\DBAL\Schema\Schema;
use Doctrine\Migrations\AbstractMigration;
use Throwable;

final class Version99999999999904 extends AbstractMigration
{
    public function getDescription(): string
    {
        return 'REPRO: self-contained nested transaction, run right after the UuidBundle migration';
    }

    public function up(Schema $schema): void
    {
        $this->connection->beginTransaction();

        try {
            $this->connection->executeStatement('THIS IS NOT VALID SQL AND WILL FAIL');
            $this->connection->commit();
        } catch (Throwable $e) {
            $this->connection->rollBack();
            $this->write('Caught and rolled back: ' . $e->getMessage());
        }
    }

    public function down(Schema $schema): void
    {
    }
}
```

## Buggy: `isTransactional()` left at the default (`true`)

```
$ bin/console doctrine:migrations:migrate --no-interaction

[notice] Migrating up to Pimcore\Bundle\GenericDataIndexBundle\Migrations\Version20251009110653
[error] Migration Pimcore\Bundle\CoreBundle\Migrations\Version99999999999904 failed during Execution.
Error: "An exception occurred while executing a query: SQLSTATE[42000]:
Syntax error or access violation: 1305 SAVEPOINT DOCTRINE_3 does not exist"
```

The migration that fails isn't the UuidBundle one — it succeeds silently. The failure lands on the *next* migration, which contains no DDL and would never fail on its own. The `ALTER TABLE`'s implicit commit desyncs DBAL's transaction/savepoint bookkeeping for the whole connection, and that corruption carries forward into the next migration's own, unrelated `beginTransaction()`/`rollBack()`. Its `ROLLBACK TO SAVEPOINT DOCTRINE_3` targets a savepoint MariaDB has no record of, because the transaction it was supposedly created in was already implicitly ended by the earlier `ALTER TABLE`.

</details>




