### PR TITLE
[Config] Enumerate configuration keys consistently with how they are loaded

### DIFF
--- a/lib/Config/LocationAwareConfigRepository.php
+++ b/lib/Config/LocationAwareConfigRepository.php
@@ -265,15 +265,17 @@ class LocationAwareConfigRepository
 
     public function fetchAllKeysByReadTargets(): array
     {
-        // Follows the same source precedence as loadConfigByKey(): a configured read target is the
-        // only source, and without one both are consulted. Enumerating only the settings store in
-        // that case hid every symfony-config entry - which is where the default write target puts
-        // them - and made a database connection mandatory to list a purely file based set.
+        // Follows the same source precedence as loadConfigByKey(): a configured read target is
+        // the only source, a disabled one reads nothing, and without one both are consulted.
+        // Enumeration previously treated every case other than symfony-config as settings-store,
+        // so it disagreed with loading whenever the read target was disabled or absent, and
+        // reached for the database in both of those cases even though loading would not have.
         return match ($this->getReadTargets()[0] ?? null) {
             self::LOCATION_SYMFONY_CONFIG => array_keys($this->containerConfig),
             self::LOCATION_SETTINGS_STORE => array_unique(
                 SettingsStore::getIdsByScope($this->settingsStoreScope)
             ),
+            self::LOCATION_DISABLED => [],
             default => $this->fetchAllKeys(),
         };
     }

--- a/lib/Config/LocationAwareConfigRepository.php
+++ b/lib/Config/LocationAwareConfigRepository.php
@@ -265,11 +265,17 @@ class LocationAwareConfigRepository
 
     public function fetchAllKeysByReadTargets(): array
     {
-        if ($this->storageConfig[self::READ_TARGET][self::TYPE] === self::LOCATION_SYMFONY_CONFIG) {
-            return array_keys($this->containerConfig);
-        }
-
-        return array_unique(SettingsStore::getIdsByScope($this->settingsStoreScope));
+        // Follows the same source precedence as loadConfigByKey(): a configured read target is the
+        // only source, and without one both are consulted. Enumerating only the settings store in
+        // that case hid every symfony-config entry - which is where the default write target puts
+        // them - and made a database connection mandatory to list a purely file based set.
+        return match ($this->getReadTargets()[0] ?? null) {
+            self::LOCATION_SYMFONY_CONFIG => array_keys($this->containerConfig),
+            self::LOCATION_SETTINGS_STORE => array_unique(
+                SettingsStore::getIdsByScope($this->settingsStoreScope)
+            ),
+            default => $this->fetchAllKeys(),
+        };
     }
 
     private function invalidateConfigCache(): void

--- a/lib/Config/LocationAwareConfigRepository.php
+++ b/lib/Config/LocationAwareConfigRepository.php
@@ -268,8 +268,9 @@ class LocationAwareConfigRepository
         // Follows the same source precedence as loadConfigByKey(): a configured read target is
         // the only source, a disabled one reads nothing, and without one both are consulted.
         // Enumeration previously treated every case other than symfony-config as settings-store,
