### PR TITLE
#19057  Avoid thumbnail file I/O when dimensions can be calculated reliably

### DIFF
--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -2,6 +2,10 @@
 
 ## Pimcore 2026.2.10
 
+### [Assets]
+
+Image thumbnails using Pimcore's existing non-rasterized SVG source-output route now expose the original SVG consistently through `exists()`, `getStream()` and `getFileSize()`. These calls no longer generate an unused raster thumbnail or dispatch `AssetEvents::IMAGE_THUMBNAIL`; integrations that relied on those low-level side effects should be adjusted.
+
 ### [Notifications]
 
 Notification `creationDate` / `modificationDate` are now written in UTC, which is the convention

--- a/lib/Image/Adapter/Dimension.php
+++ b/lib/Image/Adapter/Dimension.php
@@ -1,0 +1,271 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Image\Adapter;
+
+use Pimcore\Image\Adapter;
+
+/**
+ * Dimension-only adapter used to run thumbnail transformations without image I/O.
+ *
+ * @internal
+ */
+final class Dimension extends Adapter
+{
+    /**
+     * Every Processor mapping must be explicitly listed before it can be evaluated without image I/O.
+     * New transformations therefore fail closed.
+     *
+     * @var list<string>
+     */
+    private const RELIABLY_MODELLED_TRANSFORMATIONS = [
+        'resize',
+        'scaleByWidth',
+        'scaleByHeight',
+        'contain',
+        'cover',
+        'frame',
+        'trim',
+        'rotate',
+        'crop',
+        'setBackgroundColor',
+        'roundCorners',
+        'setBackgroundImage',
+        'addOverlay',
+        'addOverlayFit',
+        'applyMask',
+        'cropPercent',
+        'grayscale',
+        'sepia',
+        'sharpen',
+        'gaussianBlur',
+        'brightnessSaturation',
+        'mirror',
+    ];
+
+    private bool $reliable = true;
+
+    public function __construct(
+        int $width,
+        int $height,
+        private readonly bool $vectorGraphic,
+        private readonly bool $passThroughLogical = false
+    ) {
+        $this->setWidth($width);
+        $this->setHeight($height);
+    }
+
+    public function isReliable(): bool
+    {
+        return $this->reliable;
+    }
+
+    public static function supportsReliableTransformation(string $method): bool
+    {
+        return in_array($method, self::RELIABLY_MODELLED_TRANSFORMATIONS, true);
+    }
+
+    private function markUnreliable(): void
+    {
+        $this->reliable = false;
+    }
+
+    public function resize(int $width, int $height): static
+    {
+        if ($width <= 0 || $height <= 0) {
+            $this->markUnreliable();
+
+            return $this;
+        }
+
+        $this->setWidth($width);
+        $this->setHeight($height);
+
+        return $this;
+    }
+
+    public function scaleByWidth(int $width, bool $forceResize = false): static
+    {
+        if (!$this->passThroughLogical) {
+            return parent::scaleByWidth($width, $forceResize);
+        }
+
+        if ($width <= 0) {
+            $this->markUnreliable();
+
+            return $this;
+        }
+
+        // Pass-through output never invokes an image adapter.
+        // Retain the legacy estimator's logical HTML dimensions instead of generated-output floor().
+        if ($forceResize || $width <= $this->getWidth() || $this->isVectorGraphic()) {
+            $height = round(($width / $this->getWidth()) * $this->getHeight(), 0);
+            $this->resize($width, (int) max(1, $height));
+        }
+
+        return $this;
+    }
+
+    public function scaleByHeight(int $height, bool $forceResize = false): static
+    {
+        if (!$this->passThroughLogical) {
+            return parent::scaleByHeight($height, $forceResize);
+        }
+
+        if ($height <= 0) {
+            $this->markUnreliable();
+
+            return $this;
+        }
+
+        // Match Config's legacy logical estimator.
+        // Generated thumbnails continue to use Adapter's floor-based physical-output mathematics.
+        if ($forceResize || $height < $this->getHeight() || $this->isVectorGraphic()) {
+            $width = round(($height / $this->getHeight()) * $this->getWidth(), 0);
+            $this->resize((int) max(1, $width), $height);
+        }
+
+        return $this;
+    }
+
+    public function crop(int $x, int $y, int $width, int $height): static
+    {
+        if ($this->passThroughLogical) {
+            // Processor returns the source before executing the crop.
+            // Preserve Config's established logical target for HTML attributes.
+            return $this->resize($width, $height);
+        }
+
+        // GD clamps out-of-bounds crops while Imagick retains the requested canvas.
+        // Only an in-bounds crop has adapter-independent dimensions.
+        if ($x < 0 || $y < 0 || $width <= 0 || $height <= 0
+            || $x + $width > $this->getWidth()
+            || $y + $height > $this->getHeight()) {
+            $this->markUnreliable();
+
+            return $this;
+        }
+
+        $this->resize($width, $height);
+
+        return $this;
+    }
+
+    public function cover(
+        int $width,
+        int $height,
+        array|string|null $orientation = 'center',
+        bool $forceResize = false
+    ): static {
+        if ($this->passThroughLogical) {
+            // Legacy Config estimation exposed the configured cover target.
+            // The output route returns the original asset, so crop geometry, force resize and positioning never reach a runtime adapter.
+            return $this->resize($width, $height);
+        }
+
+        return parent::cover($width, $height, $orientation, $forceResize);
+    }
+
+    public function frame(int $width, int $height, bool $forceResize = false): static
+    {
+        if ($width <= 0 || $height <= 0) {
+            $this->markUnreliable();
+
+            return $this;
+        }
+
+        $this->contain($width, $height, $forceResize);
+        $this->resize($width, $height);
+
+        return $this;
+    }
+
+    public function trim(int $tolerance): static
+    {
+        $this->markUnreliable();
+
+        return $this;
+    }
+
+    public function rotate(int $angle): static
+    {
+        $this->markUnreliable();
+
+        return $this;
+    }
+
+    public function cropPercent(int $width, int $height, int $x, int $y): static
+    {
+        // Runtime vector rasterization dimensions depend on the loaded adapter.
+        // Pass-through output performs no rasterization and retains Pimcore's configured logical crop dimensions for HTML.
+        if ($this->passThroughLogical) {
+            $originalWidth = $this->getWidth();
+            $originalHeight = $this->getHeight();
+
+            return $this->resize(
+                (int) ceil($originalWidth * ($width / 100)),
+                (int) ceil($originalHeight * ($height / 100))
+            );
+        }
+
+        if ($this->isVectorGraphic()) {
+            $this->markUnreliable();
+
+            return $this;
+        }
+
+        parent::cropPercent($width, $height, $x, $y);
+
+        return $this;
+    }
+
+    public function setBackgroundImage(string $image, ?string $mode = null): static
+    {
+        // GD keeps the foreground canvas size for cropTopLeft, while Imagick replaces it with the cropped background resource.
+        // Without loading the background, no adapter-independent dimension can be guaranteed.
+        if ($mode === 'cropTopLeft' && !$this->passThroughLogical) {
+            $this->markUnreliable();
+        }
+
+        return $this;
+    }
+
+    public function isVectorGraphic(): bool
+    {
+        return $this->vectorGraphic;
+    }
+
+    public function load(string $imagePath, array $options = []): static|false
+    {
+        return false;
+    }
+
+    public function save(string $path, ?string $format = null, ?int $quality = null): static
+    {
+        return $this;
+    }
+
+    protected function destroy(): void
+    {
+    }
+
+    public function getContentOptimizedFormat(): string
+    {
+        return '';
+    }
+
+    public function supportsFormat(string $format, bool $force = false): bool
+    {
+        return false;
+    }
+}

--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -225,7 +225,34 @@ EOT;
             return null;
         }
 
+        $dimensions = $this->getDimensionsFromFile($path);
+        if ($dimensions === null) {
+            return null;
+        }
+
+        if (($width = $dimensions['width']) && ($height = $dimensions['height'])) {
+            // persist dimensions to database
+            $this->setCustomSetting('imageDimensionsCalculated', true);
+            $this->setCustomSetting('imageWidth', $width);
+            $this->setCustomSetting('imageHeight', $height);
+            $this->getDao()->updateCustomSettings();
+            $this->clearDependentCache();
+        }
+
+        return $dimensions;
+    }
+
+    /**
+     * Determines image dimensions without updating the asset or its database record.
+     *
+     * @internal
+     *
+     * @return array{width: int, height: int}|null
+     */
+    public function getDimensionsFromFile(string $path): ?array
+    {
         $dimensions = null;
+        $dimensionPath = $path;
 
         //try to get the dimensions with getimagesize because it is much faster than e.g. the Imagick-Adapter
         if (is_readable($path)) {
@@ -239,9 +266,20 @@ EOT;
         }
 
         if (!$dimensions) {
+            // Flysystem commonly materializes remote streams as extensionless temporary files.
+            // Some ImageMagick delegates (notably SVG) require the source suffix to select a decoder.
+            // Reuse the already-downloaded bytes in a local suffixed file; this performs no additional storage read and does not mutate the asset.
+            $sourceExtension = pathinfo($this->getFilename(), PATHINFO_EXTENSION);
+            if (pathinfo($dimensionPath, PATHINFO_EXTENSION) === '' && $sourceExtension !== '') {
+                $suffixedPath = File::getLocalTempFilePath($sourceExtension);
+                if (@copy($dimensionPath, $suffixedPath)) {
+                    $dimensionPath = $suffixedPath;
+                }
+            }
+
             $image = self::getImageTransformInstance();
 
-            $status = $image->load($path, ['preserveColor' => true, 'asset' => $this]);
+            $status = $image->load($dimensionPath, ['preserveColor' => true, 'asset' => $this]);
             if ($status === false) {
                 return null;
             }
@@ -254,7 +292,7 @@ EOT;
 
         // EXIF orientation
         if (function_exists('exif_read_data')) {
-            $exif = @exif_read_data($path);
+            $exif = @exif_read_data($dimensionPath);
             if (is_array($exif)) {
                 if (array_key_exists('Orientation', $exif)) {
                     $orientation = (int)$exif['Orientation'];
@@ -267,15 +305,6 @@ EOT;
                     }
                 }
             }
-        }
-
-        if (($width = $dimensions['width']) && ($height = $dimensions['height'])) {
-            // persist dimensions to database
-            $this->setCustomSetting('imageDimensionsCalculated', true);
-            $this->setCustomSetting('imageWidth', $width);
-            $this->setCustomSetting('imageHeight', $height);
-            $this->getDao()->updateCustomSettings();
-            $this->clearDependentCache();
         }
 
         return $dimensions;
@@ -323,6 +352,70 @@ EOT;
         }
 
         return false;
+    }
+
+    /**
+     * Classifies vector-sensitive transformations without image I/O.
+     * Conflicting filename and persisted MIME evidence is intentionally unknown so callers can fail closed and inspect the actual generated file.
+     *
+     * @internal
+     */
+    public function getVectorGraphicStateForDimensionEstimation(): ?bool
+    {
+        $extension = strtolower(pathinfo($this->getFilename(), PATHINFO_EXTENSION));
+        $extensionState = match (true) {
+            in_array($extension, ['svg', 'svgz', 'eps', 'pdf', 'ps', 'ai', 'indd'], true) => true,
+            in_array($extension, [
+                'avif',
+                'bmp',
+                'gif',
+                'heic',
+                'heif',
+                'jpeg',
+                'jpg',
+                'png',
+                'tif',
+                'tiff',
+                'webp',
+            ], true) => false,
+            default => null,
+        };
+
+        $mimeType = strtolower((string) $this->getMimeType());
+        $mimeState = match (true) {
+            in_array($mimeType, [
+                'application/illustrator',
+                'application/pdf',
+                'application/postscript',
+                'image/eps',
+                'image/svg+xml',
+                'image/x-eps',
+            ], true) => true,
+            in_array($mimeType, [
+                'image/avif',
+                'image/bmp',
+                'image/gif',
+                'image/heic',
+                'image/heif',
+                'image/jpeg',
+                'image/png',
+                'image/tiff',
+                'image/webp',
+            ], true) => false,
+            default => null,
+        };
+
+        // A persisted MIME type can be replaced by project event listeners and is not proof of the loaded image format.
+        // Unknown extensions therefore remain unknown for vector-sensitive estimation.
+        if ($extensionState === null) {
+            return null;
+        }
+
+        if ($mimeState !== null && $extensionState !== $mimeState) {
+            return null;
+        }
+
+        return $extensionState;
     }
 
     /**

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -53,13 +53,9 @@ final class Thumbnail implements ThumbnailInterface
         $frontend = $args['frontend'] ?? \Pimcore\Tool::isFrontend();
 
         $pathReference = null;
-        if (
-            $this->getConfig() &&
-            $this->useOriginalFile($this->asset->getFilename()) &&
-            $this->getConfig()->isSvgTargetFormatPossible()
-        ) {
-            // we still generate the raster image, to get the final size of the thumbnail
-            // we use getRealFullPath() here, to avoid double encoding (getFullPath() returns already encoded path)
+        if ($this->getConfig()?->usesOriginalSvgOutput($this->asset)) {
+            // Dimension resolution uses the same source-output predicate and falls back to the source bytes when dimensions are unavailable.
+            // Use getRealFullPath() here to avoid double encoding because getFullPath() already returns an encoded path.
             $pathReference = [
                 'src' => $this->asset->getRealFullPath(),
                 'type' => 'asset',
@@ -99,11 +95,6 @@ final class Thumbnail implements ThumbnailInterface
         return self::$hasListenersCache[$eventName];
     }
 
-    protected function useOriginalFile(string $filename): bool
-    {
-        return $this->getConfig() && preg_match("@\.svgz?$@", $filename) && !$this->getConfig()->isRasterizeSVG();
-    }
-
     /**
      * @throws ThumbnailFormatNotSupportedException
      * @throws ThumbnailMaxScalingFactorException
@@ -135,7 +126,7 @@ final class Thumbnail implements ThumbnailInterface
         }
 
         if (empty($this->pathReference)) {
-            if ($this->useOriginalFile($this->asset->getFilename()) && $this->getConfig()->isSvgTargetFormatPossible()) {
+            if ($this->getConfig()->usesOriginalSvgOutput($this->asset)) {
                 // SVG thumbnail generation failed — fall back to the original SVG file.
                 // This avoids a generic placeholder since browsers can display SVGs natively.
                 $this->pathReference = [
@@ -473,10 +464,7 @@ final class Thumbnail implements ThumbnailInterface
             // encode comma in thumbnail path as srcset is a comma separated list
             $srcSetValues[] = str_replace(',', '%2C', $this->addCacheBuster($thumb . ' ' . $descriptor, $options, $image));
 
-            if (
-                $this->useOriginalFile($this->asset->getFilename()) &&
-                $this->getConfig()?->isSvgTargetFormatPossible()
-            ) {
+            if ($this->getConfig()?->usesOriginalSvgOutput($this->asset)) {
                 break;
             }
         }

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -53,7 +53,7 @@ final class Thumbnail implements ThumbnailInterface
         $frontend = $args['frontend'] ?? \Pimcore\Tool::isFrontend();
 
         $pathReference = null;
-        if ($this->getConfig()?->usesOriginalSvgOutput($this->asset)) {
+        if ($this->asset instanceof Image && $this->getConfig()?->usesOriginalSvgOutput($this->asset)) {
             // Dimension resolution uses the same source-output predicate and falls back to the source bytes when dimensions are unavailable.
             // Use getRealFullPath() here to avoid double encoding because getFullPath() already returns an encoded path.
             $pathReference = [
@@ -126,7 +126,7 @@ final class Thumbnail implements ThumbnailInterface
         }
 
         if (empty($this->pathReference)) {
-            if ($this->getConfig()->usesOriginalSvgOutput($this->asset)) {
+            if ($this->asset instanceof Image && $this->getConfig()->usesOriginalSvgOutput($this->asset)) {
                 // SVG thumbnail generation failed — fall back to the original SVG file.
                 // This avoids a generic placeholder since browsers can display SVGs natively.
                 $this->pathReference = [
@@ -464,7 +464,7 @@ final class Thumbnail implements ThumbnailInterface
             // encode comma in thumbnail path as srcset is a comma separated list
             $srcSetValues[] = str_replace(',', '%2C', $this->addCacheBuster($thumb . ' ' . $descriptor, $options, $image));
 
-            if ($this->getConfig()?->usesOriginalSvgOutput($this->asset)) {
+            if ($this->asset instanceof Image && $this->getConfig()?->usesOriginalSvgOutput($this->asset)) {
                 break;
             }
         }

--- a/models/Asset/Image/Thumbnail/Config.php
+++ b/models/Asset/Image/Thumbnail/Config.php
@@ -775,9 +775,10 @@ final class Config extends Model\AbstractModel
 
         $highResolution = $this->getHighResolution();
         if ($usesSourceAssetOutput && $highResolution > 1) {
-            // Pass-through output uses the source bytes, but dimensions retain the legacy logical contract: transform at nominal size first, then expose the configured high-resolution real dimensions.
-            $estimatedWidth = (int) ceil($estimatedWidth * $highResolution);
-            $estimatedHeight = (int) ceil($estimatedHeight * $highResolution);
+            // Pass-through output uses the source bytes, but dimensions retain the legacy logical contract.
+            // The trait truncates real dimensions before deriving the displayed size, including fractional high-resolution products.
+            $estimatedWidth = (int) ($estimatedWidth * $highResolution);
+            $estimatedHeight = (int) ($estimatedHeight * $highResolution);
         }
 
         return [

--- a/models/Asset/Image/Thumbnail/Config.php
+++ b/models/Asset/Image/Thumbnail/Config.php
@@ -15,9 +15,13 @@ namespace Pimcore\Model\Asset\Image\Thumbnail;
 
 use Exception;
 use Pimcore\Cache\RuntimeCache;
+use Pimcore\Image\Adapter\Dimension as DimensionAdapter;
+use Pimcore\Image\Adapter\GD;
+use Pimcore\Image\Adapter\Imagick;
 use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Tool\Serialize;
+use Throwable;
 
 /**
  * @method bool isWriteable()
@@ -33,6 +37,22 @@ final class Config extends Model\AbstractModel
      * @internal
      */
     protected const PREVIEW_THUMBNAIL_NAME = 'pimcore-system-treepreview';
