### PR TITLE
[Workflow] Allow reading the workflow user permissions of an element once

### DIFF
--- a/lib/Workflow/Manager.php
+++ b/lib/Workflow/Manager.php
@@ -410,12 +410,47 @@ class Manager
 
     public function isDeniedInWorkflow(ElementInterface $element, string $permissionType): bool
     {
-        $userPermissions = $this->getWorkflowUserPermissions($element);
-
-        return ($userPermissions[$permissionType] ?? null) === false;
+        return $this->getDeniedActionsInWorkflow($element, [$permissionType])[$permissionType];
     }
 
-    private function getWorkflowUserPermissions(ElementInterface $element): array
+    /**
+     * Returns, for each requested permission type, whether the element's workflows deny it.
+     *
+     * Equivalent to calling isDeniedInWorkflow() once per type, but resolves the element's
+     * workflow permissions only once. That resolution walks every registered workflow, resolves
+     * each marking - a database read under StateTableMarkingStore - and evaluates the ordered
+     * place configs, so asking for n types one at a time costs n full scans. Callers that need
+     * several permission types for the same element should use this instead.
+     *
+     * @param string[] $permissionTypes
+     *
+     * @return array<string, bool> permission type => whether it is denied
+     */
+    public function getDeniedActionsInWorkflow(ElementInterface $element, array $permissionTypes): array
+    {
+        $userPermissions = $this->getWorkflowUserPermissions($element);
+
+        $deniedActions = [];
+        foreach ($permissionTypes as $permissionType) {
+            $deniedActions[$permissionType] = ($userPermissions[$permissionType] ?? null) === false;
+        }
+
+        return $deniedActions;
+    }
+
+    /**
+     * Returns the merged workflow user permissions for an element.
+     *
+     * Public so that a caller needing more than one permission type for the same element can read
+     * the map once: isDeniedInWorkflow() calls this internally, so checking n types costs n full
+     * scans over every workflow, marking and place config.
+     *
+     * Values are the permission values as declared by the matching place configs - bool for the
+     * element permissions, a comma-joined string for lEdit/lView.
+     *
+     * @return array<string, mixed>
+     */
+    public function getWorkflowUserPermissions(ElementInterface $element): array
     {
         $userPermissions = [];
         foreach ($this->getAllWorkflows() as $workflowName) {

--- a/tests/Unit/Workflow/ManagerTest.php
+++ b/tests/Unit/Workflow/ManagerTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\Workflow\Marking;
 use Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface;
 use Symfony\Component\Workflow\Registry;
 use Symfony\Component\Workflow\StateMachine;
+use Symfony\Component\Workflow\SupportStrategy\InstanceOfSupportStrategy;
 
 class ManagerTest extends TestCase
 {
@@ -156,6 +157,73 @@ class ManagerTest extends TestCase
 
         $this->assertSame(['end' => 1], $store->persisted);
         $this->assertSame(['end' => 1], $marking->getPlaces());
+    }
+
+    /**
+     * getDeniedActionsInWorkflow() exists so a caller needing several permission types for one
+     * element resolves the workflow permissions once instead of once per type. It must answer
+     * exactly what isDeniedInWorkflow() answers for each type, including for a type no place
+     * config mentions.
+     */
+    public function testGetDeniedActionsInWorkflowMatchesTheSingleTypeCheck(): void
+    {
+        $element = self::createStub(Concrete::class);
+        $manager = $this->buildManagerWithPlacePermissions(['publish' => false, 'settings' => true]);
+
+        $denied = $manager->getDeniedActionsInWorkflow($element, ['publish', 'settings', 'rename']);
+
+        $this->assertSame(
+            [
+                'publish' => true,
+                'settings' => false,
+                // no place config mentions 'rename', which is not the same as denying it
+                'rename' => false,
+            ],
+            $denied
+        );
+
+        foreach ($denied as $permissionType => $isDenied) {
+            $this->assertSame(
+                $manager->isDeniedInWorkflow($element, $permissionType),
+                $isDenied,
+                sprintf('Batch and single-type checks disagree about "%s".', $permissionType)
+            );
+        }
+    }
+
+    public function testGetDeniedActionsInWorkflowReturnsAnEmptyMapForNoRequestedTypes(): void
+    {
+        $manager = $this->buildManagerWithPlacePermissions(['publish' => false]);
+
+        $this->assertSame([], $manager->getDeniedActionsInWorkflow(self::createStub(Concrete::class), []));
+    }
+
+    /**
+     * A Manager whose single workflow sits in a place carrying the given permissions.
+     */
+    private function buildManagerWithPlacePermissions(array $permissions): Manager
+    {
+        $eventDispatcher = new EventDispatcher();
+        $workflow = $this->createWorkflow(
+            $this->createImmediateMarkingStore(),
+            new PimcoreTransition('go', 'start', 'end', []),
+            $eventDispatcher
+        );
+
+        $registry = new Registry();
+        $registry->addWorkflow($workflow, new InstanceOfSupportStrategy(Concrete::class));
+
+        $manager = new Manager(
+            $registry,
+            self::createStub(NotesSubscriber::class),
+            self::createStub(ExpressionService::class),
+            $eventDispatcher
+        );
+        $manager->registerWorkflow(self::WORKFLOW_NAME);
+        // no 'condition' key, so the ExpressionService mock is never consulted
+        $manager->addPlaceConfig(self::WORKFLOW_NAME, 'start', ['permissions' => [$permissions]]);
+
+        return $manager;
     }
 
     /**


### PR DESCRIPTION
Fixes pimcore/platform-version#360

## Changes in this pull request

Adds `Manager::getDeniedActionsInWorkflow(ElementInterface $element, array $permissionTypes): array<string, bool>`, and expresses `isDeniedInWorkflow()` in terms of it.

### Why

`isDeniedInWorkflow()` resolves the element's **whole** permission map on every call and then reads one key out of it:

```php
public function isDeniedInWorkflow(ElementInterface $element, string $permissionType): bool
{
    $userPermissions = $this->getWorkflowUserPermissions($element);

    return ($userPermissions[$permissionType] ?? null) === false;
}
```

and `getWorkflowUserPermissions()` iterates every registered workflow, resolves each marking — a database read under `StateTableMarkingStore` — and evaluates the ordered place configs.

So a caller that needs *n* permission types for one element pays *n* full scans. The admin UI does exactly that, per element, for every element in a tree or grid listing:

```php
// AdminBundle\Service\ElementService::mergeWorkflowPermissions()
$workflowPermission = [
    'settings' => !$workflowManager->isDeniedInWorkflow($element, 'settings'),
    'rename'   => !$workflowManager->isDeniedInWorkflow($element, 'rename'),
    'publish'  => !$workflowManager->isDeniedInWorkflow($element, 'publish'),
];

if ($element instanceof Asset) {
    $workflowPermission['remove'] = !$workflowManager->isDeniedInWorkflow($element, 'delete');
} elseif ($element instanceof DataObject) {
    $workflowPermission['delete'] = !$workflowManager->isDeniedInWorkflow($element, 'delete');
}
```

Four calls, four scans, for one element's four flags. With this method that becomes one scan and four array reads.

`Element\AbstractElement::isAllowed()` has the same shape for anything checking several types on one element. Note it already caches the *DAO* result per request via `PermissionCache`, with a comment saying the workflow-deny check deliberately stays outside that cache — so the repeated workflow work is a known, uncached cost.

### Why a batch method rather than exposing the map

The first revision of this PR simply made `getWorkflowUserPermissions()` public. That leaks a shape not worth freezing as public API: its values are heterogeneous — `bool` for the element permissions, but a comma-joined `string` for `lEdit`/`lView`, per `PlaceConfig::getUserPermissions()`. A batch method keeps that representation private and returns a plain `array<string, bool>`, and keeps the "`=== false` means denied" convention defined in exactly one place — `isDeniedInWorkflow()` now delegates to it rather than repeating it.

### Why not cache inside `Manager`

Memoising per element is not safe as a drop-in: a marking can change within a request (apply a transition, then re-read permissions), so an element-keyed memo could serve a stale map. Letting the caller decide the scope of the reuse keeps the semantics exactly as they are today.

### Tests

`tests/Unit/Workflow/ManagerTest.php` gains two cases: the batch result must agree with `isDeniedInWorkflow()` for every requested type — including a type no place config mentions, which is *not* the same as denying it — and an empty request must return an empty map.

## Additional info

Improvement, so targeting `2026.x` per the contribution guide. Additive and behaviour-preserving.