-        // so it disagreed with loading whenever the read target was disabled or absent, and
-        // reached for the database in both of those cases even though loading would not have.
+        // which disagreed with loading twice: a disabled target listed keys that loading refuses
+        // to read at all - and queried the database to find them - and an absent one listed only
+        // the store, hiding the container entries that loading falls back through.
         return match ($this->getReadTargets()[0] ?? null) {
             self::LOCATION_SYMFONY_CONFIG => array_keys($this->containerConfig),
             self::LOCATION_SETTINGS_STORE => array_unique(

--- a/tests/Unit/Config/LocationAwareConfigRepositoryTest.php
+++ b/tests/Unit/Config/LocationAwareConfigRepositoryTest.php
@@ -24,10 +24,11 @@ use Pimcore\Tests\Support\Test\TestCase;
  * no read target configured both the symfony-config entries and the settings store are.
  *
  * Enumeration used to treat every case other than symfony-config as settings-store, so it
- * disagreed with loading for the two remaining ones: a disabled read target listed keys that
- * loading refuses to read, and an absent one listed only the settings store while loading falls
- * back through the container config as well. Both also queried the database where loading would
- * not have, and an absent read_target node raised an undefined array key on the way through.
+ * disagreed with loading for the two remaining ones. A disabled read target listed keys that
+ * loading reads from no source at all, and queried the database to produce them. An absent one
+ * listed only the settings store, hiding the container entries that loading falls back through -
+ * its own store query is legitimate, since loading consults the store there too. An absent
+ * read_target node additionally raised an undefined array key on the way through.
  *
  * @internal
  */

--- a/tests/Unit/Config/LocationAwareConfigRepositoryTest.php
+++ b/tests/Unit/Config/LocationAwareConfigRepositoryTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Config;
+
+use Pimcore\Config\LocationAwareConfigRepository;
+use Pimcore\Model\Tool\SettingsStore;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * Key enumeration has to follow the same source precedence as loadConfigByKey(): a configured
+ * read target is the only source that is consulted, and with no read target configured both the
+ * symfony-config entries and the settings store are.
+ *
+ * The case that regressed is the one without a read target, which is what the shipped default
+ * uses. Enumeration went straight to the settings store there, so entries written by the default
+ * symfony-config write target were never listed - pimcore:build:classes generated no enum for a
+ * file based select option - and a database connection was required to enumerate a set of
+ * configurations that lives entirely on disk.
+ *
+ * @internal
+ */
+final class LocationAwareConfigRepositoryTest extends TestCase
+{
+    private const SCOPE = 'pimcore_test_location_aware_config';
+
+    private const CONTAINER_CONFIG = [
+        'from_symfony_config_a' => ['id' => 'from_symfony_config_a'],
+        'from_symfony_config_b' => ['id' => 'from_symfony_config_b'],
+    ];
+
+    private const SETTINGS_STORE_KEY = 'from_settings_store';
+
+    protected function needsDb(): bool
+    {
+        return true;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        SettingsStore::set(self::SETTINGS_STORE_KEY, '{}', 'string', self::SCOPE);
+    }
+
+    protected function tearDown(): void
+    {
+        SettingsStore::delete(self::SETTINGS_STORE_KEY, self::SCOPE);
+
+        parent::tearDown();
+    }
+
+    public function testReadsBothSourcesWhenNoReadTargetIsConfigured(): void
+    {
+        $keys = $this->createRepository(null)->fetchAllKeysByReadTargets();
+
+        $this->assertEqualsCanonicalizing(
+            ['from_symfony_config_a', 'from_symfony_config_b', self::SETTINGS_STORE_KEY],
+            $keys,
+            'without a read target both sources are readable, so both have to be enumerated'
+        );
+    }
+
+    public function testReadsBothSourcesWhenTheReadTargetIsAbsentEntirely(): void
+    {
+        // A storage config that carries no read_target node at all, rather than one holding null.
+        $repository = new LocationAwareConfigRepository(
+            self::CONTAINER_CONFIG,
+            self::SCOPE,
+            [LocationAwareConfigRepository::WRITE_TARGET => $this->writeTarget()]
+        );
+
+        $this->assertEqualsCanonicalizing(
+            ['from_symfony_config_a', 'from_symfony_config_b', self::SETTINGS_STORE_KEY],
+            $repository->fetchAllKeysByReadTargets()
+        );
+    }
+
+    public function testReadsOnlySymfonyConfigWhenItIsTheReadTarget(): void
+    {
+        $keys = $this->createRepository(LocationAwareConfigRepository::LOCATION_SYMFONY_CONFIG)
+            ->fetchAllKeysByReadTargets();
+
+        $this->assertEqualsCanonicalizing(['from_symfony_config_a', 'from_symfony_config_b'], $keys);
+        $this->assertNotContains(
+            self::SETTINGS_STORE_KEY,
+            $keys,
+            'a symfony-config read target must not fall back to the settings store'
+        );
+    }
+
+    public function testReadsOnlyTheSettingsStoreWhenItIsTheReadTarget(): void
+    {
+        $keys = $this->createRepository(LocationAwareConfigRepository::LOCATION_SETTINGS_STORE)
+            ->fetchAllKeysByReadTargets();
+
+        $this->assertSame([self::SETTINGS_STORE_KEY], $keys);
+    }
+
+    private function createRepository(?string $readTargetType): LocationAwareConfigRepository
+    {
+        return new LocationAwareConfigRepository(
+            self::CONTAINER_CONFIG,
+            self::SCOPE,
+            [
+                LocationAwareConfigRepository::WRITE_TARGET => $this->writeTarget(),
+                LocationAwareConfigRepository::READ_TARGET => [
+                    LocationAwareConfigRepository::TYPE => $readTargetType,
+                    LocationAwareConfigRepository::OPTIONS => [
+                        LocationAwareConfigRepository::DIRECTORY => null,
+                    ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function writeTarget(): array
+    {
+        return [
+            LocationAwareConfigRepository::TYPE => LocationAwareConfigRepository::LOCATION_SYMFONY_CONFIG,
+            LocationAwareConfigRepository::OPTIONS => [
+                LocationAwareConfigRepository::DIRECTORY => PIMCORE_PRIVATE_VAR . '/config/test',
+            ],
+        ];
+    }
+}

--- a/tests/Unit/Config/LocationAwareConfigRepositoryTest.php
+++ b/tests/Unit/Config/LocationAwareConfigRepositoryTest.php
@@ -20,14 +20,14 @@ use Pimcore\Tests\Support\Test\TestCase;
 
 /**
  * Key enumeration has to follow the same source precedence as loadConfigByKey(): a configured
- * read target is the only source that is consulted, and with no read target configured both the
- * symfony-config entries and the settings store are.
+ * read target is the only source consulted, a disabled one is not read from at all, and with
+ * no read target configured both the symfony-config entries and the settings store are.
  *
- * The case that regressed is the one without a read target, which is what the shipped default
- * uses. Enumeration went straight to the settings store there, so entries written by the default
- * symfony-config write target were never listed - pimcore:build:classes generated no enum for a
- * file based select option - and a database connection was required to enumerate a set of
- * configurations that lives entirely on disk.
+ * Enumeration used to treat every case other than symfony-config as settings-store, so it
+ * disagreed with loading for the two remaining ones: a disabled read target listed keys that
+ * loading refuses to read, and an absent one listed only the settings store while loading falls
+ * back through the container config as well. Both also queried the database where loading would
+ * not have, and an absent read_target node raised an undefined array key on the way through.
  *
  * @internal
  */
@@ -97,6 +97,18 @@ final class LocationAwareConfigRepositoryTest extends TestCase
             self::SETTINGS_STORE_KEY,
             $keys,
             'a symfony-config read target must not fall back to the settings store'
+        );
+    }
+
+    public function testReadsNothingWhenTheReadTargetIsDisabled(): void
+    {
+        $keys = $this->createRepository(LocationAwareConfigRepository::LOCATION_DISABLED)
+            ->fetchAllKeysByReadTargets();
+
+        $this->assertSame(
+            [],
+            $keys,
+            'loadConfigByKey() reads from no source for a disabled read target, so nothing is listed'
         );
     }
 


### PR DESCRIPTION
Related to pimcore/platform-version#196 — but see "Scope" below: this does **not** fix that issue, which appears already resolved. Linking it only because the investigation started there.

### Problem

`LocationAwareConfigRepository::fetchAllKeysByReadTargets()` took the symfony-config branch only when a read target was *explicitly* configured as such, and treated every other case as settings-store:

```php
if ($this->storageConfig[self::READ_TARGET][self::TYPE] === self::LOCATION_SYMFONY_CONFIG) {
    return array_keys($this->containerConfig);
}

return array_unique(SettingsStore::getIdsByScope($this->settingsStoreScope));
```

`loadConfigByKey()` recognises four cases, and enumeration disagreed with it on two of them:

| read target | `loadConfigByKey()` reads | enumeration listed | agrees |
|---|---|---|---|
| `symfony-config` | container config | container config | yes |
| `settings-store` | settings store | settings store | yes |
| `disabled` | nothing | settings store | **no** |
| not configured | container config, then settings store | settings store only | **no** |

So a disabled read target listed keys that loading reads from no source at all, and queried the database to produce them. An absent one hid every symfony-config entry, listing only the store — its store query is legitimate there, since loading consults the store too after a container miss. A storage config with no `read_target` node at all additionally raised `Warning: Undefined array key "read_target"` on the way through.

### Change

Enumeration now mirrors `loadConfigByKey()` exactly. Measured against a running install, before → after:

| `read_target` | before | after |
|---|---|---|
| not configured | `[from_store]` | `[from_file_a, from_file_b, from_store]` |
| node absent | `[from_store]` + PHP warning | `[from_file_a, from_file_b, from_store]` |
| `disabled` | `[from_store]` | `[]` |
| `symfony-config` | `[from_file_a, from_file_b]` | unchanged |
| `settings-store` | `[from_store]` | unchanged |

### Scope — this is a consistency fix, not a bug with a known victim

`loadIdListByReadTargets()` has exactly one caller, the select options listing. Every other configuration listing goes through `loadIdList()` → `fetchAllKeys()`, which already merged both sources, so nothing else changes behaviour.

And core pins that one caller to a symfony-config read target in `bundles/CoreBundle/config/pimcore/default.yaml:400-402`, so **a stock install never takes either of the two repaired paths**. They are reachable only by a project that overrides the read target to `disabled`, or nulls it out. The `disabled` case is not reachable through configuration at all, since the schema's enum for `read_target` accepts only `symfony-config` and `settings-store` — it is reachable programmatically.

I originally opened this as a fix for pimcore/platform-version#196 on the belief that the shipped default configures no read target. That was wrong — I read the default from `Configuration.php`'s schema (`null`) and missed the `default.yaml` override — and the failure I reproduced came from the demo install's own `settings-store` override. Thanks to the review comment for catching it.

Merge it if the consistency is worth having; close it if an unreachable path is not worth the churn. No objection either way.

### Tests

`tests/Unit/Config/LocationAwareConfigRepositoryTest.php`, five cases covering the table above. Verified red before the change: the no-read-target case returned only the settings-store key, the absent-node case additionally emitted the undefined-key warning, and the disabled case returned the settings-store key.

The suite was not run locally — this repository has no local `vendor/`, so CI is the validator. The before/after values above were produced by exercising `fetchAllKeysByReadTargets()` directly against a running install with a real settings store.