+
+    /**
+     * Operations which affect the legacy logical HTML dimensions even when Processor returns the original source before invoking an image adapter.
+     *
+     * @var list<string>
+     */
+    private const PASS_THROUGH_LOGICAL_TRANSFORMATIONS = [
+        'resize',
+        'scaleByWidth',
+        'scaleByHeight',
+        'contain',
+        'cover',
+        'frame',
+        'crop',
+        'cropPercent',
+    ];
 
     /**
      * format of array:
@@ -588,92 +608,300 @@ final class Config extends Model\AbstractModel
      *
      *
      * @internal
+     *
+     * @return array{width: int, height: int}|array{}
      */
     public function getEstimatedDimensions(Model\Asset\Image $asset): array
     {
-        $originalWidth = $asset->getWidth();
-        $originalHeight = $asset->getHeight();
+        $sourceWidth = $asset->getCustomSetting('imageWidth');
+        $sourceHeight = $asset->getCustomSetting('imageHeight');
 
-        $dimensions = [
-            'width' => $originalWidth,
-            'height' => $originalHeight,
-        ];
+        return $this->getEstimatedDimensionsForSource(
+            $asset,
+            is_numeric($sourceWidth) ? (int) $sourceWidth : 0,
+            is_numeric($sourceHeight) ? (int) $sourceHeight : 0
+        );
+    }
 
+    /**
+     * Estimates logical thumbnail dimensions from already-known source dimensions without reading or mutating the source asset.
+     *
+     * @internal
+     *
+     * @return array{width: int, height: int}|array{}
+     */
+    public function getEstimatedDimensionsForSource(
+        Model\Asset\Image $asset,
+        int $sourceWidth,
+        int $sourceHeight
+    ): array {
         $transformations = $this->getItems();
-        if ($originalWidth && $originalHeight) {
-            foreach ($transformations as $transformation) {
-                if (!empty($transformation)) {
-                    $arg = $transformation['arguments'];
 
-                    $forceResize = false;
-                    if (isset($arg['forceResize']) && $arg['forceResize'] === true) {
-                        $forceResize = true;
-                    }
-
-                    if (in_array($transformation['method'], ['resize', 'cover', 'frame', 'crop'])) {
-                        $dimensions['width'] = $arg['width'];
-                        $dimensions['height'] = $arg['height'];
-                    } elseif ($transformation['method'] == '1x1_pixel') {
-                        return [
-                            'width' => 1,
-                            'height' => 1,
-                        ];
-                    } elseif ($transformation['method'] == 'scaleByWidth') {
-                        if ($arg['width'] <= $dimensions['width'] || $asset->isVectorGraphic() || $forceResize) {
-                            $dimensions['height'] = round(($arg['width'] / $dimensions['width']) * $dimensions['height'], 0);
-                            $dimensions['width'] = $arg['width'];
-                        }
-                    } elseif ($transformation['method'] == 'scaleByHeight') {
-                        if ($arg['height'] < $dimensions['height'] || $asset->isVectorGraphic() || $forceResize) {
-                            $dimensions['width'] = round(($arg['height'] / $dimensions['height']) * $dimensions['width'], 0);
-                            $dimensions['height'] = $arg['height'];
-                        }
-                    } elseif ($transformation['method'] == 'contain') {
-                        $x = $dimensions['width'] / $arg['width'];
-                        $y = $dimensions['height'] / $arg['height'];
-
-                        if (!$forceResize && $x <= 1 && $y <= 1 && !$asset->isVectorGraphic()) {
-                            continue;
-                        }
-
-                        if ($x > $y) {
-                            $dimensions['height'] = round(($arg['width'] / $dimensions['width']) * $dimensions['height'], 0);
-                            $dimensions['width'] = $arg['width'];
-                        } else {
-                            $dimensions['width'] = round(($arg['height'] / $dimensions['height']) * $dimensions['width'], 0);
-                            $dimensions['height'] = $arg['height'];
-                        }
-                    } elseif ($transformation['method'] == 'cropPercent') {
-                        $dimensions['width'] = ceil($dimensions['width'] * ($arg['width'] / 100));
-                        $dimensions['height'] = ceil($dimensions['height'] * ($arg['height'] / 100));
-                    } elseif (in_array($transformation['method'], ['rotate', 'trim'])) {
-                        // unable to calculate dimensions -> return empty
-                        return [];
-                    }
-                }
-            }
-        } else {
-            // this method is only if we don't have the source dimensions
-            // this doesn't necessarily return both with & height
-            // and is only a very rough estimate, you should avoid falling back to this functionality
-            foreach ($transformations as $transformation) {
-                if (!empty($transformation)) {
-                    if (is_array($transformation['arguments']) && in_array($transformation['method'], ['resize', 'scaleByWidth', 'scaleByHeight', 'cover', 'frame'])) {
-                        foreach ($transformation['arguments'] as $key => $value) {
-                            if ($key == 'width' || $key == 'height') {
-                                $dimensions[$key] = $value;
-                            }
-                        }
-                    }
-                }
+        // Processor returns this data URI before loading the source or applying any other transformations, so its dimensions are always known.
+        foreach ($transformations as $transformation) {
+            if (($transformation['method'] ?? null) === '1x1_pixel') {
+                return [
+                    'width' => 1,
+                    'height' => 1,
+                ];
             }
         }
 
-        // ensure we return int's, sometimes $arg[...] contain strings
-        $dimensions['width'] = (int) $dimensions['width'] * ($this->getHighResolution() ?: 1);
-        $dimensions['height'] = (int) $dimensions['height'] * ($this->getHighResolution() ?: 1);
+        // Processor copies the source bytes for ORIGINAL instead of saving the transformed adapter.
+        // Inspect the generated file to retain the existing physical-file dimension semantics.
+        if (strtolower($this->getFormat()) === 'original') {
+            return [];
+        }
 
-        return $dimensions;
+        $usesSourceAssetOutput = $this->usesOriginalSvgOutput($asset)
+            || Processor::usesOriginalAssetOutput($asset, $this);
+
+        // Pass-through output returns the source before Processor creates an adapter.
+        // Generated thumbnails may only be estimated for the exact core implementations whose semantics DimensionAdapter models.
+        if (!$usesSourceAssetOutput && !$this->supportsConfiguredAdapterForDimensionEstimation()) {
+            return [];
+        }
+
+        if ($sourceWidth <= 0 || $sourceHeight <= 0) {
+            return [];
+        }
+
+        $transformationsForEstimation = [];
+
+        foreach ($transformations as $transformation) {
+            if (empty($transformation) || isset($transformation['isApplied'])) {
+                continue;
+            }
+
+            $method = $transformation['method'] ?? null;
+            if ($method === 'tifforiginal') {
+                if (!$usesSourceAssetOutput) {
+                    return [];
+                }
+
+                // Processor routing marker, not an image operation.
+                continue;
+            }
+
+            if (!is_string($method)) {
+                if ($usesSourceAssetOutput) {
+                    continue;
+                }
+
+                return [];
+            }
+
+            if ($usesSourceAssetOutput) {
+                if (in_array($method, ['rotate', 'trim'], true)) {
+                    return [];
+                }
+
+                if (!in_array($method, self::PASS_THROUGH_LOGICAL_TRANSFORMATIONS, true)) {
+                    // Processor returns the source before invoking visual-only or project-specific operations.
+                    // The legacy logical estimator ignored them, including their runtime-only argument validity.
+                    continue;
+                }
+            }
+
+            if (!Processor::hasTransformationArgumentMapping($method)
+                || !DimensionAdapter::supportsReliableTransformation($method)) {
+                // Unknown/custom operations cannot safely suppress file inspection.
+                return [];
+            }
+
+            $arguments = $transformation['arguments'] ?? null;
+            if (is_array($arguments)) {
+                $arguments = $this->normalizeReliableTransformationArguments(
+                    $method,
+                    $arguments,
+                    $usesSourceAssetOutput
+                );
+                if ($arguments === null) {
+                    return [];
+                }
+
+                $transformation['arguments'] = $arguments;
+            }
+
+            $transformationsForEstimation[] = $transformation;
+        }
+
+        // Pass-through routing is based on the filename and returns before an adapter loads the bytes.
+        // Use that same filename-based classification for logical HTML dimensions.
+        // Generated output retains the conservative extension/MIME conflict handling used to protect physical estimates.
+        $vectorGraphicState = $usesSourceAssetOutput
+            ? $asset->isVectorGraphic()
+            : $asset->getVectorGraphicStateForDimensionEstimation();
+        if (!$usesSourceAssetOutput && $vectorGraphicState !== false) {
+            // Generated output is reliable only when the source is positively known to be raster.
+            // Vector rasterization depends on the installed ImageMagick/delegate pipeline, and unknown/conflicting evidence can still describe vector bytes.
+            // Inspect the generated file instead.
+            return [];
+        }
+
+        $dimensionAdapter = new DimensionAdapter(
+            $sourceWidth,
+            $sourceHeight,
+            $vectorGraphicState === true,
+            $usesSourceAssetOutput
+        );
+
+        try {
+            // Reuse Processor's real argument mapping, focal-point handling and high-resolution normalization, and Adapter's actual dimension math.
+            Processor::applyTransformations(
+                $dimensionAdapter,
+                $asset,
+                $this,
+                $transformationsForEstimation,
+                !$usesSourceAssetOutput,
+                $sourceWidth,
+                $sourceHeight
+            );
+        } catch (Throwable $exception) {
+            // Malformed or unsupported runtime arguments require file inspection.
+            Logger::debug('Thumbnail dimension estimation declined: ' . $exception->getMessage());
+
+            return [];
+        }
+
+        if (!$dimensionAdapter->isReliable()
+            || $dimensionAdapter->getWidth() <= 0
+            || $dimensionAdapter->getHeight() <= 0) {
+            return [];
+        }
+
+        $estimatedWidth = $dimensionAdapter->getWidth();
+        $estimatedHeight = $dimensionAdapter->getHeight();
+
+        $highResolution = $this->getHighResolution();
+        if ($usesSourceAssetOutput && $highResolution > 1) {
+            // Pass-through output uses the source bytes, but dimensions retain the legacy logical contract: transform at nominal size first, then expose the configured high-resolution real dimensions.
+            $estimatedWidth = (int) ceil($estimatedWidth * $highResolution);
+            $estimatedHeight = (int) ceil($estimatedHeight * $highResolution);
+        }
+
+        return [
+            'width' => $estimatedWidth,
+            'height' => $estimatedHeight,
+        ];
+    }
+
+    private function supportsConfiguredAdapterForDimensionEstimation(): bool
+    {
+        try {
+            $adapter = Model\Asset\Image::getImageTransformInstance();
+        } catch (Throwable) {
+            return false;
+        }
+
+        return in_array($adapter::class, [GD::class, Imagick::class], true);
+    }
+
+    /**
+     * @param array<string, mixed> $arguments
+     */
+    private function normalizeReliableTransformationArguments(
+        string $method,
+        array $arguments,
+        bool $passThroughLogical = false
+    ): ?array {
+        $requiredStringArgument = match ($method) {
+            'setBackgroundColor' => 'color',
+            'setBackgroundImage', 'addOverlay', 'addOverlayFit', 'applyMask' => 'path',
+            'mirror' => 'mode',
+            default => null,
+        };
+        if ($requiredStringArgument !== null
+            && (!array_key_exists($requiredStringArgument, $arguments)
+                || !is_string($arguments[$requiredStringArgument]))) {
+            return null;
+        }
+
+        if ($method === 'roundCorners'
+            && (!array_key_exists('width', $arguments) || !array_key_exists('height', $arguments))) {
+            return null;
+        }
+
+        foreach (['width', 'height', 'x', 'y'] as $pixelArgument) {
+            if (!array_key_exists($pixelArgument, $arguments)) {
+                continue;
+            }
+
+            $normalizedValue = $this->normalizeIntegerArgument($arguments[$pixelArgument]);
+            if ($normalizedValue === null) {
+                return null;
+            }
+
+            // Normalize only the copied estimation plan.
+            // Config items, hashes and the arguments used by real thumbnail generation remain unchanged.
+            $arguments[$pixelArgument] = $normalizedValue;
+        }
+
+        if (array_key_exists('forceResize', $arguments) && !is_bool($arguments['forceResize'])) {
+            return null;
+        }
+
+        if (!$passThroughLogical
+            && $method === 'cover'
+            && !$this->hasValidCoverPositioning($arguments['positioning'] ?? 'center')) {
+            return null;
+        }
+
+        return $arguments;
+    }
+
+    private function normalizeIntegerArgument(mixed $value): ?int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (is_float($value)) {
+            // The positive bound is exclusive because PHP_INT_MAX itself is not exactly representable as a float on 64-bit runtimes.
+            $exclusiveUpperBound = -(float) PHP_INT_MIN;
+            if (!is_finite($value)
+                || floor($value) !== $value
+                || $value < (float) PHP_INT_MIN
+                || $value >= $exclusiveUpperBound) {
+                return null;
+            }
+
+            return (int) $value;
+        }
+
+        if (!is_string($value) || preg_match('/^[+-]?\d+$/D', $value) !== 1) {
+            return null;
+        }
+
+        $normalizedValue = filter_var($value, FILTER_VALIDATE_INT);
+
+        return $normalizedValue === false ? null : $normalizedValue;
+    }
+
+    private function hasValidCoverPositioning(mixed $positioning): bool
+    {
+        if (!$positioning) {
+            return true;
+        }
+
+        if (is_string($positioning)) {
+            return in_array($positioning, [
+                'center',
+                'topleft',
+                'topright',
+                'bottomleft',
+                'bottomright',
+                'centerleft',
+                'centerright',
+                'topcenter',
+                'bottomcenter',
+            ], true);
+        }
+
+        return is_array($positioning)
+            && isset($positioning['x'], $positioning['y'])
+            && is_numeric($positioning['x'])
+            && is_numeric($positioning['y']);
     }
 
     public function getModificationDate(): ?int
@@ -729,6 +957,18 @@ final class Config extends Model\AbstractModel
     public function isRasterizeSVG(): bool
     {
         return $this->rasterizeSVG;
+    }
+
+    /**
+     * Whether the image thumbnail route returns the original SVG source instead of invoking Processor.
+     *
+     * @internal
+     */
+    public function usesOriginalSvgOutput(Model\Asset\Image $asset): bool
+    {
+        return preg_match('@\.svgz?$@', $asset->getFilename()) === 1
+            && !$this->isRasterizeSVG()
+            && $this->isSvgTargetFormatPossible();
     }
 
     public function setRasterizeSVG(bool $rasterizeSVG): void

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -122,18 +122,15 @@ class Processor
             $optimizedFormat = $optimizeContent = false;
             $format = self::getAllowedFormat($fileExt, ['svg', 'jpeg', 'png', 'tiff'], 'png');
 
-            if (($format == 'tiff') && \Pimcore\Tool::isFrontendRequestByAdmin()) {
-                // return a webformat in admin -> tiff cannot be displayed in browser
-                $format = 'png';
-                $deferred = false; // deferred is default, but it's not possible when using isFrontendRequestByAdmin()
-            } elseif (
-                ($format == 'tiff' && self::containsTransformationType($config, 'tifforiginal'))
-                || $format == 'svg'
-            ) {
+            if (self::usesOriginalAssetOutput($asset, $config)) {
                 return [
                     'src' => $asset->getRealFullPath(),
                     'type' => 'asset',
                 ];
+            } elseif (($format == 'tiff') && \Pimcore\Tool::isFrontendRequestByAdmin()) {
+                // return a webformat in admin -> tiff cannot be displayed in browser
+                $format = 'png';
+                $deferred = false; // deferred is default, but it's not possible when using isFrontendRequestByAdmin()
             }
         } elseif ($format == 'tiff') {
             $optimizedFormat = $optimizeContent = false;
@@ -419,17 +416,27 @@ class Processor
         ];
     }
 
-    private static function applyTransformations(Adapter $image, Asset $asset, Config $config, ?array $transformations): void
-    {
+    /**
+     * @internal
+     */
+    public static function applyTransformations(
+        Adapter $image,
+        Asset $asset,
+        Config $config,
+        ?array $transformations,
+        bool $useHighResolution = true,
+        ?int $knownSourceWidth = null,
+        ?int $knownSourceHeight = null
+    ): void {
         if ($transformations) {
-            $sourceImageWidth = PHP_INT_MAX;
-            $sourceImageHeight = PHP_INT_MAX;
-            if ($asset instanceof Asset\Image) {
+            $sourceImageWidth = $knownSourceWidth ?? PHP_INT_MAX;
+            $sourceImageHeight = $knownSourceHeight ?? PHP_INT_MAX;
+            if (($knownSourceWidth === null || $knownSourceHeight === null) && $asset instanceof Asset\Image) {
                 $sourceImageWidth = $asset->getWidth();
                 $sourceImageHeight = $asset->getHeight();
             }
 
-            $highResFactor = $config->getHighResolution();
+            $highResFactor = $useHighResolution ? $config->getHighResolution() : null;
             $imageCropped = false;
 
             $calculateMaxFactor = function ($factor, $original, $new) {
@@ -510,6 +517,40 @@ class Processor
                 }
             }
         }
+    }
+
+    /**
+     * @internal
+     */
+    public static function hasTransformationArgumentMapping(string $method): bool
+    {
+        return array_key_exists($method, self::$argumentMapping);
+    }
+
+    /**
+     * Whether Processor returns the source asset instead of generating a thumbnail-storage file for this asset/configuration pair.
+     *
+     * @internal
+     */
+    public static function usesOriginalAssetOutput(Asset $asset, Config $config): bool
+    {
+        if (strtolower($config->getFormat()) !== 'print') {
+            return false;
+        }
+
+        $sourceFormat = self::getAllowedFormat(
+            pathinfo($asset->getFilename(), PATHINFO_EXTENSION),
+            ['svg', 'jpeg', 'png', 'tiff'],
+            'png'
+        );
+
+        if ($sourceFormat === 'svg') {
+            return true;
+        }
+
+        return $sourceFormat === 'tiff'
+            && !\Pimcore\Tool::isFrontendRequestByAdmin()
+            && self::containsTransformationType($config, 'tifforiginal');
     }
 
     private static function containsTransformationType(Config $config, string $transformationType): bool

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -435,6 +435,8 @@ trait ImageThumbnailTrait
 
             return $localFile;
         }
