### PR TITLE
Fix undefined array key when a workflow note field is not submitted

### DIFF
--- a/lib/Workflow/EventSubscriber/NotesSubscriber.php
+++ b/lib/Workflow/EventSubscriber/NotesSubscriber.php
@@ -207,7 +207,7 @@ class NotesSubscriber implements EventSubscriberInterface
     {
         $additional = $this->getAdditionalFields();
 
-        $data = $additional[$fieldConfig['name']];
+        $data = $additional[$fieldConfig['name']] ?? null;
 
         if ($fieldConfig['fieldType'] === 'checkbox') {
             return is_bool($data) ? $data : $data === 'true';

--- a/tests/Unit/Models/Workflow/EventSubscriber/NotesSubscriberTest.php
+++ b/tests/Unit/Models/Workflow/EventSubscriber/NotesSubscriberTest.php
@@ -13,9 +13,15 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Unit\Model\Workflow\EventSubscriber;
 
+use ErrorException;
+use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Model\Element\ValidationException;
 use Pimcore\Tests\Support\Test\TestCase;
 use Pimcore\Workflow\EventSubscriber\NotesSubscriber;
+use Pimcore\Workflow\Transition;
 use ReflectionMethod;
+use Symfony\Component\Workflow\Event\Event;
+use Symfony\Component\Workflow\Marking;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class NotesSubscriberTest extends TestCase
@@ -55,23 +61,136 @@ class NotesSubscriberTest extends TestCase
         $this->assertFalse($result);
     }
 
-    private function getAdditionalDataForCheckbox(mixed $rawValue): mixed
+    /**
+     * Regression: a configured additional field the client did not submit was read with an
+     * unguarded array access, so resolving it raised an "Undefined array key" diagnostic
+     * instead of resolving to an unchecked checkbox.
+     */
+    public function testAbsentCheckboxFieldIsReadAsUnchecked(): void
     {
-        $subscriber = new NotesSubscriber($this->createStub(TranslatorInterface::class));
-        $subscriber->setAdditionalData([
-            'additional' => [
-                'marketingInvolved' => $rawValue,
+        $result = $this->getAdditionalDataForField(
+            [
+                'name' => 'marketingInvolved',
+                'fieldType' => 'checkbox',
+                'title' => 'Please confirm that Marketing was sufficiently involved',
+                'required' => true,
+            ],
+            []
+        );
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Same unguarded array access, for every other field type: an absent field resolves to
+     * null, which the required-field check in handleNotesPreWorkflow() reads as "not filled in".
+     */
+    public function testAbsentFieldOfAnyOtherTypeIsReadAsNull(): void
+    {
+        $result = $this->getAdditionalDataForField(
+            [
+                'name' => 'dateLastContacted',
+                'fieldType' => 'date',
+                'title' => 'Date of Conversation',
+                'required' => false,
+            ],
+            []
+        );
+
+        $this->assertNull($result);
+    }
+
+    /**
+     * The user-facing consequence: submitting a transition without a required additional field
+     * must fail with the translated validation message, not with a PHP diagnostic escalated by
+     * the debug error handler.
+     */
+    public function testRequiredFieldAbsentFromSubmittedDataFailsValidation(): void
+    {
+        $subscriber = $this->createSubscriber([]);
+
+        $transition = new Transition('close', 'open', 'closed', [
+            'notes' => [
+                'additionalFields' => [
+                    [
+                        'name' => 'marketingInvolved',
+                        'fieldType' => 'checkbox',
+                        'title' => 'Please confirm that Marketing was sufficiently involved',
+                        'required' => true,
+                    ],
+                ],
             ],
         ]);
 
-        $method = new ReflectionMethod($subscriber, 'getAdditionalDataForField');
-        $method->setAccessible(true);
+        $event = new Event($this->createStub(ElementInterface::class), new Marking(), $transition);
 
-        return $method->invoke($subscriber, [
-            'name' => 'marketingInvolved',
-            'fieldType' => 'checkbox',
-            'title' => 'Please confirm that Marketing was sufficiently involved',
-            'required' => true,
-        ]);
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('workflow_notes_requred_field_message');
+
+        $this->withStrictErrorHandler(static function () use ($subscriber, $event): void {
+            $subscriber->onWorkflowEnter($event);
+        });
+    }
+
+    private function getAdditionalDataForCheckbox(mixed $rawValue): mixed
+    {
+        return $this->getAdditionalDataForField(
+            [
+                'name' => 'marketingInvolved',
+                'fieldType' => 'checkbox',
+                'title' => 'Please confirm that Marketing was sufficiently involved',
+                'required' => true,
+            ],
+            ['marketingInvolved' => $rawValue]
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $fieldConfig
+     * @param array<string, mixed> $submittedFields
+     */
+    private function getAdditionalDataForField(array $fieldConfig, array $submittedFields): mixed
+    {
+        $subscriber = $this->createSubscriber($submittedFields);
+
+        $method = new ReflectionMethod($subscriber, 'getAdditionalDataForField');
+
+        return $this->withStrictErrorHandler(static function () use ($method, $subscriber, $fieldConfig): mixed {
+            return $method->invoke($subscriber, $fieldConfig);
+        });
+    }
+
+    /**
+     * @param array<string, mixed> $submittedFields
+     */
+    private function createSubscriber(array $submittedFields): NotesSubscriber
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnArgument(0);
+
+        $subscriber = new NotesSubscriber($translator);
+        $subscriber->setAdditionalData(['additional' => $submittedFields]);
+
+        return $subscriber;
+    }
+
+    /**
+     * Promotes any PHP diagnostic raised inside the callback into an exception, the way the
+     * debug error handler does at runtime, so a stray "Undefined array key" warning fails the
+     * test instead of silently resolving to null.
+     *
+     * @throws ErrorException
+     */
+    private function withStrictErrorHandler(callable $callback): mixed
+    {
+        set_error_handler(static function (int $severity, string $message, string $file, int $line): bool {
+            throw new ErrorException($message, 0, $severity, $file, $line);
+        });
+
+        try {
+            return $callback();
+        } finally {
+            restore_error_handler();
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/pimcore/service-operations/issues/960

### What was wrong

`NotesSubscriber::getAdditionalDataForField()` read the submitted value with an unguarded array access:

```php
$data = $additional[$fieldConfig['name']];
```

An additional field that is configured on the transition but absent from the submitted payload therefore raised an `Undefined array key` diagnostic. With the debug error handler active that is escalated to an exception, so the transition failed with a PHP error instead of the translated required-field validation message.

The boolean-vs-string comparison reported in the same ticket was already fixed in #19342; this is the remaining part.

### The fix

Resolve an absent field to `null`. A checkbox then reads as unchecked and every other field type reads as not filled in, which the existing required-field check in `handleNotesPreWorkflow()` already handles correctly — an absent required field now produces `workflow_notes_requred_field_message` as intended.

### Tests

`tests/Unit/Models/Workflow/EventSubscriber/NotesSubscriberTest.php` gains three regression cases:

- an absent `checkbox` field reads as unchecked,
- an absent field of any other type reads as `null`,
- submitting a transition without a required additional field fails with the translated `ValidationException` rather than a PHP diagnostic.

The shared helpers now run the call under an error handler that promotes any PHP diagnostic to an exception, the way the debug error handler does at runtime — without it the stray warning would be swallowed and the tests would pass against the unfixed code. The four pre-existing checkbox cases were re-routed through the same helper and stay green.

### Verification

- All seven cases were verified red-then-green by exercising the real `NotesSubscriber` through a standalone PHP harness (the three new cases failed with `Undefined array key`, then passed after the one-line change).
- The Codeception `Unit` suite itself was **not** run locally — it requires the containerised test environment. CI is the validator here.

Co-authored-by: Claude <noreply@anthropic.com>