### PR TITLE
[DataObject] Don't copy parent query-table data into fields that don't support inheritance

### DIFF
--- a/models/DataObject/Concrete/Dao.php
+++ b/models/DataObject/Concrete/Dao.php
@@ -294,7 +294,7 @@ class Dao extends Model\DataObject\AbstractObject\Dao
                         }
 
                         // if the current value is empty and we have data from the parent, we just use it
-                        if ($isEmpty && $parentData) {
+                        if ($isEmpty && $parentData && $fd->supportsInheritance()) {
                             foreach ($columnNames as $columnName) {
                                 if (array_key_exists($columnName, $parentData)) {
                                     $data[$columnName] = $parentData[$columnName];

--- a/models/DataObject/Concrete/Dao/InheritanceHelper.php
+++ b/models/DataObject/Concrete/Dao/InheritanceHelper.php
@@ -234,6 +234,15 @@ class InheritanceHelper
                 // create entries for children that don't have an entry yet
                 $originalEntry = Helper::quoteDataIdentifiers($this->db, $this->db->fetchAssociative('SELECT * FROM ' . $this->querytable . ' WHERE ' . $this->idField . ' = ?', [$oo_id]));
 
+                // the row is copied from the parent, so columns of field types which do not
+                // support inheritance must not carry the parent's value over to the child
+                foreach ($params['nonInheritableColumns'] ?? [] as $columnName) {
+                    $quotedColumnName = $this->db->quoteIdentifier($columnName);
+                    if (array_key_exists($quotedColumnName, $originalEntry)) {
+                        $originalEntry[$quotedColumnName] = null;
+                    }
+                }
+
                 foreach ($missingIds as $id) {
                     $originalEntry[$this->db->quoteIdentifier($this->idField)] = $id;
                     $this->db->insert($this->db->quoteIdentifier($this->querytable), $originalEntry);

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -326,7 +326,7 @@ class Dao extends Model\Dao\AbstractDao
                                 }
 
                                 // if the current value is empty and we have data from the parent, we just use it
-                                if ($isEmpty && $parentData) {
+                                if ($isEmpty && $parentData && $fd->supportsInheritance()) {
                                     foreach ($columnNames as $columnName) {
                                         if (array_key_exists($columnName, $parentData)) {
                                             $data[$columnName] = $parentData[$columnName];
@@ -339,7 +339,7 @@ class Dao extends Model\Dao\AbstractDao
                                     }
                                 }
 
-                                if ($inheritanceEnabled && !$fd instanceof CalculatedValue) {
+                                if ($inheritanceEnabled && $fd->supportsInheritance()) {
                                     //get changed fields for inheritance
                                     if ($fd->isRelationType()) {
                                         if (is_array($insertData)) {

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -19,7 +19,6 @@ use Pimcore\Db\Helper;
 use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\DataObject;
-use Pimcore\Model\DataObject\ClassDefinition\Data\CalculatedValue;
 use Pimcore\Model\DataObject\ClassDefinition\Data\CustomResourcePersistingInterface;
 use Pimcore\Model\DataObject\ClassDefinition\Data\LazyLoadingSupportInterface;
 use Pimcore\Model\DataObject\ClassDefinition\Data\QueryResourcePersistenceAwareInterface;

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -302,6 +302,8 @@ class Dao extends Model\Dao\AbstractDao
                         }
                     }
 
+                    $nonInheritableColumns = [];
+
                     foreach ($fieldDefinitions as $fd) {
                         if ($fd instanceof QueryResourcePersistenceAwareInterface) {
                             $key = $fd->getName();
@@ -322,6 +324,10 @@ class Dao extends Model\Dao\AbstractDao
                                 } else {
                                     $columnNames = [$key];
                                     $data[$key] = $insertData;
+                                }
+
+                                if (!$fd->supportsInheritance()) {
+                                    $nonInheritableColumns = array_merge($nonInheritableColumns, $columnNames);
                                 }
 
                                 // if the current value is empty and we have data from the parent, we just use it
@@ -420,6 +426,7 @@ class Dao extends Model\Dao\AbstractDao
                         $this->inheritanceHelper->doUpdate($object->getId(), true, [
                             'language' => $language,
                             'inheritanceRelationContext' => $inheritanceRelationContext,
+                            'nonInheritableColumns' => $nonInheritableColumns,
                         ]);
                     }
                     $this->inheritanceHelper->resetFieldsToCheck();

--- a/models/DataObject/Objectbrick/Data/Dao.php
+++ b/models/DataObject/Objectbrick/Data/Dao.php
@@ -313,11 +313,7 @@ class Dao extends Model\Dao\AbstractDao
                 if ($fd instanceof QueryResourcePersistenceAwareInterface) {
                     //exclude untouchables if value is not an array - this means data has not been loaded
                     //get changed fields for inheritance
-                    if (!$fd->supportsInheritance()) {
-                        continue;
-                    }
-
-                    if (!empty($oldData[$key])) {
+                    if ($fd->supportsInheritance() && !empty($oldData[$key])) {
                         if ($fd->isRelationType()) {
                             $this->inheritanceHelper->addRelationToCheck($key, $fd);
                         } else {

--- a/models/DataObject/Objectbrick/Data/Dao.php
+++ b/models/DataObject/Objectbrick/Data/Dao.php
@@ -166,7 +166,7 @@ class Dao extends Model\Dao\AbstractDao
                     }
 
                     // if the current value is empty and we have data from the parent, we just use it
-                    if ($isEmpty && $parentData) {
+                    if ($isEmpty && $parentData && $fd->supportsInheritance()) {
                         foreach ($columnNames as $columnName) {
                             if (array_key_exists($columnName, $parentData)) {
                                 $data[$columnName] = $parentData[$columnName];
@@ -181,7 +181,7 @@ class Dao extends Model\Dao\AbstractDao
 
                     if ($inheritanceEnabled) {
                         //get changed fields for inheritance
-                        if ($fd instanceof DataObject\ClassDefinition\Data\CalculatedValue) {
+                        if (!$fd->supportsInheritance()) {
                             // nothing to do, see https://github.com/pimcore/pimcore/issues/727
                             continue;
                         } elseif ($fd->isRelationType()) {
@@ -304,7 +304,7 @@ class Dao extends Model\Dao\AbstractDao
                 if ($fd instanceof QueryResourcePersistenceAwareInterface) {
                     //exclude untouchables if value is not an array - this means data has not been loaded
                     //get changed fields for inheritance
-                    if ($fd instanceof DataObject\ClassDefinition\Data\CalculatedValue) {
+                    if (!$fd->supportsInheritance()) {
                         continue;
                     }
 

--- a/models/DataObject/Objectbrick/Data/Dao.php
+++ b/models/DataObject/Objectbrick/Data/Dao.php
@@ -150,6 +150,8 @@ class Dao extends Model\Dao\AbstractDao
                 }
             }
 
+            $nonInheritableColumns = [];
+
             foreach ($fieldDefinitions as $key => $fd) {
                 if ($fd instanceof QueryResourcePersistenceAwareInterface) {
                     $method = 'get' . $key;
@@ -163,6 +165,10 @@ class Dao extends Model\Dao\AbstractDao
                     } else {
                         $columnNames = [$key];
                         $data[$key] = $insertData;
+                    }
+
+                    if (!$fd->supportsInheritance()) {
+                        $nonInheritableColumns = array_merge($nonInheritableColumns, $columnNames);
                     }
 
                     // if the current value is empty and we have data from the parent, we just use it
@@ -241,9 +247,12 @@ class Dao extends Model\Dao\AbstractDao
 
             if ($inheritanceEnabled) {
                 $this->inheritanceHelper->doUpdate($object->getId(), true,
-                    ['inheritanceRelationContext' => [
-                        'ownertype' => 'objectbrick',
-                    ]]);
+                    [
+                        'inheritanceRelationContext' => [
+                            'ownertype' => 'objectbrick',
+                        ],
+                        'nonInheritableColumns' => $nonInheritableColumns,
+                    ]);
             }
             $this->inheritanceHelper->resetFieldsToCheck();
         } finally {

--- a/tests/Model/Inheritance/CalculatedValueTest.php
+++ b/tests/Model/Inheritance/CalculatedValueTest.php
@@ -1,0 +1,97 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\Inheritance;
+
+use Pimcore;
+use Pimcore\Cache\RuntimeCache;
+use Pimcore\Db;
+use Pimcore\Model\DataObject;
+use Pimcore\Model\DataObject\Inheritance;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+use Pimcore\Tests\Support\Util\TestHelper;
+
+/**
+ * Fields which do not support inheritance (e.g. calculatedValue) must never
+ * have the parent's stored query-table value copied onto the child row,
+ * even when the child's own computed value is empty.
+ *
+ * @see https://github.com/pimcore/platform-version/issues/275
+ */
+class CalculatedValueTest extends ModelTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        TestHelper::cleanUp();
+        Pimcore::setAdminMode();
+    }
+
+    public function testEmptyChildValueIsNotOverwrittenByParentData(): void
+    {
+        $db = Db::get();
+
+        // the test calculator returns this runtime-cache value for every calculated field
+        RuntimeCache::set('modeltest.testCalculatedValue.value', 'parentcalc');
+
+        $one = new Inheritance();
+        $one->setKey('calc-one');
+        $one->setParentId(1);
+        $one->setPublished(true);
+        $one->setNormalInput('parenttext');
+
+        $oneBrick = new DataObject\Objectbrick\Data\UnittestBrick($one);
+        $oneBrick->setBrickInput('parentbrick');
+        $one->getMybricks()->setUnittestBrick($oneBrick);
+
+        $one->save();
+
+        $classId = $one->getClassId();
+
+        $row = $db->fetchAssociative('SELECT * FROM object_query_' . $classId . ' WHERE oo_id = ?', [$one->getId()]);
+        $this->assertEquals('parentcalc', $row['calculatedinherited']);
+
+        $localizedRow = $db->fetchAssociative('SELECT * FROM object_localized_query_' . $classId . '_en WHERE ooo_id = ?', [$one->getId()]);
+        $this->assertEquals('parentcalc', $localizedRow['lcalculatedinherited']);
+
+        $brickRow = $db->fetchAssociative('SELECT * FROM object_brick_query_unittestBrick_' . $classId . ' WHERE id = ?', [$one->getId()]);
+        $this->assertEquals('parentcalc', $brickRow['brickcalculated']);
+
+        // for the child the calculator computes an empty value; the parent's
+        // stored value must NOT be copied in, calculatedValue does not support inheritance
+        RuntimeCache::set('modeltest.testCalculatedValue.value', '');
+
+        $two = new Inheritance();
+        $two->setKey('calc-two');
+        $two->setParentId($one->getId());
+        $two->setPublished(true);
+
+        $twoBrick = new DataObject\Objectbrick\Data\UnittestBrick($two);
+        $twoBrick->setBrickInput2('childbrick');
+        $two->getMybricks()->setUnittestBrick($twoBrick);
+
+        $two->save();
+
+        $row = $db->fetchAssociative('SELECT * FROM object_query_' . $classId . ' WHERE oo_id = ?', [$two->getId()]);
+        $this->assertSame('', (string) $row['calculatedinherited'], 'child object_query_ row must keep the empty computed value');
+
+        $localizedRow = $db->fetchAssociative('SELECT * FROM object_localized_query_' . $classId . '_en WHERE ooo_id = ?', [$two->getId()]);
+        $this->assertSame('', (string) $localizedRow['lcalculatedinherited'], 'child localized query row must keep the empty computed value');
+
+        $brickRow = $db->fetchAssociative('SELECT * FROM object_brick_query_unittestBrick_' . $classId . ' WHERE id = ?', [$two->getId()]);
+        $this->assertSame('', (string) $brickRow['brickcalculated'], 'child brick query row must keep the empty computed value');
+
+        // regular fields still inherit
+        $this->assertEquals('parenttext', $row['normalinput']);
+    }
+}

--- a/tests/Model/Inheritance/CalculatedValueTest.php
+++ b/tests/Model/Inheritance/CalculatedValueTest.php
@@ -94,4 +94,45 @@ class CalculatedValueTest extends ModelTestCase
         // regular fields still inherit
         $this->assertEquals('parenttext', $row['normalinput']);
     }
+
+    public function testBrickRowCreatedForChildWithoutBrickDoesNotCopyCalculatedValue(): void
+    {
+        $db = Db::get();
+
+        RuntimeCache::set('modeltest.testCalculatedValue.value', 'parentcalc');
+
+        // neither object has a brick yet, so the child has no brick query row at all
+        $one = new Inheritance();
+        $one->setKey('calc-one');
+        $one->setParentId(1);
+        $one->setPublished(true);
+        $one->setNormalInput('parenttext');
+        $one->save();
+
+        $two = new Inheritance();
+        $two->setKey('calc-two');
+        $two->setParentId($one->getId());
+        $two->setPublished(true);
+        $two->save();
+
+        $classId = $one->getClassId();
+        $this->assertFalse(
+            $db->fetchAssociative('SELECT * FROM object_brick_query_unittestBrick_' . $classId . ' WHERE id = ?', [$two->getId()]),
+            'child has no brick query row yet'
+        );
+
+        // adding the brick on the parent creates the missing child rows by copying the
+        // parent row — the calculated value must not be carried over
+        $one = Inheritance::getById($one->getId(), ['force' => true]);
+        $oneBrick = new DataObject\Objectbrick\Data\UnittestBrick($one);
+        $oneBrick->setBrickInput('parentbrick');
+        $one->getMybricks()->setUnittestBrick($oneBrick);
+        $one->save();
+
+        $childBrickRow = $db->fetchAssociative('SELECT * FROM object_brick_query_unittestBrick_' . $classId . ' WHERE id = ?', [$two->getId()]);
+        $this->assertIsArray($childBrickRow, 'the missing child brick query row was created');
+        $this->assertSame('', (string) $childBrickRow['brickcalculated'], 'child must not inherit the parent calculated value');
+        // the inheritable brick field is still copied over
+        $this->assertEquals('parentbrick', $childBrickRow['brickinput']);
+    }
 }

--- a/tests/Model/Inheritance/CalculatedValueTest.php
+++ b/tests/Model/Inheritance/CalculatedValueTest.php
@@ -135,4 +135,41 @@ class CalculatedValueTest extends ModelTestCase
         // the inheritable brick field is still copied over
         $this->assertEquals('parentbrick', $childBrickRow['brickinput']);
     }
+
+    public function testLocalizedRowCreatedForChildWithoutLanguageRowDoesNotCopyCalculatedValue(): void
+    {
+        $db = Db::get();
+
+        RuntimeCache::set('modeltest.testCalculatedValue.value', 'parentcalc');
+
+        $one = new Inheritance();
+        $one->setKey('calc-one');
+        $one->setParentId(1);
+        $one->setPublished(true);
+        $one->save();
+
+        $two = new Inheritance();
+        $two->setKey('calc-two');
+        $two->setParentId($one->getId());
+        $two->setPublished(true);
+        $two->save();
+
+        $queryTable = 'object_localized_query_' . $one->getClassId() . '_en';
+
+        // simulate a language introduced after the child was last saved: the
+        // child has no row in that language's query table yet
+        $db->delete($queryTable, ['ooo_id' => $two->getId()]);
+
+        // saving the parent creates the missing child row by copying the parent
+        // row — the calculated value must not be carried over
+        $one = Inheritance::getById($one->getId(), ['force' => true]);
+        $one->setInput('parentlocalized', 'en');
+        $one->save();
+
+        $childRow = $db->fetchAssociative('SELECT * FROM ' . $queryTable . ' WHERE ooo_id = ?', [$two->getId()]);
+        $this->assertIsArray($childRow, 'the missing child localized query row was created');
+        $this->assertSame('', (string) $childRow['lcalculatedinherited'], 'child must not inherit the parent calculated value');
+        // the inheritable localized field is still copied over
+        $this->assertEquals('parentlocalized', $childRow['input']);
+    }
 }

--- a/tests/Model/Inheritance/ConsentTest.php
+++ b/tests/Model/Inheritance/ConsentTest.php
@@ -129,6 +129,32 @@ class ConsentTest extends ModelTestCase
         $this->assertEquals('parentbrick', $childBrickRow['brickinput']);
     }
 
+    public function testLocalizedRowCreatedForChildWithoutLanguageRowDoesNotCopyConsent(): void
+    {
+        $db = Db::get();
+
+        $one = $this->createParent(true);
+        $two = $this->createChild($one);
+
+        $queryTable = 'object_localized_query_' . $one->getClassId() . '_en';
+
+        // simulate a language introduced after the child was last saved: the
+        // child has no row in that language's query table yet
+        $db->delete($queryTable, ['ooo_id' => $two->getId()]);
+
+        // saving the parent creates the missing child row by copying the parent
+        // row — consent must not be carried over
+        $one = Inheritance::getById($one->getId(), ['force' => true]);
+        $one->setInput('parentlocalized', 'en');
+        $one->save();
+
+        $childRow = $db->fetchAssociative('SELECT * FROM ' . $queryTable . ' WHERE ooo_id = ?', [$two->getId()]);
+        $this->assertIsArray($childRow, 'the missing child localized query row was created');
+        $this->assertSame(0, (int) $childRow['lconsentinherited'], 'child must not inherit the parent consent');
+        // the inheritable localized field is still copied over
+        $this->assertEquals('parentlocalized', $childRow['input']);
+    }
+
     private function createParent(bool $withConsent): Inheritance
     {
         $one = new Inheritance();

--- a/tests/Model/Inheritance/ConsentTest.php
+++ b/tests/Model/Inheritance/ConsentTest.php
@@ -93,6 +93,42 @@ class ConsentTest extends ModelTestCase
         $this->assertNull($childBrickRow['brickinput']);
     }
 
+    public function testBrickRowCreatedForChildWithoutBrickDoesNotCopyConsent(): void
+    {
+        $db = Db::get();
+
+        // neither object has a brick yet, so the child has no brick query row at all
+        $one = new Inheritance();
+        $one->setKey('consent-one');
+        $one->setParentId(1);
+        $one->setPublished(true);
+        $one->setNormalInput('parenttext');
+        $one->save();
+
+        $two = $this->createChild($one, false);
+
+        $classId = $one->getClassId();
+        $this->assertFalse(
+            $db->fetchAssociative('SELECT * FROM object_brick_query_unittestBrick_' . $classId . ' WHERE id = ?', [$two->getId()]),
+            'child has no brick query row yet'
+        );
+
+        // adding the brick on the parent creates the missing child rows by copying the
+        // parent row — consent must not be carried over
+        $one = Inheritance::getById($one->getId(), ['force' => true]);
+        $oneBrick = new DataObject\Objectbrick\Data\UnittestBrick($one);
+        $oneBrick->setBrickInput('parentbrick');
+        $oneBrick->setBrickconsent(new Consent(true));
+        $one->getMybricks()->setUnittestBrick($oneBrick);
+        $one->save();
+
+        $childBrickRow = $db->fetchAssociative('SELECT * FROM object_brick_query_unittestBrick_' . $classId . ' WHERE id = ?', [$two->getId()]);
+        $this->assertIsArray($childBrickRow, 'the missing child brick query row was created');
+        $this->assertSame(0, (int) $childBrickRow['brickconsent'], 'child must not inherit the parent consent');
+        // the inheritable brick field is still copied over
+        $this->assertEquals('parentbrick', $childBrickRow['brickinput']);
+    }
+
     private function createParent(bool $withConsent): Inheritance
     {
         $one = new Inheritance();
@@ -116,7 +152,7 @@ class ConsentTest extends ModelTestCase
         return $one;
     }
 
-    private function createChild(Inheritance $one): Inheritance
+    private function createChild(Inheritance $one, bool $withBrick = true): Inheritance
     {
         // the child does not give any consent
         $two = new Inheritance();
@@ -124,9 +160,11 @@ class ConsentTest extends ModelTestCase
         $two->setParentId($one->getId());
         $two->setPublished(true);
 
-        $twoBrick = new DataObject\Objectbrick\Data\UnittestBrick($two);
-        $twoBrick->setBrickInput2('childbrick');
-        $two->getMybricks()->setUnittestBrick($twoBrick);
+        if ($withBrick) {
+            $twoBrick = new DataObject\Objectbrick\Data\UnittestBrick($two);
+            $twoBrick->setBrickInput2('childbrick');
+            $two->getMybricks()->setUnittestBrick($twoBrick);
+        }
 
         $two->save();
 

--- a/tests/Model/Inheritance/ConsentTest.php
+++ b/tests/Model/Inheritance/ConsentTest.php
@@ -1,0 +1,150 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\Inheritance;
+
+use Pimcore;
+use Pimcore\Db;
+use Pimcore\Model\DataObject;
+use Pimcore\Model\DataObject\Data\Consent;
+use Pimcore\Model\DataObject\Inheritance;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+use Pimcore\Tests\Support\Util\TestHelper;
+
+/**
+ * Consent is the other query-persisted field type besides calculatedValue which
+ * does not support inheritance: a child must never report the parent's consent
+ * in its query tables — neither on child save (parent-data fallback) nor when
+ * the parent's consent changes or its brick is deleted (inheritance tracking).
+ *
+ * @see https://github.com/pimcore/platform-version/issues/275
+ */
+class ConsentTest extends ModelTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        TestHelper::cleanUp();
+        Pimcore::setAdminMode();
+    }
+
+    public function testEmptyChildConsentIsNotOverwrittenByParentData(): void
+    {
+        $one = $this->createParent(true);
+        $two = $this->createChild($one);
+
+        $this->assertConsentQueryValues($one, 1, 'parent keeps its own consent');
+        $this->assertConsentQueryValues($two, 0, 'child without consent must not get the parent value copied');
+
+        // regular fields still inherit
+        $row = Db::get()->fetchAssociative('SELECT * FROM object_query_' . $one->getClassId() . ' WHERE oo_id = ?', [$two->getId()]);
+        $this->assertEquals('parenttext', $row['normalinput']);
+    }
+
+    public function testParentConsentChangeIsNotPropagatedToChildren(): void
+    {
+        $one = $this->createParent(false);
+        $two = $this->createChild($one);
+
+        $this->assertConsentQueryValues($two, 0, 'child starts without consent');
+
+        // the parent gives consent afterwards — the inheritance tracking must
+        // skip consent fields and leave the child rows alone
+        $one->setConsentinherited(new Consent(true));
+        $one->setLconsentinherited(new Consent(true), 'en');
+        $one->getMybricks()->getUnittestBrick()->setBrickconsent(new Consent(true));
+        $one->save();
+
+        $this->assertConsentQueryValues($one, 1, 'parent stores its changed consent');
+        $this->assertConsentQueryValues($two, 0, 'parent consent change must not be pushed into child rows');
+    }
+
+    public function testParentBrickDeleteWithConsentKeepsChildRows(): void
+    {
+        $db = Db::get();
+
+        $one = $this->createParent(true);
+        $two = $this->createChild($one);
+
+        $classId = $one->getClassId();
+
+        // deleting the parent's brick must skip consent in the deletion tracking
+        $one->getMybricks()->getUnittestBrick()->setDoDelete(true);
+        $one->save();
+
+        $parentBrickRow = $db->fetchAssociative('SELECT * FROM object_brick_query_unittestBrick_' . $classId . ' WHERE id = ?', [$one->getId()]);
+        $this->assertFalse($parentBrickRow, 'parent brick query row is removed');
+
+        $childBrickRow = $db->fetchAssociative('SELECT * FROM object_brick_query_unittestBrick_' . $classId . ' WHERE id = ?', [$two->getId()]);
+        $this->assertIsArray($childBrickRow, 'child keeps its own brick query row');
+        $this->assertSame(0, (int) $childBrickRow['brickconsent'], 'child brick consent stays untouched');
+        $this->assertEquals('childbrick', $childBrickRow['brickinput2']);
+        // the inheritable brickinput was inherited from the parent and is cleared by the delete propagation
+        $this->assertNull($childBrickRow['brickinput']);
+    }
+
+    private function createParent(bool $withConsent): Inheritance
+    {
+        $one = new Inheritance();
+        $one->setKey('consent-one');
+        $one->setParentId(1);
+        $one->setPublished(true);
+        $one->setNormalInput('parenttext');
+
+        $oneBrick = new DataObject\Objectbrick\Data\UnittestBrick($one);
+        $oneBrick->setBrickInput('parentbrick');
+        $one->getMybricks()->setUnittestBrick($oneBrick);
+
+        if ($withConsent) {
+            $one->setConsentinherited(new Consent(true));
+            $one->setLconsentinherited(new Consent(true), 'en');
+            $oneBrick->setBrickconsent(new Consent(true));
+        }
+
+        $one->save();
+
+        return $one;
+    }
+
+    private function createChild(Inheritance $one): Inheritance
+    {
+        // the child does not give any consent
+        $two = new Inheritance();
+        $two->setKey('consent-two');
+        $two->setParentId($one->getId());
+        $two->setPublished(true);
+
+        $twoBrick = new DataObject\Objectbrick\Data\UnittestBrick($two);
+        $twoBrick->setBrickInput2('childbrick');
+        $two->getMybricks()->setUnittestBrick($twoBrick);
+
+        $two->save();
+
+        return $two;
+    }
+
+    private function assertConsentQueryValues(Inheritance $object, int $expected, string $message): void
+    {
+        $db = Db::get();
+        $classId = $object->getClassId();
+
+        $row = $db->fetchAssociative('SELECT * FROM object_query_' . $classId . ' WHERE oo_id = ?', [$object->getId()]);
+        $this->assertSame($expected, (int) $row['consentinherited'], $message . ' (object_query_)');
+
+        $localizedRow = $db->fetchAssociative('SELECT * FROM object_localized_query_' . $classId . '_en WHERE ooo_id = ?', [$object->getId()]);
+        $this->assertSame($expected, (int) $localizedRow['lconsentinherited'], $message . ' (object_localized_query_)');
+
+        $brickRow = $db->fetchAssociative('SELECT * FROM object_brick_query_unittestBrick_' . $classId . ' WHERE id = ?', [$object->getId()]);
+        $this->assertSame($expected, (int) $brickRow['brickconsent'], $message . ' (object_brick_query_)');
+    }
+}

--- a/tests/Support/Helper/Model.php
+++ b/tests/Support/Helper/Model.php
@@ -651,12 +651,14 @@ class Model extends AbstractDefinitionHelper
             $lCalculatedInherited = $this->createDataChild('calculatedValue', 'lcalculatedinherited');
             $lCalculatedInherited->setCalculatorClass('@test.calculatorservice');
             $lFields->addChild($lCalculatedInherited);
+            $lFields->addChild($this->createDataChild('consent', 'lconsentinherited'));
 
             $otherPanel = (new \Pimcore\Model\DataObject\ClassDefinition\Layout\Panel())->setName('Layout');
             $otherPanel->addChild($this->createDataChild('input', 'normalinput'));
             $calculatedInherited = $this->createDataChild('calculatedValue', 'calculatedinherited');
             $calculatedInherited->setCalculatorClass('@test.calculatorservice');
             $otherPanel->addChild($calculatedInherited);
+            $otherPanel->addChild($this->createDataChild('consent', 'consentinherited'));
             $otherPanel->addChild($this->createDataChild('image', 'yx'));
             $otherPanel->addChild($this->createDataChild('slider'));
             $otherPanel->addChild($this->createDataChild('manyToManyObjectRelation', 'relationobjects')
@@ -993,6 +995,7 @@ class Model extends AbstractDefinitionHelper
             $brickCalculated = $this->createDataChild('calculatedValue', 'brickcalculated');
             $brickCalculated->setCalculatorClass('@test.calculatorservice');
             $panel->addChild($brickCalculated);
+            $panel->addChild($this->createDataChild('consent', 'brickconsent'));
 
             $panel->addChild($this->createDataChild('manyToManyRelation', 'brickLazyRelation')
                 ->setDocumentTypes([])->setAssetTypes([])->setClasses([])

--- a/tests/Support/Helper/Model.php
+++ b/tests/Support/Helper/Model.php
@@ -648,9 +648,15 @@ class Model extends AbstractDefinitionHelper
             $lFields->addChild($this->createDataChild('input'));
             $lFields->addChild($this->createDataChild('textarea'));
             $lFields->addChild($this->createDataChild('wysiwyg'));
+            $lCalculatedInherited = $this->createDataChild('calculatedValue', 'lcalculatedinherited');
+            $lCalculatedInherited->setCalculatorClass('@test.calculatorservice');
+            $lFields->addChild($lCalculatedInherited);
 
             $otherPanel = (new \Pimcore\Model\DataObject\ClassDefinition\Layout\Panel())->setName('Layout');
             $otherPanel->addChild($this->createDataChild('input', 'normalinput'));
+            $calculatedInherited = $this->createDataChild('calculatedValue', 'calculatedinherited');
+            $calculatedInherited->setCalculatorClass('@test.calculatorservice');
+            $otherPanel->addChild($calculatedInherited);
             $otherPanel->addChild($this->createDataChild('image', 'yx'));
             $otherPanel->addChild($this->createDataChild('slider'));
             $otherPanel->addChild($this->createDataChild('manyToManyObjectRelation', 'relationobjects')
@@ -983,6 +989,10 @@ class Model extends AbstractDefinitionHelper
             $panel->addChild($this->createDataChild('input', 'brickinput'));
 
             $panel->addChild($this->createDataChild('input', 'brickinput2'));
+
+            $brickCalculated = $this->createDataChild('calculatedValue', 'brickcalculated');
+            $brickCalculated->setCalculatorClass('@test.calculatorservice');
+            $panel->addChild($brickCalculated);
 
             $panel->addChild($this->createDataChild('manyToManyRelation', 'brickLazyRelation')
                 ->setDocumentTypes([])->setAssetTypes([])->setClasses([])


### PR DESCRIPTION
Fixes https://github.com/pimcore/platform-version/issues/275
Supersedes #19290 — keeps @lukemacausland's commits as-is (thank you!) and completes the fix; that fork has maintainer edits disabled, so a follow-up push there wasn't possible.

## Problem

Query-table rows can end up carrying the **parent's** value for field types that explicitly opt out of inheritance (`CalculatedValue` and `Consent` — the two opt-out types implementing `QueryResourcePersistenceAwareInterface`). Grid, listing and search then report wrong values (see the calculated-checkbox repro in the linked issue). There are two independent paths:

1. **The parent-data fallback** in `Concrete\Dao`, `Localizedfield\Dao` and `Objectbrick\Data\Dao`: "child value is empty → copy the parent's stored value" ignored `$fd->supportsInheritance()`.
2. **The generated child row** in `InheritanceHelper::doUpdate()`: when a child has no query row yet (classic case: parent gets a brick, or a new language appears), the row is created by copying the parent row *verbatim* — including the opt-out columns.

## What this PR does

On top of #19290 (`Concrete\Dao` + `Localizedfield\Dao`):

- **`Objectbrick\Data\Dao`** had the exact same unguarded fallback — now guarded with `$fd->supportsInheritance()` as well.
- Its inheritance tracking (save + delete paths) special-cased only `instanceof CalculatedValue`; aligned to `!$fd->supportsInheritance()`, matching what `Concrete\Dao` already does and what #19290 applies to `Localizedfield\Dao`. This also stops `Consent` columns from being inheritance-tracked.
- **`InheritanceHelper::doUpdate()`** (path 2): the objectbrick and localizedfield Daos now pass the query columns of non-inheritable fields via `$params['nonInheritableColumns']`, and those columns are reset to `NULL` before the copied parent row is inserted for the missing children. Inheritable columns keep being copied exactly as before.
- **Regression tests** (`Model` suite) for both paths and all three query-table contexts (`object_query_*`, `object_localized_query_*`, `object_brick_query_*`):
  - `CalculatedValueTest` — child whose calculator computes an empty value; plus a child that has no brick row at all when the parent's brick is added.
  - `ConsentTest` — child save fallback, parent consent change, parent brick deletion, plus the same missing-brick-row scenario.
  - Both assert that regular fields (`normalinput`, `brickinput`) still inherit.
- Test fixtures gain calculated + consent fields on the `inheritance` class (top-level + localized) and on `unittestBrick`.

No BC break: the query rows now store what the field actually computes for the child instead of a value the field type never supports inheriting.

## Verification

- Fallback tests fail on `2026.2` without the Dao changes (all three assertions), pass with them. With only #19290 applied the brick assertion still fails, confirming the `Objectbrick` gap.
- `ConsentTest` fallback/tracking scenarios *error* on `2026.2` without the Dao changes: the inheritance helper selects the tracked field name from the store table, which for consent only has the `__consent`/`__note` columns → `InvalidFieldNameException: Unknown column 'lconsentinherited'`. So the tracked branches didn't just copy stale data, they aborted the save.
- The two missing-child-row tests fail without the `InheritanceHelper` change (child row copied `brickconsent = 1` / `brickcalculated = 'parentcalc'` from the parent) and pass with it, while `brickinput` still inherits.
- Full local `Model` suite: 434 tests, 3606 assertions, no regressions beyond the two known `Encrypted` baseline errors (empty local encryption secret).