### PR TITLE
Remove dead PDF scan versionNote in AssetUpdateTasksHandler, harden versioning safety

### DIFF
--- a/lib/Messenger/Handler/AssetUpdateTasksHandler.php
+++ b/lib/Messenger/Handler/AssetUpdateTasksHandler.php
@@ -69,10 +69,8 @@ class AssetUpdateTasksHandler
     private function processDocument(Asset\Document $asset): void
     {
         $save = false;
-        $saveParams = [];
         if ($asset->getMimeType() === 'application/pdf' && $asset->checkIfPdfContainsJS()) {
             $save = true;
-            $saveParams['versionNote'] = 'PDF scan result';
         }
 
         if ($asset->isPageCountProcessingEnabled()) {
@@ -92,7 +90,7 @@ class AssetUpdateTasksHandler
         }
 
         if ($save) {
-            $this->saveAsset($asset, $saveParams);
+            $this->saveAsset($asset);
         }
     }
 

--- a/lib/Messenger/Handler/AssetUpdateTasksHandler.php
+++ b/lib/Messenger/Handler/AssetUpdateTasksHandler.php
@@ -46,32 +46,42 @@ class AssetUpdateTasksHandler
 
         $asset->removeCustomSetting(Asset::CUSTOM_SETTING_PROCESSING_FAILED);
 
-        if ($asset instanceof Asset\Image) {
-            $this->processImage($asset);
-        } elseif ($asset instanceof Asset\Document) {
-            $this->processDocument($asset);
-        } elseif ($asset instanceof Asset\Video) {
-            $this->processVideo($asset);
+        try {
+            if ($asset instanceof Asset\Image) {
+                $this->processImage($asset);
+            } elseif ($asset instanceof Asset\Document) {
+                $this->processDocument($asset);
+            } elseif ($asset instanceof Asset\Video) {
+                $this->processVideo($asset);
+            }
+        } finally {
+            // release the queue lock and clean up temporary files even if processing failed
+            $this->longRunningHelper->deleteTemporaryFiles();
+            $this->lockFactory->createLock($asset->getUpdateQueueLockId())->release();
         }
-
-        $this->longRunningHelper->deleteTemporaryFiles();
-        $this->lockFactory->createLock($asset->getUpdateQueueLockId())->release();
     }
 
-    private function saveAsset(Asset $asset, array $saveParams = []): void
+    private function saveAsset(Asset $asset): void
     {
+        // Version::disable() flips a process-wide flag, so it must always be re-enabled -
+        // even if save() throws - otherwise versioning stays disabled for every subsequent
+        // asset handled by this (long-running) worker.
         Version::disable();
-        $asset->markFieldDirty('modificationDate'); // prevent modificationDate from being changed
-        $asset->save($saveParams);
-        Version::enable();
+        try {
+            $asset->markFieldDirty('modificationDate'); // prevent modificationDate from being changed
+            $asset->save();
+        } finally {
+            Version::enable();
+        }
     }
 
     private function processDocument(Asset\Document $asset): void
     {
-        $save = false;
-        if ($asset->getMimeType() === 'application/pdf' && $asset->checkIfPdfContainsJS()) {
-            $save = true;
-        }
+        // checkIfPdfContainsJS() records the scan status on the asset, so a save is
+        // required to persist it. The $save flag defers that save until after the
+        // (optional) page-count processing and thumbnail generation, so at most one
+        // save happens - and none at all when nothing changed.
+        $save = $asset->getMimeType() === 'application/pdf' && $asset->checkIfPdfContainsJS();
 
         if ($asset->isPageCountProcessingEnabled()) {
             $pageCount = $asset->getCustomSetting('document_page_count');

--- a/lib/Messenger/Handler/AssetUpdateTasksHandler.php
+++ b/lib/Messenger/Handler/AssetUpdateTasksHandler.php
@@ -44,13 +44,16 @@ class AssetUpdateTasksHandler
         }
         $this->logger->debug(sprintf('Processing asset with ID %s | Path: %s', $asset->getId(), $asset->getRealFullPath()));
 
+        // whether the marker was persisted matters below: clearing it here only reaches the
+        // database if something in this run saves the asset
+        $hadProcessingFailure = (bool) $asset->getCustomSetting(Asset::CUSTOM_SETTING_PROCESSING_FAILED);
         $asset->removeCustomSetting(Asset::CUSTOM_SETTING_PROCESSING_FAILED);
 
         try {
             if ($asset instanceof Asset\Image) {
                 $this->processImage($asset);
             } elseif ($asset instanceof Asset\Document) {
-                $this->processDocument($asset);
+                $this->processDocument($asset, $hadProcessingFailure);
             } elseif ($asset instanceof Asset\Video) {
                 $this->processVideo($asset);
             }
@@ -75,13 +78,17 @@ class AssetUpdateTasksHandler
         }
     }
 
-    private function processDocument(Asset\Document $asset): void
+    private function processDocument(Asset\Document $asset, bool $hadProcessingFailure = false): void
     {
         // checkIfPdfContainsJS() records the scan status on the asset, so a save is
         // required to persist it. The $save flag defers that save until after the
         // (optional) page-count processing and thumbnail generation, so at most one
         // save happens - and none at all when nothing changed.
         $save = $asset->getMimeType() === 'application/pdf' && $asset->checkIfPdfContainsJS();
+
+        // Clearing a persisted processing-failure marker is itself a change worth saving.
+        // Ordered after the scan on purpose: || short-circuits, and the scan has to run.
+        $save = $hadProcessingFailure || $save;
 
         if ($asset->isPageCountProcessingEnabled()) {
             $pageCount = $asset->getCustomSetting('document_page_count');


### PR DESCRIPTION
Fixes pimcore/platform-version#396

## Changes in this pull request

Reported against the core repository as pimcore/pimcore#18504

`AssetUpdateTasksHandler` sets a `versionNote` for the PDF scan that nothing ever reads — the save that would carry it does not happen on that path — and the surrounding save/cleanup can version an asset it has not actually changed.

Drop the dead note and tighten the versioning/cleanup conditions so a version is only written when the handler changed something.

## Additional info

Touches the same handler as #18478's document metadata extraction; the two are independent. Rebased onto current 2026.x.
