### PR TITLE
[DataObject] Do not assume every metadata entry is an ElementMetadata container

### DIFF
--- a/models/DataObject/Traits/ElementWithMetadataComparisonTrait.php
+++ b/models/DataObject/Traits/ElementWithMetadataComparisonTrait.php
@@ -43,10 +43,15 @@ trait ElementWithMetadataComparisonTrait
                 return !$container1 && !$container2;
             }
 
-            // A value can reach isEqual() as a plain element path instead of an ElementMetadata
+            // A value can reach isEqual() as a plain element path instead of a metadata
             // container - the getElement() call below would then fatal with a TypeError. Compare
             // such entries directly, and treat a container and a path as different.
-            if (!$container1 instanceof ElementMetadata || !$container2 instanceof ElementMetadata) {
+            //
+            // The check is is_object() rather than an instanceof: the trait serves both
+            // ElementMetadata (AdvancedManyToManyRelation) and ObjectMetadata
+            // (AdvancedManyToManyObjectRelation), which are siblings rather than subclasses,
+            // and any future container implementing getElement()/getData() belongs here too.
+            if (!is_object($container1) || !is_object($container2)) {
                 if ($container1 != $container2) {
                     return false;
                 }

--- a/models/DataObject/Traits/ElementWithMetadataComparisonTrait.php
+++ b/models/DataObject/Traits/ElementWithMetadataComparisonTrait.php
@@ -52,7 +52,12 @@ trait ElementWithMetadataComparisonTrait
             // (AdvancedManyToManyObjectRelation), which are siblings rather than subclasses,
             // and any future container implementing getElement()/getData() belongs here too.
             if (!is_object($container1) || !is_object($container2)) {
-                if ($container1 != $container2) {
+                // Strict on purpose, unlike the metadata comparison below. The result of this
+                // method decides whether the field is marked dirty, and a value wrongly reported
+                // as equal is never written back - so "5" and "05", or 1 and "1", must not
+                // collapse into one another here. Reporting a difference that is not one only
+                // costs a redundant write.
+                if ($container1 !== $container2) {
                     return false;
                 }
 

--- a/models/DataObject/Traits/ElementWithMetadataComparisonTrait.php
+++ b/models/DataObject/Traits/ElementWithMetadataComparisonTrait.php
@@ -43,6 +43,17 @@ trait ElementWithMetadataComparisonTrait
                 return !$container1 && !$container2;
             }
 
+            // A value can reach isEqual() as a plain element path instead of an ElementMetadata
+            // container - the getElement() call below would then fatal with a TypeError. Compare
+            // such entries directly, and treat a container and a path as different.
+            if (!$container1 instanceof ElementMetadata || !$container2 instanceof ElementMetadata) {
+                if ($container1 != $container2) {
+                    return false;
+                }
+
+                continue;
+            }
+
             /** @var ElementInterface|null $el1 */
             $el1 = $container1->getElement();
             /** @var ElementInterface|null $el2 */

--- a/models/DataObject/Traits/ElementWithMetadataComparisonTrait.php
+++ b/models/DataObject/Traits/ElementWithMetadataComparisonTrait.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Pimcore\Model\DataObject\Traits;
 
 use Pimcore\Model\DataObject\Data\ElementMetadata;
-use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Model\DataObject\Data\ObjectMetadata;
 
 /**
  * @internal
@@ -34,10 +34,9 @@ trait ElementWithMetadataComparisonTrait
         $values2 = array_filter(array_values(is_array($newValue) ? $newValue : []));
 
         for ($i = 0; $i < $count1; $i++) {
-            /** @var ElementMetadata|null $container1 */
-            $container1 = $values1[$i];
-            /** @var ElementMetadata|null $container2 */
-            $container2 = $values2[$i];
+            // array_filter() may have dropped an entry, so either side can be missing here.
+            $container1 = $values1[$i] ?? null;
+            $container2 = $values2[$i] ?? null;
 
             if (!$container1 || !$container2) {
                 return !$container1 && !$container2;
@@ -47,11 +46,10 @@ trait ElementWithMetadataComparisonTrait
             // container - the getElement() call below would then fatal with a TypeError. Compare
             // such entries directly, and treat a container and a path as different.
             //
-            // The check is is_object() rather than an instanceof: the trait serves both
-            // ElementMetadata (AdvancedManyToManyRelation) and ObjectMetadata
-            // (AdvancedManyToManyObjectRelation), which are siblings rather than subclasses,
-            // and any future container implementing getElement()/getData() belongs here too.
-            if (!is_object($container1) || !is_object($container2)) {
+            // The trait serves both ElementMetadata (AdvancedManyToManyRelation) and
+            // ObjectMetadata (AdvancedManyToManyObjectRelation), which are siblings rather than
+            // subclasses, so both have to pass the guard.
+            if (!self::isMetadataContainer($container1) || !self::isMetadataContainer($container2)) {
                 // Strict on purpose, unlike the metadata comparison below. The result of this
                 // method decides whether the field is marked dirty, and a value wrongly reported
                 // as equal is never written back - so "5" and "05", or 1 and "1", must not
@@ -64,9 +62,7 @@ trait ElementWithMetadataComparisonTrait
                 continue;
             }
 
-            /** @var ElementInterface|null $el1 */
             $el1 = $container1->getElement();
-            /** @var ElementInterface|null $el2 */
             $el2 = $container2->getElement();
 
             if (! ($el1?->getType() == $el2?->getType() && ($el1?->getId() == $el2?->getId()))) {
@@ -81,5 +77,13 @@ trait ElementWithMetadataComparisonTrait
         }
 
         return true;
+    }
+
+    /**
+     * @phpstan-assert-if-true ElementMetadata|ObjectMetadata $value
+     */
+    private static function isMetadataContainer(mixed $value): bool
+    {
+        return $value instanceof ElementMetadata || $value instanceof ObjectMetadata;
     }
 }

--- a/tests/Unit/Model/DataObject/Traits/ElementWithMetadataComparisonTraitTest.php
+++ b/tests/Unit/Model/DataObject/Traits/ElementWithMetadataComparisonTraitTest.php
@@ -97,6 +97,20 @@ class ElementWithMetadataComparisonTraitTest extends TestCase
         ));
     }
 
