### PR TITLE
[DataObject] Escape relation metadata in the advanced-relation version preview

### DIFF
--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -302,7 +302,10 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation implemen
                         if (!$value) {
                             continue;
                         }
-                        $subItems[] = $key . ': ' . $value;
+                        // the metadata is free text and this string is rendered as HTML in the
+                        // version preview, so a value must not be able to close the span below
+                        $subItems[] = htmlspecialchars((string) $key, ENT_QUOTES, 'UTF-8')
+                            . ': ' . htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8');
                     }
 
                     if (count($subItems)) {

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
@@ -430,7 +430,10 @@ class AdvancedManyToManyRelation extends ManyToManyRelation implements IdRewrite
                         if (!$value) {
                             continue;
                         }
-                        $subItems[] = $key . ': ' . $value;
+                        // the metadata is free text and this string is rendered as HTML in the
+                        // version preview, so a value must not be able to close the span below
+                        $subItems[] = htmlspecialchars((string) $key, ENT_QUOTES, 'UTF-8')
+                            . ': ' . htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8');
                     }
 
                     if (count($subItems)) {

--- a/tests/Unit/Model/DataObject/ClassDefinition/Data/AdvancedRelationVersionPreviewTest.php
+++ b/tests/Unit/Model/DataObject/ClassDefinition/Data/AdvancedRelationVersionPreviewTest.php
@@ -13,9 +13,14 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Unit\Model\DataObject\ClassDefinition\Data;
 
+use Pimcore\Model\Asset;
+use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\ClassDefinition\Data\AdvancedManyToManyObjectRelation;
+use Pimcore\Model\DataObject\ClassDefinition\Data\AdvancedManyToManyRelation;
 use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\Data\ElementMetadata;
 use Pimcore\Model\DataObject\Data\ObjectMetadata;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Tests\Support\Test\TestCase;
 
 /**
@@ -25,13 +30,52 @@ use Pimcore\Tests\Support\Test\TestCase;
  */
 class AdvancedRelationVersionPreviewTest extends TestCase
 {
+    private const PAYLOAD = '</span><img src=x onerror=alert(1)>';
+
     protected function needsDb(): bool
     {
         return false;
     }
 
-    public function testMetadataIsEscapedInTheVersionPreview(): void
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function relationProvider(): array
     {
+        return [
+            'element relation' => ['element'],
+            'object relation' => ['object'],
+        ];
+    }
+
+    /**
+     * Built inside the test rather than in the provider: providers are static, and these need
+     * mocks. The containers override the element lookup so the preview can be rendered without
+     * loading anything.
+     *
+     * @return array{0: Data, 1: ElementMetadata|ObjectMetadata}
+     */
+    private function relation(string $kind): array
+    {
+        if ($kind === 'element') {
+            $asset = $this->createMock(Asset::class);
+            $asset->method('getRealFullPath')->willReturn('/assets/one.jpg');
+
+            $metadata = new class('relation', ['comment'], $asset) extends ElementMetadata {
+                public function __construct(string $fieldname, array $columns, private Asset $stub)
+                {
+                    parent::__construct($fieldname, $columns);
+                }
+
+                public function getElement(): ?ElementInterface
+                {
+                    return $this->stub;
+                }
+            };
+
+            return [new AdvancedManyToManyRelation(), $metadata];
+        }
+
         $object = $this->createMock(Concrete::class);
         $object->method('getRealFullPath')->willReturn('/objects/one');
 
@@ -46,9 +90,19 @@ class AdvancedRelationVersionPreviewTest extends TestCase
                 return $this->stub;
             }
         };
-        $metadata->setData(['comment' => '</span><img src=x onerror=alert(1)>']);
 
-        $html = (new AdvancedManyToManyObjectRelation())->getVersionPreview([$metadata]);
+        return [new AdvancedManyToManyObjectRelation(), $metadata];
+    }
+
+    /**
+     * @dataProvider relationProvider
+     */
+    public function testMetadataValuesAreEscaped(string $kind): void
+    {
+        [$fd, $metadata] = $this->relation($kind);
+        $metadata->setData(['comment' => self::PAYLOAD]);
+
+        $html = $fd->getVersionPreview([$metadata]);
 
         $this->assertStringNotContainsString('<img', $html, 'metadata must not reach the preview as markup');
         $this->assertStringContainsString('&lt;img', $html);
@@ -57,5 +111,22 @@ class AdvancedRelationVersionPreviewTest extends TestCase
             $html,
             'the surrounding preview markup must stay intact'
         );
