### PR TITLE
[Bug] Do not re-quote brickPrefix in Checkbox, Consent and Datetime filter conditions

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Checkbox.php
+++ b/models/DataObject/ClassDefinition/Data/Checkbox.php
@@ -174,7 +174,9 @@ class Checkbox extends Data implements ResourcePersistenceAwareInterface, QueryR
         $value = $db->quote((string)$value);
         $key = $db->quoteIdentifier($this->name);
 
-        $brickPrefix = $params['brickPrefix'] ? $db->quoteIdentifier($params['brickPrefix']) . '.' : '';
+        // brickPrefix arrives ready to concatenate - already quoted where it needs to be and
+        // already carrying its trailing dot - so it must not be quoted again here.
+        $brickPrefix = !empty($params['brickPrefix']) ? $params['brickPrefix'] : '';
 
         return 'IFNULL(' . $brickPrefix . $key . ', 0) = ' . $value . ' ';
     }

--- a/models/DataObject/ClassDefinition/Data/Consent.php
+++ b/models/DataObject/ClassDefinition/Data/Consent.php
@@ -276,7 +276,9 @@ class Consent extends Data implements ResourcePersistenceAwareInterface, QueryRe
         $value = $db->quote((string) $value);
         $key = $db->quoteIdentifier($this->name);
 
-        $brickPrefix = $params['brickPrefix'] ? $db->quoteIdentifier($params['brickPrefix']) . '.' : '';
+        // brickPrefix arrives ready to concatenate - already quoted where it needs to be and
+        // already carrying its trailing dot - so it must not be quoted again here.
+        $brickPrefix = !empty($params['brickPrefix']) ? $params['brickPrefix'] : '';
 
         return 'IFNULL(' . $brickPrefix . $key . ', 0) = ' . $value . ' ';
     }