+    /**
+     * The comparison is strict: isEqual() decides whether the field is marked dirty, and a value
+     * wrongly reported as equal is never written back, so values that merely look alike under
+     * loose comparison must stay different.
+     */
+    public function testLooselyEqualValuesAreStillDifferent(): void
+    {
+        $fd = new AdvancedManyToManyRelation();
+
+        $this->assertFalse($fd->isEqual(['5'], ['05']));
+        $this->assertFalse($fd->isEqual(['1'], ['1.0']));
+        $this->assertFalse($fd->isEqual([['role' => 1]], [['role' => '1']]));
+    }
+
     public function testAContainerAndAPathAreNotEqual(): void
     {
         $fd = new AdvancedManyToManyRelation();

--- a/tests/Unit/Model/DataObject/Traits/ElementWithMetadataComparisonTraitTest.php
+++ b/tests/Unit/Model/DataObject/Traits/ElementWithMetadataComparisonTraitTest.php
@@ -1,0 +1,132 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\DataObject\Traits;
+
+use Pimcore\Model\DataObject\ClassDefinition\Data\AdvancedManyToManyObjectRelation;
+use Pimcore\Model\DataObject\ClassDefinition\Data\AdvancedManyToManyRelation;
+use Pimcore\Model\DataObject\Data\ElementMetadata;
+use Pimcore\Model\DataObject\Data\ObjectMetadata;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * Unit tests for ElementWithMetadataComparisonTrait::isEqual().
+ *
+ * The containers are built without an element on purpose: getElement() resolves through the
+ * element service, and the behaviour under test here is how entries are dispatched for
+ * comparison, not how elements are loaded.
+ *
+ * @internal
+ */
+class ElementWithMetadataComparisonTraitTest extends TestCase
+{
+    protected function needsDb(): bool
+    {
+        return false;
+    }
+
+    private function elementMetadata(array $data, array $columns = ['role']): ElementMetadata
+    {
+        $metadata = new ElementMetadata('relation', $columns);
+        $metadata->setData($data);
+
+        return $metadata;
+    }
+
+    private function objectMetadata(array $data, array $columns = ['role']): ObjectMetadata
+    {
+        $metadata = new ObjectMetadata('relation', $columns);
+        $metadata->setData($data);
+
+        return $metadata;
+    }
+
+    public function testEqualContainersAreEqual(): void
+    {
+        $fd = new AdvancedManyToManyRelation();
+
+        $this->assertTrue($fd->isEqual(
+            [$this->elementMetadata(['role' => 'hero'])],
+            [$this->elementMetadata(['role' => 'hero'])]
+        ));
+    }
+
+    public function testDifferingMetadataIsNotEqual(): void
+    {
+        $fd = new AdvancedManyToManyRelation();
+
+        $this->assertFalse($fd->isEqual(
+            [$this->elementMetadata(['role' => 'hero'])],
+            [$this->elementMetadata(['role' => 'thumbnail'])]
+        ));
+    }
+
+    /**
+     * A value can reach isEqual() as a plain element path rather than a container. getElement()
+     * was called on the string, and the comparison fatalled with a TypeError.
+     */
+    public function testPathEntriesAreComparedDirectly(): void
+    {
+        $fd = new AdvancedManyToManyRelation();
+
+        $this->assertTrue($fd->isEqual(['/images/one.jpg'], ['/images/one.jpg']));
+        $this->assertFalse($fd->isEqual(['/images/one.jpg'], ['/images/two.jpg']));
+    }
+
+    /**
+     * The comparison has to continue past an equal pair: returning early would report a
+     * collection whose first entries match as unchanged, whatever follows them.
+     */
+    public function testALaterDifferenceIsStillReported(): void
+    {
+        $fd = new AdvancedManyToManyRelation();
+
+        $this->assertFalse($fd->isEqual(
+            ['/images/one.jpg', '/images/two.jpg'],
+            ['/images/one.jpg', '/images/three.jpg']
+        ));
+    }
+
+    public function testAContainerAndAPathAreNotEqual(): void
+    {
+        $fd = new AdvancedManyToManyRelation();
+
+        $this->assertFalse($fd->isEqual(
+            [$this->elementMetadata(['role' => 'hero'])],
+            ['/images/one.jpg']
+        ));
+    }
+
+    /**
+     * ObjectMetadata is a sibling of ElementMetadata, not a subclass, so a guard written as
+     * `instanceof ElementMetadata` would push every AdvancedManyToManyObjectRelation value into
+     * the plain-value branch and compare whole containers instead of element and metadata.
+     *
+     * The two containers below differ only in their column configuration, which is part of the
+     * field definition rather than of the value: comparing them as containers says equal,
+     * comparing them as plain values says different.
+     */
+    public function testObjectMetadataIsComparedAsAContainer(): void
+    {
+        $fd = new AdvancedManyToManyObjectRelation();
+
+        $this->assertTrue($fd->isEqual(
+            [$this->objectMetadata(['role' => 'hero'], ['role'])],
+            [$this->objectMetadata(['role' => 'hero'], ['role', 'comment'])]
+        ));
+        $this->assertFalse($fd->isEqual(
+            [$this->objectMetadata(['role' => 'hero'])],
+            [$this->objectMetadata(['role' => 'thumbnail'])]
+        ));
+    }
+}


### PR DESCRIPTION
Fixes pimcore/platform-version#392

## Changes in this pull request

`ElementWithMetadataComparisonTrait::isEqual()` calls `$container->getElement()` on every entry of the compared arrays. When an entry is a plain element path rather than an `ElementMetadata` container, that is a fatal `TypeError`.

### How to reproduce

Compare two versions of an object with an advanced relation whose stored value contains a path string instead of a container (this reaches us through version comparison on objects written by an older revision). The diff view 500s with `Call to a member function getElement() on string` instead of showing a difference.

Compare such entries directly and continue with the remaining ones; a container and a path are treated as different.

## Additional info

Carried as a vendor patch here for some time; this version differs from that patch in that it continues the loop instead of returning on the first equal pair, so a later difference in the same collection is still reported.