### PR TITLE
[security] GHSA-mvh8-52hw-jrch: Escape YouTube/Dailymotion id in Video editable iframe src

### DIFF
--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -655,7 +655,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface, Edit
         }
 
         $code .= '<div id="pimcore_video_' . $this->getName() . '" class="pimcore_editable_video '. ($config['class'] ?? '') .'">
-            <iframe width="' . $width . '" height="' . $height . '" src="https://www.youtube-nocookie.com/embed/' . $seriesPrefix . $youtubeId . $wmode . $additionalParams . '" title="YouTube video" allow="fullscreen" data-type="pimcore_video_editable"></iframe>
+            <iframe width="' . $width . '" height="' . $height . '" src="https://www.youtube-nocookie.com/embed/' . $seriesPrefix . htmlspecialchars($youtubeId, ENT_QUOTES, 'UTF-8') . $wmode . $additionalParams . '" title="YouTube video" allow="fullscreen" data-type="pimcore_video_editable"></iframe>
         </div>';
 
         return $code;
@@ -805,7 +805,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface, Edit
             }
 
             $code .= '<div id="pimcore_video_' . $this->getName() . '" class="pimcore_editable_video '. ($config['class'] ?? '') .'">
-                <iframe src="https://www.dailymotion.com/embed/video/' . $dailymotionId . '?' . $additionalParams . '" width="' . $width . '" height="' . $height . '" title="DailyMotion video" allow="fullscreen" data-type="pimcore_video_editable"></iframe>
+                <iframe src="https://www.dailymotion.com/embed/video/' . htmlspecialchars($dailymotionId, ENT_QUOTES, 'UTF-8') . '?' . $additionalParams . '" width="' . $width . '" height="' . $height . '" title="DailyMotion video" allow="fullscreen" data-type="pimcore_video_editable"></iframe>
             </div>';
 
             return $code;

--- a/tests/Unit/Document/Editable/VideoTest.php
+++ b/tests/Unit/Document/Editable/VideoTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Document\Editable;
+
+use Pimcore\Model\Document\Editable\Video;
+use Pimcore\Tests\Support\Test\TestCase;
+use ReflectionProperty;
+
+/**
+ * Regression test for GHSA-mvh8-52hw-jrch: a document-edit user could store a YouTube/Dailymotion
+ * id containing a double quote, which broke out of the `<iframe src="...">` attribute of the
+ * guest-rendered frontend output and injected an event-handler attribute (stored XSS), since the
+ * id was concatenated into the markup unescaped.
+ */
+final class VideoTest extends TestCase
+{
+    private const XSS_PAYLOAD = 'x" onload="alert(document.domain)" data-x="';
+
+    protected function needsDb(): bool
+    {
+        return false;
+    }
+
+    public function testYoutubeFrontendEscapesIdContainingDoubleQuote(): void
+    {
+        $video = $this->buildVideo(Video::TYPE_YOUTUBE, self::XSS_PAYLOAD);
+
+        $rendered = $video->frontend();
+
+        $this->assertStringNotContainsString('onload="alert(document.domain)"', $rendered);
+        $this->assertStringContainsString(
+            htmlspecialchars(self::XSS_PAYLOAD, ENT_QUOTES, 'UTF-8'),
+            $rendered
+        );
+    }
+
+    public function testYoutubeFrontendStillRendersALegitimateId(): void
+    {
+        $video = $this->buildVideo(Video::TYPE_YOUTUBE, 'dQw4w9WgXcQ');
+
+        $rendered = $video->frontend();
+
+        $this->assertStringContainsString(
+            'src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?wmode=transparent"',
+            $rendered
+        );
+    }
+
+    public function testDailymotionFrontendEscapesIdContainingDoubleQuote(): void
+    {
+        $video = $this->buildVideo(Video::TYPE_DAILYMOTION, self::XSS_PAYLOAD);
+
+        $rendered = $video->frontend();
+
+        $this->assertStringNotContainsString('onload="alert(document.domain)"', $rendered);
+        $this->assertStringContainsString(
+            htmlspecialchars(self::XSS_PAYLOAD, ENT_QUOTES, 'UTF-8'),
+            $rendered
+        );
+    }
+
+    public function testDailymotionFrontendStillRendersALegitimateId(): void
+    {
+        $video = $this->buildVideo(Video::TYPE_DAILYMOTION, 'x2u2vsp');
+
+        $rendered = $video->frontend();
+
+        $this->assertStringContainsString(
+            'src="https://www.dailymotion.com/embed/video/x2u2vsp?"',
+            $rendered
+        );
+    }
+
+    /**
+     * Builds a Video editable with the given type/id without going through
+     * setDataFromEditmode(), which would otherwise resolve the id against the Asset backend.
+     */
+    private function buildVideo(string $type, string $id): Video
+    {
+        $video = new Video();
+        $video->setName('video');
+        (new ReflectionProperty($video, 'type'))->setValue($video, $type);
+        (new ReflectionProperty($video, 'id'))->setValue($video, $id);
+
+        return $video;
+    }
+}