+    }
+
+    /**
+     * The column keys are configuration rather than free text, but they are concatenated into the
+     * same string, so they are escaped on the same basis.
+     *
+     * @dataProvider relationProvider
+     */
+    public function testMetadataKeysAreEscaped(string $kind): void
+    {
+        [$fd, $metadata] = $this->relation($kind);
+        $metadata->setData([self::PAYLOAD => 'a value']);
+
+        $html = $fd->getVersionPreview([$metadata]);
+
+        $this->assertStringNotContainsString('<img', $html);
+        $this->assertStringContainsString('&lt;img', $html);
     }
 }

--- a/tests/Unit/Model/DataObject/ClassDefinition/Data/AdvancedRelationVersionPreviewTest.php
+++ b/tests/Unit/Model/DataObject/ClassDefinition/Data/AdvancedRelationVersionPreviewTest.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\DataObject\ClassDefinition\Data;
+
+use Pimcore\Model\DataObject\ClassDefinition\Data\AdvancedManyToManyObjectRelation;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\Data\ObjectMetadata;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * getVersionPreview() returns HTML, so the relation metadata it embeds has to be escaped.
+ *
+ * @internal
+ */
+class AdvancedRelationVersionPreviewTest extends TestCase
+{
+    protected function needsDb(): bool
+    {
+        return false;
+    }
+
+    public function testMetadataIsEscapedInTheVersionPreview(): void
+    {
+        $object = $this->createMock(Concrete::class);
+        $object->method('getRealFullPath')->willReturn('/objects/one');
+
+        $metadata = new class('relation', ['comment'], $object) extends ObjectMetadata {
+            public function __construct(string $fieldname, array $columns, private Concrete $stub)
+            {
+                parent::__construct($fieldname, $columns);
+            }
+
+            public function getObject(): ?Concrete
+            {
+                return $this->stub;
+            }
+        };
+        $metadata->setData(['comment' => '</span><img src=x onerror=alert(1)>']);
+
+        $html = (new AdvancedManyToManyObjectRelation())->getVersionPreview([$metadata]);
+
+        $this->assertStringNotContainsString('<img', $html, 'metadata must not reach the preview as markup');
+        $this->assertStringContainsString('&lt;img', $html);
+        $this->assertStringContainsString(
+            '<span class="preview-metadata">',
+            $html,
+            'the surrounding preview markup must stay intact'
+        );
+    }
+}


### PR DESCRIPTION
Fixes pimcore/platform-version#399

## Changes in this pull request

`AdvancedManyToManyRelation::getVersionPreview()` and `AdvancedManyToManyObjectRelation::getVersionPreview()` build an HTML string and concatenate each metadata column's key and value into it unescaped. Relation metadata is free text entered by editors, so a value containing markup renders as markup in the version/diff view — and can close the `<span class="preview-metadata">` the preview wraps it in.

Escape both key and value; the preview's own markup is untouched.

### How to reproduce

1. On a class with an `advancedManyToManyObjectRelation` field, add a metadata column.
2. On an object, relate an element and put markup in that column's value.
3. Save twice and open the version comparison: the value renders instead of being displayed.

Added a unit test asserting the value arrives escaped and the surrounding preview markup survives.

## Additional info

The same concatenation dates back to at least 2018 and was copied into the dedicated asset relation proposed in #19398, where it is escaped as part of that PR — this one covers the two existing classes. Raised publicly rather than through the security process: reaching it requires an authenticated backend user with edit rights on the metadata column, and the fix is a one-line escape rather than anything that needs coordinated disclosure. Happy to move it if you would rather handle it that way.
