### PR TITLE
[Workflow] Dispatch PRE_NOTIFICATION_SENDING before transition notifications

### DIFF
--- a/doc/13_Upgrade_Notes/README.md
+++ b/doc/13_Upgrade_Notes/README.md
@@ -34,7 +34,7 @@
   - The `ALTER TABLE`/`CONVERT TO CHARACTER SET` statements rewrite the affected columns' storage and typically run as full table rebuilds, which can take time and hold locks on `assets`, `documents`, `objects` and `properties` on large installations — plan to run this migration during a maintenance window on such installs.
 
 ### [Workflow]
-- [Notifications] A new event `Pimcore\Event\WorkflowEvents::PRE_NOTIFICATION_SENDING` (`Pimcore\Event\Workflow\NotificationEmailEvent`) is dispatched before the notification channels configured on a transition are notified. Listeners can rewrite the user and role lists - e.g. to notify the subject's owner - and the behaviour is unchanged when no listener is registered. The `@internal` `Pimcore\Workflow\EventSubscriber\NotificationSubscriber` takes an additional `EventDispatcherInterface` constructor argument.
+- [Notifications] A new event `Pimcore\Event\WorkflowEvents::PRE_NOTIFICATION_SENDING` (`Pimcore\Event\Workflow\WorkflowNotificationEvent`) is dispatched once per notification setting on a transition, before every channel that setting configures - so a listener's changes apply to the Pimcore notification as well as to the mail. Listeners can rewrite the user and role lists, e.g. to notify the subject's owner, and the behaviour is unchanged when no listener is registered. The `@internal` `Pimcore\Workflow\EventSubscriber\NotificationSubscriber` takes an additional `EventDispatcherInterface` constructor argument.
 
 ## Pimcore 2026.2.5
 

--- a/doc/13_Upgrade_Notes/README.md
+++ b/doc/13_Upgrade_Notes/README.md
@@ -33,6 +33,9 @@
   - The migration is **irreversible** (`down()` throws) — reverting `utf8mb4` columns back to `utf8`/`utf8mb3` could silently replace stored 4-byte characters (e.g. emoji) with `?` given this application's intentionally permissive `sql_mode=''`. Restore from a backup if you need to roll back.
   - The `ALTER TABLE`/`CONVERT TO CHARACTER SET` statements rewrite the affected columns' storage and typically run as full table rebuilds, which can take time and hold locks on `assets`, `documents`, `objects` and `properties` on large installations — plan to run this migration during a maintenance window on such installs.
 
+### [Workflow]
+- [Notifications] A new event `Pimcore\Event\WorkflowEvents::PRE_NOTIFICATION_SENDING` (`Pimcore\Event\Workflow\NotificationEmailEvent`) is dispatched before the notification channels configured on a transition are notified. Listeners can rewrite the user and role lists - e.g. to notify the subject's owner - and the behaviour is unchanged when no listener is registered. The `@internal` `Pimcore\Workflow\EventSubscriber\NotificationSubscriber` takes an additional `EventDispatcherInterface` constructor argument.
+
 ## Pimcore 2026.2.5
 
 ### [Custom Reports]