### PR DESCRIPTION
## Vulnerability

`Document\Editable\Video::setDataFromEditmode()` stores the editor-provided video `path` verbatim (`$this->id = $data['path']`, `models/Document/Editable/Video.php:363-368`) whenever it does not resolve to an `Asset\Video`. For the YouTube type, `parseYoutubeId()` returns that stored string verbatim as long as it contains no `//` (`Video.php:533-562`). The id was then concatenated **unescaped** into the guest-facing `<iframe src="...">` attribute in `getYoutubeCode()` (`Video.php:657-658`) and, via the same pattern, in `getDailymotionCode()` (`Video.php:807-808`). Twig's `pimcore_*` editable helpers are declared `is_safe => ['html']`, so no auto-escaping applies downstream.

A document-edit user (a standard content-editor privilege, not administrator) can therefore store an id such as:

```
x" onload="alert(document.domain)" data-x="
```

which breaks out of the `src` attribute and injects an `onload` handler that executes in the browser of every anonymous visitor of the published page — stored XSS (CWE-79).

Root cause: unlike the sibling `Image` editable (which escapes its attributes) and this same class's Vimeo branch (which gates the id with `ctype_digit`), the YouTube/Dailymotion branches never validated or escaped the id before interpolating it into HTML.

## Fix

Escape the resolved `$youtubeId` / `$dailymotionId` with `htmlspecialchars($id, ENT_QUOTES, 'UTF-8')` at the point of interpolation into the `<iframe src="...">` attribute — the same pattern already used elsewhere in this class (the editmode error `data-message` attribute and the HTML5 poster `<img src>`). This neutralizes `"`, `'`, `<`, `>`, and `&`, which is sufficient to prevent breaking out of the attribute context, while leaving every legitimate id (YouTube/Dailymotion ids only ever use `[A-Za-z0-9_-]`) byte-for-byte unchanged.

The fix is scoped to the two guest-facing sinks named in the advisory. The admin-only `editmodeImagePreview` thumbnail `<img>` tags (also using the same unescaped id, but rendered only in the editor's own edit-mode session) are a separate, self-XSS-only surface not covered by this report and are left untouched to keep the change minimal.

## Backward compatibility

Checked against `pimcore-backward-compatibility`: `parseYoutubeId()`, `getYoutubeCode()`, and `getDailymotionCode()` are all `private` methods — not public API, so no signature/visibility/BC concern there. The only observably public surface is `Video::frontend()`'s rendered HTML. For every legitimate id (the charset YouTube/Dailymotion actually issue), the escaped and unescaped output are identical, since `htmlspecialchars` only affects `"`, `'`, `<`, `>`, `&`. Output changes only for ids containing those characters — which were never valid video ids and previously produced broken/exploitable markup, not usable video embeds. This is a security-hardening escape at a rendering boundary, not a behavior change to any documented feature, per the "escape where it actually matters" guidance — no deprecation path is needed.

## Testing

Tests added: `tests/Unit/Document/Editable/VideoTest.php`

- `testYoutubeFrontendEscapesIdContainingDoubleQuote` / `testDailymotionFrontendEscapesIdContainingDoubleQuote` reproduce the PoC id from the advisory, assert the `onload` handler no longer appears unescaped in the rendered markup, and assert the escaped form is present instead. These fail against the vulnerable code (raw `onload="..."` present) and pass against the fix.
- `testYoutubeFrontendStillRendersALegitimateId` / `testDailymotionFrontendStillRendersALegitimateId` pin down that ordinary ids render into the expected `iframe src` unchanged, guarding against the escaping regressing legitimate embeds.

I could not execute the suite in this sandbox (no Composer/network access, no `vendor/`) — the tests are written to run under the existing `tests/Unit/Document/Editable` Codeception unit suite and should be verified in CI.

Security-Advisory: pimcore/pimcore/GHSA-mvh8-52hw-jrch




> Generated by [Draft a security-advisory fix](https://github.com/pimcore/workflows-centralized/actions/runs/32613328888) · sonnet50 · 75.6 AIC · ⌖ 16.6 AIC · ⊞ 6.2K · [◷](https://github.com/search?q=repo%3Apimcore%2Fpimcore+%22gh-aw-workflow-id%3A+advisory-fix%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Draft a security-advisory fix, engine: claude, model: claude-sonnet-5, id: 32613328888, workflow_id: advisory-fix, run: https://github.com/pimcore/workflows-centralized/actions/runs/32613328888 -->

<!-- gh-aw-workflow-id: advisory-fix -->
<!-- gh-aw-workflow-call-id: pimcore/workflows-centralized/advisory-fix -->