--- a/models/DataObject/ClassDefinition/Data/Datetime.php
+++ b/models/DataObject/ClassDefinition/Data/Datetime.php
@@ -310,7 +310,9 @@ class Datetime extends Data implements ResourcePersistenceAwareInterface, QueryR
             $db = Db::get();
 
             if ($this->getColumnType() == 'datetime') {
-                $brickPrefix = $params['brickPrefix'] ? $db->quoteIdentifier($params['brickPrefix']) . '.' : '';
+                // brickPrefix arrives ready to concatenate - already quoted where it needs to be
+                // and already carrying its trailing dot - so it must not be quoted again here.
+                $brickPrefix = !empty($params['brickPrefix']) ? $params['brickPrefix'] : '';
                 $condition = 'DATE(' . $brickPrefix . '`' . $params['name'] . '`) = ' . $db->quote((string) $value);
 
                 return $condition;

--- a/tests/Unit/Models/DataObject/ClassDefinition/Data/FilterConditionBrickPrefixTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/Data/FilterConditionBrickPrefixTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\DataObject\ClassDefinition\Data;
+
+use Pimcore\Db;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Checkbox;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Consent;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Datetime;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * `brickPrefix` arrives ready to concatenate - already quoted where it needs to be, and already
+ * carrying its trailing dot. Quoting it a second time splits it on that dot
+ * (quoteIdentifier('object_5.') gives `object_5`.``) and yields a malformed column reference that
+ * MySQL rejects with "Unknown column 'object_5..flag'".
+ *
+ * AdminBundle's GridHelperService sends it in two shapes - unquoted `<listing table>.` for a plain
+ * field, and quoted `` `<brickType>`. `` for an object brick field - so both are covered here,
+ * along with the case where no prefix is supplied at all.
+ */
+class FilterConditionBrickPrefixTest extends TestCase
+{
+    private const LISTING_PREFIX = 'object_5.';
+
+    public function testCheckboxConcatenatesThePrefixAsGiven(): void
+    {
+        $field = new Checkbox();
+        $field->setName('flag');
+
+        $this->assertSame(
+            'IFNULL(object_5.`flag`, 0) = \'1\' ',
+            $field->getFilterCondition(1, '=', ['brickPrefix' => self::LISTING_PREFIX])
+        );
+        $this->assertSame(
+            'IFNULL(`myBrick`.`flag`, 0) = \'1\' ',
+            $field->getFilterCondition(1, '=', ['brickPrefix' => $this->brickPrefix()])
+        );
+        $this->assertSame(
+            'IFNULL(`flag`, 0) = \'1\' ',
+            $field->getFilterCondition(1, '=', []),
+            'An absent brickPrefix must neither be read unguarded nor add a stray qualifier.'
+        );
+    }
+
+    public function testConsentConcatenatesThePrefixAsGiven(): void
+    {
+        $field = new Consent();
+        $field->setName('optin');
+
+        $this->assertSame(
+            'IFNULL(object_5.`optin`, 0) = \'1\' ',
+            $field->getFilterCondition(1, '=', ['brickPrefix' => self::LISTING_PREFIX])
+        );
+        $this->assertSame(
+            'IFNULL(`myBrick`.`optin`, 0) = \'1\' ',
+            $field->getFilterCondition(1, '=', ['brickPrefix' => $this->brickPrefix()])
+        );
+        $this->assertSame(
+            'IFNULL(`optin`, 0) = \'1\' ',
+            $field->getFilterCondition(1, '=', [])
+        );
+    }
+
+    /**
+     * Only the datetime column type reaches the branch that applies the prefix; the default
+     * bigint storage takes a BETWEEN path that never qualifies the column.
+     */
+    public function testDatetimeEqualityConcatenatesThePrefixAsGiven(): void
+    {
+        $field = new Datetime();
+        $field->setName('when');
+        $field->setColumnType('datetime');
+
+        $timestamp = mktime(0, 0, 0, 1, 1, 2026);
+
+        $this->assertSame(
+            'DATE(object_5.`when`) = \'2026-01-01\'',
+            $field->getFilterCondition($timestamp, '=', ['brickPrefix' => self::LISTING_PREFIX])
+        );
+        $this->assertSame(
+            'DATE(`myBrick`.`when`) = \'2026-01-01\'',
+            $field->getFilterCondition($timestamp, '=', ['brickPrefix' => $this->brickPrefix()])
+        );
+        $this->assertSame(
+            'DATE(`when`) = \'2026-01-01\'',
+            $field->getFilterCondition($timestamp, '=', [])
+        );
+    }
+
+    /**
+     * The shape GridHelperService builds for an object brick field.
+     */
+    private function brickPrefix(): string
+    {
+        return Db::get()->quoteIdentifier('myBrick') . '.';
+    }
+}


### PR DESCRIPTION
Fixes pimcore/platform-version#386

## Changes in this pull request

`Checkbox`, `Consent` and `Datetime` re-quote the `brickPrefix` filter parameter that every other data type concatenates as-is. This makes them match the base class.

### The bug

All three do:

```php
$brickPrefix = $params['brickPrefix'] ? $db->quoteIdentifier($params['brickPrefix']) . '.' : '';
```

`brickPrefix` already arrives quoted where it needs to be **and already carrying its trailing dot**. `quoteIdentifier()` splits on that dot — `quoteIdentifier('object_5.')` gives `` `object_5`.`` `` — and the code then appends a second one.

`GridHelperService::getFilterCondition()` passes `brickPrefix` as `<listing table>.` for every non-brick field, so this fires on any grid filter over a Checkbox or Consent column. Generated through the real call path:

| | before | after |
|---|---|---|
| Checkbox | `IFNULL(`` `object_5`.``.`flag` ``, 0) = '1'` | `IFNULL(``object_5.`flag` ``, 0) = '1'` |
| Consent | `IFNULL(`` `object_5`.``.`optin` ``, 0) = '1'` | `IFNULL(``object_5.`optin` ``, 0) = '1'` |
| Numeric *(unchanged, for contrast)* | ``object_5.`amount` = 5`` | same |
| Select *(unchanged, for contrast)* | ``object_5.`status` LIKE '%a%'`` | same |

MySQL on the before-form:

```
ERROR 1054 (42S22): Unknown column 'objects..id' in 'where clause'
```

The brick call site is affected too — it passes `` `myBrick`. ``, which re-quoting turns into ```` ```myBrick```.``. ````. After the fix it produces ``IFNULL(`myBrick`.`flag`, 0) = '1'``.

`Datetime` carries the identical line, reached when `operator === '='` and `getColumnType() === 'datetime'`. Its other branch takes a `BETWEEN` path that passes no prefix at all, which is why the fault is less visible there.

### The fix

Concatenate as-is, matching `Data::getFilterConditionExt()` and `Select` / `Numeric` / `Multiselect` / `QuantityValue`, and guard the array read with `!empty()` as the base class does — it was an unguarded access, so an absent key raised an undefined-array-key warning.

### Verification

Reproduced and verified against a running instance (v12.3.12, same code as `2026.2` here) by driving `GridHelperService::getFilterCondition()` directly: broken before, and after the change both call-site shapes produce valid SQL that executes.

## Additional info

Bug fix, so targeting the maintenance branch. Note the contribution guide still names `12.3` for bug fixes, but only `2026.2` and `2026.x` exist on this repo now — `2026.2` is the branch that forward-merges into `2026.x`, so it is the one used here. Happy to retarget.

Broader context in pimcore/platform-version#387: this is one symptom of `brickPrefix`/`tablePrefix` having no agreed format, name or contract. That issue proposes converging them; this PR only fixes the three outliers.