+
+        return null;
     }
 
     public function exists(): bool

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -401,6 +401,18 @@ trait ImageThumbnailTrait
                 $fileExtension = pathinfo($this->getAsset()->getFilename(), PATHINFO_EXTENSION);
             }
 
+            $metadata = stream_get_meta_data($stream);
+            $streamUri = $metadata['uri'] ?? null;
+            if (is_string($streamUri) && stream_is_local($stream) && is_file($streamUri)) {
+                $streamPath = (string) (parse_url($streamUri, PHP_URL_PATH) ?: $streamUri);
+                $streamExtension = pathinfo($streamPath, PATHINFO_EXTENSION);
+                if ($fileExtension !== '' && strcasecmp($streamExtension, $fileExtension) === 0) {
+                    fclose($stream);
+
+                    return $streamUri;
+                }
+            }
+
             $localFile = File::getLocalTempFilePath($fileExtension ?: null);
             $destination = fopen($localFile, 'wb', false, File::getContext());
             if ($destination === false) {
@@ -410,7 +422,6 @@ trait ImageThumbnailTrait
             }
 
             try {
-                $metadata = stream_get_meta_data($stream);
                 if ($metadata['seekable'] && !rewind($stream)) {
                     throw new Exception('Unable to rewind thumbnail stream before copying');
                 }
@@ -424,10 +435,6 @@ trait ImageThumbnailTrait
 
             return $localFile;
         }
-
-        $localFile = self::getLocalFileFromStream($stream);
-
-        return $localFile;
     }
 
     public function exists(): bool

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -15,10 +15,12 @@ namespace Pimcore\Model\Asset\Thumbnail;
 
 use Exception;
 use Pimcore\Config as PimcoreConfig;
+use Pimcore\File;
 use Pimcore\Helper\TemporaryFileHelperTrait;
 use Pimcore\Model\Asset;
 use Pimcore\Model\Asset\Image;
 use Pimcore\Model\Asset\Image\Thumbnail\Config;
+use Pimcore\Model\Asset\Image\Thumbnail\Processor;
 use Pimcore\Tool;
 use Pimcore\Tool\Storage;
 use Symfony\Component\Mime\MimeTypes;
@@ -104,6 +106,15 @@ trait ImageThumbnailTrait
             $this->pathReference = [];
         }
 
+        if (empty($this->pathReference)
+            && $this->asset instanceof Image
+            && $this->config?->usesOriginalSvgOutput($this->asset)) {
+            $this->pathReference = [
+                'src' => $this->asset->getRealFullPath(),
+                'type' => 'asset',
+            ];
+        }
+
         if (empty($this->pathReference)) {
             $this->generate($deferredAllowed);
         }
@@ -171,8 +182,29 @@ trait ImageThumbnailTrait
         if (in_array($pathReference['type'], ['thumbnail', 'asset'])) {
             try {
                 $localFile = $this->getLocalFile();
-                if (null !== $localFile && isset($pathReference['storagePath']) && $config = $this->getConfig()) {
-                    $asset = $this->getAsset();
+                $asset = $this->getAsset();
+                if (null !== $localFile && $pathReference['type'] === 'asset' && $asset instanceof Image) {
+                    $dimensions = $asset->getDimensionsFromFile($localFile) ?? [];
+
+                    // Pass-through output still exposes the configuration's logical dimensions.
+                    // Reapply the zero-I/O plan to the dimensions discovered by this single physical read.
+                    $config = $this->getConfig();
+                    if (isset($dimensions['width'], $dimensions['height'])
+                        && $config
+                        && ($config->usesOriginalSvgOutput($asset)
+                            || Processor::usesOriginalAssetOutput($asset, $config))) {
+                        $estimatedDimensions = $config->getEstimatedDimensionsForSource(
+                            $asset,
+                            $dimensions['width'],
+                            $dimensions['height']
+                        );
+                        if (isset($estimatedDimensions['width'], $estimatedDimensions['height'])
+                            && $estimatedDimensions['width'] > 0
+                            && $estimatedDimensions['height'] > 0) {
+                            $dimensions = $estimatedDimensions;
+                        }
+                    }
+                } elseif (null !== $localFile && isset($pathReference['storagePath']) && $config = $this->getConfig()) {
                     $filename = basename($pathReference['storagePath']);
                     $asset->addThumbnailFileToCache(
                         $localFile,
@@ -214,13 +246,14 @@ trait ImageThumbnailTrait
                 }
             }
 
-            if (empty($dimensions) && $this->exists()) {
-                $dimensions = $this->readDimensionsFromFile();
-            }
-
             // try to calculate the final dimensions based on the thumbnail configuration
             if (empty($dimensions) && $config && $asset instanceof Image) {
-                $dimensions = $config->getEstimatedDimensions($asset);
+                $estimatedDimensions = $config->getEstimatedDimensions($asset);
+                if (isset($estimatedDimensions['width'], $estimatedDimensions['height'])
+                    && $estimatedDimensions['width'] > 0
+                    && $estimatedDimensions['height'] > 0) {
+                    $dimensions = $estimatedDimensions;
+                }
             }
 
             if (empty($dimensions)) {
@@ -359,8 +392,40 @@ trait ImageThumbnailTrait
             return null;
         }
 
+        if (is_resource($stream)) {
+            $pathReference = $this->getPathReference();
+            $sourcePath = (string) ($pathReference['storagePath'] ?? $pathReference['src'] ?? '');
+            $sourcePath = (string) (parse_url($sourcePath, PHP_URL_PATH) ?: $sourcePath);
+            $fileExtension = pathinfo($sourcePath, PATHINFO_EXTENSION);
+            if ($fileExtension === '' && $this->getAsset() instanceof Image) {
+                $fileExtension = pathinfo($this->getAsset()->getFilename(), PATHINFO_EXTENSION);
+            }
+
+            $localFile = File::getLocalTempFilePath($fileExtension ?: null);
+            $destination = fopen($localFile, 'wb', false, File::getContext());
+            if ($destination === false) {
+                fclose($stream);
+
+                throw new Exception(sprintf('Unable to create temporary file in %s', $localFile));
+            }
+
+            try {
+                $metadata = stream_get_meta_data($stream);
+                if ($metadata['seekable'] && !rewind($stream)) {
+                    throw new Exception('Unable to rewind thumbnail stream before copying');
+                }
+                if (stream_copy_to_stream($stream, $destination) === false) {
+                    throw new Exception(sprintf('Unable to copy thumbnail stream to %s', $localFile));
+                }
+            } finally {
+                fclose($destination);
+                fclose($stream);
+            }
+
+            return $localFile;
+        }
+
         $localFile = self::getLocalFileFromStream($stream);
-        @fclose($stream);
 
         return $localFile;
     }

--- a/tests/Unit/Lib/Image/Adapter/DimensionTest.php
+++ b/tests/Unit/Lib/Image/Adapter/DimensionTest.php
@@ -1,0 +1,293 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Lib\Image\Adapter;
+
+use Pimcore\Image\Adapter\Dimension as DimensionAdapter;
+use Pimcore\Image\Adapter\GD;
+use Pimcore\Image\Adapter\Imagick as ImagickAdapter;
+use Pimcore\Model\Asset\Image\Thumbnail\Processor;
+use Pimcore\Tests\Unit\Models\Asset\Thumbnail\ImageThumbnailDimensionTestCase;
+
+/**
+ * Regression coverage for dimension estimation before thumbnail file access.
+ *
+ * The probe deliberately reports that a thumbnail exists.
+ * Reliable estimates must therefore avoid both exists() and readDimensionsFromFile(), while configurations that cannot be reproduced exactly must use the file fallback exactly once.
+ */
+class DimensionTest extends ImageThumbnailDimensionTestCase
+{
+    public function testPassThroughLogicalModeSeparatesLogicalAndGeneratedReliability(): void
+    {
+        $generatedScale = new DimensionAdapter(400, 300, true);
+        $generatedScale->scaleByWidth(202);
+        self::assertSame(202, $generatedScale->getWidth());
+        self::assertSame(151, $generatedScale->getHeight());
+
+        $passThroughScale = new DimensionAdapter(400, 300, true, true);
+        $passThroughScale->scaleByWidth(202);
+        self::assertSame(202, $passThroughScale->getWidth());
+        self::assertSame(152, $passThroughScale->getHeight());
+
+        $generatedVector = new DimensionAdapter(400, 300, true);
+        $generatedVector->cropPercent(50, 50, 0, 0);
+        self::assertFalse($generatedVector->isReliable());
+
+        $passThroughVector = new DimensionAdapter(400, 300, true, true);
+        $passThroughVector->cropPercent(50, 50, 0, 0);
+        self::assertTrue($passThroughVector->isReliable());
+        self::assertSame(200, $passThroughVector->getWidth());
+        self::assertSame(150, $passThroughVector->getHeight());
+
+        $generatedBackground = new DimensionAdapter(200, 150, true);
+        $generatedBackground->setBackgroundImage('background.png', 'cropTopLeft');
+        self::assertFalse($generatedBackground->isReliable());
+
+        $passThroughBackground = new DimensionAdapter(200, 150, true, true);
+        $passThroughBackground->setBackgroundImage('background.png', 'cropTopLeft');
+        self::assertTrue($passThroughBackground->isReliable());
+        self::assertSame(200, $passThroughBackground->getWidth());
+        self::assertSame(150, $passThroughBackground->getHeight());
+
+        $generatedCrop = new DimensionAdapter(400, 300, true);
+        $generatedCrop->crop(390, 290, 200, 100);
+        self::assertFalse($generatedCrop->isReliable());
+
+        $passThroughCrop = new DimensionAdapter(400, 300, true, true);
+        $passThroughCrop->crop(390, 290, 200, 100);
+        self::assertTrue($passThroughCrop->isReliable());
+        self::assertSame(200, $passThroughCrop->getWidth());
+        self::assertSame(100, $passThroughCrop->getHeight());
+
+        $generatedCover = new DimensionAdapter(400, 300, false);
+        $generatedCover->cover(800, 600);
+        self::assertFalse($generatedCover->isReliable());
+
+        $passThroughCover = new DimensionAdapter(400, 300, false, true);
+        $passThroughCover->cover(800, 600);
+        self::assertTrue($passThroughCover->isReliable());
+        self::assertSame(800, $passThroughCover->getWidth());
+        self::assertSame(600, $passThroughCover->getHeight());
+    }
+
+    public function testDimensionAdapterSupportContractIsFailClosed(): void
+    {
+        foreach (['resize', 'cover', 'setBackgroundImage', 'rotate', 'trim'] as $method) {
+            self::assertTrue(Processor::hasTransformationArgumentMapping($method), $method);
+            self::assertTrue(DimensionAdapter::supportsReliableTransformation($method), $method);
+        }
+
+        foreach (['1x1_pixel', 'tifforiginal', 'futureProcessorTransformation'] as $method) {
+            self::assertFalse(DimensionAdapter::supportsReliableTransformation($method), $method);
+        }
+
+        self::assertFalse(Processor::hasTransformationArgumentMapping('1x1_pixel'));
+        self::assertFalse(Processor::hasTransformationArgumentMapping('tifforiginal'));
+    }
+
+    public function testBackgroundImageCropTopLeftFallsBackAndGdKeepsForegroundDimensions(): void
+    {
+        $foreground = $this->createRasterFixture(400, 300);
+        $asset = $this->image(400, 300, 'source.png');
+
+        foreach ([[100, 100], [800, 600]] as [$width, $height]) {
+            $background = $this->createWebRootRasterFixture($width, $height);
+            $config = $this->config([[
+                'method' => 'setBackgroundImage',
+                'arguments' => [
+                    'path' => basename($background),
+                    'mode' => 'cropTopLeft',
+                ],
+            ]]);
+
+            self::assertSame([], $config->getEstimatedDimensions($asset));
+        }
+
+        $smallBackground = $this->createWebRootRasterFixture(100, 100);
+        $config = $this->config([[
+            'method' => 'setBackgroundImage',
+            'arguments' => [
+                'path' => basename($smallBackground),
+                'mode' => 'cropTopLeft',
+            ],
+        ]]);
+
+        self::assertSame(
+            ['width' => 400, 'height' => 300],
+            $this->renderedDimensions(GD::class, $foreground, $asset, $config)
+        );
+    }
+
+    public function testBackgroundImageCropTopLeftImagickOutputDemonstratesWhyFallbackIsRequired(): void
+    {
+        $this->requireImagickExtension();
+
+        $foreground = $this->createRasterFixture(400, 300);
+        $smallBackground = $this->createWebRootRasterFixture(100, 100);
+        $asset = $this->image(400, 300, 'source.png');
+        $config = $this->config([[
+            'method' => 'setBackgroundImage',
+            'arguments' => [
+                'path' => basename($smallBackground),
+                'mode' => 'cropTopLeft',
+            ],
+        ]]);
+
+        self::assertSame(
+            ['width' => 100, 'height' => 100],
+            $this->renderedDimensions(ImagickAdapter::class, $foreground, $asset, $config)
+        );
+    }
+
+    public function testBackgroundImageFitAndTextureMatchGdDimensions(): void
+    {
+        $foreground = $this->createRasterFixture(400, 300);
+        $background = $this->createWebRootRasterFixture(100, 100);
+        $asset = $this->image(400, 300, 'source.png');
+
+        foreach ([null, 'asTexture'] as $mode) {
+            $arguments = ['path' => basename($background)];
+            if ($mode !== null) {
+                $arguments['mode'] = $mode;
+            }
+            $config = $this->config([[
+                'method' => 'setBackgroundImage',
+                'arguments' => $arguments,
+            ]]);
+
+            $estimated = $config->getEstimatedDimensions($asset);
+            self::assertSame(['width' => 400, 'height' => 300], $estimated);
+            self::assertSame($estimated, $this->renderedDimensions(GD::class, $foreground, $asset, $config));
+        }
+    }
+
+    public function testBackgroundImageFitAndTextureMatchImagickDimensions(): void
+    {
+        $this->requireImagickExtension();
+
+        $foreground = $this->createRasterFixture(400, 300);
+        $background = $this->createWebRootRasterFixture(100, 100);
+        $asset = $this->image(400, 300, 'source.png');
+
+        foreach ([null, 'asTexture'] as $mode) {
+            $arguments = ['path' => basename($background)];
+            if ($mode !== null) {
+                $arguments['mode'] = $mode;
+            }
+            $config = $this->config([[
+                'method' => 'setBackgroundImage',
+                'arguments' => $arguments,
+            ]]);
+
+            $estimated = $config->getEstimatedDimensions($asset);
+            self::assertSame(
+                $estimated,
+                $this->renderedDimensions(ImagickAdapter::class, $foreground, $asset, $config)
+            );
+        }
+    }
+
+    public function testRasterBytesWithConflictingVectorMimeFallBackToActualImagickOutput(): void
+    {
+        $this->requireImagickExtension();
+
+        $source = $this->createRasterFixture(100, 100);
+        $asset = $this->image(100, 100, 'source.png');
+        $asset->setMimeType('image/svg+xml');
+        $config = $this->config([
+            ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+        ]);
+
+        self::assertSame([], $config->getEstimatedDimensions($asset));
+        self::assertSame(
+            ['width' => 100, 'height' => 100],
+            $this->renderedDimensions(ImagickAdapter::class, $source, $asset, $config)
+        );
+    }
+
+    public function testVectorBytesWithConflictingRasterMimeFallBackToActualImagickOutput(): void
+    {
+        $this->requireImagickExtension();
+
+        $source = $this->createSvgFixture(100, 100);
+        $this->requireImagickFixtureSupport($source);
+        $asset = $this->image(100, 100, 'source.svg');
+        $asset->setMimeType('image/png');
+        $config = $this->config([
+            ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+        ]);
+        $config->setRasterizeSVG(true);
+
+        self::assertSame([], $config->getEstimatedDimensions($asset));
+        $actual = $this->renderedDimensions(ImagickAdapter::class, $source, $asset, $config);
+        self::assertGreaterThan(0, $actual['width']);
+        self::assertGreaterThan(0, $actual['height']);
+
+        $thumbnail = $this->probe($asset, $config, $actual);
+        self::assertSame($actual, $thumbnail->getDimensions());
+        self::assertSame(1, $thumbnail->readDimensionsCalls);
+    }
+
+    public function testEstimatorMatchesPhysicalGdOutputForSupportedRasterPipelines(): void
+    {
+        $source = $this->createRasterFixture(400, 300);
+        $asset = $this->image(400, 300, 'source.png');
+
+        foreach ($this->supportedRasterPipelineCases() as $name => [$items, $highResolution]) {
+            $config = $this->config($items, $highResolution);
+            $estimated = $config->getEstimatedDimensions($asset);
+            self::assertNotSame([], $estimated, $name);
+            $actual = $this->renderedDimensions(GD::class, $source, $asset, $config);
+            self::assertSame($estimated, $actual, $name);
+        }
+    }
+
+    public function testEstimatorMatchesPhysicalImagickOutputForSupportedRasterPipelines(): void
+    {
+        $this->requireImagickExtension();
+
+        $source = $this->createRasterFixture(400, 300);
+        $this->requireImagickFixtureSupport($source);
+        $asset = $this->image(400, 300, 'source.png');
+
+        foreach ($this->supportedRasterPipelineCases() as $name => [$items, $highResolution]) {
+            $config = $this->config($items, $highResolution);
+            $estimated = $config->getEstimatedDimensions($asset);
+            self::assertNotSame([], $estimated, $name);
+
+            $actual = $this->renderedDimensions(ImagickAdapter::class, $source, $asset, $config);
+            self::assertSame($estimated, $actual, $name);
+        }
+    }
+
+    public function testGeneratedUppercaseSvgFallsBackToPhysicalImagickOutput(): void
+    {
+        $source = $this->createSvgFixture(100, 100, '.SVG');
+        $asset = $this->image(100, 100, 'source.SVG');
+        $config = $this->config([
+            ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+        ]);
+
+        $this->requireImagickFixtureSupport($source);
+        $actual = $this->renderedDimensions(ImagickAdapter::class, $source, $asset, $config);
+
+        self::assertSame([], $config->getEstimatedDimensions($asset));
+        self::assertGreaterThan(0, $actual['width']);
+        self::assertGreaterThan(0, $actual['height']);
+
+        $thumbnail = $this->probe($asset, $config, $actual);
+        self::assertSame($actual, $thumbnail->getDimensions());
+        self::assertSame(1, $thumbnail->readDimensionsCalls);
+    }
+}

--- a/tests/Unit/Models/Asset/Image/Thumbnail/EstimatedDimensionsTest.php
+++ b/tests/Unit/Models/Asset/Image/Thumbnail/EstimatedDimensionsTest.php
@@ -300,10 +300,10 @@ class EstimatedDimensionsTest extends ImageThumbnailDimensionTestCase
                 ['width' => 200, 'height' => 100],
             ],
             'fractional high resolution' => [
-                ['method' => 'scaleByWidth', 'arguments' => ['width' => 202]],
+                ['method' => 'scaleByHeight', 'arguments' => ['height' => 151]],
                 1.5,
-                ['width' => 202, 'height' => 152],
-                ['width' => 303, 'height' => 228],
+                ['width' => 200, 'height' => 150],
+                ['width' => 301, 'height' => 226],
             ],
         ];
 
