### PR TITLE
Add Dedicated AdvancedManyToManyAssetRelation

### DIFF
--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -250,6 +250,7 @@ pimcore:
                     link: \Pimcore\Model\DataObject\ClassDefinition\Data\Link
                     localizedfields: \Pimcore\Model\DataObject\ClassDefinition\Data\Localizedfields
                     manyToManyRelation: \Pimcore\Model\DataObject\ClassDefinition\Data\ManyToManyRelation
+                    advancedManyToManyAssetRelation: \Pimcore\Model\DataObject\ClassDefinition\Data\AdvancedManyToManyAssetRelation
                     advancedManyToManyRelation: \Pimcore\Model\DataObject\ClassDefinition\Data\AdvancedManyToManyRelation
                     manyToManyAssetRelation: \Pimcore\Model\DataObject\ClassDefinition\Data\ManyToManyAssetRelation
                     multiselect: \Pimcore\Model\DataObject\ClassDefinition\Data\Multiselect

--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -251,6 +251,7 @@ pimcore:
                     localizedfields: \Pimcore\Model\DataObject\ClassDefinition\Data\Localizedfields
                     manyToManyRelation: \Pimcore\Model\DataObject\ClassDefinition\Data\ManyToManyRelation
                     advancedManyToManyRelation: \Pimcore\Model\DataObject\ClassDefinition\Data\AdvancedManyToManyRelation
+                    manyToManyAssetRelation: \Pimcore\Model\DataObject\ClassDefinition\Data\ManyToManyAssetRelation
                     multiselect: \Pimcore\Model\DataObject\ClassDefinition\Data\Multiselect
                     reverseObjectRelation: \Pimcore\Model\DataObject\ClassDefinition\Data\ReverseObjectRelation
                     urlSlug: \Pimcore\Model\DataObject\ClassDefinition\Data\UrlSlug

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyAssetRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyAssetRelation.php
@@ -13,150 +13,74 @@ declare(strict_types=1);
 
 namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
-use Doctrine\DBAL\ArrayParameterType;
 use Exception;
+use InvalidArgumentException;
 use Pimcore;
-use Pimcore\Db;
 use Pimcore\Logger;
+use Pimcore\Model;
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\Concrete;
-use Pimcore\Model\DataObject\Fieldcollection\Data\AbstractData;
-use Pimcore\Model\DataObject\Localizedfield;
 use Pimcore\Model\Element;
+use Pimcore\Model\Metadata\Predefined;
 
