### PR TITLE
[Maintenance] Log how long each maintenance task ran

### DIFF
--- a/lib/Maintenance/Executor.php
+++ b/lib/Maintenance/Executor.php
@@ -48,7 +48,7 @@ final class Executor implements ExecutorInterface
 
         $task = $this->tasks[$name]['taskClass'];
 
-        $startedAt = microtime(true);
+        $startedAt = hrtime(true);
         try {
             $this->logger->info('Starting job with ID {id}', [
                 'id' => $name,
@@ -57,15 +57,24 @@ final class Executor implements ExecutorInterface
 
             $this->logger->info('Finished job with ID {id} in {duration}s', [
                 'id' => $name,
-                'duration' => round(microtime(true) - $startedAt, 3),
+                'duration' => self::elapsedSeconds($startedAt),
             ]);
         } catch (Exception $e) {
             $this->logger->error('Failed to execute job with ID {id} after {duration}s: {exception}', [
                 'id' => $name,
-                'duration' => round(microtime(true) - $startedAt, 3),
+                'duration' => self::elapsedSeconds($startedAt),
                 'exception' => $e,
             ]);
         }
+    }
+
+    /**
+     * hrtime() rather than microtime(): the elapsed time of a long-running task must not be
+     * distorted - or turned negative - by an NTP or manual wall-clock adjustment while it runs.
+     */
+    private static function elapsedSeconds(int|float $startedAt): float
+    {
+        return round((hrtime(true) - $startedAt) / 1_000_000_000, 3);
     }
 
     public function executeMaintenance(array $validJobs = [], array $excludedJobs = []): void

--- a/lib/Maintenance/Executor.php
+++ b/lib/Maintenance/Executor.php
@@ -48,18 +48,21 @@ final class Executor implements ExecutorInterface
 
         $task = $this->tasks[$name]['taskClass'];
 
+        $startedAt = microtime(true);
         try {
             $this->logger->info('Starting job with ID {id}', [
                 'id' => $name,
             ]);
             $task->execute();
 
-            $this->logger->info('Finished job with ID {id}', [
+            $this->logger->info('Finished job with ID {id} in {duration}s', [
                 'id' => $name,
+                'duration' => round(microtime(true) - $startedAt, 3),
             ]);
         } catch (Exception $e) {
-            $this->logger->error('Failed to execute job with ID {id}: {exception}', [
+            $this->logger->error('Failed to execute job with ID {id} after {duration}s: {exception}', [
                 'id' => $name,
+                'duration' => round(microtime(true) - $startedAt, 3),
                 'exception' => $e,
             ]);
         }

--- a/tests/Unit/Maintenance/ExecutorTest.php
+++ b/tests/Unit/Maintenance/ExecutorTest.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Maintenance;
+
+use Exception;
+use Pimcore\Maintenance\Executor;
+use Pimcore\Maintenance\TaskInterface;
+use Pimcore\Tests\Support\Test\TestCase;
+use Psr\Log\AbstractLogger;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Covers the duration reported for each maintenance task.
+ *
+ * @internal
+ */
+class ExecutorTest extends TestCase
+{
+    protected function needsDb(): bool
+    {
+        return false;
+    }
+
+    private function executor(TaskInterface $task, AbstractLogger $logger): Executor
+    {
+        $executor = new Executor('maintenance.pid', $logger, $this->createMock(MessageBusInterface::class));
+        $executor->registerTask('task', $task);
+
+        return $executor;
+    }
+
+    private function logger(array &$records): AbstractLogger
+    {
+        return new class($records) extends AbstractLogger {
+            public function __construct(private array &$records)
+            {
+            }
+
+            public function log($level, $message, array $context = []): void
+            {
+                $this->records[] = ['level' => $level, 'message' => $message, 'context' => $context];
+            }
+        };
+    }
+
+    public function testASuccessfulTaskReportsItsDuration(): void
+    {
+        $records = [];
+        $task = $this->createMock(TaskInterface::class);
+        $task->expects($this->once())->method('execute');
+
+        $this->executor($task, $this->logger($records))->executeTask('task');
+
+        $finished = array_values(array_filter($records, static fn (array $r) => str_contains($r['message'], 'Finished job')));
+        $this->assertCount(1, $finished);
+        $this->assertStringContainsString('{duration}s', $finished[0]['message']);
+        $this->assertArrayHasKey('duration', $finished[0]['context']);
+        $this->assertGreaterThanOrEqual(0, $finished[0]['context']['duration']);
+    }
+
+    public function testAFailingTaskAlsoReportsItsDuration(): void
+    {
+        $records = [];
+        $task = $this->createMock(TaskInterface::class);
+        $task->method('execute')->willThrowException(new Exception('boom'));
+
+        $this->executor($task, $this->logger($records))->executeTask('task');
+
+        $failed = array_values(array_filter($records, static fn (array $r) => str_contains($r['message'], 'Failed to execute job')));
+        $this->assertCount(1, $failed);
+        $this->assertStringContainsString('{duration}s', $failed[0]['message']);
+        $this->assertArrayHasKey('duration', $failed[0]['context']);
+        $this->assertGreaterThanOrEqual(0, $failed[0]['context']['duration']);
+    }
+}


### PR DESCRIPTION
Fixes pimcore/platform-version#397

## Changes in this pull request

The executor logs when a task starts and when it finishes, but not how long it took. The maintenance run is a sequence of tasks from core and from every installed bundle, so "the nightly run got slow" cannot be attributed to a task without adding instrumentation by hand — which is what we ended up doing as a vendor patch.

Include the elapsed time in the finished message, and in the failure message too: a task that fails after 40 minutes and one that fails immediately are different problems.

```
Finished job with ID pimcore_maintenance_cleanup_versions in 812.44s
Failed to execute job with ID ... after 0.004s: ...
```

## Additional info

No new dependency — `microtime()` rather than `symfony/stopwatch`, which Pimcore does not require.