### PR TITLE
[DataObject] Allow filtering a reverse relation for an empty relation

### DIFF
--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -227,15 +227,27 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
             throw new Exception('Function ReverseObjectRelation::getFilterConditionExt called without a table prefix.');
         }
 
+        $ownerClassId = $this->getOwnerClassId();
+        if ($ownerClassId === null) {
+            // no owner class resolved (getOwnerClassId() logs why), so there is no relation table
+            // to query - the same situation load() answers with an empty result
+            return $noResult;
+        }
+
         $db = \Pimcore\Db::get();
 
         if ($value === null || $value === 'null') {
             // An empty filter value means "no relation from the owner side": select the objects
             // that are not referenced by any object of the owner class through the owner field.
+            //
+            // The destination type is constrained as well: object_relations_* also holds asset and
+            // document destinations, whose ids share a sequence with nothing - an asset dest_id can
+            // equal an object id - so a mixed relation would otherwise mark an unrelated object as
+            // referenced and drop it from the result.
             return $tablePrefix . 'id NOT IN ('
-                . 'SELECT dest_id FROM object_relations_' . $this->getOwnerClassId()
+                . 'SELECT dest_id FROM object_relations_' . $ownerClassId
                 . ' WHERE fieldname = ' . $db->quote($this->getOwnerFieldName())
-                . " AND ownertype = 'object'"
+                . " AND ownertype = 'object' AND type = 'object'"
             . ')';
         }
 
@@ -259,7 +271,7 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
 
         // we are looking for membership in the reverse relation
         return $tablePrefix . 'id IN ('
-            . 'SELECT dest_id FROM object_relations_'. $this->getOwnerClassId()
+            . 'SELECT dest_id FROM object_relations_'. $ownerClassId
             . ' WHERE '. $subFilter
             . ' AND fieldname = ' . $db->quote($this->getOwnerFieldName())
             . " AND ownertype = 'object'"

--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -227,11 +227,17 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
             throw new Exception('Function ReverseObjectRelation::getFilterConditionExt called without a table prefix.');
         }
 
-        if ($value === null || $value === 'null') {
-            return $noResult;
-        }
-
         $db = \Pimcore\Db::get();
+
+        if ($value === null || $value === 'null') {
+            // An empty filter value means "no relation from the owner side": select the objects
+            // that are not referenced by any object of the owner class through the owner field.
+            return $tablePrefix . 'id NOT IN ('
+                . 'SELECT dest_id FROM object_relations_' . $this->getOwnerClassId()
+                . ' WHERE fieldname = ' . $db->quote($this->getOwnerFieldName())
+                . " AND ownertype = 'object'"
+            . ')';
+        }
 
         if ($operator === '=') {
             $subFilter = '`' . 'src_id' . '`' . ' = ' . $db->quote((string) $value);

--- a/tests/Model/DataType/ReverseObjectRelationFilterTest.php
+++ b/tests/Model/DataType/ReverseObjectRelationFilterTest.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\DataType;
+
+use Pimcore\Model\DataObject\ClassDefinition\Data\ReverseObjectRelation;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+
+/**
+ * Covers the grid filter conditions ReverseObjectRelation builds.
+ *
+ * @group model.datatype.reverseobjectrelation
+ *
+ * @internal
+ */
+class ReverseObjectRelationFilterTest extends ModelTestCase
+{
+    private const NO_RESULT = '1 = 0';
+
+    private function field(?string $ownerClassId = 'ABC'): ReverseObjectRelation
+    {
+        $fd = new ReverseObjectRelation();
+        $fd->setName('reverseRelation');
+        $fd->setOwnerFieldName('relation');
+        if ($ownerClassId !== null) {
+            $fd->setOwnerClassId($ownerClassId);
+        }
+
+        return $fd;
+    }
+
+    public function testEmptyValueSelectsTheUnreferencedObjects(): void
+    {
+        $condition = $this->field()->getFilterConditionExt(null, '=', ['tablePrefix' => 'o_.']);
+
+        $this->assertStringContainsString('o_.id NOT IN (', $condition);
+        $this->assertStringContainsString('SELECT dest_id FROM object_relations_ABC', $condition);
+        $this->assertStringContainsString("ownertype = 'object'", $condition);
+        $this->assertStringContainsString(
+            "type = 'object'",
+            $condition,
+            'the destination type must be constrained, or an asset dest_id sharing an object id excludes that object'
+        );
+    }
+
+    public function testTheStringNullIsTreatedAsAnEmptyValue(): void
+    {
+        $this->assertSame(
+            $this->field()->getFilterConditionExt(null, '=', ['tablePrefix' => 'o_.']),
+            $this->field()->getFilterConditionExt('null', '=', ['tablePrefix' => 'o_.'])
+        );
+    }
+
+    public function testAValueSelectsTheReferencedObjects(): void
+    {
+        $condition = $this->field()->getFilterConditionExt(7, '=', ['tablePrefix' => 'o_.']);
+
+        $this->assertStringContainsString('o_.id IN (', $condition);
+        $this->assertStringContainsString('`src_id` = ', $condition);
+    }
+
+    /**
+     * getOwnerClassId() returns null when the owner class cannot be resolved. There is no relation
+     * table to query then, which is the case load() answers with an empty result.
+     */
+    public function testAMissingOwnerClassYieldsNoResult(): void
+    {
+        $fd = $this->field(null);
+
+        $this->assertSame(self::NO_RESULT, $fd->getFilterConditionExt(null, '=', ['tablePrefix' => 'o_.']));
+        $this->assertSame(self::NO_RESULT, $fd->getFilterConditionExt(7, '=', ['tablePrefix' => 'o_.']));
+    }
+
+    public function testAMissingTablePrefixIsRejected(): void
+    {
+        $this->expectExceptionMessage('called without a table prefix');
+
+        $this->field()->getFilterConditionExt(null, '=', []);
+    }
+}


### PR DESCRIPTION
Fixes pimcore/platform-version#391

## Changes in this pull request

Filtering a `reverseObjectRelation` grid column for an empty value currently returns the never-matching `1 = 0` condition, so "show me the objects nothing points at" — the question a reverse relation is most often asked — cannot be expressed in the grid at all.

Return the complement of the membership condition the same method already builds for a non-empty value: the objects not referenced by any object of the owner class through the owner field.

## Additional info

Builds on #18036. The admin-ui half (offering the empty filter in the UI) is carried separately.