### PR TITLE
chore: ignore the local env files the test setup writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 /templates/
 /var/
 /.env
+/.env.local
+/.env.local.php
+/.env.*.local
+/translations/
 
 # Composer
 /vendor/


### PR DESCRIPTION
Fixes pimcore/platform-version#401

## Changes in this pull request

`.gitignore` covers `/.env` but not the `.env*.local` files Symfony loads local values from. Setting up the core test environment writes `.env.test.local`, containing `PIMCORE_ENCRYPTION_SECRET`, `PIMCORE_INSTANCE_IDENTIFIER` and `PIMCORE_PRODUCT_KEY` — so a working test checkout leaves a file full of secrets untracked but perfectly committable, and one `git add -A` publishes it in a PR.

**This repository's own installer writes that file.** `Pimcore\Bundle\InstallBundle\Installer::writeEnvLocal()` writes `$projectRoot . '/.env.local'`, and `ProductRegistrationEnvVarDefinition` puts `PIMCORE_ENCRYPTION_SECRET`, `PIMCORE_INSTANCE_IDENTIFIER` and `PIMCORE_PRODUCT_KEY` into it — the same three values CI holds as GitHub secrets (`PIMCORE_CI_ENCRYPTION_SECRET`, `PIMCORE_CI_PRODUCT_KEY` in `codeception.yaml`). So the code that creates the secrets file lives here, while the ignore rule that would cover it does not.

**`pimcore/skeleton` already ignores exactly these** — [lines 12-14 of its `.gitignore`](https://github.com/pimcore/skeleton/blob/2026.x/.gitignore) — so an application built on Pimcore is protected and the repository that *writes* the secrets is not. This PR adds the same three lines here:

```
/.env.local
/.env.local.php
/.env.*.local
```

Also adds `/translations/`, which shows up in a checkout after the translation unit tests run: its `messages.*.yml` files hold the `fallback_to_YML_*` fixture keys from `tests/Unit/Translation/TranslatorTest.php`, and nothing in the repository tracks that directory. Happy to drop that hunk if it is deliberate.

## Additional info

Reported from experience rather than theory — we published a `.env.test.local` this way in #19397 and had to rotate the values. The surrounding `# Test env` block already ignores everything else a test install generates in this checkout — `/config/*`, `/public/`, `/src/`, `/templates/`, `/var/`, `/bin/console` and `/.env` — so the repository has already accepted that a core checkout doubles as an application. `/.env.*.local` is the one file in that set that carries secrets, and it is the one missing.

Considered and left alone: `/composer.lock` stays ignored (correct for a library), and OS/editor files like `.DS_Store` belong in a global ignore rather than here. The gitignore.io/toptal `symfony` template was not used as a reference — it predates the `.env` convention entirely (it still targets `/app/cache`, `/web/bundles`, `parameters.yml`) and several of its entries would be wrong here, e.g. `/bin/*` where this repo deliberately ignores only `/bin/console`, and `/phpunit.xml` where the suite is Codeception.