-class AdvancedManyToManyAssetRelation extends ManyToManyAssetRelation implements IdRewriterInterface, PreGetDataInterface, LayoutDefinitionEnrichmentInterface, ClassSavedInterface
+class AdvancedManyToManyAssetRelation extends AdvancedManyToManyRelation implements LayoutDefinitionEnrichmentInterface
 {
-    use DataObject\Traits\ElementWithMetadataComparisonTrait;
-    use DataObject\ClassDefinition\Data\Extension\PositionSortTrait;
+    /**
+     * @internal
+     *
+     * @var string[]|string|null
+     */
+    public array|string|null $visibleFields = null;
 
     /**
      * @internal
      *
-     * @var string[]
+     * @var array<string, array<string, mixed>>
      */
-    public array $columnKeys = [];
+    public array $visibleFieldDefinitions = [];
 
-    /**
-     * @internal
-     *
-     */
-    public array $columns = [];
-
-    /**
-     * @internal
-     */
-    public bool $enableBatchEdit = false;
-
-    /**
-     * @internal
-     */
-    public bool $allowMultipleAssignments = false;
-
-    protected function prepareDataForPersistence(array|Element\ElementInterface $data, Localizedfield|AbstractData|\Pimcore\Model\DataObject\Objectbrick\Data\AbstractData|Concrete|null $object = null, array $params = []): mixed
+    public function __construct()
     {
-        if (is_array($data)) {
-            $return = [];
-            $counter = 1;
-            foreach ($data as $metaAsset) {
-                $asset = $metaAsset->getElement();
-                if ($asset instanceof Asset) {
-                    $return[] = [
-                        'dest_id' => $asset->getId(),
-                        'type' => 'asset',
-                        'fieldname' => $this->getName(),
-                        'index' => $counter,
-                    ];
-                    $counter++;
-                }
-            }
-
-            return $return;
-        }
-
-        return null;
+        $this->setAssetsAllowed(true);
+        $this->setObjectsAllowed(false);
+        $this->setDocumentsAllowed(false);
+        $this->assetUploadPath = '';
     }
 
-    protected function loadData(array $data, Localizedfield|AbstractData|\Pimcore\Model\DataObject\Objectbrick\Data\AbstractData|Concrete|null $object = null, array $params = []): mixed
+    public function getObjectsAllowed(): bool
     {
-        $list = [
-            'dirty' => false,
-            'data' => [],
-        ];
+        return false;
+    }
 
-        if (count($data) > 0) {
-            $db = Db::get();
-            $targets = [];
-            foreach ($data as $relation) {
-                if (!empty($relation['dest_id'])) {
-                    $targets[] = (int) $relation['dest_id'];
-                }
-            }
+    public function getDocumentsAllowed(): bool
+    {
+        return false;
+    }
 
-            $existingTargets = [];
-            if (!empty($targets)) {
-                $existingTargets = $db->fetchFirstColumn(
-                    'SELECT id FROM assets WHERE id IN (?)',
-                    [$targets],
-                    [ArrayParameterType::INTEGER]
-                );
-            }
+    public function getAssetsAllowed(): bool
+    {
+        return true;
+    }
 
-            $sources = [];
-            foreach ($data as $key => $relation) {
-                if (empty($relation['dest_id'])) {
-                    continue;
-                }
-
-                $destinationId = (int) $relation['dest_id'];
-                $destinationExists = empty($targets) || in_array($destinationId, $existingTargets);
-
-                if (!$destinationExists) {
-                    $list['dirty'] = true;
-
-                    continue;
-                }
-
-                $sourceId = $relation['src_id'] ?? null;
-                if (!array_key_exists($sourceId, $sources)) {
-                    $sources[$sourceId] = DataObject::getById($sourceId);
-                }
-                $source = $sources[$sourceId];
-                if ($source instanceof DataObject\Concrete) {
-                    /** @var DataObject\Data\ElementMetadata $metaData */
-                    $metaData = Pimcore::getContainer()->get('pimcore.model.factory')
-                        ->build(DataObject\Data\ElementMetadata::class, [
-                            'fieldname' => $this->getName(),
-                            'columns' => $this->getColumnKeys(),
-                            'element' => null,
-                        ]);
-
-                    $metaData->_setOwner($object);
-                    $metaData->_setOwnerFieldname($this->getName());
-                    $metaData->setElementTypeAndId('asset', $destinationId);
-
-                    $ownertype = $relation['ownertype'] ?? '';
-                    $ownername = $relation['ownername'] ?? '';
-                    $position = $relation['position'] ?? '0';
-                    $index = $relation['index'] ?? ($key + 1);
-
-                    $metaData->load(
-                        $source,
-                        $destinationId,
-                        $this->getName(),
-                        $ownertype,
-                        $ownername,
-                        $position,
-                        $index,
-                        'asset'
-                    );
-
-                    $list['data'][] = $metaData;
-                }
-            }
+    /**
+     * @param string[]|string|null $visibleFields
+     *
+     * @return $this
+     */
+    public function setVisibleFields(array|string|null $visibleFields): static
+    {
+        if (is_array($visibleFields) && count($visibleFields)) {
+            $visibleFields = implode(',', $visibleFields);
         }
+        $this->visibleFields = $visibleFields;
 
-        return $list;
+        return $this;
+    }
+
+    public function getVisibleFields(): array|null|string
+    {
+        return $this->visibleFields;
     }
 
     public function getDataForQueryResource(mixed $data, ?DataObject\Concrete $object = null, array $params = []): ?string
@@ -229,48 +153,22 @@ class AdvancedManyToManyAssetRelation extends ManyToManyAssetRelation implements
         return $return;
     }
 
-    public function getDataFromEditmode(mixed $data, ?DataObject\Concrete $object = null, array $params = []): ?array
+    public function getDataForGrid(?array $data, ?Concrete $object = null, array $params = []): ?array
     {
-        if ($data === null || $data === false) {
-            return null;
-        }
+        $gridData = $this->getDataForEditmode($data, $object, $params);
 
-        $assetMetadata = [];
-        if (is_array($data) && count($data) > 0) {
-            foreach ($data as $element) {
-                $asset = Asset::getById((int) $element['id']);
-                if ($asset instanceof Asset) {
-                    /** @var DataObject\Data\ElementMetadata $metaData */
-                    $metaData = Pimcore::getContainer()->get('pimcore.model.factory')
-                        ->build(
-                            DataObject\Data\ElementMetadata::class,
-                            [
-                                'fieldname' => $this->getName(),
-                                'columns' => $this->getColumnKeys(),
-                                'element' => $asset,
-                            ]
-                        );
-
-                    $metaData->_setOwner($object);
-                    $metaData->_setOwnerFieldname($this->getName());
-
-                    foreach ($this->getColumns() as $c) {
-                        $setter = 'set' . ucfirst($c['key']);
-                        $value = $element[$c['key']] ?? null;
-
-                        if ($c['type'] === 'multiselect' && is_array($value)) {
-                            $value = implode(',', $value);
-                        }
-
-                        $metaData->$setter($value);
-                    }
-
-                    $assetMetadata[] = $metaData;
+        if ($this->getPathFormatterClass() && !empty($gridData)) {
+            $params['fd'] = $object->getClass()->getFieldDefinition($this->getName(), $params['context'] ?? []);
+            foreach ($gridData as &$relatedElementData) {
+                $nicePath = $this->getNicePath($relatedElementData, $object, $params);
+                if ($nicePath) {
+                    $relatedElementData['fullpath'] = $nicePath;
                 }
             }
+            unset($relatedElementData);
         }
 
-        return $assetMetadata;
+        return $gridData;
     }
 
     public function getVersionPreview(mixed $data, ?DataObject\Concrete $object = null, array $params = []): string
@@ -312,41 +210,6 @@ class AdvancedManyToManyAssetRelation extends ManyToManyAssetRelation implements
         return '';
     }
 
-    public function checkValidity(mixed $data, bool $omitMandatoryCheck = false, array $params = []): void
-    {
-        if (!$omitMandatoryCheck && $this->getMandatory() && empty($data)) {
-            throw new Element\ValidationException('Empty mandatory field [ ' . $this->getName() . ' ]');
-        }
-
-        if (is_array($data)) {
-            $this->performMultipleAssignmentCheck($data);
-
-            foreach ($data as $assetMetadata) {
-                if (!($assetMetadata instanceof DataObject\Data\ElementMetadata)) {
-                    throw new Element\ValidationException('Expected DataObject\\Data\\ElementMetadata');
-                }
-
-                $asset = $assetMetadata->getElement();
-                if ($asset instanceof Asset) {
-                    $allowAsset = $this->allowAssetRelation($asset);
-                } elseif (empty($asset)) {
-                    $allowAsset = true;
-                } else {
-                    $allowAsset = false;
-                }
-
-                if (!$allowAsset) {
-                    $id = $asset instanceof Asset ? $asset->getId() : '??';
-                    throw new Element\ValidationException('Invalid asset relation to asset [' . $id . '] in field ' . $this->getName());
-                }
-            }
-
-            if ($this->getMaxItems() && count($data) > $this->getMaxItems()) {
-                throw new Element\ValidationException('Number of allowed relations in field `' . $this->getName() . '` exceeded (max. ' . $this->getMaxItems() . ')');
-            }
-        }
-    }
-
     public function getForCsvExport(DataObject\Localizedfield|DataObject\Fieldcollection\Data\AbstractData|DataObject\Objectbrick\Data\AbstractData|DataObject\Concrete $object, array $params = []): string
     {
         $data = $this->getDataFromObjectParam($object, $params);
@@ -363,313 +226,6 @@ class AdvancedManyToManyAssetRelation extends ManyToManyAssetRelation implements
         }
 
         return '';
-    }
-
-    public function resolveDependencies(mixed $data): array
-    {
-        $dependencies = [];
-
-        if (is_array($data) && count($data) > 0) {
-            foreach ($data as $metaAsset) {
-                $asset = $metaAsset->getElement();
-                if ($asset instanceof Asset) {
-                    $dependencies['asset_' . $asset->getId()] = [
-                        'id' => $asset->getId(),
-                        'type' => 'asset',
-                    ];
-                }
-            }
-        }
-
-        return $dependencies;
-    }
-
-    public function save(Localizedfield|AbstractData|\Pimcore\Model\DataObject\Objectbrick\Data\AbstractData|Concrete $object, array $params = []): void
-    {
-        if ($this->skipSaveCheck($object, $params)) {
-            return;
-        }
-
-        $assetsMetadata = $this->getDataFromObjectParam($object, $params);
-
-        $objectId = null;
-
-        if ($object instanceof DataObject\Concrete) {
-            $objectId = $object->getId();
-        } elseif ($object instanceof DataObject\Fieldcollection\Data\AbstractData) {
-            $objectId = $object->getObject()->getId();
-        } elseif ($object instanceof DataObject\Localizedfield) {
-            $objectId = $object->getObject()->getId();
-        } elseif ($object instanceof DataObject\Objectbrick\Data\AbstractData) {
-            $objectId = $object->getObject()->getId();
-        }
-
-        if ($object instanceof DataObject\Localizedfield) {
-            $classId = $object->getClass()->getId();
-        } elseif ($object instanceof DataObject\Objectbrick\Data\AbstractData ||
-            $object instanceof DataObject\Fieldcollection\Data\AbstractData) {
-            $classId = $object->getObject()->getClassId();
-        } else {
-            $classId = $object->getClassId();
-        }
-
-        $table = 'object_metadata_' . $classId;
-        $db = Db::get();
-
-        $relation = [];
-        $this->enrichDataRow($object, $params, $classId, $relation);
-
-        $position = isset($relation['position']) ? (string) $relation['position'] : '0';
-        $context = $params['context'] ?? null;
-
-        if (isset($context['containerType'], $context['subContainerType']) && ($context['containerType'] === 'fieldcollection' || $context['containerType'] === 'objectbrick') && $context['subContainerType'] === 'localizedfield') {
-            $index = $context['index'] ?? null;
-            $containerName = $context['fieldname'] ?? null;
-
-            if ($context['containerType'] === 'fieldcollection') {
-                $ownerName = '/' . $context['containerType'] . '~' . $containerName . '/' . $index . '/%';
-            } else {
-                $ownerName = '/' . $context['containerType'] . '~' . $containerName . '/%';
-            }
-
-            $sql = Db\Helper::quoteInto($db, 'id = ?', $objectId) . " AND ownertype = 'localizedfield' AND "
-                . Db\Helper::quoteInto($db, 'ownername LIKE ?', $ownerName)
-                . ' AND ' . Db\Helper::quoteInto($db, 'fieldname = ?', $this->getName())
-                . ' AND ' . Db\Helper::quoteInto($db, 'position = ?', $position);
-        } else {
-            $sql = Db\Helper::quoteInto($db, 'id = ?', $objectId) . ' AND ' .
-                Db\Helper::quoteInto($db, 'fieldname = ?', $this->getName())
-                . ' AND ' . Db\Helper::quoteInto($db, 'position = ?', $position);
-
-            if ($context) {
-                if (!empty($context['fieldname'])) {
-                    $sql .= ' AND ' . Db\Helper::quoteInto($db, 'ownername = ?', $context['fieldname']);
-                }
-
-                if (!DataObject::isDirtyDetectionDisabled()) {
-                    if ($context['containerType']) {
-                        if ($object instanceof Localizedfield) {
-                            $context['containerType'] = 'localizedfield';
-                        }
-                        $sql .= ' AND ' . Db\Helper::quoteInto($db, 'ownertype = ?', $context['containerType']);
-                    }
-                }
-            }
-        }
-
-        $db->executeStatement('DELETE FROM ' . $table . ' WHERE ' . $sql);
-
-        if (!empty($assetsMetadata)) {
-            if ($object instanceof DataObject\Localizedfield
-                || $object instanceof DataObject\Objectbrick\Data\AbstractData
-                || $object instanceof DataObject\Fieldcollection\Data\AbstractData
-            ) {
-                $objectConcrete = $object->getObject();
-            } else {
-                $objectConcrete = $object;
-            }
-
-            $counter = 1;
-            foreach ($assetsMetadata as $mkey => $meta) {
-                $ownerName = $relation['ownername'] ?? '';
-                $ownerType = $relation['ownertype'] ?? '';
-                $meta->save($objectConcrete, $ownerType, $ownerName, $position, $counter);
-                $counter++;
-            }
-        }
-
-        parent::save($object, $params);
-    }
-
-    public function preGetData(mixed $container, array $params = []): mixed
-    {
-        $data = null;
-        if ($container instanceof DataObject\Concrete) {
-            $data = $container->getObjectVar($this->getName());
-            if (!$container->isLazyKeyLoaded($this->getName())) {
-                $data = $this->load($container);
-
-                $container->setObjectVar($this->getName(), $data);
-                $this->markLazyloadedFieldAsLoaded($container);
-            }
-        } elseif ($container instanceof DataObject\Localizedfield || $container instanceof DataObject\Data\BlockElement) {
-            $data = $params['data'];
-        } elseif ($container instanceof DataObject\Fieldcollection\Data\AbstractData) {
-            parent::loadLazyFieldcollectionField($container);
-            $data = $container->getObjectVar($this->getName());
-        } elseif ($container instanceof DataObject\Objectbrick\Data\AbstractData) {
-            parent::loadLazyBrickField($container);
-            $data = $container->getObjectVar($this->getName());
-        }
-
-        return Element\Service::filterUnpublishedAdvancedElements($data);
-    }
-
-    public function delete(Localizedfield|AbstractData|\Pimcore\Model\DataObject\Objectbrick\Data\AbstractData|Concrete $object, array $params = []): void
-    {
-        $db = Db::get();
-        $context = $params['context'] ?? null;
-
-        if (isset($context['containerType'], $context['subContainerType']) && ($context['containerType'] === 'fieldcollection' || $context['containerType'] === 'objectbrick') && $context['subContainerType'] === 'localizedfield') {
-            $containerName = $context['fieldname'] ?? null;
-
-            if ($context['containerType'] === 'objectbrick') {
-                $db->executeStatement(
-                    'DELETE FROM object_metadata_' . $object->getClassId() . ' WHERE ' .
-                    Db\Helper::quoteInto($db, 'id = ?', $object->getId()) . " AND ownertype = 'localizedfield' AND "
-                    . Db\Helper::quoteInto($db, 'ownername LIKE ?', '/' . $context['containerType'] . '~' . $containerName . '/%')
-                    . ' AND ' . Db\Helper::quoteInto($db, 'fieldname = ?', $this->getName())
-                );
-            } else {
-                $index = $context['index'];
-
-                $db->executeStatement(
-                    'DELETE FROM object_metadata_' . $object->getClassId() . ' WHERE ' .
-                    Db\Helper::quoteInto($db, 'id = ?', $object->getId()) . " AND ownertype = 'localizedfield' AND "
-                    . Db\Helper::quoteInto($db, 'ownername LIKE ?', '/' . $context['containerType'] . '~' . $containerName . '/' . $index . '/%')
-                    . ' AND ' . Db\Helper::quoteInto($db, 'fieldname = ?', $this->getName())
-                );
-            }
-        } else {
-            $deleteCondition = [
-                'id' => $object->getId(),
-                'fieldname' => $this->getName(),
-            ];
-
-            if ($context) {
-                if (!empty($context['fieldname'])) {
-                    $deleteCondition['ownername'] = $context['fieldname'];
-                }
-
-                if (!DataObject::isDirtyDetectionDisabled()) {
-                    if (!empty($context['containerType'])) {
-                        $deleteCondition['ownertype'] = $context['containerType'];
-                    }
-                }
-            }
-
-            $db->delete('object_metadata_' . $object->getClassId(), $deleteCondition);
-        }
-    }
-
-    /**
-     * @return $this
-     */
-    public function setColumns(array $columns): static
-    {
-        if (isset($columns['key'])) {
-            $columns = [$columns];
-        }
-        usort($columns, [$this, 'sort']);
-
-        $this->columns = [];
-        $this->columnKeys = [];
-        foreach ($columns as $c) {
-            $this->columns[] = $c;
-            $this->columnKeys[] = $c['key'];
-        }
-
-        return $this;
-    }
-
-    public function getColumns(): array
-    {
-        return $this->columns;
-    }
-
-    public function getColumnKeys(): array
-    {
-        $this->columnKeys = [];
-        foreach ($this->columns as $c) {
-            $this->columnKeys[] = $c['key'];
-        }
-
-        return $this->columnKeys;
-    }
-
-    public function getEnableBatchEdit(): bool
-    {
-        return $this->enableBatchEdit;
-    }
-
-    public function setEnableBatchEdit(bool $enableBatchEdit): void
-    {
-        $this->enableBatchEdit = $enableBatchEdit;
-    }
-
-    public function classSaved(DataObject\ClassDefinition $class, array $params = []): void
-    {
-        /** @var DataObject\Data\ElementMetadata $temp */
-        $temp = Pimcore::getContainer()->get('pimcore.model.factory')
-            ->build(
-                DataObject\Data\ElementMetadata::class,
-                [
-                    'fieldname' => null,
-                ]
-            );
-
-        $temp->getDao()->createOrUpdateTable($class);
-    }
-
-    public function rewriteIds(mixed $container, array $idMapping, array $params = []): mixed
-    {
-        $data = $this->getDataFromObjectParam($container, $params);
-
-        if (is_array($data)) {
-            foreach ($data as &$metaAsset) {
-                $asset = $metaAsset->getElement();
-                if ($asset instanceof Element\ElementInterface) {
-                    $id = $asset->getId();
-                    $type = Element\Service::getElementType($asset);
-
-                    if (array_key_exists($type, $idMapping) && array_key_exists($id, $idMapping[$type])) {
-                        $newElement = Element\Service::getElementById($type, $idMapping[$type][$id]);
-                        $metaAsset->setElement($newElement);
-                    }
-                }
-            }
-        }
-
-        return $data;
-    }
-
-    public function synchronizeWithMainDefinition(DataObject\ClassDefinition\Data $mainDefinition): void
-    {
-        parent::synchronizeWithMainDefinition($mainDefinition);
-
-        if ($mainDefinition instanceof self) {
-            $this->visibleFields = $mainDefinition->getVisibleFields();
-            $this->columns = $mainDefinition->getColumns();
-            $this->enableBatchEdit = $mainDefinition->getEnableBatchEdit();
-            $this->allowMultipleAssignments = $mainDefinition->getAllowMultipleAssignments();
-        }
-    }
-
-    public function normalize(mixed $value, array $params = []): ?array
-    {
-        if (is_array($value)) {
-            $result = [];
-            /** @var DataObject\Data\ElementMetadata $elementMetadata */
-            foreach ($value as $elementMetadata) {
-                $element = $elementMetadata->getElement();
-
-                $type = Element\Service::getElementType($element);
-                $id = $element->getId();
-                $result[] = [
-                    'element' => [
-                        'type' => $type,
-                        'id' => $id,
-                    ],
-                    'fieldname' => $elementMetadata->getFieldname(),
-                    'columns' => $elementMetadata->getColumns(),
-                    'data' => $elementMetadata->getData(),
-                ];
-            }
-
-            return $result;
-        }
-
-        return null;
     }
 
     public function denormalize(mixed $value, array $params = []): ?array
@@ -702,90 +258,86 @@ class AdvancedManyToManyAssetRelation extends ManyToManyAssetRelation implements
         return null;
     }
 
-    protected function processDiffDataForEditMode(?array $originalData, ?array $data, ?DataObject\Concrete $object = null, array $params = []): ?array
+    public function enrichLayoutDefinition(?DataObject\Concrete $object, array $context = []): static
     {
-        if ($data) {
-            $data = $data[0];
-
-            $items = $data['data'];
-            $newItems = [];
-            if ($items) {
-                $columns = array_merge(['id', 'fullpath'], $this->getColumnKeys());
-                foreach ($items as $itemBeforeCleanup) {
-                    $unique = $this->buildUniqueKeyForDiffEditor($itemBeforeCleanup);
-                    $item = [];
-
-                    foreach ($itemBeforeCleanup as $key => $value) {
-                        if (in_array($key, $columns)) {
-                            $item[$key] = $value;
-                        }
-                    }
-
-                    $itemId = json_encode($item);
-                    $raw = $itemId;
-
-                    $newItems[] = [
-                        'itemId' => $itemId,
-                        'title' => $item['fullpath'] ?? '',
-                        'raw' => $raw,
-                        'gridrow' => $item,
-                        'unique' => $unique,
-                    ];
-                }
-                $data['data'] = $newItems;
-            }
-
-            $data['value'] = [
-                'type' => 'grid',
-                'columnConfig' => [
-                    'id' => [
-                        'width' => 60,
-                    ],
-                    'fullpath' => [
-                        'flex' => 2,
-                    ],
-
-                ],
-                'html' => $this->getVersionPreview($originalData, $object, $params),
-            ];
-
-            $newData = [];
-            $newData[] = $data;
-
-            return $newData;
+        if (!$this->visibleFields) {
+            return $this;
         }
 
-        return $data;
-    }
+        $translator = Pimcore::getContainer()->get('translator');
+        $this->visibleFieldDefinitions = [];
+        $visibleFields = explode(',', (string) $this->visibleFields);
 
-    public function isOptimizedAdminLoading(): bool
-    {
-        return false;
-    }
+        foreach ($visibleFields as $field) {
+            $field = trim($field);
+            $this->visibleFieldDefinitions[$field]['name'] = $field;
+            $this->visibleFieldDefinitions[$field]['title'] = $translator->trans($field, [], 'admin');
+            $this->visibleFieldDefinitions[$field]['fieldtype'] = 'input';
 
-    public function getAllowMultipleAssignments(): bool
-    {
-        return $this->allowMultipleAssignments;
-    }
+            try {
+                $predefined = Predefined::getByName($field);
+                if ($predefined && $predefined->getType()) {
+                    $metaType = $predefined->getType();
+                    $typeMap = [
+                        'input' => 'input',
+                        'textarea' => 'textarea',
+                        'checkbox' => 'checkbox',
+                        'date' => 'date',
+                    ];
 
-    /**
-     * @return $this
-     */
-    public function setAllowMultipleAssignments(bool|int|null $allowMultipleAssignments): static
-    {
-        $this->allowMultipleAssignments = (bool) $allowMultipleAssignments;
+                    if (isset($typeMap[$metaType])) {
+                        $this->visibleFieldDefinitions[$field]['fieldtype'] = $typeMap[$metaType];
+                    } elseif ($metaType === 'select') {
+                        $this->visibleFieldDefinitions[$field]['fieldtype'] = 'select';
+                        $config = $predefined->getConfig();
+                        if ($config) {
+                            $options = [];
+                            foreach (explode(',', $config) as $option) {
+                                $option = trim($option);
+                                if ($option !== '') {
+                                    $options[] = ['key' => $option, 'value' => $option];
+                                }
+                            }
+                            $this->visibleFieldDefinitions[$field]['options'] = $options;
+                        }
+                    }
+                }
+            } catch (\Exception $e) {
+                // Predefined metadata not found or error -- keep default 'input'
+            }
+        }
 
         return $this;
     }
 
-    public function getPhpdocInputType(): ?string
+    public function addListingFilter(DataObject\Listing $listing, float|array|int|string|Model\Element\ElementInterface $data, string $operator = '='): DataObject\Listing
     {
-        return '\\' . DataObject\Data\ElementMetadata::class . '[]';
+        if ($data instanceof Asset) {
+            $data = $data->getId();
+        } elseif (is_array($data)) {
+            $data = $data['id'] ?? null;
+        }
+
+        if ($data === null) {
+            throw new InvalidArgumentException('Please provide an asset id, an asset, or an array containing the key "id".');
+        }
+
+        if ($operator === '=') {
+            $listing->addConditionParam('`'.$this->getName().'` LIKE ?', '%,'.$data.',%');
+
+            return $listing;
+        }
+
+        throw new InvalidArgumentException('Filtering '.__CLASS__.' does only support "=" operator');
     }
 
-    public function getPhpdocReturnType(): ?string
+    public function synchronizeWithMainDefinition(DataObject\ClassDefinition\Data $mainDefinition): void
     {
-        return '\\' . DataObject\Data\ElementMetadata::class . '[]';
+        parent::synchronizeWithMainDefinition($mainDefinition);
+
+        if ($mainDefinition instanceof self) {
+            $this->visibleFields = $mainDefinition->getVisibleFields();
+        }
     }
 
     public function getFieldType(): string

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyAssetRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyAssetRelation.php
@@ -258,6 +258,61 @@ class AdvancedManyToManyAssetRelation extends AdvancedManyToManyRelation impleme
         return null;
     }
 
+    protected function processDiffDataForEditMode(?array $originalData, ?array $data, ?DataObject\Concrete $object = null, array $params = []): ?array
+    {
+        if ($data) {
+            $data = $data[0];
+
+            $items = $data['data'];
+            $newItems = [];
+            if ($items) {
+                $columns = array_merge(['id', 'fullpath'], $this->getColumnKeys());
+                foreach ($items as $itemBeforeCleanup) {
+                    $unique = $this->buildUniqueKeyForDiffEditor($itemBeforeCleanup);
+                    $item = [];
+
+                    foreach ($itemBeforeCleanup as $key => $value) {
+                        if (in_array($key, $columns)) {
+                            $item[$key] = $value;
+                        }
+                    }
+
+                    $itemId = json_encode($item);
+                    $raw = $itemId;
+
+                    $newItems[] = [
+                        'itemId' => $itemId,
+                        'title' => $item['fullpath'] ?? '',
+                        'raw' => $raw,
+                        'gridrow' => $item,
+                        'unique' => $unique,
+                    ];
+                }
+                $data['data'] = $newItems;
+            }
+
+            $data['value'] = [
+                'type' => 'grid',
+                'columnConfig' => [
+                    'id' => [
+                        'width' => 60,
+                    ],
+                    'fullpath' => [
+                        'flex' => 2,
+                    ],
+                ],
+                'html' => $this->getVersionPreview($originalData, $object, $params),
+            ];
+
+            $newData = [];
+            $newData[] = $data;
+
+            return $newData;
+        }
+
+        return $data;
+    }
+
     public function enrichLayoutDefinition(?DataObject\Concrete $object, array $context = []): static
     {
         if (!$this->visibleFields) {

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyAssetRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyAssetRelation.php
@@ -16,7 +16,6 @@ namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 use Exception;
 use InvalidArgumentException;
 use Pimcore;
-use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
@@ -105,50 +104,33 @@ class AdvancedManyToManyAssetRelation extends AdvancedManyToManyRelation impleme
         throw new Exception('invalid data passed to getDataForQueryResource - must be array');
     }
 
-    public function getDataForEditmode(mixed $data, ?DataObject\Concrete $object = null, array $params = []): array
+    public function getDataForEditmode(mixed $data, ?DataObject\Concrete $object = null, array $params = []): ?array
     {
-        $return = [];
+        $return = parent::getDataForEditmode($data, $object, $params);
+
         $visibleFieldsArray = $this->getVisibleFields() ? explode(',', (string) $this->getVisibleFields()) : [];
+        if (!is_array($return) || empty($visibleFieldsArray)) {
+            return $return;
+        }
 
-        if (is_array($data) && count($data) > 0) {
-            foreach ($data as $mkey => $metaAsset) {
-                $index = $mkey + 1;
-                $asset = $metaAsset->getElement();
-                if ($asset instanceof Asset) {
-                    $row = Element\Service::gridElementData($asset);
+        foreach ($return as &$row) {
+            $asset = Asset::getById($row['id']);
+            if (!$asset instanceof Asset) {
+                continue;
+            }
 
-                    if (!empty($visibleFieldsArray)) {
-                        foreach ($visibleFieldsArray as $field) {
-                            if (array_key_exists($field, $row)) {
-                                continue;
-                            }
-
-                            $getter = 'get' . ucfirst($field);
-                            if (method_exists($asset, $getter)) {
-                                $row[$field] = $asset->{$getter}();
-                                continue;
-                            }
-
-                            $row[$field] = $asset->getMetadata($field);
-                        }
-                    }
-
-                    foreach ($this->getColumns() as $c) {
-                        $getter = 'get' . ucfirst($c['key']);
-
-                        try {
-                            $row[$c['key']] = $metaAsset->$getter();
-                        } catch (Exception $e) {
-                            Logger::debug('Meta column ' . $c['key'] . ' does not exist');
-                        }
-                    }
-
-                    $row['rowId'] = $row['id'] . self::RELATION_ID_SEPARATOR . $index . self::RELATION_ID_SEPARATOR . ($row['type'] ?? 'asset');
-
-                    $return[] = $row;
+            foreach ($visibleFieldsArray as $field) {
+                if (array_key_exists($field, $row)) {
+                    continue;
                 }
+
+                $getter = 'get' . ucfirst($field);
+                $row[$field] = method_exists($asset, $getter)
+                    ? $asset->{$getter}()
+                    : $asset->getMetadata($field);
             }
         }
+        unset($row);
 
         return $return;
     }
@@ -162,7 +144,7 @@ class AdvancedManyToManyAssetRelation extends AdvancedManyToManyRelation impleme
             foreach ($gridData as &$relatedElementData) {
                 $nicePath = $this->getNicePath($relatedElementData, $object, $params);
                 if ($nicePath) {
-                    $relatedElementData['fullpath'] = $nicePath;
+                    $relatedElementData['path'] = $nicePath;
                 }
             }
             unset($relatedElementData);

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyAssetRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyAssetRelation.php
@@ -273,11 +273,6 @@ class AdvancedManyToManyAssetRelation extends ManyToManyAssetRelation implements
         return $assetMetadata;
     }
 
-    public function getDataFromGridEditor(array $data, ?Concrete $object = null, array $params = []): ?array
-    {
-        return $this->getDataFromEditmode($data, $object, $params);
-    }
-
     public function getVersionPreview(mixed $data, ?DataObject\Concrete $object = null, array $params = []): string
     {
         $items = [];
@@ -476,8 +471,8 @@ class AdvancedManyToManyAssetRelation extends ManyToManyAssetRelation implements
 
             $counter = 1;
             foreach ($assetsMetadata as $mkey => $meta) {
-                $ownerName = isset($relation['ownername']) ? $relation['ownername'] : '';
-                $ownerType = isset($relation['ownertype']) ? $relation['ownertype'] : '';
+                $ownerName = $relation['ownername'] ?? '';
+                $ownerType = $relation['ownertype'] ?? '';
                 $meta->save($objectConcrete, $ownerType, $ownerName, $position, $counter);
                 $counter++;
             }

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyAssetRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyAssetRelation.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Exception;
 use Pimcore;
 use Pimcore\Db;
@@ -28,13 +29,6 @@ class AdvancedManyToManyAssetRelation extends ManyToManyAssetRelation implements
 {
     use DataObject\Traits\ElementWithMetadataComparisonTrait;
     use DataObject\ClassDefinition\Data\Extension\PositionSortTrait;
-
-    /**
-     * @internal
-     *
-     * @var array<string, array<string, mixed>>
-     */
-    public array $visibleFieldDefinitions = [];
 
     /**
      * @internal
@@ -73,8 +67,8 @@ class AdvancedManyToManyAssetRelation extends ManyToManyAssetRelation implements
                         'fieldname' => $this->getName(),
                         'index' => $counter,
                     ];
+                    $counter++;
                 }
-                $counter++;
             }
 
             return $return;
@@ -102,10 +96,13 @@ class AdvancedManyToManyAssetRelation extends ManyToManyAssetRelation implements
             $existingTargets = [];
             if (!empty($targets)) {
                 $existingTargets = $db->fetchFirstColumn(
-                    'SELECT id FROM assets WHERE id IN (' . implode(',', $targets) . ')'
+                    'SELECT id FROM assets WHERE id IN (?)',
+                    [$targets],
+                    [ArrayParameterType::INTEGER]
                 );
             }
 
+            $sources = [];
             foreach ($data as $key => $relation) {
                 if (empty($relation['dest_id'])) {
                     continue;
@@ -120,7 +117,11 @@ class AdvancedManyToManyAssetRelation extends ManyToManyAssetRelation implements
                     continue;
                 }
 
-                $source = DataObject::getById($relation['src_id']);
+                $sourceId = $relation['src_id'] ?? null;
+                if (!array_key_exists($sourceId, $sources)) {
+                    $sources[$sourceId] = DataObject::getById($sourceId);
+                }
+                $source = $sources[$sourceId];
                 if ($source instanceof DataObject\Concrete) {
                     /** @var DataObject\Data\ElementMetadata $metaData */
                     $metaData = Pimcore::getContainer()->get('pimcore.model.factory')

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyAssetRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyAssetRelation.php
@@ -392,6 +392,8 @@ class AdvancedManyToManyAssetRelation extends AdvancedManyToManyRelation impleme
 
         if ($mainDefinition instanceof self) {
             $this->visibleFields = $mainDefinition->getVisibleFields();
+            $this->enableBatchEdit = $mainDefinition->getEnableBatchEdit();
+            $this->allowMultipleAssignments = $mainDefinition->getAllowMultipleAssignments();
         }
     }
 

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyAssetRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyAssetRelation.php
@@ -758,6 +758,11 @@ class AdvancedManyToManyAssetRelation extends ManyToManyAssetRelation implements
         return $data;
     }
 
+    public function isOptimizedAdminLoading(): bool
+    {
+        return false;
+    }
+
     public function getAllowMultipleAssignments(): bool
     {
         return $this->allowMultipleAssignments;

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyAssetRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyAssetRelation.php
@@ -138,7 +138,7 @@ class AdvancedManyToManyAssetRelation extends ManyToManyAssetRelation implements
                     $ownertype = $relation['ownertype'] ?? '';
                     $ownername = $relation['ownername'] ?? '';
                     $position = $relation['position'] ?? '0';
-                    $index = $key + 1;
+                    $index = $relation['index'] ?? ($key + 1);
 
                     $metaData->load(
                         $source,

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyAssetRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyAssetRelation.php
@@ -1,0 +1,794 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Model\DataObject\ClassDefinition\Data;
+
+use Exception;
+use Pimcore;
+use Pimcore\Db;
+use Pimcore\Logger;
+use Pimcore\Model\Asset;
+use Pimcore\Model\DataObject;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\Fieldcollection\Data\AbstractData;
+use Pimcore\Model\DataObject\Localizedfield;
+use Pimcore\Model\Element;
+
+class AdvancedManyToManyAssetRelation extends ManyToManyAssetRelation implements IdRewriterInterface, PreGetDataInterface, LayoutDefinitionEnrichmentInterface, ClassSavedInterface
+{
+    use DataObject\Traits\ElementWithMetadataComparisonTrait;
+    use DataObject\ClassDefinition\Data\Extension\PositionSortTrait;
+
+    /**
+     * @internal
+     *
+     * @var array<string, array<string, mixed>>
+     */
+    public array $visibleFieldDefinitions = [];
+
+    /**
+     * @internal
+     *
+     * @var string[]
+     */
+    public array $columnKeys = [];
+
+    /**
+     * @internal
+     *
+     */
+    public array $columns = [];
+
+    /**
+     * @internal
+     */
+    public bool $enableBatchEdit = false;
+
+    /**
+     * @internal
+     */
+    public bool $allowMultipleAssignments = false;
+
+    protected function prepareDataForPersistence(array|Element\ElementInterface $data, Localizedfield|AbstractData|\Pimcore\Model\DataObject\Objectbrick\Data\AbstractData|Concrete|null $object = null, array $params = []): mixed
+    {
+        if (is_array($data)) {
+            $return = [];
+            $counter = 1;
+            foreach ($data as $metaAsset) {
+                $asset = $metaAsset->getElement();
+                if ($asset instanceof Asset) {
+                    $return[] = [
+                        'dest_id' => $asset->getId(),
+                        'type' => 'asset',
+                        'fieldname' => $this->getName(),
+                        'index' => $counter,
+                    ];
+                }
+                $counter++;
+            }
+
+            return $return;
+        }
+
+        return null;
+    }
+
+    protected function loadData(array $data, Localizedfield|AbstractData|\Pimcore\Model\DataObject\Objectbrick\Data\AbstractData|Concrete|null $object = null, array $params = []): mixed
+    {
+        $list = [
+            'dirty' => false,
+            'data' => [],
+        ];
+
+        if (count($data) > 0) {
+            $db = Db::get();
+            $targets = [];
+            foreach ($data as $relation) {
+                if (!empty($relation['dest_id'])) {
+                    $targets[] = (int) $relation['dest_id'];
+                }
+            }
+
+            $existingTargets = [];
+            if (!empty($targets)) {
+                $existingTargets = $db->fetchFirstColumn(
+                    'SELECT id FROM assets WHERE id IN (' . implode(',', $targets) . ')'
+                );
+            }
+
+            foreach ($data as $key => $relation) {
+                if (empty($relation['dest_id'])) {
+                    continue;
+                }
+
+                $destinationId = (int) $relation['dest_id'];
+                $destinationExists = empty($targets) || in_array($destinationId, $existingTargets);
+
+                if (!$destinationExists) {
+                    $list['dirty'] = true;
+
+                    continue;
+                }
+
+                $source = DataObject::getById($relation['src_id']);
+                if ($source instanceof DataObject\Concrete) {
+                    /** @var DataObject\Data\ElementMetadata $metaData */
+                    $metaData = Pimcore::getContainer()->get('pimcore.model.factory')
+                        ->build(DataObject\Data\ElementMetadata::class, [
+                            'fieldname' => $this->getName(),
+                            'columns' => $this->getColumnKeys(),
+                            'element' => null,
+                        ]);
+
+                    $metaData->_setOwner($object);
+                    $metaData->_setOwnerFieldname($this->getName());
+                    $metaData->setElementTypeAndId('asset', $destinationId);
+
+                    $ownertype = $relation['ownertype'] ?? '';
+                    $ownername = $relation['ownername'] ?? '';
+                    $position = $relation['position'] ?? '0';
+                    $index = $key + 1;
+
+                    $metaData->load(
+                        $source,
+                        $destinationId,
+                        $this->getName(),
+                        $ownertype,
+                        $ownername,
+                        $position,
+                        $index,
+                        'asset'
+                    );
+
+                    $list['data'][] = $metaData;
+                }
+            }
+        }
+
+        return $list;
+    }
+
+    public function getDataForQueryResource(mixed $data, ?DataObject\Concrete $object = null, array $params = []): ?string
+    {
+        if (!$data) {
+            return null;
+        }
+
+        $ids = [];
+
+        if (is_array($data)) {
+            foreach ($data as $metaAsset) {
+                $asset = $metaAsset->getElement();
+                if ($asset instanceof Asset) {
+                    $ids[] = $asset->getId();
+                }
+            }
+
+            return ',' . implode(',', $ids) . ',';
+        }
+
+        throw new Exception('invalid data passed to getDataForQueryResource - must be array');
+    }
+
+    public function getDataForEditmode(mixed $data, ?DataObject\Concrete $object = null, array $params = []): array
+    {
+        $return = [];
+        $visibleFieldsArray = $this->getVisibleFields() ? explode(',', (string) $this->getVisibleFields()) : [];
+
+        if (is_array($data) && count($data) > 0) {
+            foreach ($data as $mkey => $metaAsset) {
+                $index = $mkey + 1;
+                $asset = $metaAsset->getElement();
+                if ($asset instanceof Asset) {
+                    $row = Element\Service::gridElementData($asset);
+
+                    if (!empty($visibleFieldsArray)) {
+                        foreach ($visibleFieldsArray as $field) {
+                            if (array_key_exists($field, $row)) {
+                                continue;
+                            }
+
+                            $getter = 'get' . ucfirst($field);
+                            if (method_exists($asset, $getter)) {
+                                $row[$field] = $asset->{$getter}();
+                                continue;
+                            }
+
+                            $row[$field] = $asset->getMetadata($field);
+                        }
+                    }
+
+                    foreach ($this->getColumns() as $c) {
+                        $getter = 'get' . ucfirst($c['key']);
+
+                        try {
+                            $row[$c['key']] = $metaAsset->$getter();
+                        } catch (Exception $e) {
+                            Logger::debug('Meta column ' . $c['key'] . ' does not exist');
+                        }
+                    }
+
+                    $row['rowId'] = $row['id'] . self::RELATION_ID_SEPARATOR . $index . self::RELATION_ID_SEPARATOR . ($row['type'] ?? 'asset');
+
+                    $return[] = $row;
+                }
+            }
+        }
+
+        return $return;
+    }
+
+    public function getDataFromEditmode(mixed $data, ?DataObject\Concrete $object = null, array $params = []): ?array
+    {
+        if ($data === null || $data === false) {
+            return null;
+        }
+
+        $assetMetadata = [];
+        if (is_array($data) && count($data) > 0) {
+            foreach ($data as $element) {
+                $asset = Asset::getById((int) $element['id']);
+                if ($asset instanceof Asset) {
+                    /** @var DataObject\Data\ElementMetadata $metaData */
+                    $metaData = Pimcore::getContainer()->get('pimcore.model.factory')
+                        ->build(
+                            DataObject\Data\ElementMetadata::class,
+                            [
+                                'fieldname' => $this->getName(),
+                                'columns' => $this->getColumnKeys(),
+                                'element' => $asset,
+                            ]
+                        );
+
+                    $metaData->_setOwner($object);
+                    $metaData->_setOwnerFieldname($this->getName());
+
+                    foreach ($this->getColumns() as $c) {
+                        $setter = 'set' . ucfirst($c['key']);
+                        $value = $element[$c['key']] ?? null;
+
+                        if ($c['type'] === 'multiselect' && is_array($value)) {
+                            $value = implode(',', $value);
+                        }
+
+                        $metaData->$setter($value);
+                    }
+
+                    $assetMetadata[] = $metaData;
+                }
+            }
+        }
+
+        return $assetMetadata;
+    }
+
+    public function getDataFromGridEditor(array $data, ?Concrete $object = null, array $params = []): ?array
+    {
+        return $this->getDataFromEditmode($data, $object, $params);
+    }
+
+    public function getVersionPreview(mixed $data, ?DataObject\Concrete $object = null, array $params = []): string
+    {
+        $items = [];
+        if (is_array($data) && count($data) > 0) {
+            foreach ($data as $metaAsset) {
+                if (!($metaAsset instanceof DataObject\Data\ElementMetadata)) {
+                    continue;
+                }
+
+                $asset = $metaAsset->getElement();
+                if (!$asset instanceof Asset) {
+                    continue;
+                }
+
+                $item = $asset->getRealFullPath();
+
+                if (count($metaAsset->getData())) {
+                    $subItems = [];
+                    foreach ($metaAsset->getData() as $key => $value) {
+                        if (!$value) {
+                            continue;
+                        }
+                        $subItems[] = $key . ': ' . $value;
+                    }
+
+                    if (count($subItems)) {
+                        $item .= ' <br/><span class="preview-metadata">[' . implode(' | ', $subItems) . ']</span>';
+                    }
+                }
+
+                $items[] = $item;
+            }
+
+            return implode('<br />', $items);
+        }
+
+        return '';
+    }
+
+    public function checkValidity(mixed $data, bool $omitMandatoryCheck = false, array $params = []): void
+    {
+        if (!$omitMandatoryCheck && $this->getMandatory() && empty($data)) {
+            throw new Element\ValidationException('Empty mandatory field [ ' . $this->getName() . ' ]');
+        }
+
+        if (is_array($data)) {
+            $this->performMultipleAssignmentCheck($data);
+
+            foreach ($data as $assetMetadata) {
+                if (!($assetMetadata instanceof DataObject\Data\ElementMetadata)) {
+                    throw new Element\ValidationException('Expected DataObject\\Data\\ElementMetadata');
+                }
+
+                $asset = $assetMetadata->getElement();
+                if ($asset instanceof Asset) {
+                    $allowAsset = $this->allowAssetRelation($asset);
+                } elseif (empty($asset)) {
+                    $allowAsset = true;
+                } else {
+                    $allowAsset = false;
+                }
+
+                if (!$allowAsset) {
+                    $id = $asset instanceof Asset ? $asset->getId() : '??';
+                    throw new Element\ValidationException('Invalid asset relation to asset [' . $id . '] in field ' . $this->getName());
+                }
+            }
+
+            if ($this->getMaxItems() && count($data) > $this->getMaxItems()) {
+                throw new Element\ValidationException('Number of allowed relations in field `' . $this->getName() . '` exceeded (max. ' . $this->getMaxItems() . ')');
+            }
+        }
+    }
+
+    public function getForCsvExport(DataObject\Localizedfield|DataObject\Fieldcollection\Data\AbstractData|DataObject\Objectbrick\Data\AbstractData|DataObject\Concrete $object, array $params = []): string
+    {
+        $data = $this->getDataFromObjectParam($object, $params);
+        if (is_array($data)) {
+            $paths = [];
+            foreach ($data as $metaAsset) {
+                $asset = $metaAsset->getElement();
+                if ($asset instanceof Element\ElementInterface) {
+                    $paths[] = $asset->getRealFullPath();
+                }
+            }
+
+            return implode(',', $paths);
+        }
+
+        return '';
+    }
+
+    public function resolveDependencies(mixed $data): array
+    {
+        $dependencies = [];
+
+        if (is_array($data) && count($data) > 0) {
+            foreach ($data as $metaAsset) {
+                $asset = $metaAsset->getElement();
+                if ($asset instanceof Asset) {
+                    $dependencies['asset_' . $asset->getId()] = [
+                        'id' => $asset->getId(),
+                        'type' => 'asset',
+                    ];
+                }
+            }
+        }
+
+        return $dependencies;
+    }
+
+    public function save(Localizedfield|AbstractData|\Pimcore\Model\DataObject\Objectbrick\Data\AbstractData|Concrete $object, array $params = []): void
+    {
+        if ($this->skipSaveCheck($object, $params)) {
+            return;
+        }
+
+        $assetsMetadata = $this->getDataFromObjectParam($object, $params);
+
+        $objectId = null;
+
+        if ($object instanceof DataObject\Concrete) {
+            $objectId = $object->getId();
+        } elseif ($object instanceof DataObject\Fieldcollection\Data\AbstractData) {
+            $objectId = $object->getObject()->getId();
+        } elseif ($object instanceof DataObject\Localizedfield) {
+            $objectId = $object->getObject()->getId();
+        } elseif ($object instanceof DataObject\Objectbrick\Data\AbstractData) {
+            $objectId = $object->getObject()->getId();
+        }
+
+        if ($object instanceof DataObject\Localizedfield) {
+            $classId = $object->getClass()->getId();
+        } elseif ($object instanceof DataObject\Objectbrick\Data\AbstractData ||
+            $object instanceof DataObject\Fieldcollection\Data\AbstractData) {
+            $classId = $object->getObject()->getClassId();
+        } else {
+            $classId = $object->getClassId();
+        }
+
+        $table = 'object_metadata_' . $classId;
+        $db = Db::get();
+
+        $relation = [];
+        $this->enrichDataRow($object, $params, $classId, $relation);
+
+        $position = isset($relation['position']) ? (string) $relation['position'] : '0';
+        $context = $params['context'] ?? null;
+
+        if (isset($context['containerType'], $context['subContainerType']) && ($context['containerType'] === 'fieldcollection' || $context['containerType'] === 'objectbrick') && $context['subContainerType'] === 'localizedfield') {
+            $index = $context['index'] ?? null;
+            $containerName = $context['fieldname'] ?? null;
+
+            if ($context['containerType'] === 'fieldcollection') {
+                $ownerName = '/' . $context['containerType'] . '~' . $containerName . '/' . $index . '/%';
+            } else {
+                $ownerName = '/' . $context['containerType'] . '~' . $containerName . '/%';
+            }
+
+            $sql = Db\Helper::quoteInto($db, 'id = ?', $objectId) . " AND ownertype = 'localizedfield' AND "
+                . Db\Helper::quoteInto($db, 'ownername LIKE ?', $ownerName)
+                . ' AND ' . Db\Helper::quoteInto($db, 'fieldname = ?', $this->getName())
+                . ' AND ' . Db\Helper::quoteInto($db, 'position = ?', $position);
+        } else {
+            $sql = Db\Helper::quoteInto($db, 'id = ?', $objectId) . ' AND ' .
+                Db\Helper::quoteInto($db, 'fieldname = ?', $this->getName())
+                . ' AND ' . Db\Helper::quoteInto($db, 'position = ?', $position);
+
+            if ($context) {
+                if (!empty($context['fieldname'])) {
+                    $sql .= ' AND ' . Db\Helper::quoteInto($db, 'ownername = ?', $context['fieldname']);
+                }
+
+                if (!DataObject::isDirtyDetectionDisabled()) {
+                    if ($context['containerType']) {
+                        if ($object instanceof Localizedfield) {
+                            $context['containerType'] = 'localizedfield';
+                        }
+                        $sql .= ' AND ' . Db\Helper::quoteInto($db, 'ownertype = ?', $context['containerType']);
+                    }
+                }
+            }
+        }
+
+        $db->executeStatement('DELETE FROM ' . $table . ' WHERE ' . $sql);
+
+        if (!empty($assetsMetadata)) {
+            if ($object instanceof DataObject\Localizedfield
+                || $object instanceof DataObject\Objectbrick\Data\AbstractData
+                || $object instanceof DataObject\Fieldcollection\Data\AbstractData
+            ) {
+                $objectConcrete = $object->getObject();
+            } else {
+                $objectConcrete = $object;
+            }
+
+            $counter = 1;
+            foreach ($assetsMetadata as $mkey => $meta) {
+                $ownerName = isset($relation['ownername']) ? $relation['ownername'] : '';
+                $ownerType = isset($relation['ownertype']) ? $relation['ownertype'] : '';
+                $meta->save($objectConcrete, $ownerType, $ownerName, $position, $counter);
+                $counter++;
+            }
+        }
+
+        parent::save($object, $params);
+    }
+
+    public function preGetData(mixed $container, array $params = []): mixed
+    {
+        $data = null;
+        if ($container instanceof DataObject\Concrete) {
+            $data = $container->getObjectVar($this->getName());
+            if (!$container->isLazyKeyLoaded($this->getName())) {
+                $data = $this->load($container);
+
+                $container->setObjectVar($this->getName(), $data);
+                $this->markLazyloadedFieldAsLoaded($container);
+            }
+        } elseif ($container instanceof DataObject\Localizedfield || $container instanceof DataObject\Data\BlockElement) {
+            $data = $params['data'];
+        } elseif ($container instanceof DataObject\Fieldcollection\Data\AbstractData) {
+            parent::loadLazyFieldcollectionField($container);
+            $data = $container->getObjectVar($this->getName());
+        } elseif ($container instanceof DataObject\Objectbrick\Data\AbstractData) {
+            parent::loadLazyBrickField($container);
+            $data = $container->getObjectVar($this->getName());
+        }
+
+        return Element\Service::filterUnpublishedAdvancedElements($data);
+    }
+
+    public function delete(Localizedfield|AbstractData|\Pimcore\Model\DataObject\Objectbrick\Data\AbstractData|Concrete $object, array $params = []): void
+    {
+        $db = Db::get();
+        $context = $params['context'] ?? null;
+
+        if (isset($context['containerType'], $context['subContainerType']) && ($context['containerType'] === 'fieldcollection' || $context['containerType'] === 'objectbrick') && $context['subContainerType'] === 'localizedfield') {
+            $containerName = $context['fieldname'] ?? null;
+
+            if ($context['containerType'] === 'objectbrick') {
+                $db->executeStatement(
+                    'DELETE FROM object_metadata_' . $object->getClassId() . ' WHERE ' .
+                    Db\Helper::quoteInto($db, 'id = ?', $object->getId()) . " AND ownertype = 'localizedfield' AND "
+                    . Db\Helper::quoteInto($db, 'ownername LIKE ?', '/' . $context['containerType'] . '~' . $containerName . '/%')
+                    . ' AND ' . Db\Helper::quoteInto($db, 'fieldname = ?', $this->getName())
+                );
+            } else {
+                $index = $context['index'];
+
+                $db->executeStatement(
+                    'DELETE FROM object_metadata_' . $object->getClassId() . ' WHERE ' .
+                    Db\Helper::quoteInto($db, 'id = ?', $object->getId()) . " AND ownertype = 'localizedfield' AND "
+                    . Db\Helper::quoteInto($db, 'ownername LIKE ?', '/' . $context['containerType'] . '~' . $containerName . '/' . $index . '/%')
+                    . ' AND ' . Db\Helper::quoteInto($db, 'fieldname = ?', $this->getName())
+                );
+            }
+        } else {
+            $deleteCondition = [
+                'id' => $object->getId(),
+                'fieldname' => $this->getName(),
+            ];
+
+            if ($context) {
+                if (!empty($context['fieldname'])) {
+                    $deleteCondition['ownername'] = $context['fieldname'];
+                }
+
+                if (!DataObject::isDirtyDetectionDisabled()) {
+                    if (!empty($context['containerType'])) {
+                        $deleteCondition['ownertype'] = $context['containerType'];
+                    }
+                }
+            }
+
+            $db->delete('object_metadata_' . $object->getClassId(), $deleteCondition);
+        }
+    }
+
+    /**
+     * @return $this
+     */
+    public function setColumns(array $columns): static
+    {
+        if (isset($columns['key'])) {
+            $columns = [$columns];
+        }
+        usort($columns, [$this, 'sort']);
+
+        $this->columns = [];
+        $this->columnKeys = [];
+        foreach ($columns as $c) {
+            $this->columns[] = $c;
+            $this->columnKeys[] = $c['key'];
+        }
+
+        return $this;
+    }
+
+    public function getColumns(): array
+    {
+        return $this->columns;
+    }
+
+    public function getColumnKeys(): array
+    {
+        $this->columnKeys = [];
+        foreach ($this->columns as $c) {
+            $this->columnKeys[] = $c['key'];
+        }
+
+        return $this->columnKeys;
+    }
+
+    public function getEnableBatchEdit(): bool
+    {
+        return $this->enableBatchEdit;
+    }
+
+    public function setEnableBatchEdit(bool $enableBatchEdit): void
+    {
+        $this->enableBatchEdit = $enableBatchEdit;
+    }
+
+    public function classSaved(DataObject\ClassDefinition $class, array $params = []): void
+    {
+        /** @var DataObject\Data\ElementMetadata $temp */
+        $temp = Pimcore::getContainer()->get('pimcore.model.factory')
+            ->build(
+                DataObject\Data\ElementMetadata::class,
+                [
+                    'fieldname' => null,
+                ]
+            );
+
+        $temp->getDao()->createOrUpdateTable($class);
+    }
+
+    public function rewriteIds(mixed $container, array $idMapping, array $params = []): mixed
+    {
+        $data = $this->getDataFromObjectParam($container, $params);
+
+        if (is_array($data)) {
+            foreach ($data as &$metaAsset) {
+                $asset = $metaAsset->getElement();
+                if ($asset instanceof Element\ElementInterface) {
+                    $id = $asset->getId();
+                    $type = Element\Service::getElementType($asset);
+
+                    if (array_key_exists($type, $idMapping) && array_key_exists($id, $idMapping[$type])) {
+                        $newElement = Element\Service::getElementById($type, $idMapping[$type][$id]);
+                        $metaAsset->setElement($newElement);
+                    }
+                }
+            }
+        }
+
+        return $data;
+    }
+
+    public function synchronizeWithMainDefinition(DataObject\ClassDefinition\Data $mainDefinition): void
+    {
+        parent::synchronizeWithMainDefinition($mainDefinition);
+
+        if ($mainDefinition instanceof self) {
+            $this->visibleFields = $mainDefinition->getVisibleFields();
+            $this->columns = $mainDefinition->getColumns();
+            $this->enableBatchEdit = $mainDefinition->getEnableBatchEdit();
+            $this->allowMultipleAssignments = $mainDefinition->getAllowMultipleAssignments();
+        }
+    }
+
+    public function normalize(mixed $value, array $params = []): ?array
+    {
+        if (is_array($value)) {
+            $result = [];
+            /** @var DataObject\Data\ElementMetadata $elementMetadata */
+            foreach ($value as $elementMetadata) {
+                $element = $elementMetadata->getElement();
+
+                $type = Element\Service::getElementType($element);
+                $id = $element->getId();
+                $result[] = [
+                    'element' => [
+                        'type' => $type,
+                        'id' => $id,
+                    ],
+                    'fieldname' => $elementMetadata->getFieldname(),
+                    'columns' => $elementMetadata->getColumns(),
+                    'data' => $elementMetadata->getData(),
+                ];
+            }
+
+            return $result;
+        }
+
+        return null;
+    }
+
+    public function denormalize(mixed $value, array $params = []): ?array
+    {
+        if (is_array($value)) {
+            $result = [];
+            $object = $params['object'] ?? null;
+            foreach ($value as $elementMetadata) {
+                $elementData = $elementMetadata['element'];
+
+                $type = $elementData['type'];
+                $id = $elementData['id'];
+                $element = Element\Service::getElementById($type, $id);
+                if ($element instanceof Asset) {
+                    $columns = $elementMetadata['columns'];
+                    $fieldname = $elementMetadata['fieldname'];
+                    $data = $elementMetadata['data'];
+
+                    $item = new DataObject\Data\ElementMetadata($fieldname, $columns, $element);
+                    $item->_setOwner($object);
+                    $item->_setOwnerFieldname($this->getName());
+                    $item->setData($data);
+                    $result[] = $item;
+                }
+            }
+
+            return $result;
+        }
+
+        return null;
+    }
+
+    protected function processDiffDataForEditMode(?array $originalData, ?array $data, ?DataObject\Concrete $object = null, array $params = []): ?array
+    {
+        if ($data) {
+            $data = $data[0];
+
+            $items = $data['data'];
+            $newItems = [];
+            if ($items) {
+                $columns = array_merge(['id', 'fullpath'], $this->getColumnKeys());
+                foreach ($items as $itemBeforeCleanup) {
+                    $unique = $this->buildUniqueKeyForDiffEditor($itemBeforeCleanup);
+                    $item = [];
+
+                    foreach ($itemBeforeCleanup as $key => $value) {
+                        if (in_array($key, $columns)) {
+                            $item[$key] = $value;
+                        }
+                    }
+
+                    $itemId = json_encode($item);
+                    $raw = $itemId;
+
+                    $newItems[] = [
+                        'itemId' => $itemId,
+                        'title' => $item['fullpath'] ?? '',
+                        'raw' => $raw,
+                        'gridrow' => $item,
+                        'unique' => $unique,
+                    ];
+                }
+                $data['data'] = $newItems;
+            }
+
+            $data['value'] = [
+                'type' => 'grid',
+                'columnConfig' => [
+                    'id' => [
+                        'width' => 60,
+                    ],
+                    'fullpath' => [
+                        'flex' => 2,
+                    ],
+
+                ],
+                'html' => $this->getVersionPreview($originalData, $object, $params),
+            ];
+
+            $newData = [];
+            $newData[] = $data;
+
+            return $newData;
+        }
+
+        return $data;
+    }
+
+    public function getAllowMultipleAssignments(): bool
+    {
+        return $this->allowMultipleAssignments;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setAllowMultipleAssignments(bool|int|null $allowMultipleAssignments): static
+    {
+        $this->allowMultipleAssignments = (bool) $allowMultipleAssignments;
+
+        return $this;
+    }
+
+    public function getPhpdocInputType(): ?string
+    {
+        return '\\' . DataObject\Data\ElementMetadata::class . '[]';
+    }
+
+    public function getPhpdocReturnType(): ?string
+    {
+        return '\\' . DataObject\Data\ElementMetadata::class . '[]';
+    }
+
+    public function getFieldType(): string
+    {
+        return 'advancedManyToManyAssetRelation';
+    }
+}

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyAssetRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyAssetRelation.php
@@ -252,7 +252,9 @@ class AdvancedManyToManyAssetRelation extends AdvancedManyToManyRelation impleme
             $items = $data['data'];
             $newItems = [];
             if ($items) {
-                $columns = array_merge(['id', 'fullpath'], $this->getColumnKeys());
+                // the parent's getDataForEditmode() emits rows keyed 'path', so the diff editor
+                // has to read the same key or every row loses its path and title
+                $columns = array_merge(['id', 'path'], $this->getColumnKeys());
                 foreach ($items as $itemBeforeCleanup) {
                     $unique = $this->buildUniqueKeyForDiffEditor($itemBeforeCleanup);
                     $item = [];
@@ -268,7 +270,7 @@ class AdvancedManyToManyAssetRelation extends AdvancedManyToManyRelation impleme
 
                     $newItems[] = [
                         'itemId' => $itemId,
-                        'title' => $item['fullpath'] ?? '',
+                        'title' => $item['path'] ?? '',
                         'raw' => $raw,
                         'gridrow' => $item,
                         'unique' => $unique,
@@ -283,7 +285,7 @@ class AdvancedManyToManyAssetRelation extends AdvancedManyToManyRelation impleme
                     'id' => [
                         'width' => 60,
                     ],
-                    'fullpath' => [
+                    'path' => [
                         'flex' => 2,
                     ],
                 ],

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyAssetRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyAssetRelation.php
@@ -175,7 +175,11 @@ class AdvancedManyToManyAssetRelation extends AdvancedManyToManyRelation impleme
                         if (!$value) {
                             continue;
                         }
-                        $subItems[] = $key . ': ' . $value;
+                        // relation metadata is free text, and this string is rendered as HTML in
+                        // the version preview - escape it rather than letting a value close the
+                        // surrounding span
+                        $subItems[] = htmlspecialchars((string) $key, ENT_QUOTES, 'UTF-8')
+                            . ': ' . htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8');
                     }
 
                     if (count($subItems)) {

--- a/models/DataObject/ClassDefinition/Data/ManyToManyAssetRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyAssetRelation.php
@@ -51,6 +51,11 @@ class ManyToManyAssetRelation extends ManyToManyRelation implements LayoutDefini
         return false;
     }
 
+    public function getDocumentsAllowed(): bool
+    {
+        return false;
+    }
+
     public function getAssetsAllowed(): bool
     {
         return true;
@@ -202,17 +207,6 @@ class ManyToManyAssetRelation extends ManyToManyRelation implements LayoutDefini
         return $assets;
     }
 
-    /**
-     * @param null|DataObject\Concrete $object
-     *
-     * @see Data::getDataFromEditmode
-     *
-     */
-    public function getDataFromGridEditor(array $data, ?DataObject\Concrete $object = null, array $params = []): ?array
-    {
-        return $this->getDataFromEditmode($data, $object, $params);
-    }
-
     public function getDataForGrid(?array $data, ?DataObject\Concrete $object = null, array $params = []): ?array
     {
         $gridData = $this->getDataForEditmode($data, $object, $params);
@@ -280,41 +274,6 @@ class ManyToManyAssetRelation extends ManyToManyRelation implements LayoutDefini
         }
     }
 
-    public function getForCsvExport(DataObject\Localizedfield|DataObject\Fieldcollection\Data\AbstractData|DataObject\Objectbrick\Data\AbstractData|DataObject\Concrete $object, array $params = []): string
-    {
-        $data = $this->getDataFromObjectParam($object, $params);
-        if (is_array($data)) {
-            $paths = [];
-            foreach ($data as $eo) {
-                if ($eo instanceof Element\ElementInterface) {
-                    $paths[] = $eo->getRealFullPath();
-                }
-            }
-
-            return implode(',', $paths);
-        }
-
-        return '';
-    }
-
-    public function resolveDependencies(mixed $data): array
-    {
-        $dependencies = [];
-
-        if (is_array($data) && count($data) > 0) {
-            foreach ($data as $asset) {
-                if ($asset instanceof Asset) {
-                    $dependencies['asset_' . $asset->getId()] = [
-                        'id' => $asset->getId(),
-                        'type' => 'asset',
-                    ];
-                }
-            }
-        }
-
-        return $dependencies;
-    }
-
     /**
      * @param DataObject\ClassDefinition\Data\ManyToManyAssetRelation $mainDefinition
      */
@@ -366,44 +325,15 @@ class ManyToManyAssetRelation extends ManyToManyRelation implements LayoutDefini
         return $this;
     }
 
-    protected function getPhpdocType(): string
-    {
-        return $this->getPhpDocClassString(true);
-    }
-
-    public function normalize(mixed $value, array $params = []): ?array
-    {
-        if (is_array($value)) {
-            $result = [];
-            foreach ($value as $element) {
-                $type = Element\Service::getElementType($element);
-                $id = $element->getId();
-                $result[] = [
-                    'type' => $type,
-                    'id' => $id,
-                ];
-            }
-
-            return $result;
-        }
-
-        return null;
-    }
-
-    /** See marshal
-     *
-     *
-     */
     public function denormalize(mixed $value, array $params = []): ?array
     {
         if (is_array($value)) {
             $result = [];
             foreach ($value as $elementData) {
-                $type = $elementData['type'];
                 $id = $elementData['id'];
-                $element = Element\Service::getElementById($type, $id);
-                if ($element) {
-                    $result[] = $element;
+                $asset = Asset::getById($id);
+                if ($asset instanceof Asset) {
+                    $result[] = $asset;
                 }
             }
 

--- a/models/DataObject/ClassDefinition/Data/ManyToManyAssetRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyAssetRelation.php
@@ -21,6 +21,7 @@ use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\Localizedfield;
 use Pimcore\Model\Element;
+use Pimcore\Model\Metadata\Predefined;
 
 class ManyToManyAssetRelation extends ManyToManyRelation implements LayoutDefinitionEnrichmentInterface
 {
@@ -152,7 +153,6 @@ class ManyToManyAssetRelation extends ManyToManyRelation implements LayoutDefini
 
                     if (!empty($visibleFieldsArray)) {
                         foreach ($visibleFieldsArray as $field) {
-                            // don't override existing system columns (id, fullpath, subtype, etc.)
                             if (array_key_exists($field, $row)) {
                                 continue;
                             }
@@ -317,9 +317,42 @@ class ManyToManyAssetRelation extends ManyToManyRelation implements LayoutDefini
         $visibleFields = explode(',', (string) $this->visibleFields);
 
         foreach ($visibleFields as $field) {
+            $field = trim($field);
             $this->visibleFieldDefinitions[$field]['name'] = $field;
             $this->visibleFieldDefinitions[$field]['title'] = $translator->trans($field, [], 'admin');
             $this->visibleFieldDefinitions[$field]['fieldtype'] = 'input';
+
+            try {
+                $predefined = Predefined::getByName($field);
+                if ($predefined && $predefined->getType()) {
+                    $metaType = $predefined->getType();
+                    $typeMap = [
+                        'input' => 'input',
+                        'textarea' => 'textarea',
+                        'checkbox' => 'checkbox',
+                        'date' => 'date',
+                    ];
+
+                    if (isset($typeMap[$metaType])) {
+                        $this->visibleFieldDefinitions[$field]['fieldtype'] = $typeMap[$metaType];
+                    } elseif ($metaType === 'select') {
+                        $this->visibleFieldDefinitions[$field]['fieldtype'] = 'select';
+                        $config = $predefined->getConfig();
+                        if ($config) {
+                            $options = [];
+                            foreach (explode(',', $config) as $option) {
+                                $option = trim($option);
+                                if ($option !== '') {
+                                    $options[] = ['key' => $option, 'value' => $option];
+                                }
+                            }
+                            $this->visibleFieldDefinitions[$field]['options'] = $options;
+                        }
+                    }
+                }
+            } catch (\Exception $e) {
+                // Predefined metadata not found or error — keep default 'input'
+            }
         }
 
         return $this;
@@ -330,6 +363,10 @@ class ManyToManyAssetRelation extends ManyToManyRelation implements LayoutDefini
         if (is_array($value)) {
             $result = [];
             foreach ($value as $elementData) {
+                $type = $elementData['type'] ?? 'asset';
+                if ($type !== 'asset') {
+                    continue;
+                }
                 $id = $elementData['id'];
                 $asset = Asset::getById($id);
                 if ($asset instanceof Asset) {

--- a/models/DataObject/ClassDefinition/Data/ManyToManyAssetRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyAssetRelation.php
@@ -1,0 +1,432 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Model\DataObject\ClassDefinition\Data;
+
+use Exception;
+use Pimcore;
+use Pimcore\Model;
+use Pimcore\Model\Asset;
+use Pimcore\Model\DataObject;
+use Pimcore\Model\DataObject\Localizedfield;
+use Pimcore\Model\Element;
+use Pimcore\Normalizer\NormalizerInterface;
+
+class ManyToManyAssetRelation extends ManyToManyRelation implements LayoutDefinitionEnrichmentInterface
+{
+    /**
+     * @internal
+     *
+     * @var string[]|string|null
+     */
+    public array|string|null $visibleFields = null;
+
+    /**
+     * @internal
+     *
+     * @var array<string, array<string, mixed>>
+     */
+    public array $visibleFieldDefinitions = [];
+
+    public function __construct()
+    {
+        $this->setAssetsAllowed(true);
+        $this->setObjectsAllowed(false);
+        $this->setDocumentsAllowed(false);
+        $this->assetUploadPath = '';
+    }
+
+    public function getObjectsAllowed(): bool
+    {
+        return false;
+    }
+
+    public function getAssetsAllowed(): bool
+    {
+        return true;
+    }
+
+    protected function prepareDataForPersistence(array|Element\ElementInterface $data, Localizedfield|DataObject\Fieldcollection\Data\AbstractData|DataObject\Objectbrick\Data\AbstractData|DataObject\Concrete|null $object = null, array $params = []): mixed
+    {
+        if (is_array($data)) {
+            $return = [];
+            $counter = 1;
+            foreach ($data as $asset) {
+                if ($asset instanceof Asset) {
+                    $return[] = [
+                        'dest_id' => $asset->getId(),
+                        'type' => 'asset',
+                        'fieldname' => $this->getName(),
+                        'index' => $counter,
+                    ];
+                }
+                $counter++;
+            }
+
+            return $return;
+        }
+
+        return null;
+    }
+
+    protected function loadData(array $data, Localizedfield|DataObject\Fieldcollection\Data\AbstractData|DataObject\Objectbrick\Data\AbstractData|DataObject\Concrete|null $object = null, array $params = []): mixed
+    {
+        $assets = [
+            'dirty' => false,
+            'data' => [],
+        ];
+        foreach ($data as $relation) {
+            $asset = Asset::getById($relation['dest_id']);
+            if ($asset instanceof Asset) {
+                $assets['data'][] = $asset;
+            } else {
+                $assets['dirty'] = true;
+            }
+        }
+
+        //must return array - otherwise this means data is not loaded
+        return $assets;
+    }
+
+    /**
+     *
+     *
+     * @throws Exception
+     *
+     * @see QueryResourcePersistenceAwareInterface::getDataForQueryResource
+     *
+     */
+    public function getDataForQueryResource(mixed $data, ?DataObject\Concrete $object = null, array $params = []): ?string
+    {
+        //return null when data is not set
+        if (!$data) {
+            return null;
+        }
+
+        $ids = [];
+
+        if (is_array($data)) {
+            foreach ($data as $relation) {
+                if ($relation instanceof Asset) {
+                    $ids[] = $relation->getId();
+                }
+            }
+
+            return ',' . implode(',', $ids) . ',';
+        }
+
+        throw new Exception('invalid data passed to getDataForQueryResource - must be array and it is: ' . print_r($data, true));
+    }
+
+    /**
+     *
+     *
+     * @see Data::getDataForEditmode
+     *
+     */
+    public function getDataForEditmode(mixed $data, ?DataObject\Concrete $object = null, array $params = []): array
+    {
+        $return = [];
+
+        // add data
+        if (is_array($data) && count($data) > 0) {
+            foreach ($data as $asset) {
+                if ($asset instanceof Asset) {
+                    $return[] = Element\Service::gridElementData($asset);
+                }
+            }
+        }
+
+        return $return;
+    }
+
+    /**
+     *
+     *
+     * @see Data::getDataFromEditmode
+     *
+     */
+    public function getDataFromEditmode(mixed $data, ?DataObject\Concrete $object = null, array $params = []): ?array
+    {
+        //if not set, return null
+        if ($data === null || $data === false) {
+            return null;
+        }
+
+        $assets = [];
+        if (is_array($data) && count($data) > 0) {
+            foreach ($data as $element) {
+                $id = $element['id'] ?? null;
+                if (null === $id && isset($element[0])) {
+                    $id = $element[0];
+                }
+
+                if ($id === null) {
+                    continue;
+                }
+
+                $asset = Asset::getById((int) $id);
+                if ($asset instanceof Asset) {
+                    $assets[] = $asset;
+                }
+            }
+        }
+
+        //must return array if data shall be set
+        return $assets;
+    }
+
+    /**
+     * @param null|DataObject\Concrete $object
+     *
+     * @see Data::getDataFromEditmode
+     *
+     */
+    public function getDataFromGridEditor(array $data, ?DataObject\Concrete $object = null, array $params = []): ?array
+    {
+        return $this->getDataFromEditmode($data, $object, $params);
+    }
+
+    public function getDataForGrid(?array $data, ?DataObject\Concrete $object = null, array $params = []): ?array
+    {
+        $gridData = $this->getDataForEditmode($data, $object, $params);
+
+        if ($this->getPathFormatterClass() && !empty($gridData)) {
+            $params['fd'] = $object->getClass()->getFieldDefinition($this->getName(), $params['context'] ?? []);
+            foreach ($gridData as &$relatedElementData) {
+                $nicePath = $this->getNicePath($relatedElementData, $object, $params);
+                if ($nicePath) {
+                    $relatedElementData['fullpath'] = $nicePath;
+                }
+            }
+            unset($relatedElementData);
+        }
+
+        return $gridData;
+    }
+
+    /**
+     *
+     *
+     * @see Data::getVersionPreview
+     *
+     */
+    public function getVersionPreview(mixed $data, ?DataObject\Concrete $object = null, array $params = []): string
+    {
+        if (is_array($data) && count($data) > 0) {
+            $paths = [];
+            foreach ($data as $asset) {
+                if ($asset instanceof Element\ElementInterface) {
+                    $paths[] = $asset->getRealFullPath();
+                }
+            }
+
+            return implode('<br />', $paths);
+        }
+
+        return '';
+    }
+
+    public function checkValidity(mixed $data, bool $omitMandatoryCheck = false, array $params = []): void
+    {
+        if (!$omitMandatoryCheck && $this->getMandatory() && empty($data)) {
+            throw new Element\ValidationException('Empty mandatory field [ ' . $this->getName() . ' ]');
+        }
+
+        if (is_array($data)) {
+            $this->performMultipleAssignmentCheck($data);
+
+            foreach ($data as $asset) {
+                if (empty($asset)) {
+                    continue;
+                }
+
+                $allowAsset = $asset instanceof Asset && $this->allowAssetRelation($asset);
+                if (!$allowAsset) {
+                    $id = $asset instanceof Asset ? $asset->getId() : '??';
+                    throw new Element\ValidationException('Invalid asset relation to asset [' . $id . '] in field ' . $this->getName());
+                }
+            }
+
+            if ($this->getMaxItems() && count($data) > $this->getMaxItems()) {
+                throw new Element\ValidationException('Number of allowed relations in field `' . $this->getName() . '` exceeded (max. ' . $this->getMaxItems() . ')');
+            }
+        }
+    }
+
+    public function getForCsvExport(DataObject\Localizedfield|DataObject\Fieldcollection\Data\AbstractData|DataObject\Objectbrick\Data\AbstractData|DataObject\Concrete $object, array $params = []): string
+    {
+        $data = $this->getDataFromObjectParam($object, $params);
+        if (is_array($data)) {
+            $paths = [];
+            foreach ($data as $eo) {
+                if ($eo instanceof Element\ElementInterface) {
+                    $paths[] = $eo->getRealFullPath();
+                }
+            }
+
+            return implode(',', $paths);
+        }
+
+        return '';
+    }
+
+    public function resolveDependencies(mixed $data): array
+    {
+        $dependencies = [];
+
+        if (is_array($data) && count($data) > 0) {
+            foreach ($data as $asset) {
+                if ($asset instanceof Asset) {
+                    $dependencies['asset_' . $asset->getId()] = [
+                        'id' => $asset->getId(),
+                        'type' => 'asset',
+                    ];
+                }
+            }
+        }
+
+        return $dependencies;
+    }
+
+    /**
+     * @param DataObject\ClassDefinition\Data\ManyToManyAssetRelation $mainDefinition
+     */
+    public function synchronizeWithMainDefinition(DataObject\ClassDefinition\Data $mainDefinition): void
+    {
+        $this->maxItems = $mainDefinition->maxItems;
+        $this->assetUploadPath = $mainDefinition->assetUploadPath;
+        $this->relationType = $mainDefinition->relationType;
+        $this->objectsAllowed = $mainDefinition->objectsAllowed;
+        $this->assetsAllowed = $mainDefinition->assetsAllowed;
+        $this->assetTypes = $mainDefinition->assetTypes;
+        $this->documentsAllowed = $mainDefinition->documentsAllowed;
+        $this->documentTypes = $mainDefinition->documentTypes;
+    }
+
+    /**
+     * @param string[]|string|null $visibleFields
+     *
+     * @return $this
+     */
+    public function setVisibleFields(array|string|null $visibleFields): static
+    {
+        if (is_array($visibleFields) && count($visibleFields)) {
+            $visibleFields = implode(',', $visibleFields);
+        }
+        $this->visibleFields = $visibleFields;
+
+        return $this;
+    }
+
+    public function getVisibleFields(): array|null|string
+    {
+        return $this->visibleFields;
+    }
+
+    public function enrichLayoutDefinition(?DataObject\Concrete $object, array $context = []): static
+    {
+        if (!$this->visibleFields) {
+            return $this;
+        }
+
+        $translator = Pimcore::getContainer()->get('translator');
+        $this->visibleFieldDefinitions = [];
+        $visibleFields = explode(',', (string) $this->visibleFields);
+
+        foreach ($visibleFields as $field) {
+            $this->visibleFieldDefinitions[$field]['name'] = $field;
+            $this->visibleFieldDefinitions[$field]['title'] = $translator->trans($field, [], 'admin');
+            $this->visibleFieldDefinitions[$field]['fieldtype'] = 'input';
+        }
+
+        return $this;
+    }
+
+    protected function getPhpdocType(): string
+    {
+        return $this->getPhpDocClassString(true);
+    }
+
+    public function normalize(mixed $value, array $params = []): ?array
+    {
+        if (is_array($value)) {
+            $result = [];
+            foreach ($value as $element) {
+                $type = Element\Service::getElementType($element);
+                $id = $element->getId();
+                $result[] = [
+                    'type' => $type,
+                    'id' => $id,
+                ];
+            }
+
+            return $result;
+        }
+
+        return null;
+    }
+
+    /** See marshal
+     *
+     *
+     */
+    public function denormalize(mixed $value, array $params = []): ?array
+    {
+        if (is_array($value)) {
+            $result = [];
+            foreach ($value as $elementData) {
+                $type = $elementData['type'];
+                $id = $elementData['id'];
+                $element = Element\Service::getElementById($type, $id);
+                if ($element) {
+                    $result[] = $element;
+                }
+            }
+
+            return $result;
+        }
+
+        return null;
+    }
+
+    public function isFilterable(): bool
+    {
+        return true;
+    }
+
+    public function addListingFilter(DataObject\Listing $listing, float|array|int|string|Model\Element\ElementInterface $data, string $operator = '='): DataObject\Listing
+    {
+        if ($data instanceof Asset) {
+            $data = $data->getId();
+        }
+
+        if ($operator === '=') {
+            $listing->addConditionParam('`'.$this->getName().'` LIKE ?', '%,'.$data.',%');
+
+            return $listing;
+        }
+
+        throw new Exception('Filtering '.__CLASS__.' does only support "=" operator');
+    }
+
+    public function getQueryColumnType(): string
+    {
+        return 'text';
+    }
+
+    public function getFieldType(): string
+    {
+        return 'manyToManyAssetRelation';
+    }
+}

--- a/models/DataObject/ClassDefinition/Data/ManyToManyAssetRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyAssetRelation.php
@@ -418,7 +418,7 @@ class ManyToManyAssetRelation extends ManyToManyRelation implements LayoutDefini
         return '';
     }
 
-    protected function buildUniqueKeyForDiffEditor(array $item): string
+    public function buildUniqueKeyForDiffEditor(array $item): string
     {
         return (string) $item['id'];
     }

--- a/models/DataObject/ClassDefinition/Data/ManyToManyAssetRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyAssetRelation.php
@@ -137,12 +137,32 @@ class ManyToManyAssetRelation extends ManyToManyRelation implements LayoutDefini
     public function getDataForEditmode(mixed $data, ?DataObject\Concrete $object = null, array $params = []): array
     {
         $return = [];
+        $visibleFieldsArray = $this->getVisibleFields() ? explode(',', (string) $this->getVisibleFields()) : [];
 
         // add data
         if (is_array($data) && count($data) > 0) {
             foreach ($data as $asset) {
                 if ($asset instanceof Asset) {
-                    $return[] = Element\Service::gridElementData($asset);
+                    $row = Element\Service::gridElementData($asset);
+
+                    if (!empty($visibleFieldsArray)) {
+                        foreach ($visibleFieldsArray as $field) {
+                            // don't override existing system columns (id, fullpath, subtype, etc.)
+                            if (array_key_exists($field, $row)) {
+                                continue;
+                            }
+
+                            $getter = 'get' . ucfirst($field);
+                            if (method_exists($asset, $getter)) {
+                                $row[$field] = $asset->{$getter}();
+                                continue;
+                            }
+
+                            $row[$field] = $asset->getMetadata($field);
+                        }
+                    }
+
+                    $return[] = $row;
                 }
             }
         }

--- a/models/DataObject/ClassDefinition/Data/ManyToManyAssetRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyAssetRelation.php
@@ -14,13 +14,13 @@ declare(strict_types=1);
 namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
 use Exception;
+use InvalidArgumentException;
 use Pimcore;
 use Pimcore\Model;
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\Localizedfield;
 use Pimcore\Model\Element;
-use Pimcore\Normalizer\NormalizerInterface;
 
 class ManyToManyAssetRelation extends ManyToManyRelation implements LayoutDefinitionEnrichmentInterface
 {
@@ -187,10 +187,6 @@ class ManyToManyAssetRelation extends ManyToManyRelation implements LayoutDefini
         if (is_array($data) && count($data) > 0) {
             foreach ($data as $element) {
                 $id = $element['id'] ?? null;
-                if (null === $id && isset($element[0])) {
-                    $id = $element[0];
-                }
-
                 if ($id === null) {
                     continue;
                 }
@@ -324,14 +320,11 @@ class ManyToManyAssetRelation extends ManyToManyRelation implements LayoutDefini
      */
     public function synchronizeWithMainDefinition(DataObject\ClassDefinition\Data $mainDefinition): void
     {
-        $this->maxItems = $mainDefinition->maxItems;
-        $this->assetUploadPath = $mainDefinition->assetUploadPath;
-        $this->relationType = $mainDefinition->relationType;
-        $this->objectsAllowed = $mainDefinition->objectsAllowed;
-        $this->assetsAllowed = $mainDefinition->assetsAllowed;
-        $this->assetTypes = $mainDefinition->assetTypes;
-        $this->documentsAllowed = $mainDefinition->documentsAllowed;
-        $this->documentTypes = $mainDefinition->documentTypes;
+        parent::synchronizeWithMainDefinition($mainDefinition);
+
+        if ($mainDefinition instanceof self) {
+            $this->visibleFields = $mainDefinition->getVisibleFields();
+        }
     }
 
     /**
@@ -420,15 +413,16 @@ class ManyToManyAssetRelation extends ManyToManyRelation implements LayoutDefini
         return null;
     }
 
-    public function isFilterable(): bool
-    {
-        return true;
-    }
-
     public function addListingFilter(DataObject\Listing $listing, float|array|int|string|Model\Element\ElementInterface $data, string $operator = '='): DataObject\Listing
     {
         if ($data instanceof Asset) {
             $data = $data->getId();
+        } elseif (is_array($data)) {
+            $data = $data['id'] ?? null;
+        }
+
+        if ($data === null) {
+            throw new InvalidArgumentException('Please provide an asset id, an asset, or an array containing the key "id".');
         }
 
         if ($operator === '=') {
@@ -437,12 +431,7 @@ class ManyToManyAssetRelation extends ManyToManyRelation implements LayoutDefini
             return $listing;
         }
 
-        throw new Exception('Filtering '.__CLASS__.' does only support "=" operator');
-    }
-
-    public function getQueryColumnType(): string
-    {
-        return 'text';
+        throw new InvalidArgumentException('Filtering '.__CLASS__.' does only support "=" operator');
     }
 
     public function getFieldType(): string

--- a/models/DataObject/ClassDefinition/Data/ManyToManyAssetRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyAssetRelation.php
@@ -364,6 +364,108 @@ class ManyToManyAssetRelation extends ManyToManyRelation implements LayoutDefini
         throw new InvalidArgumentException('Filtering '.__CLASS__.' does only support "=" operator');
     }
 
+    public function getForCsvExport(DataObject\Localizedfield|DataObject\Fieldcollection\Data\AbstractData|DataObject\Objectbrick\Data\AbstractData|DataObject\Concrete $object, array $params = []): string
+    {
+        $data = $this->getDataFromObjectParam($object, $params);
+        if (is_array($data)) {
+            $paths = [];
+            foreach ($data as $eo) {
+                if ($eo instanceof Element\ElementInterface) {
+                    $paths[] = $eo->getRealFullPath();
+                }
+            }
+
+            return implode(',', $paths);
+        }
+
+        return '';
+    }
+
+    protected function buildUniqueKeyForDiffEditor(array $item): string
+    {
+        return (string) $item['id'];
+    }
+
+    protected function processDiffDataForEditMode(?array $originalData, ?array $data, ?DataObject\Concrete $object = null, array $params = []): ?array
+    {
+        if ($data) {
+            $data = $data[0];
+
+            $items = $data['data'];
+            $newItems = [];
+            if ($items) {
+                foreach ($items as $in) {
+                    $item = [];
+                    $item['id'] = $in['id'];
+                    $item['path'] = $in['fullpath'];
+                    $item['type'] = $in['type'] ?? 'asset';
+
+                    $unique = $this->buildUniqueKeyForDiffEditor($item);
+
+                    $itemId = json_encode($item);
+                    $raw = $itemId;
+
+                    $newItems[] = [
+                        'itemId' => $itemId,
+                        'title' => $item['path'],
+                        'raw' => $raw,
+                        'gridrow' => $item,
+                        'unique' => $unique,
+                    ];
+                }
+                $data['data'] = $newItems;
+            }
+
+            $data['value'] = [
+                'type' => 'grid',
+                'columnConfig' => [
+                    'id' => [
+                        'width' => 60,
+                    ],
+                    'path' => [
+                        'flex' => 2,
+                    ],
+                ],
+                'html' => $this->getVersionPreview($originalData, $object, $params),
+            ];
+
+            $newData = [];
+            $newData[] = $data;
+
+            return $newData;
+        }
+
+        return $data;
+    }
+
+    public function getDiffDataForEditMode(mixed $data, ?DataObject\Concrete $object = null, array $params = []): ?array
+    {
+        $originalData = $data;
+        $data = parent::getDiffDataForEditMode($data, $object, $params);
+        $data = $this->processDiffDataForEditMode($originalData, $data, $object, $params);
+
+        return $data;
+    }
+
+    public function getDiffDataFromEditmode(array $data, ?DataObject\Concrete $object = null, array $params = []): ?array
+    {
+        if ($data) {
+            $tabledata = $data[0]['data'];
+
+            $result = [];
+            if ($tabledata) {
+                foreach ($tabledata as $in) {
+                    $out = json_decode($in['raw'], true);
+                    $result[] = $out;
+                }
+            }
+
+            return $this->getDataFromEditmode($result, $object, $params);
+        }
+
+        return null;
+    }
+
     public function getFieldType(): string
     {
         return 'manyToManyAssetRelation';

--- a/tests/Model/DataType/AdvancedManyToManyAssetRelationEditModeTest.php
+++ b/tests/Model/DataType/AdvancedManyToManyAssetRelationEditModeTest.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Tests\Model\DataType;
+
+use Pimcore\Model\Asset;
+use Pimcore\Model\DataObject;
+use Pimcore\Tests\Support\Util\TestHelper;
+use Pimcore\Tests\Test\ModelTestCase;
+
+class AdvancedManyToManyAssetRelationEditModeTest extends ModelTestCase
+{
+    public function testGetDataForEditmodeWithColumns(): void
+    {
+        $asset = TestHelper::createImageAsset();
+
+        $fd = new DataObject\ClassDefinition\Data\AdvancedManyToManyAssetRelation();
+        $fd->setColumns([['position' => 1, 'key' => 'meta1', 'type' => 'text', 'label' => 'Meta 1']]);
+
+        $metaData = new DataObject\Data\ElementMetadata('testField', ['meta1'], $asset);
+        $metaData->setMeta1('test-value');
+
+        $result = $fd->getDataForEditmode([$metaData]);
+
+        $this->assertCount(1, $result);
+        $this->assertSame($asset->getId(), $result[0]['id']);
+        $this->assertArrayHasKey('fullpath', $result[0]);
+        $this->assertSame('test-value', $result[0]['meta1']);
+        $this->assertArrayHasKey('rowId', $result[0]);
+    }
+
+    public function testGetDataForEditmodeWithVisibleFields(): void
+    {
+        $asset = TestHelper::createImageAsset();
+        $asset->addMetadata('altText', 'input', 'my alt text');
+        $asset->save();
+
+        $fd = new DataObject\ClassDefinition\Data\AdvancedManyToManyAssetRelation();
+        $fd->setVisibleFields('altText');
+        $fd->setColumns([['position' => 1, 'key' => 'note', 'type' => 'text', 'label' => 'Note']]);
+
+        $metaData = new DataObject\Data\ElementMetadata('testField', ['note'], $asset);
+        $metaData->setNote('a note');
+
+        $result = $fd->getDataForEditmode([$metaData]);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('my alt text', $result[0]['altText']);
+        $this->assertSame('a note', $result[0]['note']);
+    }
+
+    public function testGetDataFromEditmodeReturnsElementMetadata(): void
+    {
+        $asset = TestHelper::createImageAsset();
+
+        $fd = new DataObject\ClassDefinition\Data\AdvancedManyToManyAssetRelation();
+        $fd->setColumns([['position' => 1, 'key' => 'meta1', 'type' => 'text', 'label' => 'Meta 1']]);
+
+        $result = $fd->getDataFromEditmode([
+            ['id' => $asset->getId(), 'meta1' => 'from-edit'],
+        ]);
+
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf(DataObject\Data\ElementMetadata::class, $result[0]);
+        $this->assertSame($asset->getId(), $result[0]->getElement()->getId());
+        $this->assertSame('from-edit', $result[0]->getMeta1());
+    }
+
+    public function testNormalizeDenormalizeRoundtrip(): void
+    {
+        $asset = TestHelper::createImageAsset();
+
+        $fd = new DataObject\ClassDefinition\Data\AdvancedManyToManyAssetRelation();
+        $fd->setColumns([['position' => 1, 'key' => 'meta1', 'type' => 'text', 'label' => 'Meta 1']]);
+
+        $metaData = new DataObject\Data\ElementMetadata('testField', ['meta1'], $asset);
+        $metaData->setMeta1('round-trip');
+
+        $normalized = $fd->normalize([$metaData]);
+        $this->assertSame('asset', $normalized[0]['element']['type']);
+        $this->assertSame($asset->getId(), $normalized[0]['element']['id']);
+        $this->assertSame('round-trip', $normalized[0]['data']['meta1']);
+
+        $denormalized = $fd->denormalize($normalized);
+        $this->assertCount(1, $denormalized);
+        $this->assertSame($asset->getId(), $denormalized[0]->getElement()->getId());
+    }
+}

--- a/tests/Model/DataType/AdvancedManyToManyAssetRelationEditModeTest.php
+++ b/tests/Model/DataType/AdvancedManyToManyAssetRelationEditModeTest.php
@@ -16,7 +16,7 @@ namespace Pimcore\Tests\Model\DataType;
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
 use Pimcore\Tests\Support\Util\TestHelper;
-use Pimcore\Tests\Test\ModelTestCase;
+use Pimcore\Tests\Support\Test\ModelTestCase;
 
 class AdvancedManyToManyAssetRelationEditModeTest extends ModelTestCase
 {

--- a/tests/Model/DataType/AdvancedManyToManyAssetRelationEditModeTest.php
+++ b/tests/Model/DataType/AdvancedManyToManyAssetRelationEditModeTest.php
@@ -68,7 +68,7 @@ class AdvancedManyToManyAssetRelationEditModeTest extends ModelTestCase
         $fd->setColumns([['position' => 1, 'key' => 'meta1', 'type' => 'text', 'label' => 'Meta 1']]);
 
         $result = $fd->getDataFromEditmode([
-            ['id' => $asset->getId(), 'meta1' => 'from-edit'],
+            ['id' => $asset->getId(), 'type' => 'asset', 'meta1' => 'from-edit'],
         ]);
 
         $this->assertCount(1, $result);

--- a/tests/Model/DataType/AdvancedManyToManyAssetRelationEditModeTest.php
+++ b/tests/Model/DataType/AdvancedManyToManyAssetRelationEditModeTest.php
@@ -34,7 +34,8 @@ class AdvancedManyToManyAssetRelationEditModeTest extends ModelTestCase
 
         $this->assertCount(1, $result);
         $this->assertSame($asset->getId(), $result[0]['id']);
-        $this->assertArrayHasKey('fullpath', $result[0]);
+        $this->assertArrayHasKey('path', $result[0], 'the row shape follows the parent, which emits path');
+        $this->assertSame($asset->getRealFullPath(), $result[0]['path']);
         $this->assertSame('test-value', $result[0]['meta1']);
         $this->assertArrayHasKey('rowId', $result[0]);
     }

--- a/tests/Model/DataType/AdvancedManyToManyAssetRelationEditModeTest.php
+++ b/tests/Model/DataType/AdvancedManyToManyAssetRelationEditModeTest.php
@@ -1,6 +1,16 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
 namespace Pimcore\Tests\Model\DataType;
 
 use Pimcore\Model\Asset;

--- a/tests/Model/DataType/ManyToManyAssetRelationEditModeTest.php
+++ b/tests/Model/DataType/ManyToManyAssetRelationEditModeTest.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Tests\Model\DataType;
+
+use Pimcore\Model\Asset;
+use Pimcore\Model\DataObject;
+use Pimcore\Tests\Support\Util\TestHelper;
+use Pimcore\Tests\Test\ModelTestCase;
+
+class ManyToManyAssetRelationEditModeTest extends ModelTestCase
+{
+    public function testGetDataForEditmodeWithoutVisibleFields(): void
+    {
+        $asset1 = TestHelper::createImageAsset();
+        $asset2 = TestHelper::createImageAsset();
+
+        $fd = new DataObject\ClassDefinition\Data\ManyToManyAssetRelation();
+
+        $result = $fd->getDataForEditmode([$asset1, $asset2]);
+
+        $this->assertCount(2, $result);
+        $this->assertSame($asset1->getId(), $result[0]['id']);
+        $this->assertSame($asset2->getId(), $result[1]['id']);
+        $this->assertArrayHasKey('fullpath', $result[0]);
+        $this->assertArrayHasKey('type', $result[0]);
+    }
+
+    public function testGetDataForEditmodeWithVisibleFields(): void
+    {
+        $asset = TestHelper::createImageAsset();
+        $asset->addMetadata('altText', 'input', 'test alt text');
+        $asset->addMetadata('copyright', 'input', 'test copyright');
+        $asset->save();
+
+        $fd = new DataObject\ClassDefinition\Data\ManyToManyAssetRelation();
+        $fd->setVisibleFields('altText,copyright');
+
+        $result = $fd->getDataForEditmode([$asset]);
+
+        $this->assertCount(1, $result);
+        $this->assertSame($asset->getId(), $result[0]['id']);
+        $this->assertSame('test alt text', $result[0]['altText']);
+        $this->assertSame('test copyright', $result[0]['copyright']);
+    }
+
+    public function testGetDataForEditmodeDoesNotOverrideSystemColumns(): void
+    {
+        $asset = TestHelper::createImageAsset();
+        $asset->addMetadata('id', 'input', 'should-not-override');
+        $asset->save();
+
+        $fd = new DataObject\ClassDefinition\Data\ManyToManyAssetRelation();
+        $fd->setVisibleFields('id');
+
+        $result = $fd->getDataForEditmode([$asset]);
+
+        $this->assertCount(1, $result);
+        $this->assertSame($asset->getId(), $result[0]['id']);
+    }
+
+    public function testGetDataFromEditmodeReturnsAssets(): void
+    {
+        $asset = TestHelper::createImageAsset();
+
+        $fd = new DataObject\ClassDefinition\Data\ManyToManyAssetRelation();
+        $result = $fd->getDataFromEditmode([['id' => $asset->getId()]]);
+
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf(Asset::class, $result[0]);
+        $this->assertSame($asset->getId(), $result[0]->getId());
+    }
+
+    public function testGetDataFromEditmodeReturnsNullForNullInput(): void
+    {
+        $fd = new DataObject\ClassDefinition\Data\ManyToManyAssetRelation();
+        $this->assertNull($fd->getDataFromEditmode(null));
+    }
+
+    public function testGetDataFromEditmodeSkipsMissingAssets(): void
+    {
+        $fd = new DataObject\ClassDefinition\Data\ManyToManyAssetRelation();
+        $result = $fd->getDataFromEditmode([['id' => 999999999]]);
+
+        $this->assertCount(0, $result);
+    }
+}

--- a/tests/Model/DataType/ManyToManyAssetRelationEditModeTest.php
+++ b/tests/Model/DataType/ManyToManyAssetRelationEditModeTest.php
@@ -16,7 +16,7 @@ namespace Pimcore\Tests\Model\DataType;
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
 use Pimcore\Tests\Support\Util\TestHelper;
-use Pimcore\Tests\Test\ModelTestCase;
+use Pimcore\Tests\Support\Test\ModelTestCase;
 
 class ManyToManyAssetRelationEditModeTest extends ModelTestCase
 {

--- a/tests/Model/DataType/ManyToManyAssetRelationEditModeTest.php
+++ b/tests/Model/DataType/ManyToManyAssetRelationEditModeTest.php
@@ -1,6 +1,16 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
 namespace Pimcore\Tests\Model\DataType;
 
 use Pimcore\Model\Asset;

--- a/tests/Model/DataType/NormalizerTest.php
+++ b/tests/Model/DataType/NormalizerTest.php
@@ -441,6 +441,27 @@ class NormalizerTest extends ModelTestCase
         $this->assertEquals($targetObject2->getId(), $denormalizedValue[1]->getId());
     }
 
+    public function testManyToManyAssetRelation(): void
+    {
+        $targetAsset1 = TestHelper::createImageAsset();
+        $targetAsset2 = TestHelper::createImageAsset();
+
+        $originalValue = [$targetAsset1, $targetAsset2];
+
+        $fd = new DataObject\ClassDefinition\Data\ManyToManyAssetRelation();
+        $this->assertTrue($fd instanceof NormalizerInterface, 'expected NormalizerInterface');
+
+        $normalizedValue = $fd->normalize($originalValue);
+        $this->assertTrue(is_array($normalizedValue));
+        $this->assertCount(2, $normalizedValue);
+        $this->assertSame('asset', $normalizedValue[0]['type']);
+        $this->assertSame($targetAsset1->getId(), $normalizedValue[0]['id']);
+
+        $denormalizedValue = $fd->denormalize($normalizedValue);
+        $this->assertEquals($targetAsset1->getId(), $denormalizedValue[0]->getId());
+        $this->assertEquals($targetAsset2->getId(), $denormalizedValue[1]->getId());
+    }
+
     public function testManyToManyRelation(): void
     {
         $targetObject1 = TestHelper::createEmptyObject();

--- a/tests/Model/LazyLoading/AdvancedManyToManyAssetRelationTest.php
+++ b/tests/Model/LazyLoading/AdvancedManyToManyAssetRelationTest.php
@@ -1,0 +1,128 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\LazyLoading;
+
+use Pimcore;
+use Pimcore\Cache;
+use Pimcore\Model\DataObject\Data\ElementMetadata;
+use Pimcore\Model\DataObject\LazyLoading;
+use Pimcore\Tests\Support\Util\TestHelper;
+
+class AdvancedManyToManyAssetRelationTest extends AbstractLazyLoadingTest
+{
+    private array $assets = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->assets = $this->createAssets();
+    }
+
+    private function createAssets(): array
+    {
+        $assets = [];
+        for ($i = 0; $i < self::RELATION_COUNT; $i++) {
+            $assets[] = TestHelper::createImageAsset('lazy-asset-');
+        }
+
+        return $assets;
+    }
+
+    /**
+     * @return ElementMetadata[]
+     */
+    protected function loadMetadataAssets(string $fieldname, string $metaKey = 'metadata'): array
+    {
+        $metaDataList = [];
+        foreach ($this->assets as $asset) {
+            $assetMetadata = new ElementMetadata($fieldname, [$metaKey], $asset);
+            $setter = 'set' . ucfirst($metaKey);
+            $assetMetadata->$setter('some-metadata');
+            $metaDataList[] = $assetMetadata;
+        }
+
+        return $metaDataList;
+    }
+
+    protected function checkSerialization(LazyLoading $object, string $messagePrefix, bool $contentShouldBeIncluded = false): void
+    {
+        parent::checkSerialization($object, $messagePrefix, false);
+        $serializedString = serialize($object);
+        $this->checkSerializedStringForNeedle($serializedString, 'some-metadata', $contentShouldBeIncluded, $messagePrefix);
+    }
+
+    public function testClassAttributes(): void
+    {
+        $object = $this->createDataObject();
+        $object->setAdvancedAssetRelations($this->loadMetadataAssets('advancedAssetRelations'));
+        $object->save();
+        $parentId = $object->getId();
+        $childId = $this->createChildDataObject($object)->getId();
+
+        foreach (['parent' => $parentId, 'inherited' => $childId] as $objectType => $id) {
+            $messagePrefix = "Testing object-type $objectType: ";
+
+            Cache::clearAll();
+            Pimcore::collectGarbage();
+
+            $object = LazyLoading::getById($id, ['force' => true]);
+
+            $this->checkSerialization($object, $messagePrefix);
+
+            $relationAssets = $object->getAdvancedAssetRelations();
+            $this->assertEquals(self::RELATION_COUNT, count($relationAssets), $messagePrefix . 'asset relations not loaded properly');
+            $this->assertEquals('some-metadata', $relationAssets[2]->getMetadata(), $messagePrefix . 'asset relation metadata not loaded properly');
+
+            $this->checkSerialization($object, $messagePrefix);
+
+            $this->forceSavingAndLoadingFromCache($object, function ($objectCache) use ($messagePrefix) {
+                $relationAssets = $objectCache->getAdvancedAssetRelations();
+                $this->assertEquals(self::RELATION_COUNT, count($relationAssets), $messagePrefix . 'asset relations not loaded properly');
+                $this->assertEquals('some-metadata', $relationAssets[2]->getMetadata(), $messagePrefix . 'asset relation metadata not loaded properly');
+            });
+        }
+    }
+
+    public function testLocalizedClassAttributes(): void
+    {
+        $object = $this->createDataObject();
+        $object->setLadvancedAssetRelations($this->loadMetadataAssets('ladvancedAssetRelations'));
+        $object->save();
+        $parentId = $object->getId();
+        $childId = $this->createChildDataObject($object)->getId();
+
+        foreach (['parent' => $parentId, 'inherited' => $childId] as $objectType => $id) {
+            $messagePrefix = "Testing object-type $objectType: ";
+
+            Cache::clearAll();
+            Pimcore::collectGarbage();
+
+            $object = LazyLoading::getById($id, ['force' => true]);
+
+            $this->checkSerialization($object, $messagePrefix);
+
+            $relationAssets = $object->getLadvancedAssetRelations();
+            $this->assertEquals(self::RELATION_COUNT, count($relationAssets), $messagePrefix . 'asset relations not loaded properly');
+            $this->assertEquals('some-metadata', $relationAssets[2]->getMetadata(), $messagePrefix . 'asset relation metadata not loaded properly');
+
+            $this->checkSerialization($object, $messagePrefix);
+
+            $this->forceSavingAndLoadingFromCache($object, function ($objectCache) use ($messagePrefix) {
+                $relationAssets = $objectCache->getLadvancedAssetRelations();
+                $this->assertEquals(self::RELATION_COUNT, count($relationAssets), $messagePrefix . 'asset relations not loaded properly');
+                $this->assertEquals('some-metadata', $relationAssets[2]->getMetadata(), $messagePrefix . 'asset relation metadata not loaded properly');
+            });
+        }
+    }
+}

--- a/tests/Model/LazyLoading/AdvancedManyToManyAssetRelationTest.php
+++ b/tests/Model/LazyLoading/AdvancedManyToManyAssetRelationTest.php
@@ -15,8 +15,13 @@ namespace Pimcore\Tests\Model\LazyLoading;
 
 use Pimcore;
 use Pimcore\Cache;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\Data\BlockElement;
 use Pimcore\Model\DataObject\Data\ElementMetadata;
+use Pimcore\Model\DataObject\Fieldcollection;
 use Pimcore\Model\DataObject\LazyLoading;
+use Pimcore\Model\DataObject\Objectbrick\Data\LazyLoadingLocalizedTest;
+use Pimcore\Model\DataObject\Objectbrick\Data\LazyLoadingTest;
 use Pimcore\Tests\Support\Util\TestHelper;
 
 class AdvancedManyToManyAssetRelationTest extends AbstractLazyLoadingTest
@@ -94,6 +99,24 @@ class AdvancedManyToManyAssetRelationTest extends AbstractLazyLoadingTest
         }
     }
 
+    public function testDirtyFlag(): void
+    {
+        $object = $this->createDataObject();
+
+        $relations = $this->loadMetadataAssets('advancedAssetRelations');
+
+        $object->setAdvancedAssetRelations($relations);
+        $object->save();
+        $this->assertFalse($object->isFieldDirty('advancedAssetRelations'), 'Advanced asset relation must not be dirty after saving');
+
+        Cache\RuntimeCache::clear();
+        $object = LazyLoading::getByPath('/lazy1');
+        $this->assertFalse($object->isFieldDirty('advancedAssetRelations'), 'Advanced asset relation must not be dirty directly after loading');
+
+        $object->getAdvancedAssetRelations()[0]->setMetadata('some-other-metadata');
+        $this->assertTrue($object->isFieldDirty('advancedAssetRelations'), 'Advanced asset relation must be dirty after changing a metadata field');
+    }
+
     public function testLocalizedClassAttributes(): void
     {
         $object = $this->createDataObject();
@@ -120,6 +143,266 @@ class AdvancedManyToManyAssetRelationTest extends AbstractLazyLoadingTest
 
             $this->forceSavingAndLoadingFromCache($object, function ($objectCache) use ($messagePrefix) {
                 $relationAssets = $objectCache->getLadvancedAssetRelations();
+                $this->assertEquals(self::RELATION_COUNT, count($relationAssets), $messagePrefix . 'asset relations not loaded properly');
+                $this->assertEquals('some-metadata', $relationAssets[2]->getMetadata(), $messagePrefix . 'asset relation metadata not loaded properly');
+            });
+        }
+    }
+
+    public function testBlockClassAttributes(): void
+    {
+        $object = $this->createDataObject();
+        $data = [
+            'blockadvancedAssetRelations' => new BlockElement('blockadvancedAssetRelations', 'advancedManyToManyAssetRelation', $this->loadMetadataAssets('blockadvancedAssetRelations')),
+        ];
+        $object->setTestBlock([$data]);
+        $object->save();
+        $parentId = $object->getId();
+        $childId = $this->createChildDataObject($object)->getId();
+
+        foreach (['parent' => $parentId, 'inherited' => $childId] as $objectType => $id) {
+            $messagePrefix = "Testing object-type $objectType: ";
+
+            Cache::clearAll();
+            Pimcore::collectGarbage();
+
+            $object = LazyLoading::getById($id, ['force' => true]);
+
+            $contentShouldBeIncluded = $objectType !== 'inherited';
+
+            $this->checkSerialization($object, $messagePrefix, $contentShouldBeIncluded);
+
+            $blockItems = $object->getTestBlock();
+            $relationAssets = $blockItems[0]['blockadvancedAssetRelations']->getData();
+            $this->assertEquals(self::RELATION_COUNT, count($relationAssets), $messagePrefix . 'asset relations not loaded properly');
+            $this->assertEquals('some-metadata', $relationAssets[2]->getMetadata(), $messagePrefix . 'asset relation metadata not loaded properly');
+
+            $this->checkSerialization($object, $messagePrefix, $contentShouldBeIncluded);
+
+            $this->forceSavingAndLoadingFromCache($object, function ($objectCache) use ($messagePrefix) {
+                $blockItems = $objectCache->getTestBlock();
+                $relationAssets = $blockItems[0]['blockadvancedAssetRelations']->getData();
+                $this->assertEquals(self::RELATION_COUNT, count($relationAssets), $messagePrefix . 'asset relations not loaded properly');
+                $this->assertEquals('some-metadata', $relationAssets[2]->getMetadata(), $messagePrefix . 'asset relation metadata not loaded properly');
+            });
+        }
+    }
+
+    public function testLazyBlockClassAttributes(): void
+    {
+        $object = $this->createDataObject();
+        $data = [
+            'blockadvancedAssetRelationsLazyLoaded' => new BlockElement('blockadvancedAssetRelationsLazyLoaded', 'advancedManyToManyAssetRelation', $this->loadMetadataAssets('blockadvancedAssetRelationsLazyLoaded')),
+        ];
+        $object->setTestBlockLazyloaded([$data]);
+        $object->save();
+        $parentId = $object->getId();
+        $childId = $this->createChildDataObject($object)->getId();
+
+        foreach (['parent' => $parentId, 'inherited' => $childId] as $objectType => $id) {
+            $messagePrefix = "Testing object-type $objectType: ";
+
+            Cache::clearAll();
+            Pimcore::collectGarbage();
+
+            $object = LazyLoading::getById($id, ['force' => true]);
+
+            $this->checkSerialization($object, $messagePrefix);
+
+            $blockItems = $object->getTestBlockLazyloaded();
+            $relationAssets = $blockItems[0]['blockadvancedAssetRelationsLazyLoaded']->getData();
+            $this->assertEquals(self::RELATION_COUNT, count($relationAssets), $messagePrefix . 'asset relations not loaded properly');
+            $this->assertEquals('some-metadata', $relationAssets[2]->getMetadata(), $messagePrefix . 'asset relation metadata not loaded properly');
+
+            $this->checkSerialization($object, $messagePrefix);
+
+            $this->forceSavingAndLoadingFromCache($object, function ($objectCache) use ($messagePrefix) {
+                $blockItems = $objectCache->getTestBlockLazyloaded();
+                $relationAssets = $blockItems[0]['blockadvancedAssetRelationsLazyLoaded']->getData();
+                $this->assertEquals(self::RELATION_COUNT, count($relationAssets), $messagePrefix . 'asset relations not loaded properly');
+                $this->assertEquals('some-metadata', $relationAssets[2]->getMetadata(), $messagePrefix . 'asset relation metadata not loaded properly');
+            });
+        }
+    }
+
+    public function testFieldCollectionAttributes(): void
+    {
+        $object = $this->createDataObject();
+
+        $items = new Fieldcollection();
+        $item = new Fieldcollection\Data\LazyLoadingTest();
+        $item->setAdvancedAssetRelations($this->loadMetadataAssets('advancedAssetRelations', 'metadataUpper'));
+        $items->add($item);
+        $object->setFieldcollection($items);
+        $object->save();
+        $parentId = $object->getId();
+        $childId = $this->createChildDataObject($object)->getId();
+
+        foreach (['parent' => $parentId, 'inherited' => $childId] as $objectType => $id) {
+            $messagePrefix = "Testing object-type $objectType: ";
+
+            Cache::clearAll();
+            Pimcore::collectGarbage();
+
+            $object = LazyLoading::getById($id, ['force' => true]);
+
+            $this->checkSerialization($object, $messagePrefix, false);
+
+            $collection = $object->getFieldcollection();
+            if ($objectType === 'parent') {
+                $item = $collection->get(0);
+                $relationAssets = $item->getAdvancedAssetRelations();
+                $this->assertEquals(self::RELATION_COUNT, count($relationAssets), $messagePrefix . 'asset relations not loaded properly');
+                $this->assertEquals('some-metadata', $relationAssets[2]->getMetadataUpper(), $messagePrefix . 'asset relation metadata not loaded properly');
+            }
+
+            $this->checkSerialization($object, $messagePrefix, false);
+
+            $this->forceSavingAndLoadingFromCache($object, function ($objectCache) use ($objectType, $messagePrefix) {
+                $collection = $objectCache->getFieldcollection();
+                if ($objectType === 'parent') {
+                    $item = $collection->get(0);
+                    $relationAssets = $item->getAdvancedAssetRelations();
+                    $this->assertEquals(self::RELATION_COUNT, count($relationAssets), $messagePrefix . 'asset relations not loaded properly');
+                    $this->assertEquals('some-metadata', $relationAssets[2]->getMetadataUpper(), $messagePrefix . 'asset relation metadata not loaded properly');
+                }
+            });
+        }
+    }
+
+    public function testFieldCollectionLocalizedAttributes(): void
+    {
+        $object = $this->createDataObject();
+
+        $items = new Fieldcollection();
+        $item = new Fieldcollection\Data\LazyLoadingLocalizedTest();
+        $item->setLadvancedAssetRelations($this->loadMetadataAssets('ladvancedAssetRelations'));
+        $items->add($item);
+        $object->setFieldcollection($items);
+        $object->save();
+        $parentId = $object->getId();
+        $childId = $this->createChildDataObject($object)->getId();
+
+        foreach (['parent' => $parentId, 'inherited' => $childId] as $objectType => $id) {
+            $messagePrefix = "Testing object-type $objectType: ";
+
+            Cache::clearAll();
+            Pimcore::collectGarbage();
+
+            $object = LazyLoading::getById($id, ['force' => true]);
+
+            $this->checkSerialization($object, $messagePrefix, false);
+
+            $collection = $object->getFieldcollection();
+            if ($objectType === 'parent') {
+                $item = $collection->get(0);
+                $relationAssets = $item->getLadvancedAssetRelations();
+                $this->assertEquals(self::RELATION_COUNT, count($relationAssets), $messagePrefix . 'asset relations not loaded properly');
+                $this->assertEquals('some-metadata', $relationAssets[2]->getMetadata(), $messagePrefix . 'asset relation metadata not loaded properly');
+            }
+
+            $this->checkSerialization($object, $messagePrefix, false);
+
+            $this->forceSavingAndLoadingFromCache($object, function ($objectCache) use ($objectType, $messagePrefix) {
+                $collection = $objectCache->getFieldcollection();
+                if ($objectType === 'parent') {
+                    $item = $collection->get(0);
+                    $relationAssets = $item->getLadvancedAssetRelations();
+                    $this->assertEquals(self::RELATION_COUNT, count($relationAssets), $messagePrefix . 'asset relations not loaded properly');
+                    $this->assertEquals('some-metadata', $relationAssets[2]->getMetadata(), $messagePrefix . 'asset relation metadata not loaded properly');
+                }
+            });
+        }
+    }
+
+    public function testBrickAttributes(): void
+    {
+        $object = $this->createDataObject();
+        $brick = new LazyLoadingTest($object);
+        $brick->setAdvancedAssetRelations($this->loadMetadataAssets('advancedAssetRelations', 'metadataUpper'));
+        $object->getBricks()->setLazyLoadingTest($brick);
+        $object->save();
+        $parentId = $object->getId();
+        $childId = $this->createChildDataObject($object)->getId();
+
+        foreach (['parent' => $parentId, 'inherited' => $childId] as $objectType => $id) {
+            $messagePrefix = "Testing object-type $objectType: ";
+
+            Cache::clearAll();
+            Pimcore::collectGarbage();
+
+            $object = LazyLoading::getById($id, ['force' => true]);
+
+            $this->checkSerialization($object, $messagePrefix, false);
+
+            $brick = $object->getBricks()->getLazyLoadingTest();
+            $relationAssets = $brick->getAdvancedAssetRelations();
+            $this->assertEquals(self::RELATION_COUNT, count($relationAssets), $messagePrefix . 'asset relations not loaded properly');
+            $this->assertEquals('some-metadata', $relationAssets[2]->getMetadataUpper(), $messagePrefix . 'asset relation metadata not loaded properly');
+
+            $this->checkSerialization($object, $messagePrefix, false);
+
+            $this->forceSavingAndLoadingFromCache($object, function ($objectCache) use ($messagePrefix) {
+                $brick = $objectCache->getBricks()->getLazyLoadingTest();
+                $relationAssets = $brick->getAdvancedAssetRelations();
+                $this->assertEquals(self::RELATION_COUNT, count($relationAssets), $messagePrefix . 'asset relations not loaded properly');
+                $this->assertEquals('some-metadata', $relationAssets[2]->getMetadataUpper(), $messagePrefix . 'asset relation metadata not loaded properly');
+            });
+        }
+    }
+
+    public function testLocalizedBrickAttributes(): void
+    {
+        $object = $this->createDataObject();
+        $relations = $this->loadMetadataAssets('ladvancedAssetRelations');
+        $brick = new LazyLoadingLocalizedTest($object);
+
+        $brick->getLocalizedfields()->setLocalizedValue('ladvancedAssetRelations', $relations, 'en');
+        $brick->getLocalizedfields()->setLocalizedValue('ladvancedAssetRelations', $relations, 'de');
+
+        $object->getBricks()->setLazyLoadingLocalizedTest($brick);
+        $object->save();
+
+        $object = Concrete::getById($object->getId(), ['force' => true]);
+        $this->assertTrue(count($object->getBricks()->getLazyLoadingLocalizedTest()->getLadvancedAssetRelations('en')) > 0);
+        $this->assertTrue(count($object->getBricks()->getLazyLoadingLocalizedTest()->getLadvancedAssetRelations('de')) > 0);
+
+        $object = Concrete::getById($object->getId(), ['force' => true]);
+        array_pop($relations);
+
+        $brick = $object->getBricks()->getLazyLoadingLocalizedTest();
+        $lFields = $brick->getLocalizedfields();
+        // change one language and make sure that it does not affect the other one
+        $lFields->setLocalizedValue('ladvancedAssetRelations', $relations, 'de');
+        $object->save();
+
+        $object = Concrete::getById($object->getId(), ['force' => true]);
+        $this->assertTrue(count($object->getBricks()->getLazyLoadingLocalizedTest()->getLadvancedAssetRelations('en')) > 0);
+        $this->assertTrue(count($object->getBricks()->getLazyLoadingLocalizedTest()->getLadvancedAssetRelations('de')) > 0);
+
+        $parentId = $object->getId();
+        $childId = $this->createChildDataObject($object)->getId();
+
+        foreach (['parent' => $parentId, 'inherited' => $childId] as $objectType => $id) {
+            $messagePrefix = "Testing object-type $objectType: ";
+
+            Cache::clearAll();
+            Pimcore::collectGarbage();
+
+            $object = LazyLoading::getById($id, ['force' => true]);
+
+            $this->checkSerialization($object, $messagePrefix, false);
+
+            $brick = $object->getBricks()->getLazyLoadingLocalizedTest();
+            $relationAssets = $brick->getLocalizedFields()->getLocalizedValue('ladvancedAssetRelations');
+            $this->assertEquals(self::RELATION_COUNT, count($relationAssets), $messagePrefix . 'asset relations not loaded properly');
+            $this->assertEquals('some-metadata', $relationAssets[2]->getMetadata(), $messagePrefix . 'asset relation metadata not loaded properly');
+
+            $this->checkSerialization($object, $messagePrefix, false);
+
+            $this->forceSavingAndLoadingFromCache($object, function ($objectCache) use ($messagePrefix) {
+                $brick = $objectCache->getBricks()->getLazyLoadingLocalizedTest();
+                $relationAssets = $brick->getLocalizedFields()->getLocalizedValue('ladvancedAssetRelations');
                 $this->assertEquals(self::RELATION_COUNT, count($relationAssets), $messagePrefix . 'asset relations not loaded properly');
                 $this->assertEquals('some-metadata', $relationAssets[2]->getMetadata(), $messagePrefix . 'asset relation metadata not loaded properly');
             });

--- a/tests/Model/LazyLoading/AdvancedManyToManyAssetRelationTest.php
+++ b/tests/Model/LazyLoading/AdvancedManyToManyAssetRelationTest.php
@@ -28,7 +28,7 @@ class AdvancedManyToManyAssetRelationTest extends AbstractLazyLoadingTest
 {
     private array $assets = [];
 
-    protected function setUp(): void
+    public function setUp(): void
     {
         parent::setUp();
         $this->assets = $this->createAssets();

--- a/tests/Model/LazyLoading/ManyToManyAssetRelationTest.php
+++ b/tests/Model/LazyLoading/ManyToManyAssetRelationTest.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\LazyLoading;
+
+use Pimcore;
+use Pimcore\Cache;
+use Pimcore\Model\Asset;
+use Pimcore\Model\DataObject\LazyLoading;
+use Pimcore\Tests\Support\Util\TestHelper;
+
+class ManyToManyAssetRelationTest extends AbstractLazyLoadingTest
+{
+    /**
+     * @return Asset[]
+     */
+    private function createAssets(): array
+    {
+        $assets = [];
+        for ($i = 0; $i < self::RELATION_COUNT; $i++) {
+            $assets[] = TestHelper::createImageAsset('lazy-asset-');
+        }
+
+        return $assets;
+    }
+
+    public function testClassAttributes(): void
+    {
+        $object = $this->createDataObject();
+        $object->setAssetRelations($this->createAssets());
+        $object->save();
+        $parentId = $object->getId();
+        $childId = $this->createChildDataObject($object)->getId();
+
+        foreach (['parent' => $parentId, 'inherited' => $childId] as $objectType => $id) {
+            $messagePrefix = "Testing object-type $objectType: ";
+
+            Cache::clearAll();
+            Pimcore::collectGarbage();
+
+            $object = LazyLoading::getById($id, ['force' => true]);
+
+            $this->checkSerialization($object, $messagePrefix);
+
+            $relationAssets = $object->getAssetRelations();
+            $this->assertEquals(self::RELATION_COUNT, count($relationAssets), $messagePrefix . 'asset relations not loaded properly');
+
+            $this->checkSerialization($object, $messagePrefix);
+
+            $this->forceSavingAndLoadingFromCache($object, function ($objectCache) use ($messagePrefix) {
+                $relationAssets = $objectCache->getAssetRelations();
+                $this->assertEquals(self::RELATION_COUNT, count($relationAssets), $messagePrefix . 'asset relations not loaded properly');
+            });
+        }
+    }
+
+    public function testLocalizedClassAttributes(): void
+    {
+        $object = $this->createDataObject();
+        $object->setLassetRelations($this->createAssets());
+        $object->save();
+        $parentId = $object->getId();
+        $childId = $this->createChildDataObject($object)->getId();
+
+        foreach (['parent' => $parentId, 'inherited' => $childId] as $objectType => $id) {
+            $messagePrefix = "Testing object-type $objectType: ";
+
+            Cache::clearAll();
+            Pimcore::collectGarbage();
+
+            $object = LazyLoading::getById($id, ['force' => true]);
+
+            $this->checkSerialization($object, $messagePrefix);
+
+            $relationAssets = $object->getLassetRelations();
+            $this->assertEquals(self::RELATION_COUNT, count($relationAssets), $messagePrefix . 'asset relations not loaded properly');
+
+            $this->checkSerialization($object, $messagePrefix);
+
+            $this->forceSavingAndLoadingFromCache($object, function ($objectCache) use ($messagePrefix) {
+                $relationAssets = $objectCache->getLassetRelations();
+                $this->assertEquals(self::RELATION_COUNT, count($relationAssets), $messagePrefix . 'asset relations not loaded properly');
+            });
+        }
+    }
+}

--- a/tests/Support/Helper/Model.php
+++ b/tests/Support/Helper/Model.php
@@ -72,6 +72,8 @@ class Model extends AbstractDefinitionHelper
                 ->setClasses(['RelationTest'])
             );
 
+            $panel->addChild($this->createDataChild('manyToManyAssetRelation', 'assetRelations'));
+
             $panel->addChild($this->createDataChild('manyToOneRelation', 'relation')
                 ->setDocumentTypes([])->setAssetTypes([])->setClasses(['RelationTest'])
                 ->setDocumentsAllowed(false)->setAssetsAllowed(false)->setObjectsAllowed(true));
@@ -100,6 +102,8 @@ class Model extends AbstractDefinitionHelper
             $lFields->addChild($this->createDataChild('manyToManyObjectRelation', 'lobjects')
                 ->setClasses(['RelationTest'])
             );
+
+            $lFields->addChild($this->createDataChild('manyToManyAssetRelation', 'lassetRelations'));
 
             $lFields->addChild($this->createDataChild('manyToOneRelation', 'lrelation')
                 ->setDocumentTypes([])->setAssetTypes([])->setClasses(['RelationTest'])

--- a/tests/Support/Helper/Model.php
+++ b/tests/Support/Helper/Model.php
@@ -163,6 +163,11 @@ class Model extends AbstractDefinitionHelper
                 ->setColumns([ ['position' => 1, 'key' => 'metadata', 'type' => 'text', 'label' => 'metadata'],
                 ]));
 
+            $block->addChild($this->createDataChild('advancedManyToManyAssetRelation', 'blockadvancedAssetRelations')
+                ->setAllowMultipleAssignments(false)
+                ->setColumns([ ['position' => 1, 'key' => 'metadata', 'type' => 'text', 'label' => 'metadata'],
+                ]));
+
             $block->addChild($this->createDataChild('advancedManyToManyRelation', 'blockadvancedRelations')
                 ->setAllowMultipleAssignments(false)
                 ->setDocumentTypes([])->setAssetTypes([])->setClasses(['RelationTest'])
@@ -190,6 +195,11 @@ class Model extends AbstractDefinitionHelper
                 ->setAllowMultipleAssignments(false)
                 ->setAllowedClassId('RelationTest')
                 ->setClasses([])
+                ->setColumns([ ['position' => 1, 'key' => 'metadata', 'type' => 'text', 'label' => 'metadata'],
+                ]));
+
+            $blockLazyLoaded->addChild($this->createDataChild('advancedManyToManyAssetRelation', 'blockadvancedAssetRelationsLazyLoaded')
+                ->setAllowMultipleAssignments(false)
                 ->setColumns([ ['position' => 1, 'key' => 'metadata', 'type' => 'text', 'label' => 'metadata'],
                 ]));
 
@@ -767,6 +777,11 @@ class Model extends AbstractDefinitionHelper
                 ->setColumns([ ['position' => 1, 'key' => 'metadataUpper', 'type' => 'text', 'label' => 'metadata'],
                 ]));
 
+            $panel->addChild($this->createDataChild('advancedManyToManyAssetRelation', 'advancedAssetRelations')
+                ->setAllowMultipleAssignments(false)
+                ->setColumns([ ['position' => 1, 'key' => 'metadataUpper', 'type' => 'text', 'label' => 'metadata'],
+                ]));
+
             $panel->addChild($this->createDataChild('advancedManyToManyRelation', 'advancedRelations')
                 ->setAllowMultipleAssignments(false)
                 ->setDocumentTypes([])->setAssetTypes([])->setClasses(['RelationTest'])
@@ -823,6 +838,11 @@ class Model extends AbstractDefinitionHelper
                 ->setColumns([ ['position' => 1, 'key' => 'metadata', 'type' => 'text', 'label' => 'metadata'],
                 ]));
 
+            $lFields->addChild($this->createDataChild('advancedManyToManyAssetRelation', 'ladvancedAssetRelations')
+                ->setAllowMultipleAssignments(false)
+                ->setColumns([ ['position' => 1, 'key' => 'metadata', 'type' => 'text', 'label' => 'metadata'],
+                ]));
+
             $lFields->addChild($this->createDataChild('advancedManyToManyRelation', 'ladvancedRelations')
                 ->setAllowMultipleAssignments(false)
                 ->setDocumentTypes([])->setAssetTypes([])->setClasses(['RelationTest'])
@@ -871,6 +891,11 @@ class Model extends AbstractDefinitionHelper
                 ->setAllowMultipleAssignments(false)
                 ->setAllowedClassId('RelationTest')
                 ->setClasses([])
+                ->setColumns([ ['position' => 1, 'key' => 'metadataUpper', 'type' => 'text', 'label' => 'metadata'],
+                ]));
+
+            $panel->addChild($this->createDataChild('advancedManyToManyAssetRelation', 'advancedAssetRelations')
+                ->setAllowMultipleAssignments(false)
                 ->setColumns([ ['position' => 1, 'key' => 'metadataUpper', 'type' => 'text', 'label' => 'metadata'],
                 ]));
 
@@ -928,6 +953,11 @@ class Model extends AbstractDefinitionHelper
                 ->setAllowMultipleAssignments(false)
                 ->setAllowedClassId('RelationTest')
                 ->setClasses([])
+                ->setColumns([ ['position' => 1, 'key' => 'metadata', 'type' => 'text', 'label' => 'metadata'],
+                ]));
+
+            $lFields->addChild($this->createDataChild('advancedManyToManyAssetRelation', 'ladvancedAssetRelations')
+                ->setAllowMultipleAssignments(false)
                 ->setColumns([ ['position' => 1, 'key' => 'metadata', 'type' => 'text', 'label' => 'metadata'],
                 ]));
 

--- a/tests/Support/Helper/Model.php
+++ b/tests/Support/Helper/Model.php
@@ -89,6 +89,11 @@ class Model extends AbstractDefinitionHelper
                 ->setColumns([ ['position' => 1, 'key' => 'metadataUpper', 'type' => 'text', 'label' => 'metadata'],
                 ]));
 
+            $panel->addChild($this->createDataChild('advancedManyToManyAssetRelation', 'advancedAssetRelations')
+                ->setAllowMultipleAssignments(false)
+                ->setColumns([ ['position' => 1, 'key' => 'metadata', 'type' => 'text', 'label' => 'metadata'],
+                ]));
+
             $panel->addChild($this->createDataChild('advancedManyToManyRelation', 'advancedRelations')
                 ->setAllowMultipleAssignments(false)
                 ->setDocumentTypes([])->setAssetTypes([])->setClasses(['RelationTest'])
@@ -117,6 +122,11 @@ class Model extends AbstractDefinitionHelper
                 ->setAllowMultipleAssignments(false)
                 ->setAllowedClassId('RelationTest')
                 ->setClasses([])
+                ->setColumns([ ['position' => 1, 'key' => 'metadata', 'type' => 'text', 'label' => 'metadata'],
+                ]));
+
+            $lFields->addChild($this->createDataChild('advancedManyToManyAssetRelation', 'ladvancedAssetRelations')
+                ->setAllowMultipleAssignments(false)
                 ->setColumns([ ['position' => 1, 'key' => 'metadata', 'type' => 'text', 'label' => 'metadata'],
                 ]));
 


### PR DESCRIPTION
Fixes pimcore/platform-version#393

## Changes in this pull request

The advanced (metadata-carrying) counterpart of #18879: a dedicated `advancedManyToManyAssetRelation` field type extending `AdvancedManyToManyRelation`, so an asset relation with per-relation metadata no longer has to go through the generic type and branch on the element type in its editor, CSV export and diff view.

**Stacked on #18879** — it contains those commits as well, so review that one first; this PR's own change is the `AdvancedManyToManyAssetRelation` class plus its registration and tests.

## Additional info

Both types have been running in production here (carried as vendor patches) for months.