@@ -392,18 +392,18 @@ class EstimatedDimensionsTest extends ImageThumbnailDimensionTestCase
         }
     }
 
-    public function testFractionalPassThroughHighResolutionPreservesNominalPixels(): void
+    public function testFractionalPassThroughHighResolutionMatchesLegacyTruncation(): void
     {
         foreach ([
             'scale by width' => [
-                ['method' => 'scaleByWidth', 'arguments' => ['width' => 202]],
-                ['width' => 202, 'height' => 152],
-                ['width' => 303, 'height' => 228],
+                ['method' => 'scaleByWidth', 'arguments' => ['width' => 201]],
+                ['width' => 200, 'height' => 150],
+                ['width' => 301, 'height' => 226],
             ],
             'scale by height' => [
                 ['method' => 'scaleByHeight', 'arguments' => ['height' => 151]],
-                ['width' => 201, 'height' => 151],
-                ['width' => 302, 'height' => 227],
+                ['width' => 200, 'height' => 150],
+                ['width' => 301, 'height' => 226],
             ],
         ] as $name => [$transformation, $displayDimensions, $realDimensions]) {
             $asset = $this->image(400, 300, 'source.svg');

--- a/tests/Unit/Models/Asset/Image/Thumbnail/EstimatedDimensionsTest.php
+++ b/tests/Unit/Models/Asset/Image/Thumbnail/EstimatedDimensionsTest.php
@@ -1,0 +1,776 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Models\Asset\Image\Thumbnail;
+
+use Doctrine\Persistence\ConnectionRegistry;
+use Pimcore as PimcoreRuntime;
+use Pimcore\Helper\LongRunningHelper;
+use Pimcore\Image\Adapter;
+use Pimcore\Image\Adapter\GD;
+use Pimcore\Image\AdapterInterface;
+use Pimcore\Model\Asset\Image\Thumbnail;
+use Pimcore\Tests\Unit\Models\Asset\Thumbnail\ImageThumbnailDimensionTestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * Regression coverage for dimension estimation before thumbnail file access.
+ *
+ * The probe deliberately reports that a thumbnail exists.
+ * Reliable estimates must therefore avoid both exists() and readDimensionsFromFile(), while configurations that cannot be reproduced exactly must use the file fallback exactly once.
+ */
+class EstimatedDimensionsTest extends ImageThumbnailDimensionTestCase
+{
+    public function testProjectSpecificImageAdapterFailsClosedToFileInspection(): void
+    {
+        $this->installImageAdapter(new ProjectSpecificImageAdapter());
+
+        $asset = $this->image(400, 300);
+        $config = $this->config([
+            ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+        ]);
+        self::assertSame([], $config->getEstimatedDimensions($asset));
+
+        $thumbnail = $this->probe($asset, $config, ['width' => 73, 'height' => 41]);
+        self::assertSame(['width' => 73, 'height' => 41], $thumbnail->getDimensions());
+        self::assertSame(1, $thumbnail->readDimensionsCalls);
+    }
+
+    public function testProjectSpecificAdapterDoesNotBlockOriginalAssetLogicalDimensions(): void
+    {
+        $this->installImageAdapter(new ProjectSpecificImageAdapter());
+
+        foreach ([
+            'SVG pass-through' => [
+                'source.svg',
+                [['method' => 'scaleByWidth', 'arguments' => ['width' => 200]]],
+            ],
+            'TIFF original marker' => [
+                'source.tiff',
+                [
+                    ['method' => 'tifforiginal', 'arguments' => []],
+                    ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+                ],
+            ],
+        ] as $name => [$filename, $items]) {
+            $asset = $this->image(400, 300, $filename);
+            $config = $this->config($items);
+            $config->setFormat('PRINT');
+
+            self::assertSame(
+                ['width' => 200, 'height' => 150],
+                $config->getEstimatedDimensions($asset),
+                $name
+            );
+
+            $thumbnail = $this->probe($asset, $config, ['width' => 73, 'height' => 41]);
+            self::assertSame(['width' => 200, 'height' => 150], $thumbnail->getDimensions(), $name);
+            self::assertSame(0, $thumbnail->readDimensionsCalls, $name);
+        }
+    }
+
+    public function testGdSubclassFailsClosedToFileInspection(): void
+    {
+        $this->installImageAdapter(new ProjectSpecificGdAdapter());
+
+        $asset = $this->image(400, 300, 'source.png');
+        $config = $this->config([
+            ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+        ]);
+        self::assertSame([], $config->getEstimatedDimensions($asset));
+
+        $thumbnail = $this->probe($asset, $config, ['width' => 91, 'height' => 67]);
+        self::assertSame(['width' => 91, 'height' => 67], $thumbnail->getDimensions());
+        self::assertSame(1, $thumbnail->readDimensionsCalls);
+    }
+
+    public function testScaleByWidthUsesStoredSourceDimensionsWithoutFileAccess(): void
+    {
+        $thumbnail = $this->probe(
+            $this->image(400, 300),
+            $this->config([
+                ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+            ])
+        );
+
+        self::assertSame(['width' => 200, 'height' => 150], $thumbnail->getDimensions());
+        self::assertSame(0, $thumbnail->existsCalls);
+        self::assertSame(0, $thumbnail->readDimensionsCalls);
+    }
+
+    public function testStoredSourceAndSourceIndependentDimensionsAvoidFileAccess(): void
+    {
+        $cases = [
+            'untransformed source' => [
+                $this->image(400, 300),
+                [],
+                null,
+                ['width' => 400, 'height' => 300],
+            ],
+            '1x1 without stored source dimensions' => [
+                $this->image(null, null),
+                [['method' => '1x1_pixel', 'arguments' => []]],
+                null,
+                ['width' => 1, 'height' => 1],
+            ],
+            'scale by height' => [
+                $this->image(400, 300),
+                [['method' => 'scaleByHeight', 'arguments' => ['height' => 150]]],
+                null,
+                ['width' => 200, 'height' => 150],
+            ],
+            'frame' => [
+                $this->image(400, 300),
+                [['method' => 'frame', 'arguments' => ['width' => 500, 'height' => 400]]],
+                null,
+                ['width' => 500, 'height' => 400],
+            ],
+        ];
+
+        foreach ($cases as $name => [$asset, $items, $highResolution, $expected]) {
+            $thumbnail = $this->probe($asset, $this->config($items, $highResolution));
+
+            self::assertSame($expected, $thumbnail->getDimensions(), $name);
+            self::assertSame(0, $thumbnail->existsCalls, $name);
+            self::assertSame(0, $thumbnail->readDimensionsCalls, $name);
+        }
+    }
+
+    public function testReliableTransformationPipelinesAvoidFileAccess(): void
+    {
+        $cases = [
+            'contain' => [
+                [['method' => 'contain', 'arguments' => ['width' => 100, 'height' => 100]]],
+                ['width' => 100, 'height' => 75],
+            ],
+            'cover' => [
+                [['method' => 'cover', 'arguments' => ['width' => 100, 'height' => 100]]],
+                ['width' => 100, 'height' => 100],
+            ],
+            'safe crop' => [
+                [['method' => 'crop', 'arguments' => ['x' => 10, 'y' => 20, 'width' => 100, 'height' => 50]]],
+                ['width' => 100, 'height' => 50],
+            ],
+            'crop percent' => [
+                [['method' => 'cropPercent', 'arguments' => ['width' => 50, 'height' => 25, 'x' => 10, 'y' => 20]]],
+                ['width' => 200, 'height' => 75],
+            ],
+            'dimension-neutral mixed pipeline' => [
+                [
+                    ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+                    ['method' => 'setBackgroundColor', 'arguments' => ['color' => '#ffffff']],
+                    ['method' => 'grayscale', 'arguments' => []],
+                    ['method' => 'sepia', 'arguments' => []],
+                    ['method' => 'sharpen', 'arguments' => ['radius' => 0, 'sigma' => 1, 'amount' => 1, 'threshold' => 0]],
+                    ['method' => 'mirror', 'arguments' => ['mode' => 'horizontal']],
+                ],
+                ['width' => 200, 'height' => 150],
+            ],
+        ];
+
+        foreach ($cases as $name => [$items, $expected]) {
+            $thumbnail = $this->probe($this->image(400, 300), $this->config($items));
+
+            self::assertSame($expected, $thumbnail->getDimensions(), $name);
+            self::assertSame(0, $thumbnail->existsCalls, $name);
+            self::assertSame(0, $thumbnail->readDimensionsCalls, $name);
+        }
+    }
+
+    public function testAttainableHighResolutionUsesEstimatedNominalAndRealDimensions(): void
+    {
+        $thumbnail = $this->probe(
+            $this->image(800, 600),
+            $this->config([
+                ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+            ], 2.0)
+        );
+
+        self::assertSame(['width' => 200, 'height' => 150], $thumbnail->getDimensions());
+        self::assertSame(400, $thumbnail->getRealWidth());
+        self::assertSame(300, $thumbnail->getRealHeight());
+        self::assertSame(0, $thumbnail->existsCalls);
+        self::assertSame(0, $thumbnail->readDimensionsCalls);
+    }
+
+    public function testFractionalHighResolutionMatchesProcessorRounding(): void
+    {
+        $thumbnail = $this->probe(
+            $this->image(800, 600),
+            $this->config([
+                ['method' => 'scaleByWidth', 'arguments' => ['width' => 201]],
+                ['method' => 'grayscale', 'arguments' => []],
+            ], 1.5)
+        );
+
+        self::assertSame(['width' => 201, 'height' => 150], $thumbnail->getDimensions());
+        self::assertSame(302, $thumbnail->getRealWidth());
+        self::assertSame(226, $thumbnail->getRealHeight());
+        self::assertSame(0, $thumbnail->readDimensionsCalls);
+    }
+
+    public function testCappedHighResolutionUsesProcessorNormalizedEstimate(): void
+    {
+        $thumbnail = $this->probe(
+            $this->image(300, 225),
+            $this->config([
+                ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+            ], 2.0),
+            ['width' => 300, 'height' => 225]
+        );
+
+        self::assertSame(['width' => 150, 'height' => 112], $thumbnail->getDimensions());
+
+        self::assertSame(300, $thumbnail->getRealWidth());
+        self::assertSame(225, $thumbnail->getRealHeight());
+        self::assertSame(0, $thumbnail->readDimensionsCalls);
+    }
+
+    public function testScaleRoundingMatchesImageAdapter(): void
+    {
+        $thumbnail = $this->probe(
+            $this->image(4, 3),
+            $this->config([
+                ['method' => 'scaleByWidth', 'arguments' => ['width' => 2]],
+            ])
+        );
+
+        self::assertSame(['width' => 2, 'height' => 1], $thumbnail->getDimensions());
+        self::assertSame(0, $thumbnail->readDimensionsCalls);
+    }
+
+    public function testOutOfBoundsCropFallsBackToFile(): void
+    {
+        $thumbnail = $this->probe(
+            $this->image(100, 80),
+            $this->config([
+                ['method' => 'crop', 'arguments' => ['x' => 90, 'y' => 70, 'width' => 50, 'height' => 40]],
+            ]),
+            ['width' => 10, 'height' => 10]
+        );
+
+        self::assertSame(['width' => 10, 'height' => 10], $thumbnail->getDimensions());
+        self::assertSame(1, $thumbnail->readDimensionsCalls);
+    }
+
+    public function testOriginalFormatDeclinesTransformationEstimate(): void
+    {
+        $asset = $this->image(400, 300);
+        $config = $this->config([
+            ['method' => 'resize', 'arguments' => ['width' => 200, 'height' => 100]],
+        ]);
+        $config->setFormat('ORIGINAL');
+
+        self::assertSame([], $config->getEstimatedDimensions($asset));
+    }
+
+    public function testSourceSvgPassThroughRetainsLogicalTransformations(): void
+    {
+        $cases = [
+            'scale by width' => [
+                ['method' => 'scaleByWidth', 'arguments' => ['width' => 202]],
+                null,
+                ['width' => 202, 'height' => 152],
+                ['width' => 202, 'height' => 152],
+            ],
+            'scale by height' => [
+                ['method' => 'scaleByHeight', 'arguments' => ['height' => 151]],
+                null,
+                ['width' => 201, 'height' => 151],
+                ['width' => 201, 'height' => 151],
+            ],
+            'resize' => [
+                ['method' => 'resize', 'arguments' => ['width' => 200, 'height' => 100]],
+                null,
+                ['width' => 200, 'height' => 100],
+                ['width' => 200, 'height' => 100],
+            ],
+            'fractional high resolution' => [
+                ['method' => 'scaleByWidth', 'arguments' => ['width' => 202]],
+                1.5,
+                ['width' => 202, 'height' => 152],
+                ['width' => 303, 'height' => 228],
+            ],
+        ];
+
+        foreach ($cases as $name => [$transformation, $highResolution, $displayDimensions, $realDimensions]) {
+            $asset = $this->image(400, 300, 'source.svg');
+            $config = $this->config([$transformation], $highResolution);
+            $config->setFormat('SOURCE');
+
+            self::assertTrue($config->usesOriginalSvgOutput($asset), $name);
+            self::assertSame($realDimensions, $config->getEstimatedDimensions($asset), $name);
+
+            $thumbnail = $this->probe($asset, $config);
+            self::assertSame($displayDimensions, $thumbnail->getDimensions(), $name);
+            self::assertSame($realDimensions['width'], $thumbnail->getRealWidth(), $name);
+            self::assertSame($realDimensions['height'], $thumbnail->getRealHeight(), $name);
+            self::assertSame(0, $thumbnail->readDimensionsCalls, $name);
+        }
+    }
+
+    public function testSourceSvgShortcutDeclinesWhenRouteDoesNotReturnSource(): void
+    {
+        $cases = [
+            'rasterization enabled' => ['source.svg', true, [
+                ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+            ]],
+            'unsupported transformation' => ['source.svg', false, [
+                ['method' => 'crop', 'arguments' => ['x' => 0, 'y' => 0, 'width' => 50, 'height' => 50]],
+            ]],
+            'upper-case extension' => ['source.SVG', false, [
+                ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+            ]],
+        ];
+
+        foreach ($cases as $name => [$filename, $rasterizeSvg, $items]) {
+            $asset = $this->image(400, 300, $filename);
+            $config = $this->config($items);
+            $config->setFormat('SOURCE');
+            $config->setRasterizeSVG($rasterizeSvg);
+
+            self::assertFalse($config->usesOriginalSvgOutput($asset), $name);
+            self::assertSame([], $config->getEstimatedDimensions($asset), $name);
+
+            $thumbnail = $this->probe($asset, $config, ['width' => 73, 'height' => 59]);
+            self::assertSame(['width' => 73, 'height' => 59], $thumbnail->getDimensions(), $name);
+            self::assertSame(1, $thumbnail->readDimensionsCalls, $name);
+        }
+    }
+
+    public function testPrintSvgPassThroughRetainsLogicalTransformationsAndHighResolutionDimensions(): void
+    {
+        $cases = [
+            'scale by width' => [
+                ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+                ['width' => 200, 'height' => 150],
+            ],
+            'scale by height' => [
+                ['method' => 'scaleByHeight', 'arguments' => ['height' => 150]],
+                ['width' => 200, 'height' => 150],
+            ],
+            'resize' => [
+                ['method' => 'resize', 'arguments' => ['width' => 200, 'height' => 100]],
+                ['width' => 200, 'height' => 100],
+            ],
+        ];
+
+        foreach ($cases as $name => [$transformation, $displayDimensions]) {
+            foreach ([null, 2.0] as $highResolution) {
+                $asset = $this->image(400, 300, 'source.svg');
+                $config = $this->config([$transformation], $highResolution);
+                $config->setFormat('PRINT');
+                $realDimensions = $highResolution === null
+                    ? $displayDimensions
+                    : [
+                        'width' => $displayDimensions['width'] * 2,
+                        'height' => $displayDimensions['height'] * 2,
+                    ];
+
+                self::assertSame($realDimensions, $config->getEstimatedDimensions($asset), $name);
+
+                $thumbnail = $this->probe($asset, $config);
+                self::assertSame($displayDimensions, $thumbnail->getDimensions(), $name);
+                self::assertSame($realDimensions['width'], $thumbnail->getRealWidth(), $name);
+                self::assertSame($realDimensions['height'], $thumbnail->getRealHeight(), $name);
+                self::assertSame(0, $thumbnail->readDimensionsCalls, $name);
+            }
+        }
+    }
+
+    public function testFractionalPassThroughHighResolutionPreservesNominalPixels(): void
+    {
+        foreach ([
+            'scale by width' => [
+                ['method' => 'scaleByWidth', 'arguments' => ['width' => 202]],
+                ['width' => 202, 'height' => 152],
+                ['width' => 303, 'height' => 228],
+            ],
+            'scale by height' => [
+                ['method' => 'scaleByHeight', 'arguments' => ['height' => 151]],
+                ['width' => 201, 'height' => 151],
+                ['width' => 302, 'height' => 227],
+            ],
+        ] as $name => [$transformation, $displayDimensions, $realDimensions]) {
+            $asset = $this->image(400, 300, 'source.svg');
+            $config = $this->config([$transformation], 1.5);
+            $config->setFormat('PRINT');
+
+            self::assertSame($realDimensions, $config->getEstimatedDimensions($asset), $name);
+
+            $thumbnail = $this->probe($asset, $config);
+            self::assertSame($displayDimensions, $thumbnail->getDimensions(), $name);
+            self::assertSame($realDimensions['width'], $thumbnail->getRealWidth(), $name);
+            self::assertSame($realDimensions['height'], $thumbnail->getRealHeight(), $name);
+            self::assertSame(0, $thumbnail->readDimensionsCalls, $name);
+        }
+    }
+
+    public function testPassThroughUsesLegacyLogicalHtmlDimensionRules(): void
+    {
+        $cases = [
+            'rounded proportional scale' => [
+                'source.svg',
+                [['method' => 'scaleByWidth', 'arguments' => ['width' => 202]]],
+                ['width' => 202, 'height' => 152],
+            ],
+            'absolute crop target outside source canvas' => [
+                'source.svg',
+                [['method' => 'crop', 'arguments' => ['x' => 390, 'y' => 290, 'width' => 200, 'height' => 100]]],
+                ['width' => 200, 'height' => 100],
+            ],
+            'TIFF original marker and cover upscale' => [
+                'source.tiff',
+                [
+                    ['method' => 'tifforiginal', 'arguments' => []],
+                    ['method' => 'cover', 'arguments' => ['width' => 800, 'height' => 600]],
+                ],
+                ['width' => 800, 'height' => 600],
+            ],
+            'malformed visual-only operation after scale' => [
+                'source.svg',
+                [
+                    ['method' => 'scaleByWidth', 'arguments' => ['width' => 202]],
+                    ['method' => 'setBackgroundColor', 'arguments' => []],
+                ],
+                ['width' => 202, 'height' => 152],
+            ],
+        ];
+
+        foreach ($cases as $name => [$filename, $items, $expected]) {
+            $asset = $this->image(400, 300, $filename);
+            $config = $this->config($items);
+            $config->setFormat('PRINT');
+
+            self::assertSame($expected, $config->getEstimatedDimensions($asset), $name);
+
+            $thumbnail = $this->probe($asset, $config);
+            self::assertSame($expected, $thumbnail->getDimensions(), $name);
+            self::assertSame(0, $thumbnail->readDimensionsCalls, $name);
+        }
+    }
+
+    public function testGeneratedRasterCoverUpscaleWithoutForceStillFallsBack(): void
+    {
+        $thumbnail = $this->probe(
+            $this->image(400, 300, 'source.png'),
+            $this->config([
+                ['method' => 'cover', 'arguments' => ['width' => 800, 'height' => 600]],
+            ]),
+            ['width' => 400, 'height' => 300]
+        );
+
+        self::assertSame(['width' => 400, 'height' => 300], $thumbnail->getDimensions());
+        self::assertSame(1, $thumbnail->readDimensionsCalls);
+    }
+
+    public function testSvgSourceOutputHtmlUsesLogicalDimensions(): void
+    {
+        $eventDispatcher = new EventDispatcher();
+        $requestStack = new RequestStack();
+        $longRunningHelper = new LongRunningHelper($this->createStub(ConnectionRegistry::class));
+        $container = $this->createStub(ContainerInterface::class);
+        $container->method('get')
+            ->willReturnCallback(static fn (string $id) => match ($id) {
+                'event_dispatcher' => $eventDispatcher,
+                'request_stack' => $requestStack,
+                AdapterInterface::class => new GD(),
+                LongRunningHelper::class => $longRunningHelper,
+                default => null,
+            });
+        $kernel = $this->createStub(KernelInterface::class);
+        $kernel->method('getContainer')->willReturn($container);
+        PimcoreRuntime::setKernel($kernel);
+
+        $asset = $this->countingImage(400, 300, 'source.svg');
+        $asset->setMimeType('image/png');
+        $config = $this->config([
+            ['method' => 'scaleByWidth', 'arguments' => ['width' => 202]],
+        ]);
+        $config->setFormat('SOURCE');
+        self::assertTrue($config->usesOriginalSvgOutput($asset));
+        $sourceThumbnail = new Thumbnail($asset, $config, false);
+        $sourceHtml = $sourceThumbnail->getImageTag([
+            'alt' => 'source',
+            'title' => 'source',
+            'disableAutoCopyright' => true,
+        ]);
+
+        self::assertStringContainsString('src="source.svg"', $sourceHtml);
+        self::assertStringContainsString('width="202"', $sourceHtml);
+        self::assertStringContainsString('height="152"', $sourceHtml);
+        self::assertSame('asset', $sourceThumbnail->getPathReference()['type']);
+        self::assertSame(0, $asset->streamCalls);
+        self::assertSame(0, $asset->dimensionsFromFileCalls);
+
+        $config->setFormat('PRINT');
+        $thumbnail = new Thumbnail($asset, $config, false);
+
+        $html = $thumbnail->getImageTag([
+            'alt' => 'source',
+            'title' => 'source',
+            'disableAutoCopyright' => true,
+        ]);
+
+        self::assertStringContainsString('src="source.svg"', $html);
+        self::assertStringContainsString('width="202"', $html);
+        self::assertStringContainsString('height="152"', $html);
+
+        $source = $this->createRasterFixture(400, 300);
+        $config->setFormat('SOURCE');
+        $sourceMissingAsset = $this->countingImage(
+            null,
+            null,
+            'source.svg',
+            $source,
+            ['width' => 400, 'height' => 300]
+        );
+        $sourceMissingThumbnail = new Thumbnail($sourceMissingAsset, $config, false);
+        $sourceMissingHtml = $sourceMissingThumbnail->getImageTag([
+            'alt' => 'source',
+            'title' => 'source',
+            'disableAutoCopyright' => true,
+        ]);
+
+        self::assertStringContainsString('src="source.svg"', $sourceMissingHtml);
+        self::assertStringContainsString('width="202"', $sourceMissingHtml);
+        self::assertStringContainsString('height="152"', $sourceMissingHtml);
+        self::assertSame('asset', $sourceMissingThumbnail->getPathReference()['type']);
+        self::assertSame(1, $sourceMissingAsset->streamCalls);
+        self::assertSame(1, $sourceMissingAsset->dimensionsFromFileCalls);
+        self::assertNull($sourceMissingAsset->getCustomSetting('imageWidth'));
+        self::assertNull($sourceMissingAsset->getCustomSetting('imageHeight'));
+
+        $config->setFormat('PRINT');
+        $missingAsset = $this->countingImage(
+            null,
+            null,
+            'source.svg',
+            $source,
+            ['width' => 400, 'height' => 300]
+        );
+        $missingAsset->setMimeType('image/png');
+        $missingThumbnail = new Thumbnail($missingAsset, $config, false);
+        $missingHtml = $missingThumbnail->getImageTag([
+            'alt' => 'source',
+            'title' => 'source',
+            'disableAutoCopyright' => true,
+        ]);
+
+        self::assertStringContainsString('src="source.svg"', $missingHtml);
+        self::assertStringContainsString('width="202"', $missingHtml);
+        self::assertStringContainsString('height="152"', $missingHtml);
+        self::assertSame(1, $missingAsset->streamCalls);
+        self::assertSame(1, $missingAsset->dimensionsFromFileCalls);
+        self::assertNull($missingAsset->getCustomSetting('imageWidth'));
+        self::assertNull($missingAsset->getCustomSetting('imageHeight'));
+
+        $cropConfig = $this->config([[
+            'method' => 'cropPercent',
+            'arguments' => ['width' => 50, 'height' => 50, 'x' => 0, 'y' => 0],
+        ]]);
+        $cropConfig->setFormat('PRINT');
+
+        $cropHtml = (new Thumbnail($this->image(400, 300, 'source.svg'), $cropConfig, false))->getImageTag([
+            'alt' => 'source',
+            'title' => 'source',
+            'disableAutoCopyright' => true,
+        ]);
+        self::assertStringContainsString('width="200"', $cropHtml);
+        self::assertStringContainsString('height="150"', $cropHtml);
+
+        $missingCropAsset = $this->countingImage(
+            null,
+            null,
+            'source.svg',
+            $source,
+            ['width' => 400, 'height' => 300]
+        );
+        $missingCropHtml = (new Thumbnail($missingCropAsset, $cropConfig, false))->getImageTag([
+            'alt' => 'source',
+            'title' => 'source',
+            'disableAutoCopyright' => true,
+        ]);
+        self::assertStringContainsString('width="200"', $missingCropHtml);
+        self::assertStringContainsString('height="150"', $missingCropHtml);
+        self::assertSame(1, $missingCropAsset->streamCalls);
+        self::assertSame(1, $missingCropAsset->dimensionsFromFileCalls);
+    }
+
+    public function testDimensionEstimationVectorClassificationIsCaseInsensitiveWithoutChangingPublicContract(): void
+    {
+        foreach (['source.svg', 'source.pdf'] as $filename) {
+            $asset = $this->image(100, 100, $filename);
+            self::assertTrue($asset->isVectorGraphic(), $filename);
+            self::assertTrue($asset->getVectorGraphicStateForDimensionEstimation(), $filename);
+        }
+
+        foreach (['source.SVG', 'source.PDF'] as $filename) {
+            $asset = $this->image(100, 100, $filename);
+            self::assertFalse($asset->isVectorGraphic(), $filename);
+            self::assertTrue($asset->getVectorGraphicStateForDimensionEstimation(), $filename);
+        }
+
+        $vectorThumbnail = $this->probe(
+            $this->image(100, 100, 'source.SVG'),
+            $this->config([
+                ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+            ]),
+            ['width' => 100, 'height' => 100]
+        );
+        self::assertSame(['width' => 100, 'height' => 100], $vectorThumbnail->getDimensions());
+        self::assertSame(1, $vectorThumbnail->readDimensionsCalls);
+
+        $rasterThumbnail = $this->probe(
+            $this->image(100, 100, 'source.png'),
+            $this->config([
+                ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+            ])
+        );
+        self::assertSame(['width' => 100, 'height' => 100], $rasterThumbnail->getDimensions());
+
+        $misnamedVector = $this->image(100, 100, 'source.bin');
+        $misnamedVector->setMimeType('image/svg+xml');
+        self::assertFalse($misnamedVector->isVectorGraphic());
+        self::assertNull($misnamedVector->getVectorGraphicStateForDimensionEstimation());
+        self::assertSame(
+            [],
+            $this->config([
+                ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+            ])->getEstimatedDimensions($misnamedVector)
+        );
+
+        $unknownAsset = $this->image(100, 100, 'source.bin');
+        self::assertNull($unknownAsset->getVectorGraphicStateForDimensionEstimation());
+        self::assertSame(
+            [],
+            $this->config([
+                ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+            ])->getEstimatedDimensions($unknownAsset)
+        );
+
+        $misnamedRaster = $this->image(100, 100, 'source.bin');
+        $misnamedRaster->setMimeType('image/png');
+        self::assertFalse($misnamedRaster->isVectorGraphic());
+        self::assertNull($misnamedRaster->getVectorGraphicStateForDimensionEstimation());
+        self::assertSame(
+            [],
+            $this->config([
+                ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+            ])->getEstimatedDimensions($misnamedRaster)
+        );
+    }
+
+    public function testConflictingVectorExtensionAndMimeEvidenceFallsBack(): void
+    {
+        foreach ([
+            ['source.png', 'image/svg+xml'],
+            ['source.svg', 'image/png'],
+        ] as [$filename, $mimeType]) {
+            $asset = $this->image(100, 100, $filename);
+            $asset->setMimeType($mimeType);
+            self::assertNull($asset->getVectorGraphicStateForDimensionEstimation(), $filename . ' + ' . $mimeType);
+
+            $config = $this->config([
+                ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+            ]);
+            $config->setRasterizeSVG(true);
+            self::assertSame([], $config->getEstimatedDimensions($asset), $filename . ' + ' . $mimeType);
+
+            $thumbnail = $this->probe($asset, $config, ['width' => 73, 'height' => 59]);
+            self::assertSame(['width' => 73, 'height' => 59], $thumbnail->getDimensions());
+            self::assertSame(1, $thumbnail->readDimensionsCalls);
+        }
+    }
+
+    public function testGeneratedResizeRequiresDefinitivelyRasterSource(): void
+    {
+        $config = $this->config([
+            ['method' => 'resize', 'arguments' => ['width' => 200, 'height' => 200]],
+        ]);
+        $config->setRasterizeSVG(true);
+
+        $knownVector = $this->image(100, 100, 'source.svg');
+        $knownVector->setMimeType('image/svg+xml');
+        self::assertTrue($knownVector->getVectorGraphicStateForDimensionEstimation());
+        self::assertSame([], $config->getEstimatedDimensions($knownVector));
+
+        $knownVectorThumbnail = $this->probe($knownVector, $config, ['width' => 73, 'height' => 59]);
+        self::assertSame(['width' => 73, 'height' => 59], $knownVectorThumbnail->getDimensions());
+        self::assertSame(1, $knownVectorThumbnail->readDimensionsCalls);
+
+        foreach ([
+            'conflicting SVG extension' => ['source.svg', 'image/png'],
+            'unknown extension with vector MIME' => ['source.bin', 'image/svg+xml'],
+            'unknown extension with raster MIME' => ['source.bin', 'image/png'],
+        ] as $name => [$filename, $mimeType]) {
+            $asset = $this->image(100, 100, $filename);
+            $asset->setMimeType($mimeType);
+
+            self::assertNull($asset->getVectorGraphicStateForDimensionEstimation(), $name);
+            self::assertSame([], $config->getEstimatedDimensions($asset), $name);
+
+            $thumbnail = $this->probe($asset, $config, ['width' => 73, 'height' => 59]);
+            self::assertSame(['width' => 73, 'height' => 59], $thumbnail->getDimensions(), $name);
+            self::assertSame(1, $thumbnail->readDimensionsCalls, $name);
+        }
+
+        $rasterAsset = $this->image(100, 100, 'source.png');
+        $rasterAsset->setMimeType('image/png');
+        self::assertFalse($rasterAsset->getVectorGraphicStateForDimensionEstimation());
+        self::assertSame(['width' => 200, 'height' => 200], $config->getEstimatedDimensions($rasterAsset));
+
+        $rasterThumbnail = $this->probe($rasterAsset, $config, ['width' => 73, 'height' => 59]);
+        self::assertSame(['width' => 200, 'height' => 200], $rasterThumbnail->getDimensions());
+        self::assertSame(0, $rasterThumbnail->readDimensionsCalls);
+    }
+}
+
+final class ProjectSpecificImageAdapter extends Adapter
+{
+    public function load(string $imagePath, array $options = []): static
+    {
+        return $this;
+    }
+
+    public function save(string $path, ?string $format = null, ?int $quality = null): static
+    {
+        return $this;
+    }
+
+    protected function destroy(): void
+    {
+    }
+
+    public function getContentOptimizedFormat(): string
+    {
+        return 'png';
+    }
+
+    public function supportsFormat(string $format, bool $force = false): bool
+    {
+        return true;
+    }
+}
+
+final class ProjectSpecificGdAdapter extends GD
+{
+    public function resize(int $width, int $height): static
+    {
+        return $this;
+    }
+}

--- a/tests/Unit/Models/Asset/Thumbnail/ImageThumbnailDimensionTestCase.php
+++ b/tests/Unit/Models/Asset/Thumbnail/ImageThumbnailDimensionTestCase.php
@@ -1,0 +1,563 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Models\Asset\Thumbnail;
+
+use Doctrine\Persistence\ConnectionRegistry;
+use Imagick;
+use ImagickException;
+use ImagickPixel;
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\TestCase;
+use Pimcore as PimcoreRuntime;
+use Pimcore\Config as PimcoreConfig;
+use Pimcore\Helper\LongRunningHelper;
+use Pimcore\Image\Adapter;
+use Pimcore\Image\Adapter\GD;
+use Pimcore\Image\Adapter\Imagick as ImagickAdapter;
+use Pimcore\Image\AdapterInterface;
+use Pimcore\Model\Asset;
+use Pimcore\Model\Asset\Image;
+use Pimcore\Model\Asset\Image\Thumbnail\Config;
+use Pimcore\Model\Asset\Image\Thumbnail\Processor;
+use Pimcore\Model\Asset\Thumbnail\ImageThumbnailTrait;
+use Pimcore\Tool\Storage;
+use Psr\Container\ContainerInterface;
+use Psr\Log\NullLogger;
+use ReflectionProperty;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * Regression coverage for dimension estimation before thumbnail file access.
+ *
+ * The probe deliberately reports that a thumbnail exists.
+ * Reliable estimates must therefore avoid both exists() and readDimensionsFromFile(), while configurations that cannot be reproduced exactly must use the file fallback exactly once.
+ */
+abstract class ImageThumbnailDimensionTestCase extends TestCase
+{
+    protected ?array $previousSystemConfiguration;
+
+    protected ?KernelInterface $previousKernel;
+
+    /** @var list<string> */
+    protected array $temporaryFiles = [];
+
+    private Adapter $configuredImageAdapter;
+
+    private ?FilesystemOperator $assetStorage = null;
+
+    private ?FilesystemOperator $thumbnailStorage = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $systemConfiguration = new ReflectionProperty(PimcoreConfig::class, 'systemConfig');
+        $this->previousSystemConfiguration = $systemConfiguration->getValue();
+        $kernel = new ReflectionProperty(PimcoreRuntime::class, 'kernel');
+        $this->previousKernel = $kernel->getValue();
+
+        PimcoreConfig::setSystemConfiguration([
+            'assets' => [
+                'thumbnails' => [
+                    'allowed_formats' => ['png', 'jpeg', 'webp', 'avif', 'tiff', 'print'],
+                    'max_scaling_factor' => 10,
+                ],
+                'image' => [
+                    'thumbnails' => [
+                        'status_cache' => false,
+                        'clip_auto_support' => false,
+                        'max_srcset_dpi_factor' => 1,
+                        'image_optimizers' => [
+                            'enabled' => false,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $this->configuredImageAdapter = new GD();
+        $this->installRuntimeServices();
+    }
+
+    protected function tearDown(): void
+    {
+        PimcoreConfig::setSystemConfiguration($this->previousSystemConfiguration);
+        $kernel = new ReflectionProperty(PimcoreRuntime::class, 'kernel');
+        $kernel->setValue(null, $this->previousKernel);
+
+        foreach ($this->temporaryFiles as $temporaryFile) {
+            if (is_file($temporaryFile)) {
+                unlink($temporaryFile);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * @param class-string<Adapter> $adapterClass
+     *
+     * @return array{width: int, height: int}
+     */
+    protected function renderedDimensions(
+        string $adapterClass,
+        string $source,
+        Image $asset,
+        Config $config
+    ): array {
+        $adapter = new $adapterClass();
+        if ($adapter->load($source, ['preserveColor' => true]) === false) {
+            throw new RuntimeException($adapterClass . ' could not load ' . $source);
+        }
+
+        Processor::applyTransformations($adapter, $asset, $config, $config->getItems());
+
+        $output = $this->temporaryPath('.png');
+        $adapter->save($output, 'png');
+        $imageSize = getimagesize($output);
+        self::assertIsArray($imageSize);
+
+        return [
+            'width' => $imageSize[0],
+            'height' => $imageSize[1],
+        ];
+    }
+
+    /**
+     * @return array<string, array{list<array{method: string, arguments: array<string, mixed>}>, float|null}>
+     */
+    protected function supportedRasterPipelineCases(): array
+    {
+        return [
+            'scale by width' => [
+                [['method' => 'scaleByWidth', 'arguments' => ['width' => 201]]],
+                null,
+            ],
+            'scale by height' => [
+                [['method' => 'scaleByHeight', 'arguments' => ['height' => 151]]],
+                null,
+            ],
+            'contain' => [
+                [['method' => 'contain', 'arguments' => ['width' => 121, 'height' => 101]]],
+                null,
+            ],
+            'cover' => [
+                [['method' => 'cover', 'arguments' => ['width' => 121, 'height' => 101]]],
+                null,
+            ],
+            'crop' => [
+                [['method' => 'crop', 'arguments' => ['x' => 17, 'y' => 19, 'width' => 121, 'height' => 101]]],
+                null,
+            ],
+            'crop percent' => [
+                [['method' => 'cropPercent', 'arguments' => ['width' => 51, 'height' => 41, 'x' => 7, 'y' => 9]]],
+                null,
+            ],
+            'frame' => [
+                [['method' => 'frame', 'arguments' => ['width' => 501, 'height' => 401]]],
+                null,
+            ],
+            'fractional high resolution' => [
+                [['method' => 'scaleByWidth', 'arguments' => ['width' => 201]]],
+                1.5,
+            ],
+            'capped high resolution' => [
+                [['method' => 'scaleByWidth', 'arguments' => ['width' => 300]]],
+                2.0,
+            ],
+        ];
+    }
+
+    protected function requireImagickExtension(): void
+    {
+        if (!extension_loaded('imagick')) {
+            self::markTestSkipped('Imagick is not installed.');
+        }
+    }
+
+    protected function requireImagickFixtureSupport(string $source): void
+    {
+        $this->requireImagickExtension();
+
+        $adapter = new ImagickAdapter();
+
+        try {
+            $loaded = $adapter->load($source, ['preserveColor' => true]);
+        } catch (ImagickException $exception) {
+            self::markTestSkipped('Imagick fixture delegate is unavailable: ' . $exception->getMessage());
+        }
+
+        if ($loaded === false) {
+            self::markTestSkipped('Imagick fixture delegate is unavailable for ' . pathinfo($source, PATHINFO_EXTENSION));
+        }
+    }
+
+    protected function createRasterFixture(int $width, int $height): string
+    {
+        $path = $this->temporaryPath('.png');
+        $image = imagecreatetruecolor($width, $height);
+        $color = imagecolorallocate($image, 40, 120, 200);
+        imagefill($image, 0, 0, $color);
+        imagepng($image, $path);
+        imagedestroy($image);
+
+        return $path;
+    }
+
+    protected function createWebRootRasterFixture(int $width, int $height): string
+    {
+        $path = $this->temporaryPath('.png', PIMCORE_WEB_ROOT);
+        $image = imagecreatetruecolor($width, $height);
+        $color = imagecolorallocate($image, 220, 90, 40);
+        imagefill($image, 0, 0, $color);
+        imagepng($image, $path);
+        imagedestroy($image);
+
+        return $path;
+    }
+
+    protected function createTiffFixture(int $width, int $height): string
+    {
+        $this->requireImagickExtension();
+
+        $path = $this->temporaryPath('.tiff');
+
+        try {
+            $image = new Imagick();
+            $image->newImage($width, $height, new ImagickPixel('#2878c8'));
+            $image->setImageFormat('tiff');
+            $image->writeImage($path);
+            $image->clear();
+        } catch (ImagickException $exception) {
+            self::markTestSkipped('Imagick TIFF coder is unavailable: ' . $exception->getMessage());
+        }
+
+        return $path;
+    }
+
+    protected function createExifOrientedJpegFixture(int $width, int $height, int $orientation): string
+    {
+        $path = $this->temporaryPath('.jpg');
+        $image = imagecreatetruecolor($width, $height);
+        imagejpeg($image, $path, 90);
+        imagedestroy($image);
+
+        $jpeg = file_get_contents($path);
+        self::assertIsString($jpeg);
+        $tiffHeader = "MM\x00\x2A\x00\x00\x00\x08"
+            . "\x00\x01"
+            . "\x01\x12\x00\x03\x00\x00\x00\x01"
+            . pack('n', $orientation) . "\x00\x00"
+            . "\x00\x00\x00\x00";
+        $payload = "Exif\x00\x00" . $tiffHeader;
+        $segment = "\xFF\xE1" . pack('n', strlen($payload) + 2) . $payload;
+        file_put_contents($path, substr($jpeg, 0, 2) . $segment . substr($jpeg, 2));
+
+        return $path;
+    }
+
+    protected function createSvgFixture(int $width, int $height, string $extension = '.svg'): string
+    {
+        $path = $this->temporaryPath($extension);
+        file_put_contents($path, sprintf(
+            '<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d" viewBox="0 0 %d %d">'
+            . '<rect width="100%%" height="100%%" fill="#2878c8"/></svg>',
+            $width,
+            $height,
+            $width,
+            $height
+        ));
+
+        return $path;
+    }
+
+    protected function temporaryPath(string $extension, ?string $directory = null): string
+    {
+        $temporaryPath = tempnam($directory ?? sys_get_temp_dir(), 'pimcore-thumbnail-dimensions-');
+        self::assertNotFalse($temporaryPath);
+        $path = $temporaryPath . $extension;
+        rename($temporaryPath, $path);
+        $this->temporaryFiles[] = $path;
+
+        return $path;
+    }
+
+    protected function installAssetStorage(FilesystemOperator $assetStorage): void
+    {
+        $this->installStorages($assetStorage, null);
+    }
+
+    protected function installStorages(
+        ?FilesystemOperator $assetStorage,
+        ?FilesystemOperator $thumbnailStorage
+    ): void {
+        $this->assetStorage = $assetStorage;
+        $this->thumbnailStorage = $thumbnailStorage;
+        $this->installRuntimeServices();
+    }
+
+    protected function installImageAdapter(Adapter $adapter): void
+    {
+        $this->configuredImageAdapter = $adapter;
+        $this->installRuntimeServices();
+    }
+
+    private function installRuntimeServices(): void
+    {
+        $storages = [];
+        if ($this->assetStorage !== null) {
+            $storages['pimcore.asset.storage'] = $this->assetStorage;
+        }
+        if ($this->thumbnailStorage !== null) {
+            $storages['pimcore.thumbnail.storage'] = $this->thumbnailStorage;
+        }
+
+        $locator = $this->createStub(ContainerInterface::class);
+        $locator->method('get')
+            ->willReturnCallback(static function (string $id) use ($storages): FilesystemOperator {
+                if (!isset($storages[$id])) {
+                    throw new RuntimeException('Unexpected storage service: ' . $id);
+                }
+
+                return $storages[$id];
+            });
+        $storage = new Storage($locator);
+        $imageAdapter = $this->configuredImageAdapter;
+        $logger = new NullLogger();
+        $requestStack = new RequestStack();
+        $longRunningHelper = new LongRunningHelper($this->createStub(ConnectionRegistry::class));
+
+        $container = $this->createStub(\Symfony\Component\DependencyInjection\ContainerInterface::class);
+        $container->method('get')
+            ->willReturnCallback(static fn (string $id) => match ($id) {
+                Storage::class => $storage,
+                AdapterInterface::class => $imageAdapter,
+                LongRunningHelper::class => $longRunningHelper,
+                'monolog.logger.pimcore' => $logger,
+                'request_stack' => $requestStack,
+                default => null,
+            });
+        $kernel = $this->createStub(KernelInterface::class);
+        $kernel->method('getContainer')->willReturn($container);
+        PimcoreRuntime::setKernel($kernel);
+    }
+
+    protected function image(?int $width, ?int $height, string $filename = 'source.jpg'): Image
+    {
+        $asset = new Image();
+        $this->configureImage($asset, $width, $height, $filename);
+
+        return $asset;
+    }
+
+    protected function countingImage(
+        ?int $width,
+        ?int $height,
+        string $filename,
+        ?string $streamPath = null,
+        ?array $sourceDimensions = null
+    ): CountingImage {
+        $asset = new CountingImage($streamPath, $sourceDimensions);
+        $this->configureImage($asset, $width, $height, $filename);
+
+        return $asset;
+    }
+
+    protected function configureImage(Image $asset, ?int $width, ?int $height, string $filename): void
+    {
+        $asset->setFilename($filename);
+
+        $customSettings = [];
+        if ($width !== null) {
+            $customSettings['imageWidth'] = $width;
+        }
+        if ($height !== null) {
+            $customSettings['imageHeight'] = $height;
+        }
+        $asset->setCustomSettings($customSettings);
+    }
+
+    /**
+     * @param list<array{method: string, arguments: array<string, mixed>}> $items
+     */
+    protected function config(array $items, ?float $highResolution = null): Config
+    {
+        $config = new Config();
+        $config->setName('dimension-probe');
+        $config->setItems($items);
+        $config->setHighResolution($highResolution);
+
+        return $config;
+    }
+
+    /**
+     * @param array{width?: int, height?: int} $fileDimensions
+     */
+    protected function probe(Image $asset, Config $config, array $fileDimensions = ['width' => 901, 'height' => 701]): ImageThumbnailTraitProbe
+    {
+        return new ImageThumbnailTraitProbe($asset, $config, $fileDimensions);
+    }
+
+    protected function setStatusCacheEnabled(bool $enabled): void
+    {
+        $assetsConfig = PimcoreConfig::getSystemConfiguration('assets');
+        $assetsConfig['image']['thumbnails']['status_cache'] = $enabled;
+        PimcoreConfig::setSystemConfiguration($assetsConfig, 'assets');
+    }
+}
+
+final class ImageThumbnailTraitProbe
+{
+    use ImageThumbnailTrait;
+
+    public int $existsCalls = 0;
+
+    public int $readDimensionsCalls = 0;
+
+    /**
+     * @param array{width?: int, height?: int} $fileDimensions
+     */
+    public function __construct(Asset $asset, Config $config, private readonly array $fileDimensions)
+    {
+        $this->asset = $asset;
+        $this->config = $config;
+    }
+
+    public function getFilename(): string
+    {
+        return 'dimension-probe.jpg';
+    }
+
+    public function getPath(array $args = []): string
+    {
+        return 'dimension-probe.jpg';
+    }
+
+    public function generate(bool $deferredAllowed = true): void
+    {
+    }
+
+    public function exists(): bool
+    {
+        ++$this->existsCalls;
+
+        return true;
+    }
+
+    /**
+     * @return array{width?: int, height?: int}
+     */
+    public function readDimensionsFromFile(): array
+    {
+        ++$this->readDimensionsCalls;
+
+        return $this->fileDimensions;
+    }
+}
+
+final class RealAssetImageThumbnailTraitProbe
+{
+    use ImageThumbnailTrait;
+
+    public int $generationCalls = 0;
+
+    public function __construct(Asset $asset, Config $config)
+    {
+        $this->asset = $asset;
+        $this->config = $config;
+    }
+
+    public function generate(bool $deferredAllowed = true): void
+    {
+        ++$this->generationCalls;
+        $this->pathReference = [
+            'src' => $this->asset->getRealFullPath(),
+            'type' => 'asset',
+        ];
+    }
+
+    public function getPath(array $args = []): string
+    {
+        return $this->asset->getRealFullPath();
+    }
+}
+
+final class RealThumbnailImageThumbnailTraitProbe
+{
+    use ImageThumbnailTrait;
+
+    public int $generationCalls = 0;
+
+    public function __construct(Asset $asset, Config $config, private readonly string $storagePath)
+    {
+        $this->asset = $asset;
+        $this->config = $config;
+    }
+
+    public function generate(bool $deferredAllowed = true): void
+    {
+        ++$this->generationCalls;
+        $this->pathReference = [
+            'src' => $this->storagePath,
+            'type' => 'thumbnail',
+            'storagePath' => $this->storagePath,
+        ];
+    }
+
+    public function getPath(array $args = []): string
+    {
+        return $this->storagePath;
+    }
+}
+
+final class CountingImage extends Image
+{
+    public int $streamCalls = 0;
+
+    public int $dimensionsFromFileCalls = 0;
+
+    /**
+     * @param array{width: int, height: int}|null $sourceDimensions
+     */
+    public function __construct(
+        private readonly ?string $streamPath = null,
+        private readonly ?array $sourceDimensions = null
+    ) {
+    }
+
+    /**
+     * @return resource|null
+     */
+    public function getStream()
+    {
+        ++$this->streamCalls;
+
+        if ($this->streamPath === null) {
+            return null;
+        }
+
+        $stream = fopen($this->streamPath, 'rb');
+
+        return $stream === false ? null : $stream;
+    }
+
+    public function getDimensionsFromFile(string $path): ?array
+    {
+        ++$this->dimensionsFromFileCalls;
+
+        return $this->sourceDimensions ?? parent::getDimensionsFromFile($path);
+    }
+}

--- a/tests/Unit/Models/Asset/Thumbnail/ImageThumbnailTraitTest.php
+++ b/tests/Unit/Models/Asset/Thumbnail/ImageThumbnailTraitTest.php
@@ -1,0 +1,775 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Models\Asset\Thumbnail;
+
+use Doctrine\Persistence\ConnectionRegistry;
+use League\Flysystem\FilesystemOperator;
+use Pimcore as PimcoreRuntime;
+use Pimcore\Helper\LongRunningHelper;
+use Pimcore\Http\RequestHelper;
+use Pimcore\Image\Adapter\GD;
+use Pimcore\Image\Adapter\Imagick as ImagickAdapter;
+use Pimcore\Image\AdapterInterface;
+use Pimcore\Model\Asset;
+use Pimcore\Model\Asset\Image\Thumbnail\Processor;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Routing\RequestContext;
+
+/**
+ * Regression coverage for dimension estimation before thumbnail file access.
+ *
+ * The probe deliberately reports that a thumbnail exists.
+ * Reliable estimates must therefore avoid both exists() and readDimensionsFromFile(), while configurations that cannot be reproduced exactly must use the file fallback exactly once.
+ */
+class ImageThumbnailTraitTest extends ImageThumbnailDimensionTestCase
+{
+    public function testStatusCacheHitSkipsEstimationAndFileAccess(): void
+    {
+        $this->setStatusCacheEnabled(true);
+
+        // Deliberately omit stored source dimensions and use an unknown operation.
+        // If the status-cache result did not win, estimation/file access would be required.
+        $asset = $this->image(null, null);
+        $dao = $this->createMock(Asset\Dao::class);
+        $dao->expects(self::once())
+            ->method('getCachedThumbnail')
+            ->with('dimension-probe', 'dimension-probe.jpg')
+            ->willReturn(['width' => 640, 'height' => 480]);
+        $asset->setDao($dao);
+
+        $thumbnail = $this->probe(
+            $asset,
+            $this->config([
+                ['method' => 'projectSpecificTransformation', 'arguments' => []],
+            ])
+        );
+
+        self::assertSame(['width' => 640, 'height' => 480], $thumbnail->getDimensions());
+        self::assertSame(0, $thumbnail->existsCalls);
+        self::assertSame(0, $thumbnail->readDimensionsCalls);
+    }
+
+    public function testUnreliableTransformationsFallBackToFileExactlyOnce(): void
+    {
+        $cases = [
+            'rotate' => [
+                $this->image(400, 300),
+                [['method' => 'rotate', 'arguments' => ['angle' => 45]]],
+            ],
+            'trim' => [
+                $this->image(400, 300),
+                [['method' => 'trim', 'arguments' => ['tolerance' => 10]]],
+            ],
+            'unknown/custom operation' => [
+                $this->image(400, 300),
+                [['method' => 'projectSpecificTransformation', 'arguments' => []]],
+            ],
+            'malformed operation' => [
+                $this->image(400, 300),
+                [['method' => 'scaleByWidth', 'arguments' => []]],
+            ],
+            'fractional pixel argument' => [
+                $this->image(400, 300),
+                [['method' => 'scaleByWidth', 'arguments' => ['width' => 200.5]]],
+            ],
+            'non-boolean force resize' => [
+                $this->image(400, 300),
+                [['method' => 'scaleByWidth', 'arguments' => ['width' => 200, 'forceResize' => 1]]],
+            ],
+            'background color without color' => [
+                $this->image(400, 300),
+                [['method' => 'setBackgroundColor', 'arguments' => []]],
+            ],
+            'overlay without path' => [
+                $this->image(400, 300),
+                [['method' => 'addOverlay', 'arguments' => ['x' => 10, 'y' => 20]]],
+            ],
+            'mirror without mode' => [
+                $this->image(400, 300),
+                [['method' => 'mirror', 'arguments' => []]],
+            ],
+            'invalid cover positioning' => [
+                $this->image(400, 300),
+                [['method' => 'cover', 'arguments' => ['width' => 200, 'height' => 200, 'positioning' => 'invalid']]],
+            ],
+            'out-of-bounds percentage crop' => [
+                $this->image(400, 300),
+                [['method' => 'cropPercent', 'arguments' => ['width' => 60, 'height' => 50, 'x' => 50, 'y' => 0]]],
+            ],
+            'incomplete source dimensions' => [
+                $this->image(400, null),
+                [['method' => 'scaleByWidth', 'arguments' => ['width' => 200]]],
+            ],
+            'percentage crop on vector graphic' => [
+                $this->image(400, 300, 'source.svg'),
+                [['method' => 'cropPercent', 'arguments' => ['width' => 50, 'height' => 50, 'x' => 0, 'y' => 0]]],
+            ],
+        ];
+
+        foreach ($cases as $name => [$asset, $items]) {
+            $thumbnail = $this->probe($asset, $this->config($items), ['width' => 73, 'height' => 41]);
+
+            self::assertSame(['width' => 73, 'height' => 41], $thumbnail->getDimensions(), $name);
+            self::assertSame(1, $thumbnail->readDimensionsCalls, $name);
+        }
+    }
+
+    public function testFailedFileFallbackIsAttemptedOnlyOncePerDirectDimensionRead(): void
+    {
+        $thumbnail = $this->probe(
+            $this->image(400, 300),
+            $this->config([
+                ['method' => 'projectSpecificTransformation', 'arguments' => []],
+            ]),
+            []
+        );
+
+        self::assertSame(['width' => null, 'height' => null], $thumbnail->getDimensions());
+        self::assertSame(1, $thumbnail->readDimensionsCalls);
+    }
+
+    public function testAssetPathFallbackExtractsDimensionsWithoutPersistingOrRepeatingTheRead(): void
+    {
+        $source = $this->createRasterFixture(400, 300);
+        $assetStorage = $this->createMock(FilesystemOperator::class);
+        $assetStorage->expects(self::once())
+            ->method('readStream')
+            ->with('source.png')
+            ->willReturnCallback(static function () use ($source) {
+                $stream = fopen($source, 'rb');
+                self::assertIsResource($stream);
+
+                return $stream;
+            });
+        $assetStorage->expects(self::never())->method('fileExists');
+        $this->installAssetStorage($assetStorage);
+
+        $asset = $this->image(null, null, 'source.png');
+        $config = $this->config([
+            ['method' => 'resize', 'arguments' => ['width' => 200, 'height' => 100]],
+        ]);
+        $config->setFormat('ORIGINAL');
+        $thumbnail = new RealAssetImageThumbnailTraitProbe($asset, $config);
+
+        self::assertSame(400, $thumbnail->getWidth());
+        self::assertSame(300, $thumbnail->getHeight());
+        self::assertSame(400, $thumbnail->getRealWidth());
+        self::assertSame(300, $thumbnail->getRealHeight());
+        self::assertSame(1, $thumbnail->generationCalls);
+        self::assertNull($asset->getCustomSetting('imageWidth'));
+        self::assertNull($asset->getCustomSetting('imageHeight'));
+    }
+
+    public function testMissingPassThroughSourceDimensionsRetainPersistedLogicalOutput(): void
+    {
+        $source = $this->createRasterFixture(400, 300);
+        $cases = [
+            'SVG scale by width' => [
+                'source.svg',
+                [['method' => 'scaleByWidth', 'arguments' => ['width' => 202]]],
+            ],
+            'SVG scale by height' => [
+                'source.svg',
+                [['method' => 'scaleByHeight', 'arguments' => ['height' => 151]]],
+            ],
+            'SVG resize' => [
+                'source.svg',
+                [['method' => 'resize', 'arguments' => ['width' => 200, 'height' => 100]]],
+            ],
+            'SVG percentage crop' => [
+                'source.svg',
+                [['method' => 'cropPercent', 'arguments' => ['width' => 50, 'height' => 50, 'x' => 0, 'y' => 0]]],
+            ],
+            'SVG absolute crop outside source canvas' => [
+                'source.svg',
+                [['method' => 'crop', 'arguments' => ['x' => 390, 'y' => 290, 'width' => 200, 'height' => 100]]],
+            ],
+            'SVG scale and background crop' => [
+                'source.svg',
+                [
+                    ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+                    [
+                        'method' => 'setBackgroundImage',
+                        'arguments' => ['path' => 'background.png', 'mode' => 'cropTopLeft'],
+                    ],
+                ],
+            ],
+            'SVG scale and project operation' => [
+                'source.svg',
+                [
+                    ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+                    ['method' => 'projectSpecificTransformation', 'arguments' => []],
+                ],
+            ],
+            'SVG scale and malformed visual operation' => [
+                'source.svg',
+                [
+                    ['method' => 'scaleByWidth', 'arguments' => ['width' => 202]],
+                    ['method' => 'setBackgroundColor', 'arguments' => []],
+                ],
+            ],
+            'TIFF original marker' => [
+                'source.tiff',
+                [['method' => 'tifforiginal', 'arguments' => []]],
+            ],
+            'TIFF original marker and percentage crop' => [
+                'source.tiff',
+                [
+                    ['method' => 'tifforiginal', 'arguments' => []],
+                    ['method' => 'cropPercent', 'arguments' => ['width' => 50, 'height' => 50, 'x' => 0, 'y' => 0]],
+                ],
+            ],
+            'TIFF original marker and scale' => [
+                'source.tiff',
+                [
+                    ['method' => 'tifforiginal', 'arguments' => []],
+                    ['method' => 'scaleByWidth', 'arguments' => ['width' => 202]],
+                ],
+            ],
+            'TIFF original marker and cover upscale' => [
+                'source.tiff',
+                [
+                    ['method' => 'tifforiginal', 'arguments' => []],
+                    ['method' => 'cover', 'arguments' => ['width' => 800, 'height' => 600]],
+                ],
+            ],
+        ];
+
+        foreach ($cases as $name => [$filename, $items]) {
+            foreach ([null, 1.5, 2.0] as $highResolution) {
+                $config = $this->config($items, $highResolution);
+                $config->setFormat('PRINT');
+
+                $persistedThumbnail = $this->probe($this->image(400, 300, $filename), $config);
+                $expectedDisplay = $persistedThumbnail->getDimensions();
+                $expectedReal = [
+                    'width' => $persistedThumbnail->getRealWidth(),
+                    'height' => $persistedThumbnail->getRealHeight(),
+                ];
+
+                $missingAsset = $this->countingImage(
+                    null,
+                    null,
+                    $filename,
+                    $source,
+                    ['width' => 400, 'height' => 300]
+                );
+                self::assertTrue(Processor::usesOriginalAssetOutput($missingAsset, $config), $name);
+                self::assertSame(
+                    $expectedReal,
+                    $config->getEstimatedDimensionsForSource($missingAsset, 400, 300),
+                    $name
+                );
+                $missingThumbnail = new RealAssetImageThumbnailTraitProbe($missingAsset, $config);
+
+                self::assertSame($expectedDisplay, $missingThumbnail->getDimensions(), $name);
+                self::assertSame($expectedReal['width'], $missingThumbnail->getRealWidth(), $name);
+                self::assertSame($expectedReal['height'], $missingThumbnail->getRealHeight(), $name);
+                self::assertSame(1, $missingAsset->streamCalls, $name);
+                self::assertSame(1, $missingAsset->dimensionsFromFileCalls, $name);
+                self::assertNull($missingAsset->getCustomSetting('imageWidth'), $name);
+                self::assertNull($missingAsset->getCustomSetting('imageHeight'), $name);
+            }
+        }
+    }
+
+    public function testPassThroughMimeConflictsFollowProcessorFilenameRouting(): void
+    {
+        $source = $this->createRasterFixture(400, 300);
+        $cases = [
+            'SVG filename with raster MIME' => [
+                'source.svg',
+                'image/png',
+                100,
+                100,
+                [['method' => 'scaleByWidth', 'arguments' => ['width' => 200]]],
+                ['width' => 200, 'height' => 200],
+            ],
+            'TIFF filename with vector MIME' => [
+                'source.tiff',
+                'image/svg+xml',
+                400,
+                300,
+                [
+                    ['method' => 'tifforiginal', 'arguments' => []],
+                    ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+                ],
+                ['width' => 200, 'height' => 150],
+            ],
+        ];
+
+        foreach ($cases as $name => [$filename, $mimeType, $sourceWidth, $sourceHeight, $items, $expected]) {
+            $config = $this->config($items);
+            $config->setFormat('PRINT');
+
+            $persistedAsset = $this->countingImage($sourceWidth, $sourceHeight, $filename, $source);
+            $persistedAsset->setMimeType($mimeType);
+            $persistedThumbnail = new RealAssetImageThumbnailTraitProbe($persistedAsset, $config);
+
+            self::assertSame($expected, $persistedThumbnail->getDimensions(), $name);
+            self::assertSame(0, $persistedAsset->streamCalls, $name);
+            self::assertSame(0, $persistedAsset->dimensionsFromFileCalls, $name);
+
+            $missingAsset = $this->countingImage(
+                null,
+                null,
+                $filename,
+                $source,
+                ['width' => $sourceWidth, 'height' => $sourceHeight]
+            );
+            $missingAsset->setMimeType($mimeType);
+            $missingThumbnail = new RealAssetImageThumbnailTraitProbe($missingAsset, $config);
+
+            self::assertSame($expected, $missingThumbnail->getDimensions(), $name);
+            self::assertSame(1, $missingAsset->streamCalls, $name);
+            self::assertSame(1, $missingAsset->dimensionsFromFileCalls, $name);
+            self::assertNull($missingAsset->getCustomSetting('imageWidth'), $name);
+            self::assertNull($missingAsset->getCustomSetting('imageHeight'), $name);
+        }
+    }
+
+    public function testOriginalThumbnailStorageFallbackUsesPhysicalBytesWithoutAssetRead(): void
+    {
+        $source = $this->createRasterFixture(400, 300);
+        $storagePath = 'asset/1/image-thumb__1__dimension-probe/source.png';
+        $assetStorage = $this->createMock(FilesystemOperator::class);
+        $assetStorage->expects(self::never())->method('readStream');
+        $assetStorage->expects(self::never())->method('fileExists');
+        $thumbnailStorage = $this->createMock(FilesystemOperator::class);
+        $thumbnailStorage->expects(self::once())
+            ->method('readStream')
+            ->with($storagePath)
+            ->willReturnCallback(static function () use ($source) {
+                $stream = fopen($source, 'rb');
+                self::assertIsResource($stream);
+
+                return $stream;
+            });
+        $thumbnailStorage->expects(self::never())->method('fileExists');
+        $this->installStorages($assetStorage, $thumbnailStorage);
+
+        $asset = $this->image(null, null, 'source.png');
+        $dao = $this->createMock(Asset\Dao::class);
+        $dao->expects(self::once())
+            ->method('addToThumbnailCache')
+            ->with('dimension-probe', 'source.png', filesize($source), 400, 300);
+        $dao->expects(self::once())
+            ->method('getCachedThumbnail')
+            ->with('dimension-probe', 'source.png')
+            ->willReturn(['width' => 400, 'height' => 300]);
+        $asset->setDao($dao);
+
+        $config = $this->config([
+            ['method' => 'resize', 'arguments' => ['width' => 200, 'height' => 100]],
+        ]);
+        $config->setFormat('ORIGINAL');
+        $thumbnail = new RealThumbnailImageThumbnailTraitProbe($asset, $config, $storagePath);
+
+        self::assertSame(400, $thumbnail->getWidth());
+        self::assertSame(300, $thumbnail->getHeight());
+        self::assertSame(400, $thumbnail->getRealWidth());
+        self::assertSame(300, $thumbnail->getRealHeight());
+        self::assertSame(1, $thumbnail->generationCalls);
+        self::assertNull($asset->getCustomSetting('imageWidth'));
+        self::assertNull($asset->getCustomSetting('imageHeight'));
+    }
+
+    public function testOriginalThumbnailCacheUsesPhysicalDimensionsWhileAssetFallbackRemainsExifAware(): void
+    {
+        $source = $this->createExifOrientedJpegFixture(400, 300, 6);
+        $physicalSize = getimagesize($source);
+        self::assertIsArray($physicalSize);
+        self::assertSame([400, 300], array_slice($physicalSize, 0, 2));
+        self::assertSame(6, exif_read_data($source)['Orientation'] ?? null);
+
+        $storagePath = 'asset/1/image-thumb__1__dimension-probe/oriented.jpg';
+        $assetStorage = $this->createMock(FilesystemOperator::class);
+        $assetStorage->expects(self::never())->method('readStream');
+        $thumbnailStorage = $this->createMock(FilesystemOperator::class);
+        $thumbnailStorage->expects(self::once())
+            ->method('readStream')
+            ->with($storagePath)
+            ->willReturnCallback(static function () use ($source) {
+                $stream = fopen($source, 'rb');
+                self::assertIsResource($stream);
+
+                return $stream;
+            });
+        $this->installStorages($assetStorage, $thumbnailStorage);
+
+        $asset = $this->image(300, 400, 'oriented.jpg');
+        self::assertSame(['width' => 300, 'height' => 400], $asset->getDimensionsFromFile($source));
+        $dao = $this->createMock(Asset\Dao::class);
+        $dao->expects(self::once())
+            ->method('addToThumbnailCache')
+            ->with('dimension-probe', 'oriented.jpg', filesize($source), 400, 300);
+        $dao->expects(self::once())
+            ->method('getCachedThumbnail')
+            ->willReturn(['width' => 400, 'height' => 300]);
+        $asset->setDao($dao);
+
+        $config = $this->config([]);
+        $config->setFormat('ORIGINAL');
+        $thumbnail = new RealThumbnailImageThumbnailTraitProbe($asset, $config, $storagePath);
+
+        self::assertSame(['width' => 400, 'height' => 300], $thumbnail->getDimensions());
+        self::assertSame(400, $thumbnail->getRealWidth());
+        self::assertSame(300, $thumbnail->getRealHeight());
+    }
+
+    public function testGeneratedExifThumbnailCacheDoesNotApplyOrientationTwice(): void
+    {
+        $this->requireImagickExtension();
+
+        $source = $this->createExifOrientedJpegFixture(400, 300, 6);
+        $this->requireImagickFixtureSupport($source);
+
+        foreach ([true, false] as $preserveMetaData) {
+            $adapter = new ImagickAdapter();
+            $adapter->setPreserveMetaData($preserveMetaData);
+            self::assertNotFalse($adapter->load($source, ['preserveColor' => true]));
+
+            $asset = $this->image(300, 400, 'oriented.jpg');
+            // Processor prepends this exact transformation for EXIF orientation 6.
+            $config = $this->config([
+                ['method' => 'rotate', 'arguments' => ['angle' => 90]],
+            ]);
+            $config->setPreserveMetaData($preserveMetaData);
+            Processor::applyTransformations($adapter, $asset, $config, $config->getItems());
+
+            $generatedThumbnail = $this->temporaryPath('.jpg');
+            $adapter->save($generatedThumbnail, 'jpeg');
+            $physicalSize = getimagesize($generatedThumbnail);
+            self::assertIsArray($physicalSize);
+            self::assertSame([300, 400], array_slice($physicalSize, 0, 2));
+
+            $generatedExif = @exif_read_data($generatedThumbnail);
+            $generatedOrientation = is_array($generatedExif) ? ($generatedExif['Orientation'] ?? null) : null;
+            if ($preserveMetaData) {
+                self::assertSame(6, $generatedOrientation);
+            } else {
+                self::assertNotSame(6, $generatedOrientation);
+            }
+
+            $dao = $this->createMock(Asset\Dao::class);
+            $dao->expects(self::once())
+                ->method('addToThumbnailCache')
+                ->with(
+                    'dimension-probe',
+                    'generated.jpg',
+                    filesize($generatedThumbnail),
+                    300,
+                    400
+                );
+            $asset->setDao($dao);
+            $asset->addThumbnailFileToCache($generatedThumbnail, 'generated.jpg', $config);
+        }
+    }
+
+    public function testReliableEstimateUsesRealTraitWithoutGenerationOrAssetStreamAccess(): void
+    {
+        $assetStorage = $this->createMock(FilesystemOperator::class);
+        $assetStorage->expects(self::never())->method('readStream');
+        $assetStorage->expects(self::never())->method('fileExists');
+        $this->installAssetStorage($assetStorage);
+
+        $asset = $this->image(400, 300, 'source.png');
+        $config = $this->config([
+            ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+        ]);
+        $thumbnail = new RealAssetImageThumbnailTraitProbe($asset, $config);
+
+        self::assertSame(['width' => 200, 'height' => 150], $thumbnail->getDimensions());
+        self::assertSame(0, $thumbnail->generationCalls);
+    }
+
+    public function testIntegralNumericStringArgumentsRetainZeroIoEstimation(): void
+    {
+        $assetStorage = $this->createMock(FilesystemOperator::class);
+        $assetStorage->expects(self::never())->method('readStream');
+        $assetStorage->expects(self::never())->method('fileExists');
+        $this->installAssetStorage($assetStorage);
+
+        $cases = [
+            'scale by width' => [
+                [['method' => 'scaleByWidth', 'arguments' => ['width' => '200']]],
+                ['width' => 200, 'height' => 150],
+            ],
+            'resize' => [
+                [['method' => 'resize', 'arguments' => ['width' => '200', 'height' => '100']]],
+                ['width' => 200, 'height' => 100],
+            ],
+            'percentage crop' => [
+                [[
+                    'method' => 'cropPercent',
+                    'arguments' => ['width' => '50', 'height' => '50', 'x' => '0', 'y' => '0'],
+                ]],
+                ['width' => 200, 'height' => 150],
+            ],
+        ];
+
+        foreach ($cases as $name => [$items, $expected]) {
+            $config = $this->config($items);
+            $thumbnail = new RealAssetImageThumbnailTraitProbe(
+                $this->image(400, 300, 'source.png'),
+                $config
+            );
+
+            self::assertSame($expected, $thumbnail->getDimensions(), $name);
+            self::assertSame(0, $thumbnail->generationCalls, $name);
+            self::assertSame($items, $config->getItems(), $name . ' config mutation');
+        }
+    }
+
+    public function testInvalidNumericStringArgumentsFailClosed(): void
+    {
+        foreach ([
+            'fractional numeric string' => '200.5',
+            'out-of-range numeric string' => '9223372036854775808',
+            'non-numeric string' => 'not-a-number',
+        ] as $name => $width) {
+            $thumbnail = $this->probe(
+                $this->image(400, 300, 'source.png'),
+                $this->config([
+                    ['method' => 'scaleByWidth', 'arguments' => ['width' => $width]],
+                ]),
+                ['width' => 91, 'height' => 73]
+            );
+
+            self::assertSame(['width' => 91, 'height' => 73], $thumbnail->getDimensions(), $name);
+            self::assertSame(1, $thumbnail->readDimensionsCalls, $name);
+        }
+    }
+
+    public function testFailedAssetExtractionReadsAtMostOncePerDimensionsInvocation(): void
+    {
+        $source = $this->temporaryPath('.invalid');
+        file_put_contents($source, 'not an image');
+        $asset = $this->countingImage(null, null, 'source.invalid', $source);
+        $config = $this->config([]);
+        $config->setFormat('ORIGINAL');
+        $thumbnail = new RealAssetImageThumbnailTraitProbe($asset, $config);
+
+        $adapterCalls = 0;
+        $longRunningHelper = new LongRunningHelper($this->createStub(ConnectionRegistry::class));
+        $container = $this->createStub(\Symfony\Component\DependencyInjection\ContainerInterface::class);
+        $container->method('get')
+            ->willReturnCallback(static function (string $id) use (&$adapterCalls, $longRunningHelper): mixed {
+                if ($id === AdapterInterface::class) {
+                    ++$adapterCalls;
+
+                    return new GD();
+                }
+
+                return $id === LongRunningHelper::class ? $longRunningHelper : null;
+            });
+        $kernel = $this->createStub(KernelInterface::class);
+        $kernel->method('getContainer')->willReturn($container);
+        PimcoreRuntime::setKernel($kernel);
+
+        self::assertSame(['width' => null, 'height' => null], $thumbnail->getDimensions());
+        self::assertSame(1, $asset->streamCalls);
+
+        self::assertSame(['width' => null, 'height' => null], $thumbnail->getDimensions());
+        self::assertSame(2, $asset->streamCalls);
+        self::assertSame(2, $adapterCalls);
+    }
+
+    public function testPrintTiffOriginalUsesSourceDimensionsWithoutAssetRead(): void
+    {
+        foreach ([null, 2.0] as $highResolution) {
+            $asset = $this->countingImage(400, 300, 'source.tiff');
+            $config = $this->config([
+                ['method' => 'tifforiginal', 'arguments' => []],
+            ], $highResolution);
+            $config->setFormat('PRINT');
+            $thumbnail = new RealAssetImageThumbnailTraitProbe($asset, $config);
+
+            self::assertSame(['width' => 400, 'height' => 300], $thumbnail->getDimensions());
+            self::assertSame($highResolution === null ? 400 : 800, $thumbnail->getRealWidth());
+            self::assertSame($highResolution === null ? 300 : 600, $thumbnail->getRealHeight());
+            self::assertSame(0, $thumbnail->generationCalls);
+            self::assertSame(0, $asset->streamCalls);
+        }
+    }
+
+    public function testPrintTiffOriginalAppliesLogicalScalingWithCompatibleHighResolutionDimensions(): void
+    {
+        foreach ([null, 2.0] as $highResolution) {
+            $asset = $this->countingImage(400, 300, 'source.tiff');
+            $config = $this->config([
+                ['method' => 'tifforiginal', 'arguments' => []],
+                ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+            ], $highResolution);
+            $config->setFormat('PRINT');
+            $thumbnail = new RealAssetImageThumbnailTraitProbe($asset, $config);
+
+            self::assertSame(['width' => 200, 'height' => 150], $thumbnail->getDimensions());
+            self::assertSame($highResolution === null ? 200 : 400, $thumbnail->getRealWidth());
+            self::assertSame($highResolution === null ? 150 : 300, $thumbnail->getRealHeight());
+            self::assertSame(0, $thumbnail->generationCalls);
+            self::assertSame(0, $asset->streamCalls);
+        }
+    }
+
+    public function testProcessorOwnsOriginalAssetOutputRouting(): void
+    {
+        $printConfig = $this->config([
+            ['method' => 'tifforiginal', 'arguments' => []],
+        ]);
+        $printConfig->setFormat('PRINT');
+
+        self::assertTrue(Processor::usesOriginalAssetOutput($this->image(400, 300, 'source.tif'), $printConfig));
+        self::assertTrue(Processor::usesOriginalAssetOutput($this->image(400, 300, 'source.tiff'), $printConfig));
+        self::assertTrue(Processor::usesOriginalAssetOutput($this->image(400, 300, 'source.svg'), $printConfig));
+        self::assertFalse(Processor::usesOriginalAssetOutput($this->image(400, 300, 'source.TIFF'), $printConfig));
+        self::assertFalse(Processor::usesOriginalAssetOutput($this->image(400, 300, 'source.SVG'), $printConfig));
+        self::assertFalse(Processor::usesOriginalAssetOutput($this->image(400, 300, 'source.png'), $printConfig));
+
+        $printConfig->setFormat('ORIGINAL');
+        self::assertFalse(Processor::usesOriginalAssetOutput($this->image(400, 300, 'source.tiff'), $printConfig));
+    }
+
+    public function testAdminPrintTiffDoesNotUseOriginalAssetOutput(): void
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(new Request(['pimcore_admin' => '1']));
+        $requestHelper = new RequestHelper($requestStack, new RequestContext());
+        $container = $this->createStub(\Symfony\Component\DependencyInjection\ContainerInterface::class);
+        $container->method('get')
+            ->willReturnCallback(static fn (string $id) => match ($id) {
+                RequestHelper::class => $requestHelper,
+                'request_stack' => $requestStack,
+                default => null,
+            });
+        $kernel = $this->createStub(KernelInterface::class);
+        $kernel->method('getContainer')->willReturn($container);
+        PimcoreRuntime::setKernel($kernel);
+
+        $config = $this->config([
+            ['method' => 'tifforiginal', 'arguments' => []],
+        ]);
+        $config->setFormat('PRINT');
+
+        self::assertFalse(Processor::usesOriginalAssetOutput($this->image(400, 300, 'source.tiff'), $config));
+    }
+
+    public function testPrintTiffOriginalWithoutStoredDimensionsUsesRealAssetFallback(): void
+    {
+        $source = $this->createTiffFixture(400, 300);
+        $assetStorage = $this->createMock(FilesystemOperator::class);
+        $assetStorage->expects(self::once())
+            ->method('readStream')
+            ->with('source.tiff')
+            ->willReturnCallback(static function () use ($source) {
+                $stream = fopen($source, 'rb');
+                self::assertIsResource($stream);
+
+                return $stream;
+            });
+        $this->installAssetStorage($assetStorage);
+
+        $asset = $this->image(null, null, 'source.tiff');
+        $config = $this->config([
+            ['method' => 'tifforiginal', 'arguments' => []],
+        ], 2.0);
+        $config->setFormat('PRINT');
+        $thumbnail = new RealAssetImageThumbnailTraitProbe($asset, $config);
+
+        self::assertSame(['width' => 400, 'height' => 300], $thumbnail->getDimensions());
+        self::assertSame(800, $thumbnail->getRealWidth());
+        self::assertSame(600, $thumbnail->getRealHeight());
+        self::assertSame(1, $thumbnail->generationCalls);
+        self::assertNull($asset->getCustomSetting('imageWidth'));
+        self::assertNull($asset->getCustomSetting('imageHeight'));
+    }
+
+    public function testSourceSvgWithoutStoredDimensionsReadsSourceOnceWithoutGeneration(): void
+    {
+        $source = $this->createRasterFixture(400, 300);
+        $asset = $this->countingImage(
+            null,
+            null,
+            'source.svg',
+            $source,
+            ['width' => 400, 'height' => 300]
+        );
+        $config = $this->config([
+            ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+        ]);
+        $config->setFormat('SOURCE');
+        $thumbnail = new RealAssetImageThumbnailTraitProbe($asset, $config);
+
+        self::assertSame(['width' => 200, 'height' => 150], $thumbnail->getDimensions());
+        self::assertSame(0, $thumbnail->generationCalls);
+        self::assertSame(1, $asset->streamCalls);
+        self::assertSame(1, $asset->dimensionsFromFileCalls);
+        self::assertNull($asset->getCustomSetting('imageWidth'));
+        self::assertNull($asset->getCustomSetting('imageHeight'));
+    }
+
+    public function testPrintSvgWithoutStoredDimensionsPreservesExtensionForRealAssetFallback(): void
+    {
+        $this->requireImagickExtension();
+
+        $source = $this->createSvgFixture(192, 336);
+        $this->requireImagickFixtureSupport($source);
+        $this->installImageAdapter(new ImagickAdapter());
+
+        $assetStorage = $this->createMock(FilesystemOperator::class);
+        $assetStorage->expects(self::once())
+            ->method('readStream')
+            ->with('source.svg')
+            ->willReturnCallback(static function () use ($source) {
+                $sourceStream = fopen($source, 'rb');
+                self::assertIsResource($sourceStream);
+                // Flysystem can return a tmpfile()-backed stream whose URI is extensionless and disappears as soon as the stream is closed.
+                $stream = tmpfile();
+                self::assertIsResource($stream);
+                stream_copy_to_stream($sourceStream, $stream);
+                fclose($sourceStream);
+
+                return $stream;
+            });
+        $this->installAssetStorage($assetStorage);
+
+        $asset = $this->image(null, null, 'source.svg');
+        $config = $this->config([
+            ['method' => 'scaleByWidth', 'arguments' => ['width' => 100]],
+        ]);
+        $config->setFormat('PRINT');
+        $thumbnail = new RealAssetImageThumbnailTraitProbe($asset, $config);
+
+        self::assertSame(['width' => 100, 'height' => 175], $thumbnail->getDimensions());
+        self::assertSame(0, $thumbnail->generationCalls);
+        self::assertNull($asset->getCustomSetting('imageWidth'));
+        self::assertNull($asset->getCustomSetting('imageHeight'));
+    }
+
+    public function testTiffOriginalOutsideProcessorOriginalAssetBranchFallsBack(): void
+    {
+        $asset = $this->image(400, 300, 'source.tiff');
+        $config = $this->config([
+            ['method' => 'tifforiginal', 'arguments' => []],
+        ]);
+        $config->setFormat('PNG');
+        $thumbnail = $this->probe($asset, $config, ['width' => 91, 'height' => 73]);
+
+        self::assertSame(['width' => 91, 'height' => 73], $thumbnail->getDimensions());
+        self::assertSame(1, $thumbnail->readDimensionsCalls);
+    }
+}

--- a/tests/Unit/Models/Asset/Thumbnail/ImageThumbnailTraitTest.php
+++ b/tests/Unit/Models/Asset/Thumbnail/ImageThumbnailTraitTest.php
@@ -722,6 +722,37 @@ class ImageThumbnailTraitTest extends ImageThumbnailDimensionTestCase
         self::assertNull($asset->getCustomSetting('imageHeight'));
     }
 
+    public function testGetLocalFileReusesStableLocalStreamWithMatchingExtension(): void
+    {
+        $source = $this->createRasterFixture(400, 300);
+        $asset = $this->countingImage(400, 300, 'source.png', $source);
+        $thumbnail = new RealAssetImageThumbnailTraitProbe($asset, $this->config([]));
+
+        self::assertSame($source, $thumbnail->getLocalFile());
+        self::assertSame(1, $asset->streamCalls);
+        self::assertFileExists($source);
+    }
+
+    public function testGetLocalFileCopiesLocalStreamWhenSourceExtensionDiffers(): void
+    {
+        $source = $this->createRasterFixture(400, 300);
+        $asset = $this->countingImage(400, 300, 'source.svg', $source);
+        $config = $this->config([
+            ['method' => 'scaleByWidth', 'arguments' => ['width' => 200]],
+        ]);
+        $config->setFormat('SOURCE');
+        $thumbnail = new RealAssetImageThumbnailTraitProbe($asset, $config);
+
+        $localFile = $thumbnail->getLocalFile();
+
+        self::assertNotNull($localFile);
+        $this->temporaryFiles[] = $localFile;
+        self::assertNotSame($source, $localFile);
+        self::assertSame('svg', pathinfo($localFile, PATHINFO_EXTENSION));
+        self::assertSame(file_get_contents($source), file_get_contents($localFile));
+        self::assertSame(1, $asset->streamCalls);
+    }
+
     public function testPrintSvgWithoutStoredDimensionsPreservesExtensionForRealAssetFallback(): void
     {
         $this->requireImagickExtension();


### PR DESCRIPTION
Changes in this pull request
--- 
Resolves #349

Fixes pimcore/platform-version#349

Related to pimcore/pimcore#19057

`ImageThumbnailTrait::getDimensions()` currently checks the physical thumbnail or source file before trying `getEstimatedDimensions()`.

With remote Flysystem storage such as S3, Azure Blob Storage or GCS, rendering an image can therefore trigger a remote storage request only to determine its width and height, even when the source dimensions are already stored on the asset and the thumbnail dimensions can be calculated in memory.

### Reproduction

1.  Configure asset or thumbnail storage using a remote Flysystem adapter.
2.  Upload images so `imageWidth` and `imageHeight` are available in the asset custom settings.
3.  Render multiple images with a thumbnail configuration from Twig.
4.  Render the page without Pimcore output cache.
5.  Observe remote storage access from `getDimensions()`.

For example:

``` twig
{% for i in 1..10 %}
    {% set image = pimcore_image('image_' ~ i, {thumbnail: 'my_thumbnail_config'}) %}
    {{ image.thumbnail('my_thumbnail_config').html({imgAttributes: {class: 'img'}})|raw }}
{% endfor %}
```

Before this change, the effective lookup order is:

``` text
thumbnail status cache
physical file inspection
dimension estimation
```

This PR changes it to:

``` text
thumbnail status cache
reliable dimension estimation
physical file inspection as fallback
```

On the Azure Blob Storage environment from #19057, approximately 80 image references changed from 79 remote storage calls and 5,735 ms render time to 0 remote storage calls and 170 ms.

The physical file remains authoritative whenever the dimensions cannot be calculated reliably.

## Additional info

A simple reorder is not sufficient because the existing estimator cannot safely predict every possible GD, Imagick, vector, custom adapter and transformation result.

The implementation therefore uses a dimension-only adapter and the existing thumbnail transformation planning to calculate dimensions without image I/O only for cases that can be reproduced reliably.

Generated thumbnails are estimated only when the source dimensions are already persisted, the source is positively identified as raster, the configured adapter is Pimcore's core GD or Imagick adapter, and all involved transformations and arguments are supported.

Unsupported or uncertain cases continue to use physical file inspection. This includes generated vectors, unknown or conflicting source formats, custom adapters, adapter subclasses, unsupported transformations, malformed arguments, `rotate`, `trim` and `ORIGINAL`.

Existing source-output behavior for SVG and TIFF is preserved. Non-rasterized SVG output uses the original asset and its logical HTML dimensions without generating an unnecessary raster derivative.

If source dimensions are missing, the source is read once to determine them without persisting asset metadata or saving the asset.

Remote Flysystem streams that are extensionless or positioned at EOF are handled by rewinding and materializing them into a Pimcore temporary file with the original extension before inspection.

No thumbnail hashes, storage paths, database schema, Messenger routing, generation locks or public configuration are changed.

Validation performed locally:

``` text
PHP 8.4.22
PHPUnit 11.5.55

54 tests
922 assertions
0 failures
```

Application-level probes confirmed:

``` text
Persisted raster:
dimensions:               200x150
asset storage calls:      0
thumbnail storage calls:  0

Persisted source SVG:
dimensions:               200x150
asset storage calls:      0
thumbnail storage calls:  0

Source SVG without stored dimensions:
asset readStream calls:   1
thumbnail storage calls:  0
metadata writes:          0
```

Four parallel PHP processes returned identical dimensions with zero storage calls and unchanged configuration.
