### PR TITLE
[security] GHSA-9g27-c28m-8xg5: Stored XSS via Link editable — unescaped href path

### DIFF
--- a/models/Document/Editable/Link.php
+++ b/models/Document/Editable/Link.php
@@ -169,6 +169,7 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
         $this->updatePathFromInternal();
 
         $url = $this->data['path'] ?? '';
+        $url = $this->hasDangerousUrlScheme($url) ? '' : htmlspecialchars($url, ENT_QUOTES, 'UTF-8');
 
         if (strlen($this->data['parameters'] ?? '') > 0) {
             $url .= (str_contains($url, '?') ? '&' : '?') . htmlspecialchars(str_replace('?', '', $this->getParameters()));
@@ -180,6 +181,26 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
         }
 
         return $url;
+    }
+
+    /**
+     * A `direct`-type link keeps the editor-supplied path verbatim (see setDataFromEditmode()),
+     * so the href value can carry a script-executing scheme even after HTML-escaping. Browsers
+     * ignore leading/trailing whitespace and embedded control characters (e.g. tabs, newlines)
+     * when parsing a URL scheme, so those are stripped before the comparison to prevent bypasses
+     * such as "java\tscript:".
+     */
+    private function hasDangerousUrlScheme(string $url): bool
+    {
+        $normalized = strtolower(preg_replace('/[\x00-\x20]+/', '', $url) ?? '');
+
+        foreach (['javascript:', 'vbscript:', 'data:'] as $scheme) {
+            if (str_starts_with($normalized, $scheme)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function updatePathFromInternal(bool $realPath = false, bool $editmode = false): void

--- a/tests/Unit/Document/Editable/LinkTest.php
+++ b/tests/Unit/Document/Editable/LinkTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Document\Editable;
+
+use Pimcore\Model\Document\Editable\Link;
+use Pimcore\Tests\Support\Test\TestCase;
+
+class LinkTest extends TestCase
+{
+    public function testGetHrefEscapesAttributeBreakoutCharacters(): void
+    {
+        $link = new Link();
+        $link->setDataFromResource([
+            'path' => '#x" onclick="alert(document.domain)',
+            'linktype' => 'direct',
+        ]);
+
+        $this->assertSame('#x&quot; onclick=&quot;alert(document.domain)', $link->getHref());
+    }
+
+    public function testGetHrefStripsJavascriptScheme(): void
+    {
+        $link = new Link();
+        $link->setDataFromResource([
+            'path' => 'javascript:alert(document.domain)',
+            'linktype' => 'direct',
+        ]);
+
+        $this->assertSame('', $link->getHref());
+    }
+
+    public function testGetHrefStripsJavascriptSchemeWithEmbeddedWhitespace(): void
+    {
+        $link = new Link();
+        $link->setDataFromResource([
+            'path' => "java\tscript:alert(document.domain)",
+            'linktype' => 'direct',
+        ]);
+
+        $this->assertSame('', $link->getHref());
+    }
+
+    public function testGetHrefStripsDataScheme(): void
+    {
+        $link = new Link();
+        $link->setDataFromResource([
+            'path' => 'data:text/html,<script>alert(document.domain)</script>',
+            'linktype' => 'direct',
+        ]);
+
+        $this->assertSame('', $link->getHref());
+    }
+
+    public function testFrontendDoesNotEmitAttributeBreakoutOrScriptScheme(): void
+    {
+        $xssAttribute = new Link();
+        $xssAttribute->setDataFromResource([
+            'path' => '#x" onclick="alert(document.domain)',
+            'linktype' => 'direct',
+        ]);
+
+        $this->assertStringNotContainsString('onclick=', $xssAttribute->frontend());
+
+        $xssScheme = new Link();
+        $xssScheme->setDataFromResource([
+            'path' => 'javascript:alert(document.domain)',
+            'linktype' => 'direct',
+        ]);
+
+        $this->assertSame('', $xssScheme->frontend());
+    }
+
+    public function testGetHrefKeepsLegitimatePathIntact(): void
+    {
+        $link = new Link();
+        $link->setDataFromResource([
+            'path' => 'https://example.com/some/page',
+            'linktype' => 'direct',
+        ]);
+
+        $this->assertSame('https://example.com/some/page', $link->getHref());
+    }
+}


### PR DESCRIPTION
## Vulnerability

`Document\Editable\Link::frontend()` interpolates the stored `path` directly into `<a href="...">` without escaping (`Link.php:121`, sink). For a `direct`-type link whose path does not resolve to a document/asset/object, `setDataFromEditmode()` keeps that path verbatim (`Link.php:314-332`) and `getHref()` returns it raw (`Link.php:171`) — only `parameters`/`anchor` were escaped, not `path`. There was also no scheme filter anywhere in the model.

A document editor (document-edit permission, not admin) can therefore store a link path such as:
- `#x" onclick="alert(document.domain)` — breaks out of the `href` attribute and injects an event handler, or
- `(redacted) — a script-executing scheme that fires on click.

Because Twig's `pimcore_*` editable functions are `is_safe => ['html']`, the resulting markup is emitted unescaped to every anonymous visitor who views/clicks the published link (CWE-79, CVSS 4.0 base 5.1/Medium).

## Fix

`getHref()` now:
1. HTML-escapes the raw `path` (`htmlspecialchars($url, ENT_QUOTES, 'UTF-8')`), the same treatment already applied to the sibling `parameters`/`anchor` fields — this closes the attribute break-out.
2. Rejects `(redacted) `(redacted) and `(redacted) schemes outright (returns an empty href), since HTML-escaping alone does not neutralize a script-executing URL scheme. The scheme check normalizes away embedded whitespace/control characters first (e.g. tabs/newlines) to prevent trivial bypasses like `java\tscript:`.

The escaping is applied inside `getHref()` at the point the raw path is read — not by re-escaping the whole assembled return value at the `frontend()` call site — because `parameters` and `anchor` are already individually pre-escaped further down in the same method; escaping the full assembled string a second time at the sink would double-encode those parts (e.g. `&` → `&`). This mirrors the existing escaping pattern in the file rather than introducing a new one.

## Backward compatibility

Checked against `pimcore-backward-compatibility`. `getHref()` and `frontend()` are non-`@internal` public methods, so this is scrutinized as a potential behavior change, not exempted for being a security fix:

- **HTML-escaping the path**: for any well-formed URL (the overwhelming majority of real usage — no literal `"`, `<`, `>`, `&`, `'` in the path itself), `htmlspecialchars` is a no-op, so `getHref()`/`frontend()` output is byte-identical to before. It only changes output for paths containing HTML-attribute-breaking characters, which were never renderable safely in the first place.
- **Scheme rejection**: `(redacted) are not part of any documented "direct" link use case (see `doc/01_Documents/02_Templates/03_Editables/18_Link.md`) and are exactly the vector this advisory reports — there is no legitimate, currently-documented behavior being removed.
- No signature, default argument, return type, or visibility changed.

Net: this is a defect fix that only changes output for inputs that were already unsafe/unintended; it does not alter behavior for legitimate content.

## Testing

Tests added: `tests/Unit/Document/Editable/LinkTest.php`

These tests fail against the pre-fix code (raw `"`/`(redacted) pass straight through `getHref()`/`frontend()`) and pass against the fix:
- attribute break-out payload is escaped (`&quot;` instead of raw `"`), and `onclick=` never appears in `frontend()` output
- `(redacted) `(redacted) and a whitespace-obfuscated `java\tscript:` scheme are all rejected to an empty href, in both `getHref()` and `frontend()`
- a legitimate `(example.com/redacted) path is returned byte-for-byte unchanged, confirming no regression for normal links

I could not execute the test suite in this sandbox (no Composer/network access); the tests were written and manually traced against both the vulnerable and fixed code paths.

Security-Advisory: pimcore/pimcore/GHSA-9g27-c28m-8xg5




> Generated by [Draft a security-advisory fix](https://github.com/pimcore/workflows-centralized/actions/runs/32613313808) · sonnet50 · 99.4 AIC · ⌖ 6.71 AIC · ⊞ 6.2K · [◷](https://github.com/search?q=repo%3Apimcore%2Fpimcore+%22gh-aw-workflow-id%3A+advisory-fix%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Draft a security-advisory fix, engine: claude, model: claude-sonnet-5, id: 32613313808, workflow_id: advisory-fix, run: https://github.com/pimcore/workflows-centralized/actions/runs/32613313808 -->

<!-- gh-aw-workflow-id: advisory-fix -->
<!-- gh-aw-workflow-call-id: pimcore/workflows-centralized/advisory-fix -->