--- a/lib/Event/Workflow/NotificationEmailEvent.php
+++ b/lib/Event/Workflow/NotificationEmailEvent.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Event\Workflow;
+
+use Pimcore\Model\Element\ElementInterface;
+use Symfony\Component\Workflow\Transition;
+use Symfony\Component\Workflow\WorkflowInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Dispatched before a workflow transition notification is sent, so that listeners can adjust the
+ * recipients configured on the transition - for example to add the element's owner, or to resolve a
+ * role to the users that currently hold it.
+ */
+class NotificationEmailEvent extends Event
+{
+    /**
+     * @param string[] $users names of the users to notify
+     * @param string[] $roles names of the roles to notify
+     */
+    public function __construct(
+        private readonly Transition $transition,
+        private readonly WorkflowInterface $workflow,
+        private readonly ElementInterface $subject,
+        private readonly string $mailType,
+        private readonly string $mailPath,
+        private array $users,
+        private array $roles,
+    ) {
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getUsers(): array
+    {
+        return $this->users;
+    }
+
+    /**
+     * @param string[] $users
+     */
+    public function setUsers(array $users): void
+    {
+        $this->users = $users;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getRoles(): array
+    {
+        return $this->roles;
+    }
+
+    /**
+     * @param string[] $roles
+     */
+    public function setRoles(array $roles): void
+    {
+        $this->roles = $roles;
+    }
+
+    public function getWorkflow(): WorkflowInterface
+    {
+        return $this->workflow;
+    }
+
+    public function getTransition(): Transition
+    {
+        return $this->transition;
+    }
+
+    public function getSubject(): ElementInterface
+    {
+        return $this->subject;
+    }
+
+    public function getMailType(): string
+    {
+        return $this->mailType;
+    }
+
+    public function getMailPath(): string
+    {
+        return $this->mailPath;
+    }
+}

--- a/lib/Event/Workflow/WorkflowNotificationEvent.php
+++ b/lib/Event/Workflow/WorkflowNotificationEvent.php
@@ -19,11 +19,16 @@ use Symfony\Component\Workflow\WorkflowInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
- * Dispatched before a workflow transition notification is sent, so that listeners can adjust the
- * recipients configured on the transition - for example to add the element's owner, or to resolve a
+ * Dispatched before the notifications configured on a workflow transition are sent, so that
+ * listeners can adjust the recipients - for example to add the element's owner, or to resolve a
  * role to the users that currently hold it.
+ *
+ * One event per notification setting, dispatched before *every* channel that setting configures,
+ * so a listener's changes apply to the Pimcore notification as well as to the mail. The mail type
+ * and path describe the setting's mail configuration and are carried for context; they are set
+ * whether or not the mail channel is among the configured ones.
  */
-class NotificationEmailEvent extends Event
+class WorkflowNotificationEvent extends Event
 {
     /**
      * @param string[] $users names of the users to notify

--- a/lib/Event/WorkflowEvents.php
+++ b/lib/Event/WorkflowEvents.php
@@ -36,10 +36,11 @@ final class WorkflowEvents
     const POST_GLOBAL_ACTION = 'pimcore.workflow.postGlobalAction';
 
     /**
-     * Fired BEFORE the notifications configured on a workflow transition are sent. Use this to adjust
-     * the recipients, i.e. to add the subject's owner to the list of notified users.
+     * Fired BEFORE the notifications configured on a workflow transition are sent - once per
+     * notification setting, ahead of every channel that setting configures. Use this to adjust the
+     * recipients, i.e. to add the subject's owner to the list of notified users.
      *
-     * @Event("Pimcore\Event\Workflow\NotificationEmailEvent")
+     * @Event("Pimcore\Event\Workflow\WorkflowNotificationEvent")
      *
      * @var string
      */

--- a/lib/Event/WorkflowEvents.php
+++ b/lib/Event/WorkflowEvents.php
@@ -34,4 +34,14 @@ final class WorkflowEvents
      * @var string
      */
     const POST_GLOBAL_ACTION = 'pimcore.workflow.postGlobalAction';
+
+    /**
+     * Fired BEFORE the notifications configured on a workflow transition are sent. Use this to adjust
+     * the recipients, i.e. to add the subject's owner to the list of notified users.
+     *
+     * @Event("Pimcore\Event\Workflow\NotificationEmailEvent")
+     *
+     * @var string
+     */
+    const PRE_NOTIFICATION_SENDING = 'pimcore.workflow.preNotificationSending';
 }

--- a/lib/Workflow/EventSubscriber/NotificationSubscriber.php
+++ b/lib/Workflow/EventSubscriber/NotificationSubscriber.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Pimcore\Workflow\EventSubscriber;
 
+use Pimcore\Event\Workflow\NotificationEmailEvent;
+use Pimcore\Event\WorkflowEvents;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Element\Service;
@@ -25,6 +27,7 @@ use Pimcore\Workflow\Transition;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Workflow\Event\Event;
 use Symfony\Component\Workflow\WorkflowInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -54,18 +57,22 @@ class NotificationSubscriber implements EventSubscriberInterface
 
     protected Workflow\Manager $workflowManager;
 
+    protected EventDispatcherInterface $eventDispatcher;
+
     public function __construct(
         NotificationEmailService $mailService,
         PimcoreNotificationService $pimcoreNotificationService,
         TranslatorInterface $translator,
         ExpressionService $expressionService,
-        Manager $workflowManager
+        Manager $workflowManager,
+        EventDispatcherInterface $eventDispatcher
     ) {
         $this->mailService = $mailService;
         $this->pimcoreNotificationService = $pimcoreNotificationService;
         $this->translator = $translator;
         $this->expressionService = $expressionService;
         $this->workflowManager = $workflowManager;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     public function onWorkflowCompleted(Event $event): void
@@ -92,6 +99,20 @@ class NotificationSubscriber implements EventSubscriberInterface
             if (empty($condition) || $this->expressionService->evaluateExpression($workflow, $subject, $condition)) {
                 $notifyUsers = $notificationSetting['notifyUsers'] ?? [];
                 $notifyRoles = $notificationSetting['notifyRoles'] ?? [];
+
+                $notificationEmailEvent = new NotificationEmailEvent(
+                    $transition,
+                    $workflow,
+                    $subject,
+                    $notificationSetting['mailType'],
+                    $notificationSetting['mailPath'],
+                    $notifyUsers,
+                    $notifyRoles
+                );
+                $this->eventDispatcher->dispatch($notificationEmailEvent, WorkflowEvents::PRE_NOTIFICATION_SENDING);
+
+                $notifyUsers = $notificationEmailEvent->getUsers();
+                $notifyRoles = $notificationEmailEvent->getRoles();
 
                 if (in_array(self::NOTIFICATION_CHANNEL_MAIL, $notificationSetting['channelType'])) {
                     $this->handleNotifyPostWorkflowEmail(

--- a/lib/Workflow/EventSubscriber/NotificationSubscriber.php
+++ b/lib/Workflow/EventSubscriber/NotificationSubscriber.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Workflow\EventSubscriber;
 
-use Pimcore\Event\Workflow\NotificationEmailEvent;
+use Pimcore\Event\Workflow\WorkflowNotificationEvent;
 use Pimcore\Event\WorkflowEvents;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\Element\ElementInterface;
@@ -100,7 +100,7 @@ class NotificationSubscriber implements EventSubscriberInterface
                 $notifyUsers = $notificationSetting['notifyUsers'] ?? [];
                 $notifyRoles = $notificationSetting['notifyRoles'] ?? [];
 
-                $notificationEmailEvent = new NotificationEmailEvent(
+                $notificationEvent = new WorkflowNotificationEvent(
                     $transition,
                     $workflow,
                     $subject,
@@ -109,10 +109,10 @@ class NotificationSubscriber implements EventSubscriberInterface
                     $notifyUsers,
                     $notifyRoles
                 );
-                $this->eventDispatcher->dispatch($notificationEmailEvent, WorkflowEvents::PRE_NOTIFICATION_SENDING);
+                $this->eventDispatcher->dispatch($notificationEvent, WorkflowEvents::PRE_NOTIFICATION_SENDING);
 
-                $notifyUsers = $notificationEmailEvent->getUsers();
-                $notifyRoles = $notificationEmailEvent->getRoles();
+                $notifyUsers = $notificationEvent->getUsers();
+                $notifyRoles = $notificationEvent->getRoles();
 
                 if (in_array(self::NOTIFICATION_CHANNEL_MAIL, $notificationSetting['channelType'])) {
                     $this->handleNotifyPostWorkflowEmail(

--- a/tests/Unit/Workflow/EventSubscriber/NotificationSubscriberTest.php
+++ b/tests/Unit/Workflow/EventSubscriber/NotificationSubscriberTest.php
@@ -1,0 +1,362 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Workflow\EventSubscriber;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Pimcore\Event\Workflow\WorkflowNotificationEvent;
+use Pimcore\Event\WorkflowEvents;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Tests\Support\Test\TestCase;
+use Pimcore\Workflow\EventSubscriber\NotificationSubscriber;
+use Pimcore\Workflow\ExpressionService;
+use Pimcore\Workflow\Manager;
+use Pimcore\Workflow\Notification\NotificationEmailService;
+use Pimcore\Workflow\Notification\PimcoreNotificationService;
+use Pimcore\Workflow\Transition as PimcoreTransition;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Workflow\Event\CompletedEvent;
+use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\WorkflowInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Covers the WorkflowEvents::PRE_NOTIFICATION_SENDING event dispatched by the
+ * NotificationSubscriber before the notifications configured on a transition are sent.
+ */
+class NotificationSubscriberTest extends TestCase
+{
+    private const WORKFLOW_NAME = 'test_wf';
+
+    private const SUBJECT_TYPE = 'Product';
+
+    private const CONFIGURED_USERS = ['configured_user'];
+
+    private const CONFIGURED_ROLES = ['configured_role'];
+
+    private NotificationEmailService&MockObject $mailService;
+
+    private PimcoreNotificationService&MockObject $pimcoreNotificationService;
+
+    private ExpressionService&MockObject $expressionService;
+
+    private WorkflowInterface $workflow;
+
+    private Concrete&MockObject $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mailService = $this->createMock(NotificationEmailService::class);
+        $this->pimcoreNotificationService = $this->createMock(PimcoreNotificationService::class);
+        $this->expressionService = $this->createMock(ExpressionService::class);
+
+        $workflow = $this->createStub(WorkflowInterface::class);
+        $workflow->method('getName')->willReturn(self::WORKFLOW_NAME);
+        $this->workflow = $workflow;
+
+        $this->subject = $this->createMock(Concrete::class);
+        $this->subject->method('getClassName')->willReturn(self::SUBJECT_TYPE);
+    }
+
+    /**
+     * Regression: with no listener registered, both channels must still receive exactly the
+     * users and roles configured on the transition.
+     */
+    public function testRecipientsAreUnchangedWhenNoListenerIsRegistered(): void
+    {
+        $transition = $this->createTransition([
+            $this->createNotificationSetting([
+                NotificationSubscriber::NOTIFICATION_CHANNEL_MAIL,
+                NotificationSubscriber::NOTIFICATION_CHANNEL_PIMCORE_NOTIFICATION,
+            ]),
+        ]);
+
+        $this->expectMail($transition, self::CONFIGURED_USERS, self::CONFIGURED_ROLES);
+        $this->expectPimcoreNotification($transition, self::CONFIGURED_USERS, self::CONFIGURED_ROLES);
+
+        $subscriber = $this->createSubscriber(new EventDispatcher());
+        $subscriber->onWorkflowCompleted($this->createCompletedEvent($transition));
+    }
+
+    /**
+     * A listener rewriting the recipients must affect the mail *and* the Pimcore notification
+     * channel - the event is not mail-specific.
+     */
+    public function testListenerCanRewriteRecipientsForBothChannels(): void
+    {
+        $transition = $this->createTransition([
+            $this->createNotificationSetting([
+                NotificationSubscriber::NOTIFICATION_CHANNEL_MAIL,
+                NotificationSubscriber::NOTIFICATION_CHANNEL_PIMCORE_NOTIFICATION,
+            ]),
+        ]);
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addListener(
+            WorkflowEvents::PRE_NOTIFICATION_SENDING,
+            static function (WorkflowNotificationEvent $event): void {
+                $event->setUsers([...$event->getUsers(), 'owner']);
+                $event->setRoles(['reviewer']);
+            }
+        );
+
+        $this->expectMail($transition, ['configured_user', 'owner'], ['reviewer']);
+        $this->expectPimcoreNotification($transition, ['configured_user', 'owner'], ['reviewer']);
+
+        $subscriber = $this->createSubscriber($eventDispatcher);
+        $subscriber->onWorkflowCompleted($this->createCompletedEvent($transition));
+    }
+
+    public function testEventCarriesTransitionWorkflowSubjectRecipientsAndMailSettings(): void
+    {
+        $transition = $this->createTransition([
+            $this->createNotificationSetting(
+                [NotificationSubscriber::NOTIFICATION_CHANNEL_PIMCORE_NOTIFICATION],
+                NotificationSubscriber::MAIL_TYPE_DOCUMENT,
+                '/emails/%_locale%/workflow'
+            ),
+        ]);
+
+        /** @var WorkflowNotificationEvent[] $dispatched */
+        $dispatched = [];
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addListener(
+            WorkflowEvents::PRE_NOTIFICATION_SENDING,
+            static function (WorkflowNotificationEvent $event) use (&$dispatched): void {
+                $dispatched[] = $event;
+            }
+        );
+
+        $subscriber = $this->createSubscriber($eventDispatcher);
+        $subscriber->onWorkflowCompleted($this->createCompletedEvent($transition));
+
+        $this->assertCount(1, $dispatched);
+        $event = $dispatched[0];
+        $this->assertSame($transition, $event->getTransition());
+        $this->assertSame($this->workflow, $event->getWorkflow());
+        $this->assertSame($this->subject, $event->getSubject());
+        $this->assertSame(self::CONFIGURED_USERS, $event->getUsers());
+        $this->assertSame(self::CONFIGURED_ROLES, $event->getRoles());
+        $this->assertSame(NotificationSubscriber::MAIL_TYPE_DOCUMENT, $event->getMailType());
+        $this->assertSame(
+            '/emails/%_locale%/workflow',
+            $event->getMailPath(),
+            'The mail settings are carried for context even when the mail channel is not configured.'
+        );
+    }
+
+    /**
+     * One event per notification setting, so a listener can decide per setting - and the
+     * rewritten recipients of one setting must not leak into another.
+     */
+    public function testEventIsDispatchedOncePerNotificationSetting(): void
+    {
+        $transition = $this->createTransition([
+            $this->createNotificationSetting(
+                [NotificationSubscriber::NOTIFICATION_CHANNEL_MAIL],
+                NotificationSubscriber::MAIL_TYPE_TEMPLATE,
+                '/mail/first'
+            ),
+            $this->createNotificationSetting(
+                [NotificationSubscriber::NOTIFICATION_CHANNEL_PIMCORE_NOTIFICATION],
+                NotificationSubscriber::MAIL_TYPE_TEMPLATE,
+                '/mail/second'
+            ),
+        ]);
+
+        $seenMailPaths = [];
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addListener(
+            WorkflowEvents::PRE_NOTIFICATION_SENDING,
+            static function (WorkflowNotificationEvent $event) use (&$seenMailPaths): void {
+                $seenMailPaths[] = $event->getMailPath();
+
+                if ($event->getMailPath() === '/mail/first') {
+                    $event->setUsers(['mail_only_user']);
+                }
+            }
+        );
+
+        $this->expectMail($transition, ['mail_only_user'], self::CONFIGURED_ROLES, '/mail/first');
+        $this->expectPimcoreNotification($transition, self::CONFIGURED_USERS, self::CONFIGURED_ROLES);
+
+        $subscriber = $this->createSubscriber($eventDispatcher);
+        $subscriber->onWorkflowCompleted($this->createCompletedEvent($transition));
+
+        $this->assertSame(['/mail/first', '/mail/second'], $seenMailPaths);
+    }
+
+    public function testEventIsNotDispatchedWhenConditionIsNotMet(): void
+    {
+        $transition = $this->createTransition([
+            $this->createNotificationSetting(
+                [
+                    NotificationSubscriber::NOTIFICATION_CHANNEL_MAIL,
+                    NotificationSubscriber::NOTIFICATION_CHANNEL_PIMCORE_NOTIFICATION,
+                ],
+                condition: 'subject.getPublished()'
+            ),
+        ]);
+
+        $this->expressionService
+            ->expects($this->once())
+            ->method('evaluateExpression')
+            ->with($this->workflow, $this->subject, 'subject.getPublished()')
+            ->willReturn(false);
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addListener(
+            WorkflowEvents::PRE_NOTIFICATION_SENDING,
+            static function (): void {
+                self::fail('The event must not be dispatched when the notification condition is not met.');
+            }
+        );
+
+        $this->mailService->expects($this->never())->method('sendWorkflowEmailNotification');
+        $this->pimcoreNotificationService->expects($this->never())->method('sendPimcoreNotification');
+
+        $subscriber = $this->createSubscriber($eventDispatcher);
+        $subscriber->onWorkflowCompleted($this->createCompletedEvent($transition));
+    }
+
+    public function testEventIsDispatchedWhenConditionIsMet(): void
+    {
+        $transition = $this->createTransition([
+            $this->createNotificationSetting(
+                [NotificationSubscriber::NOTIFICATION_CHANNEL_MAIL],
+                condition: 'subject.getPublished()'
+            ),
+        ]);
+
+        $this->expressionService
+            ->expects($this->once())
+            ->method('evaluateExpression')
+            ->with($this->workflow, $this->subject, 'subject.getPublished()')
+            ->willReturn(true);
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addListener(
+            WorkflowEvents::PRE_NOTIFICATION_SENDING,
+            static function (WorkflowNotificationEvent $event): void {
+                $event->setRoles([]);
+            }
+        );
+
+        $this->expectMail($transition, self::CONFIGURED_USERS, []);
+        $this->pimcoreNotificationService->expects($this->never())->method('sendPimcoreNotification');
+
+        $subscriber = $this->createSubscriber($eventDispatcher);
+        $subscriber->onWorkflowCompleted($this->createCompletedEvent($transition));
+    }
+
+    public function testEventIsNotDispatchedWhenSubscriberIsDisabled(): void
+    {
+        $transition = $this->createTransition([
+            $this->createNotificationSetting([NotificationSubscriber::NOTIFICATION_CHANNEL_MAIL]),
+        ]);
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addListener(
+            WorkflowEvents::PRE_NOTIFICATION_SENDING,
+            static function (): void {
+                self::fail('The event must not be dispatched when the subscriber is disabled.');
+            }
+        );
+
+        $this->mailService->expects($this->never())->method('sendWorkflowEmailNotification');
+
+        $subscriber = $this->createSubscriber($eventDispatcher);
+        $subscriber->setEnabled(false);
+        $subscriber->onWorkflowCompleted($this->createCompletedEvent($transition));
+    }
+
+    private function createSubscriber(EventDispatcher $eventDispatcher): NotificationSubscriber
+    {
+        $workflowManager = $this->createMock(Manager::class);
+        $workflowManager
+            ->method('getWorkflowByName')
+            ->with(self::WORKFLOW_NAME)
+            ->willReturn($this->workflow);
+
+        return new NotificationSubscriber(
+            $this->mailService,
+            $this->pimcoreNotificationService,
+            $this->createStub(TranslatorInterface::class),
+            $this->expressionService,
+            $workflowManager,
+            $eventDispatcher
+        );
+    }
+
+    /**
+     * @param string[] $channelType
+     */
+    private function createNotificationSetting(
+        array $channelType,
+        string $mailType = NotificationSubscriber::MAIL_TYPE_TEMPLATE,
+        string $mailPath = NotificationSubscriber::DEFAULT_MAIL_TEMPLATE_PATH,
+        ?string $condition = null
+    ): array {
+        return [
+            'condition' => $condition,
+            'notifyUsers' => self::CONFIGURED_USERS,
+            'notifyRoles' => self::CONFIGURED_ROLES,
+            'channelType' => $channelType,
+            'mailType' => $mailType,
+            'mailPath' => $mailPath,
+        ];
+    }
+
+    private function createTransition(array $notificationSettings): PimcoreTransition
+    {
+        return new PimcoreTransition('go', 'start', 'end', [
+            'notificationSettings' => $notificationSettings,
+        ]);
+    }
+
+    private function createCompletedEvent(PimcoreTransition $transition): CompletedEvent
+    {
+        return new CompletedEvent($this->subject, new Marking(['start' => 1]), $transition, $this->workflow);
+    }
+
+    private function expectMail(
+        PimcoreTransition $transition,
+        array $users,
+        array $roles,
+        string $mailPath = NotificationSubscriber::DEFAULT_MAIL_TEMPLATE_PATH
+    ): void {
+        $this->mailService
+            ->expects($this->once())
+            ->method('sendWorkflowEmailNotification')
+            ->with(
+                $users,
+                $roles,
+                $this->workflow,
+                self::SUBJECT_TYPE,
+                $this->subject,
+                $transition,
+                NotificationSubscriber::MAIL_TYPE_TEMPLATE,
+                $mailPath
+            );
+    }
+
+    private function expectPimcoreNotification(PimcoreTransition $transition, array $users, array $roles): void
+    {
+        $this->pimcoreNotificationService
+            ->expects($this->once())
+            ->method('sendPimcoreNotification')
+            ->with($users, $roles, $this->workflow, self::SUBJECT_TYPE, $this->subject, $transition);
+    }
+}


### PR DESCRIPTION
Fixes pimcore/platform-version#390

## Changes in this pull request

The users and roles notified on a workflow transition are fixed in the workflow YAML. Adjusting them at runtime — notifying the element's owner, or the users who edited it since the last transition — is not expressible in configuration today, so the only way to do it is to replace `NotificationSubscriber` wholesale.

This dispatches a `NotificationEmailEvent` before the configured channels are notified. A listener receives the transition, workflow, subject, mail type and mail path, and can rewrite the user and role lists. With no listener registered the behaviour is unchanged.

- new event class `Pimcore\\Event\\Workflow\\NotificationEmailEvent`
- new constant `Pimcore\\Event\\WorkflowEvents::PRE_NOTIFICATION_SENDING`
- `NotificationSubscriber` (`@internal`) takes an `EventDispatcherInterface` and dispatches once per notification setting, after the condition is evaluated
- upgrade note added

## Additional info

This is broader than #19134, which passes the recipients to the mail template but leaves the recipient list itself fixed. We have run this in production since 2025 as a vendor patch — a `USER_OWNER` keyword in the workflow config that the listener expands to the object's owner.