### PR TITLE
fix: Imagick materialize clip path before thumbnail transforms

### DIFF
--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -146,6 +146,12 @@ class Imagick extends Adapter
                     $i->setImageAlphaChannel(\Imagick::ALPHACHANNEL_TRANSPARENT);
                     $i->clipImage();
                     $i->setImageAlphaChannel(\Imagick::ALPHACHANNEL_OPAQUE);
+
+                    // Save and reload the cut-out image as PNG32.
+                    // Keep alpha pixels. Remove the active ImageMagick mask.
+                    $this->setIsAlphaPossible($i->getImageAlphaChannel());
+                    $this->setModified(true);
+                    $this->preModify();
                     $unclipped->clear();
                 } catch (Exception $e) {
                     // the image is entirely transparent at this point, so restore the copy instead of
@@ -224,7 +230,7 @@ class Imagick extends Adapter
 
             if ($i->getImageAlphaChannel()) {
                 // Imagick version compatibility
-                $alphaChannel = 11; // This works at least as far back as version 3.1.0~rc1-1
+                $alphaChannel = \Imagick::ALPHACHANNEL_OPAQUE;
                 if (defined('Imagick::ALPHACHANNEL_REMOVE')) {
                     // Imagick::ALPHACHANNEL_REMOVE has been added in 3.2.0b2
                     $alphaChannel = \Imagick::ALPHACHANNEL_REMOVE;

--- a/tests/Unit/Image/Adapter/ImagickTest.php
+++ b/tests/Unit/Image/Adapter/ImagickTest.php
@@ -156,6 +156,29 @@ final class ImagickTest extends TestCase
         $this->assertPixelTransparent($result, 2, 2);
     }
 
+    /**
+     * clipImage() keeps an active ImageMagick mask. The clipped image must therefore be
+     * materialized before resize and crop operations use it for a thumbnail.
+     */
+    public function testClippingPathIsMaterializedBeforeCover(): void
+    {
+        $path = $this->createImageWithClippingPath();
+        $this->assertClippingPathIsSupported($path);
+
+        $adapter = $this->adapter($path, false);
+
+        $this->assertSame('png32', $adapter->getContentOptimizedFormat());
+
+        // cover() scales the square fixture to 20 x 20 and crops it to 20 x 10.
+        $adapter->cover(20, 10);
+
+        $result = $this->saveAndReload($adapter, 'png32', 'png');
+
+        $this->assertPixelOpaque($result, 10, 5);
+        $this->assertPixelColor(self::SOURCE_RGB, $result, 10, 5, self::DELTA);
+        $this->assertPixelTransparent($result, 2, 5);
+    }
+
     private function adapter(string $path, bool $preserveColor): Imagick
     {
         $adapter = new Imagick();
@@ -225,6 +248,40 @@ final class ImagickTest extends TestCase
         );
 
         return $path;
+    }
+
+    /**
+     * Creates an image using a Photoshop path that is set as a clipping path.
+     */
+    private function createImageWithClippingPath(): string
+    {
+        $path = $this->createImageWithPhotoshopPath();
+
+        $image = new \Imagick($path);
+        $image->profileImage('8bim', $image->getImageProfile('8bim') . $this->clippingPathNameImageResource());
+        $image->writeImage($path);
+
+        $this->assertStringContainsString(
+            "8BIM\x0b\xb7",
+            (string) file_get_contents($path),
+            'The test fixture was created without a clipping path.'
+        );
+
+        return $path;
+    }
+
+    private function assertClippingPathIsSupported(string $path): void
+    {
+        $image = new \Imagick($path);
+
+        try {
+            $image->setImageAlphaChannel(\Imagick::ALPHACHANNEL_TRANSPARENT);
+            $image->clipImage();
+        } catch (\ImagickException) {
+            $this->markTestSkipped('The current ImageMagick installation does not support clipping paths.');
+        } finally {
+            $image->clear();
+        }
     }
 
     /**


### PR DESCRIPTION
## Changes in this pull request  
Save and reload the clipped image as PNG32. 
The PNG32 image keeps the alpha pixels from the clipping path and removes the active ImageMagick write mask.

Resolves pimcore/platform-version#348
