### PR TITLE
[Asset] Make missing binaries detectable in getStream() instead of silently substituting an empty stream

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -99,6 +99,11 @@ class Asset extends Element\AbstractElement
 
     /**
      * @internal
+     */
+    protected bool $streamIsPlaceholder = false;
+
+    /**
+     * @internal
      *
      */
     protected ?array $versions = null;
@@ -170,7 +175,7 @@ class Asset extends Element\AbstractElement
 
     protected function getBlockedVars(): array
     {
-        $blockedVars = ['scheduledTasks', 'versions', 'stream'];
+        $blockedVars = ['scheduledTasks', 'versions', 'stream', 'streamIsPlaceholder'];
 
         if (!$this->isInDumpState()) {
             // for caching asset
@@ -1136,12 +1141,25 @@ class Asset extends Element\AbstractElement
         if (!$this->stream && $this->getType() !== 'folder') {
             try {
                 $this->stream = Storage::get('asset')->readStream($this->getRealFullPath());
+                $this->streamIsPlaceholder = false;
             } catch (Exception $e) {
+                Logger::error('Unable to read the data of asset ' . $this->getRealFullPath() . ' from storage, returning an empty placeholder stream instead: ' . $e);
                 $this->stream = tmpfile();
+                $this->streamIsPlaceholder = true;
             }
         }
 
         return $this->stream;
+    }
+
+    /**
+     * Returns true if the stream returned by getStream() is an empty placeholder that was substituted
+     * because the asset's binary data could not be read from storage (e.g. the file is missing),
+     * false if the stream contains the asset's actual data.
+     */
+    public function isStreamPlaceholder(): bool
+    {
+        return $this->streamIsPlaceholder;
     }
 
     public function getChecksum(): string
@@ -1188,6 +1206,7 @@ class Asset extends Element\AbstractElement
             $this->setDataChanged();
             $this->setDataModificationDate(time());
             $this->stream = $stream;
+            $this->streamIsPlaceholder = false;
 
             $isRewindable = @rewind($this->stream);
 
@@ -1198,6 +1217,7 @@ class Asset extends Element\AbstractElement
             }
         } elseif (is_null($stream)) {
             $this->stream = null;
+            $this->streamIsPlaceholder = false;
         }
 
         return $this;
@@ -1209,6 +1229,7 @@ class Asset extends Element\AbstractElement
             @fclose($this->stream);
             $this->stream = null;
         }
+        $this->streamIsPlaceholder = false;
     }
 
     public function getDataChanged(): bool
@@ -1567,6 +1588,7 @@ class Asset extends Element\AbstractElement
         try {
             $bytes = Storage::get('asset')->fileSize($this->getRealFullPath());
         } catch (Exception $e) {
+            Logger::error('Unable to determine the file size of asset ' . $this->getRealFullPath() . ': ' . $e);
             $bytes = 0;
         }
 

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -97,10 +97,7 @@ class Asset extends Element\AbstractElement
      */
     protected $stream;
 
-    /**
-     * @internal
-     */
-    protected bool $streamIsPlaceholder = false;
+    private bool $streamIsPlaceholder = false;
 
     /**
      * @internal

--- a/tests/Model/Asset/AssetTest.php
+++ b/tests/Model/Asset/AssetTest.php
@@ -648,4 +648,48 @@ class AssetTest extends ModelTestCase
             'pathExists() must return true for the same NFD path that getByPath() resolves.'
         );
     }
+
+    public function testGetStreamReturnsPlaceholderForMissingBinary(): void
+    {
+        $asset = TestHelper::createImageAsset('', null, true, 'assets/images/image5.jpg');
+
+        $stream = $asset->getStream();
+        $this->assertIsResource($stream);
+        $this->assertFalse($asset->isStreamPlaceholder());
+
+        // remove the binary from storage while keeping the database row
+        Storage::get('asset')->delete($asset->getRealFullPath());
+
+        // fresh instance, so no stream is cached on the model
+        $reloaded = Asset::getById($asset->getId(), ['force' => true]);
+        $stream = $reloaded->getStream();
+        $this->assertIsResource($stream, 'an empty placeholder stream is still returned for a missing binary');
+        $this->assertSame(0, fstat($stream)['size']);
+        $this->assertTrue($reloaded->isStreamPlaceholder());
+        $this->assertSame(0, $reloaded->getFileSize());
+
+        // setting new data replaces the placeholder and resets the flag
+        $reloaded->setData('fresh data');
+        $this->assertFalse($reloaded->isStreamPlaceholder());
+    }
+
+    public function testIsStreamPlaceholderIsFalseForLegitimatelyEmptyFile(): void
+    {
+        $asset = new Asset();
+        $asset->setParentId(1);
+        $asset->setUserOwner(1);
+        $asset->setUserModification(1);
+        $asset->setFilename('empty-' . uniqid() . '.txt');
+        $asset->setData('');
+        $asset->save();
+
+        $reloaded = Asset::getById($asset->getId(), ['force' => true]);
+        $stream = $reloaded->getStream();
+        $this->assertIsResource($stream);
+        $this->assertSame(0, fstat($stream)['size']);
+        $this->assertFalse(
+            $reloaded->isStreamPlaceholder(),
+            'an empty file that exists in storage must not be reported as a placeholder'
+        );
+    }
 }


### PR DESCRIPTION
Fixes pimcore/platform-version#279

### Problem

`Asset::getStream()` substitutes a fresh `tmpfile()` when the storage read throws and discards the exception entirely — not rethrown, not logged. A missing binary therefore reaches every caller as a valid, rewindable, zero-byte stream, and **no caller can detect the condition**. ZIP downloads (Studio `ZipService::addFile()`, classic `downloadAsZipAddFilesAction()`) ship archives full of silent 0-byte entries that are indistinguishable from legitimately empty uploads. `getFileSize()` has the same swallow-and-substitute shape, returning `0` from its `catch`.

### Fix (Option A from the issue — fully backward compatible)

- `getStream()` records when the returned stream is a substituted placeholder and logs the swallowed exception. The placeholder is still returned, so nothing relying on a non-null resource changes (cf. #13260).
- New accessor `isStreamPlaceholder(): bool` lets consumers distinguish "binary missing from storage" from "legitimately empty file" with no extra storage round trip and no heuristics.
- The flag is reset everywhere `$stream` changes (`setStream()`, `closeStream()`, successful re-read) and excluded from serialization via `$blockedVars`.
- `getFileSize()` now logs the swallowed exception too (behavior unchanged: still returns `0`).

### Consumer follow-ups (separate repos, once this lands)

Consumers can then surface the condition — tracked in pimcore/studio-backend-bundle#1987 for the Studio ZIP path.

### Tests

- `testGetStreamReturnsPlaceholderForMissingBinary` — DB row present, binary deleted from storage: placeholder returned (BC), flag set, `getFileSize()` still `0`, flag reset on `setData()`.
- `testIsStreamPlaceholderIsFalseForLegitimatelyEmptyFile` — a genuinely empty stored file is not reported as a placeholder.

Model suite `AssetTest.php`: 23 tests, 90 assertions, green.

This should be forward-merged into `2026.x` after merging.
