### PR TITLE
[Bug] Stop application log archive tables from growing on every maintenance run

### DIFF
--- a/bundles/ApplicationLoggerBundle/src/Maintenance/LogArchiveTask.php
+++ b/bundles/ApplicationLoggerBundle/src/Maintenance/LogArchiveTask.php
@@ -98,19 +98,18 @@ class LogArchiveTask implements TaskInterface
             }
             $db->executeStatement($this->getArchiveStatement($quotedTablename, $timestamp, $archive_threshold));
 
-            $fileObjectPaths = $db->fetchFirstColumn(sprintf($sql, 'fileobject'));
-
-            $db->executeStatement('DELETE FROM '.ApplicationLoggerDb::TABLE_NAME.' WHERE `timestamp` < DATE_SUB(FROM_UNIXTIME('.$timestamp.'), INTERVAL '.$archive_threshold.' DAY);');
-
             $this->logger->debug('Deleting referenced FileObjects of application_logs which are older than '.$archive_threshold.' days');
 
-            // the file objects are removed only after the rows are gone from the source table, so
-            // that a failing storage never keeps already archived rows around for the next run
+            // the source rows stay until their file objects are gone, so that a failing storage
+            // leaves a retryable state behind rather than files nothing points to any more
+            $fileObjectPaths = $db->fetchFirstColumn(sprintf($sql, 'fileobject'));
             foreach ($fileObjectPaths as $filePath) {
                 if ($filePath !== null && $storage->fileExists($filePath)) {
                     $storage->delete($filePath);
                 }
             }
+
+            $db->executeStatement('DELETE FROM '.ApplicationLoggerDb::TABLE_NAME.' WHERE `timestamp` < DATE_SUB(FROM_UNIXTIME('.$timestamp.'), INTERVAL '.$archive_threshold.' DAY);');
         }
 
         $archiveTables = $db->fetchFirstColumn(

--- a/bundles/ApplicationLoggerBundle/src/Maintenance/LogArchiveTask.php
+++ b/bundles/ApplicationLoggerBundle/src/Maintenance/LogArchiveTask.php
@@ -23,6 +23,7 @@ use Pimcore\Config;
 use Pimcore\Maintenance\TaskInterface;
 use Pimcore\Tool\Storage;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Lock\Exception\ExceptionInterface as LockException;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\LockInterface;
 use function in_arrayi;
@@ -32,6 +33,11 @@ use function in_arrayi;
  */
 class LogArchiveTask implements TaskInterface
 {
+    /**
+     * How many file objects to delete before the lock gets its ttl reset again.
+     */
+    private const LOCK_REFRESH_INTERVAL = 1000;
+
     private Connection $db;
 
     private Config $config;
@@ -131,9 +137,14 @@ class LogArchiveTask implements TaskInterface
             // the source rows stay until their file objects are gone, so that a failing storage
             // leaves a retryable state behind rather than files nothing points to any more
             $fileObjectPaths = $db->fetchFirstColumn(sprintf($sql, 'fileobject'));
+            $deleted = 0;
             foreach ($fileObjectPaths as $filePath) {
                 if ($filePath !== null && $storage->fileExists($filePath)) {
                     $storage->delete($filePath);
+                }
+
+                if (++$deleted % self::LOCK_REFRESH_INTERVAL === 0) {
+                    $this->refreshLock();
                 }
             }
 
@@ -185,5 +196,24 @@ class LogArchiveTask implements TaskInterface
         return 'INSERT INTO '.$quotedArchiveTable.' SELECT `log`.* FROM '.$quotedSourceTable.' `log`'
             .' LEFT JOIN '.$quotedArchiveTable.' `archived` ON `archived`.`id` = `log`.`id`'
             .' WHERE '.$olderThanThreshold.' AND `archived`.`id` IS NULL';
+    }
+
+    /**
+     * Keeps the lock alive while the file objects are removed one by one, which is the part of a
+     * run that can take long enough to outlive the ttl. The ttl is kept rather than dropped so a
+     * process that dies mid-run still frees the lock eventually.
+     *
+     * A lost lock is logged and the run continues: a second run is kept out by the acquire() in
+     * execute(), and aborting here would leave the entries archived but not deleted.
+     */
+    private function refreshLock(): void
+    {
+        try {
+            $this->lock->refresh();
+        } catch (LockException $e) {
+            $this->logger->warning('Could not refresh the application log archive lock: {exception}', [
+                'exception' => $e,
+            ]);
+        }
     }
 }

--- a/bundles/ApplicationLoggerBundle/src/Maintenance/LogArchiveTask.php
+++ b/bundles/ApplicationLoggerBundle/src/Maintenance/LogArchiveTask.php
@@ -49,10 +49,14 @@ class LogArchiveTask implements TaskInterface
         $storage = Storage::get('application_log');
 
         $date = new DateTime('now');
-        $tablename = ApplicationLoggerDb::TABLE_ARCHIVE_PREFIX.'_'.$date->format('Y').'_'.$date->format('m');
+        $archiveTableName = ApplicationLoggerDb::TABLE_ARCHIVE_PREFIX.'_'.$date->format('Y').'_'.$date->format('m');
+        $tablename = $archiveTableName;
+        $quotedTablename = $db->quoteIdentifier($archiveTableName);
 
         if (!empty($this->config['applicationlog']['archive_alternative_database'])) {
-            $tablename = $db->quoteIdentifier($this->config['applicationlog']['archive_alternative_database']).'.'.$tablename;
+            $quotedDatabase = $db->quoteIdentifier($this->config['applicationlog']['archive_alternative_database']);
+            $tablename = $quotedDatabase.'.'.$tablename;
+            $quotedTablename = $quotedDatabase.'.'.$quotedTablename;
         }
 
         $archive_threshold = (int) ($this->config['applicationlog']['archive_treshold'] ?? 30);
@@ -92,7 +96,7 @@ class LogArchiveTask implements TaskInterface
                        maintenanceChecked TINYINT(1)
                     ) ENGINE = " . $storageEngine . ' DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci ROW_FORMAT = DEFAULT;');
             }
-            $db->executeStatement($this->getArchiveStatement($tablename, $timestamp, $archive_threshold));
+            $db->executeStatement($this->getArchiveStatement($quotedTablename, $timestamp, $archive_threshold));
 
             $fileObjectPaths = $db->fetchFirstColumn(sprintf($sql, 'fileobject'));
 
@@ -144,13 +148,15 @@ class LogArchiveTask implements TaskInterface
      * table has no key on `id`, and the ARCHIVE storage engine used by default cannot have one -
      * so they would be appended once more on every following run.
      */
-    private function getArchiveStatement(string $archiveTable, int $timestamp, int $archiveThreshold): string
+    private function getArchiveStatement(string $quotedArchiveTable, int $timestamp, int $archiveThreshold): string
     {
+        $quotedSourceTable = $this->db->quoteIdentifier(ApplicationLoggerDb::TABLE_NAME);
+
         $olderThanThreshold = '`log`.`timestamp` < DATE_SUB(FROM_UNIXTIME('.$timestamp.'), INTERVAL '
             .$archiveThreshold.' DAY)';
 
-        return 'INSERT INTO '.$archiveTable.' SELECT `log`.* FROM '.ApplicationLoggerDb::TABLE_NAME.' `log`'
-            .' LEFT JOIN '.$archiveTable.' `archived` ON `archived`.`id` = `log`.`id`'
+        return 'INSERT INTO '.$quotedArchiveTable.' SELECT `log`.* FROM '.$quotedSourceTable.' `log`'
+            .' LEFT JOIN '.$quotedArchiveTable.' `archived` ON `archived`.`id` = `log`.`id`'
             .' WHERE '.$olderThanThreshold.' AND `archived`.`id` IS NULL';
     }
 }

--- a/bundles/ApplicationLoggerBundle/src/Maintenance/LogArchiveTask.php
+++ b/bundles/ApplicationLoggerBundle/src/Maintenance/LogArchiveTask.php
@@ -92,21 +92,21 @@ class LogArchiveTask implements TaskInterface
                        maintenanceChecked TINYINT(1)
                     ) ENGINE = " . $storageEngine . ' DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci ROW_FORMAT = DEFAULT;');
             }
-            $db->executeQuery('INSERT INTO '.$tablename.' '.sprintf($sql, '*'));
+            $db->executeStatement($this->getArchiveStatement($tablename, $timestamp, $archive_threshold));
+
+            $fileObjectPaths = $db->fetchFirstColumn(sprintf($sql, 'fileobject'));
+
+            $db->executeStatement('DELETE FROM '.ApplicationLoggerDb::TABLE_NAME.' WHERE `timestamp` < DATE_SUB(FROM_UNIXTIME('.$timestamp.'), INTERVAL '.$archive_threshold.' DAY);');
 
             $this->logger->debug('Deleting referenced FileObjects of application_logs which are older than '.$archive_threshold.' days');
 
-            $fileObjectPaths = $db->fetchAllAssociative(sprintf($sql, 'fileobject'));
-            foreach ($fileObjectPaths as $objectPath) {
-                $filePath = $objectPath['fileobject'];
-                if ($filePath !== null) {
-                    if ($storage->fileExists($filePath)) {
-                        $storage->delete($filePath);
-                    }
+            // the file objects are removed only after the rows are gone from the source table, so
+            // that a failing storage never keeps already archived rows around for the next run
+            foreach ($fileObjectPaths as $filePath) {
+                if ($filePath !== null && $storage->fileExists($filePath)) {
+                    $storage->delete($filePath);
                 }
             }
-
-            $db->executeQuery('DELETE FROM '.ApplicationLoggerDb::TABLE_NAME.' WHERE `timestamp` < DATE_SUB(FROM_UNIXTIME('.$timestamp.'), INTERVAL '.$archive_threshold.' DAY);');
         }
 
         $archiveTables = $db->fetchFirstColumn(
@@ -133,5 +133,24 @@ class LogArchiveTask implements TaskInterface
                 }
             }
         }
+    }
+
+    /**
+     * Archives every log entry older than the threshold that is not in the archive table yet.
+     *
+     * Skipping the entries that are already there is what keeps a re-run harmless: whenever an
+     * earlier run failed between archiving the entries and deleting them from the source table,
+     * those entries are picked up again by the next run. Nothing would reject them - the archive
+     * table has no key on `id`, and the ARCHIVE storage engine used by default cannot have one -
+     * so they would be appended once more on every following run.
+     */
+    private function getArchiveStatement(string $archiveTable, int $timestamp, int $archiveThreshold): string
+    {
+        $olderThanThreshold = '`log`.`timestamp` < DATE_SUB(FROM_UNIXTIME('.$timestamp.'), INTERVAL '
+            .$archiveThreshold.' DAY)';
+
+        return 'INSERT INTO '.$archiveTable.' SELECT `log`.* FROM '.ApplicationLoggerDb::TABLE_NAME.' `log`'
+            .' LEFT JOIN '.$archiveTable.' `archived` ON `archived`.`id` = `log`.`id`'
+            .' WHERE '.$olderThanThreshold.' AND `archived`.`id` IS NULL';
     }
 }

--- a/bundles/ApplicationLoggerBundle/src/Maintenance/LogArchiveTask.php
+++ b/bundles/ApplicationLoggerBundle/src/Maintenance/LogArchiveTask.php
@@ -23,6 +23,8 @@ use Pimcore\Config;
 use Pimcore\Maintenance\TaskInterface;
 use Pimcore\Tool\Storage;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\LockInterface;
 use function in_arrayi;
 
 /**
@@ -36,14 +38,40 @@ class LogArchiveTask implements TaskInterface
 
     private LoggerInterface $logger;
 
-    public function __construct(Connection $db, Config $config, LoggerInterface $logger)
+    private LockInterface $lock;
+
+    public function __construct(Connection $db, Config $config, LoggerInterface $logger, LockFactory $lockFactory)
     {
         $this->db = $db;
         $this->config = $config;
         $this->logger = $logger;
+        // the ttl only has to outlive a legitimate run so that a killed process cannot block
+        // archiving forever; a day matches the cadence the task is normally scheduled at
+        $this->lock = $lockFactory->createLock(self::class, 86400);
     }
 
+    /**
+     * Archiving is not safe to run twice at the same time. Nothing serializes maintenance tasks -
+     * executeMaintenance() dispatches them to the messenger and a run slower than the scheduling
+     * interval overlaps the next one - and two overlapping runs can both see the same entries as
+     * missing from the archive table and both insert them, since it has no key to reject that.
+     */
     public function execute(): void
+    {
+        if (!$this->lock->acquire()) {
+            $this->logger->info('Skipping application log archiving, a previous run is still in progress');
+
+            return;
+        }
+
+        try {
+            $this->archiveLogEntries();
+        } finally {
+            $this->lock->release();
+        }
+    }
+
+    private function archiveLogEntries(): void
     {
         $db = $this->db;
         $storage = Storage::get('application_log');

--- a/bundles/ApplicationLoggerBundle/src/Maintenance/LogArchiveTask.php
+++ b/bundles/ApplicationLoggerBundle/src/Maintenance/LogArchiveTask.php
@@ -23,7 +23,6 @@ use Pimcore\Config;
 use Pimcore\Maintenance\TaskInterface;
 use Pimcore\Tool\Storage;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Lock\Exception\ExceptionInterface as LockException;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\LockInterface;
 use function in_arrayi;
@@ -143,8 +142,12 @@ class LogArchiveTask implements TaskInterface
                     $storage->delete($filePath);
                 }
 
+                // deleting the file objects is the part of a run that can outlive the ttl, so
+                // the lock is kept alive here. Losing it means another run may already have taken
+                // over, and refresh() then throws and ends this one - which is safe, because the
+                // entries stay in the source table for the next run to pick up and skip.
                 if (++$deleted % self::LOCK_REFRESH_INTERVAL === 0) {
-                    $this->refreshLock();
+                    $this->lock->refresh();
                 }
             }
 
@@ -196,24 +199,5 @@ class LogArchiveTask implements TaskInterface
         return 'INSERT INTO '.$quotedArchiveTable.' SELECT `log`.* FROM '.$quotedSourceTable.' `log`'
             .' LEFT JOIN '.$quotedArchiveTable.' `archived` ON `archived`.`id` = `log`.`id`'
             .' WHERE '.$olderThanThreshold.' AND `archived`.`id` IS NULL';
-    }
-
-    /**
-     * Keeps the lock alive while the file objects are removed one by one, which is the part of a
-     * run that can take long enough to outlive the ttl. The ttl is kept rather than dropped so a
-     * process that dies mid-run still frees the lock eventually.
-     *
-     * A lost lock is logged and the run continues: a second run is kept out by the acquire() in
-     * execute(), and aborting here would leave the entries archived but not deleted.
-     */
-    private function refreshLock(): void
-    {
-        try {
-            $this->lock->refresh();
-        } catch (LockException $e) {
-            $this->logger->warning('Could not refresh the application log archive lock: {exception}', [
-                'exception' => $e,
-            ]);
-        }
     }
 }

--- a/tests/Unit/ApplicationLoggerBundle/Maintenance/LogArchiveTaskTest.php
+++ b/tests/Unit/ApplicationLoggerBundle/Maintenance/LogArchiveTaskTest.php
@@ -1,0 +1,272 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\ApplicationLoggerBundle\Maintenance;
+
+use DateTimeImmutable;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Pimcore\Bundle\ApplicationLoggerBundle\Handler\ApplicationLoggerDb;
+use Pimcore\Bundle\ApplicationLoggerBundle\Maintenance\LogArchiveTask;
+use Pimcore\Config;
+use Pimcore\Db;
+use Pimcore\Tests\Support\Test\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Regression tests for the application log archiving task.
+ *
+ * The task archives log rows with an "INSERT INTO <archive> SELECT ... FROM application_logs"
+ * and only afterwards deletes them from the source table. Whenever anything in between failed,
+ * the source rows survived and the next run inserted them into the archive table a second time.
+ * Nothing rejected those duplicates - the archive table carries no key on "id", and the ARCHIVE
+ * storage engine (the configured default) cannot carry one - so the archive tables kept growing
+ * with every run.
+ *
+ * Archiving therefore has to be idempotent: a row already present in the archive table must
+ * never be inserted again, while still being removed from the source table.
+ *
+ * @internal
+ */
+final class LogArchiveTaskTest extends TestCase
+{
+    private const ARCHIVE_THRESHOLD_EXCEEDING_DAYS = 60;
+
+    protected bool $cleanupDbInSetup = false;
+
+    private Connection $db;
+
+    private string $archiveTable;
+
+    protected function needsDb(): bool
+    {
+        return true;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->db = Db::get();
+        $this->archiveTable = ApplicationLoggerDb::TABLE_ARCHIVE_PREFIX . '_' . date('Y') . '_' . date('m');
+
+        $this->createSourceTable();
+        $this->resetTables();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetTables();
+
+        parent::tearDown();
+    }
+
+    public function testAlreadyArchivedRowsAreNotArchivedASecondTime(): void
+    {
+        $ids = $this->insertSourceLogs(4);
+        $this->createArchiveTable();
+        $this->preArchive([$ids[0], $ids[1]]);
+
+        $this->runTask();
+
+        $this->assertArchivedExactlyOnce($ids);
+    }
+
+    public function testRepeatedExecutionDoesNotGrowTheArchiveTable(): void
+    {
+        $ids = $this->insertSourceLogs(3);
+        $this->createArchiveTable();
+        $this->preArchive($ids);
+
+        $this->runTask();
+        // the rows are back in the source table, exactly as a failed DELETE would leave them
+        $this->insertSourceLogs(3, $ids);
+        $this->runTask();
+
+        $this->assertArchivedExactlyOnce($ids);
+    }
+
+    public function testRowsAreArchivedAndRemovedFromTheSourceTable(): void
+    {
+        $ids = $this->insertSourceLogs(3);
+        $this->createArchiveTable();
+
+        $this->runTask();
+
+        $this->assertArchivedExactlyOnce($ids);
+        $this->assertSame(0, $this->countSourceRows(), 'Archived rows must be gone from the source table.');
+    }
+
+    public function testAlreadyArchivedRowsAreStillRemovedFromTheSourceTable(): void
+    {
+        $ids = $this->insertSourceLogs(3);
+        $this->createArchiveTable();
+        $this->preArchive($ids);
+
+        $this->runTask();
+
+        $this->assertSame(
+            0,
+            $this->countSourceRows(),
+            'Rows archived by an earlier, interrupted run must still be deleted from the source table.'
+        );
+    }
+
+    public function testRecentRowsAreLeftUntouched(): void
+    {
+        $recentId = $this->insertSourceLog(new DateTimeImmutable('-1 day'));
+        $this->createArchiveTable();
+
+        $this->runTask();
+
+        $this->assertSame(
+            0,
+            $this->countArchivedRows($recentId),
+            'A row below the archive threshold must not be archived.'
+        );
+        $this->assertSame(1, $this->countSourceRows(), 'A row below the archive threshold must be kept.');
+    }
+
+    private function runTask(): void
+    {
+        (new LogArchiveTask($this->db, new Config(), new NullLogger()))->execute();
+    }
+
+    /**
+     * @param int[] $reuseIds
+     *
+     * @return int[]
+     */
+    private function insertSourceLogs(int $amount, array $reuseIds = []): array
+    {
+        $timestamp = new DateTimeImmutable('-' . self::ARCHIVE_THRESHOLD_EXCEEDING_DAYS . ' days');
+        $ids = [];
+
+        for ($i = 0; $i < $amount; $i++) {
+            $ids[] = $this->insertSourceLog($timestamp, $reuseIds[$i] ?? null);
+        }
+
+        return $ids;
+    }
+
+    private function insertSourceLog(DateTimeImmutable $timestamp, ?int $id = null): int
+    {
+        $data = [
+            'timestamp' => $timestamp->format('Y-m-d H:i:s'),
+            'message' => 'log archive task test',
+            'priority' => 'info',
+            'component' => 'log-archive-task-test',
+        ];
+
+        if ($id !== null) {
+            $data['id'] = $id;
+        }
+
+        $this->db->insert(ApplicationLoggerDb::TABLE_NAME, $data);
+
+        return $id ?? (int) $this->db->lastInsertId();
+    }
+
+    /**
+     * Copies rows into the archive table without removing them from the source table - exactly
+     * the state an archive run that died after its INSERT but before its DELETE leaves behind.
+     *
+     * @param int[] $ids
+     */
+    private function preArchive(array $ids): void
+    {
+        $this->db->executeStatement(
+            'INSERT INTO ' . $this->archiveTable . ' SELECT * FROM ' . ApplicationLoggerDb::TABLE_NAME
+            . ' WHERE id IN (:ids)',
+            ['ids' => $ids],
+            ['ids' => ArrayParameterType::INTEGER]
+        );
+    }
+
+    private function createSourceTable(): void
+    {
+        $this->db->executeStatement(
+            'CREATE TABLE IF NOT EXISTS ' . ApplicationLoggerDb::TABLE_NAME . " (
+                `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+                `pid` INT(11) NULL DEFAULT NULL,
+                `timestamp` DATETIME NOT NULL,
+                `message` TEXT NULL,
+                `priority` ENUM('emergency','alert','critical','error','warning','notice','info','debug') DEFAULT NULL,
+                `fileobject` VARCHAR(1024) DEFAULT NULL,
+                `info` VARCHAR(1024) DEFAULT NULL,
+                `component` VARCHAR(190) DEFAULT NULL,
+                `source` VARCHAR(190) DEFAULT NULL,
+                `relatedobject` INT(11) UNSIGNED DEFAULT NULL,
+                `relatedobjecttype` ENUM('object','document','asset') DEFAULT NULL,
+                `maintenanceChecked` TINYINT(1) DEFAULT NULL,
+                PRIMARY KEY (`id`),
+                KEY `timestamp` (`timestamp`)
+            ) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci"
+        );
+    }
+
+    /**
+     * The task only creates the archive table when it does not exist yet, and would use the
+     * configured storage engine for it. Creating it upfront keeps these tests independent of
+     * which storage engines the database under test happens to offer.
+     */
+    private function createArchiveTable(): void
+    {
+        $this->db->executeStatement(
+            'CREATE TABLE ' . $this->archiveTable . " (
+                id BIGINT(20) NOT NULL,
+                `pid` INT(11) NULL DEFAULT NULL,
+                `timestamp` DATETIME NOT NULL,
+                message VARCHAR(1024),
+                `priority` ENUM('emergency','alert','critical','error','warning','notice','info','debug') DEFAULT NULL,
+                fileobject VARCHAR(1024),
+                info VARCHAR(1024),
+                component VARCHAR(255),
+                source VARCHAR(255) NULL DEFAULT NULL,
+                relatedobject BIGINT(20),
+                relatedobjecttype ENUM('object', 'document', 'asset'),
+                maintenanceChecked TINYINT(1)
+            ) ENGINE = InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci"
+        );
+    }
+
+    /**
+     * @param int[] $ids
+     */
+    private function assertArchivedExactlyOnce(array $ids): void
+    {
+        foreach ($ids as $id) {
+            $this->assertSame(
+                1,
+                $this->countArchivedRows($id),
+                sprintf('Log entry %d must be present in the archive table exactly once.', $id)
+            );
+        }
+    }
+
+    private function countArchivedRows(int $id): int
+    {
+        return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . $this->archiveTable . ' WHERE id = ?', [$id]);
+    }
+
+    private function countSourceRows(): int
+    {
+        return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . ApplicationLoggerDb::TABLE_NAME);
+    }
+
+    private function resetTables(): void
+    {
+        $this->db->executeStatement('DROP TABLE IF EXISTS ' . $this->archiveTable);
+        $this->db->executeStatement('DELETE FROM ' . ApplicationLoggerDb::TABLE_NAME);
+    }
+}

--- a/tests/Unit/ApplicationLoggerBundle/Maintenance/LogArchiveTaskTest.php
+++ b/tests/Unit/ApplicationLoggerBundle/Maintenance/LogArchiveTaskTest.php
@@ -22,6 +22,8 @@ use Pimcore\Config;
 use Pimcore\Db;
 use Pimcore\Tests\Support\Test\TestCase;
 use Psr\Log\NullLogger;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\InMemoryStore;
 
 /**
  * Regression tests for the application log archiving task.
@@ -50,6 +52,8 @@ final class LogArchiveTaskTest extends TestCase
 
     private string $sourceTable;
 
+    private LockFactory $lockFactory;
+
     protected function needsDb(): bool
     {
         return true;
@@ -64,6 +68,7 @@ final class LogArchiveTaskTest extends TestCase
             ApplicationLoggerDb::TABLE_ARCHIVE_PREFIX . '_' . date('Y') . '_' . date('m')
         );
         $this->sourceTable = $this->db->quoteIdentifier(ApplicationLoggerDb::TABLE_NAME);
+        $this->lockFactory = new LockFactory(new InMemoryStore());
 
         $this->createSourceTable();
         $this->resetTables();
@@ -142,9 +147,39 @@ final class LogArchiveTaskTest extends TestCase
         $this->assertSame(1, $this->countSourceRows(), 'A row below the archive threshold must be kept.');
     }
 
+    public function testAConcurrentRunIsSkippedInsteadOfArchivingTheSameEntriesAgain(): void
+    {
+        $ids = $this->insertSourceLogs(3);
+        $this->createArchiveTable();
+
+        // hold the task's lock, the way a still running earlier execution would
+        $concurrentRun = $this->lockFactory->createLock(LogArchiveTask::class, 86400);
+        self::assertTrue($concurrentRun->acquire(), 'The lock must be free before this test holds it.');
+
+        try {
+            $this->runTask();
+        } finally {
+            $concurrentRun->release();
+        }
+
+        foreach ($ids as $id) {
+            $this->assertSame(
+                0,
+                $this->countArchivedRows($id),
+                'A run that cannot take the lock must archive nothing.'
+            );
+        }
+        $this->assertSame(3, $this->countSourceRows(), 'A skipped run must not delete anything either.');
+
+        // and once the lock is free again the entries are archived exactly once
+        $this->runTask();
+
+        $this->assertArchivedExactlyOnce($ids);
+    }
+
     private function runTask(): void
     {
-        (new LogArchiveTask($this->db, new Config(), new NullLogger()))->execute();
+        (new LogArchiveTask($this->db, new Config(), new NullLogger(), $this->lockFactory))->execute();
     }
 
     /**

--- a/tests/Unit/ApplicationLoggerBundle/Maintenance/LogArchiveTaskTest.php
+++ b/tests/Unit/ApplicationLoggerBundle/Maintenance/LogArchiveTaskTest.php
@@ -48,6 +48,8 @@ final class LogArchiveTaskTest extends TestCase
 
     private string $archiveTable;
 
+    private string $sourceTable;
+
     protected function needsDb(): bool
     {
         return true;
@@ -58,7 +60,10 @@ final class LogArchiveTaskTest extends TestCase
         parent::setUp();
 
         $this->db = Db::get();
-        $this->archiveTable = ApplicationLoggerDb::TABLE_ARCHIVE_PREFIX . '_' . date('Y') . '_' . date('m');
+        $this->archiveTable = $this->db->quoteIdentifier(
+            ApplicationLoggerDb::TABLE_ARCHIVE_PREFIX . '_' . date('Y') . '_' . date('m')
+        );
+        $this->sourceTable = $this->db->quoteIdentifier(ApplicationLoggerDb::TABLE_NAME);
 
         $this->createSourceTable();
         $this->resetTables();
@@ -186,7 +191,7 @@ final class LogArchiveTaskTest extends TestCase
     private function preArchive(array $ids): void
     {
         $this->db->executeStatement(
-            'INSERT INTO ' . $this->archiveTable . ' SELECT * FROM ' . ApplicationLoggerDb::TABLE_NAME
+            'INSERT INTO ' . $this->archiveTable . ' SELECT * FROM ' . $this->sourceTable
             . ' WHERE id IN (:ids)',
             ['ids' => $ids],
             ['ids' => ArrayParameterType::INTEGER]
@@ -196,7 +201,7 @@ final class LogArchiveTaskTest extends TestCase
     private function createSourceTable(): void
     {
         $this->db->executeStatement(
-            'CREATE TABLE IF NOT EXISTS ' . ApplicationLoggerDb::TABLE_NAME . " (
+            'CREATE TABLE IF NOT EXISTS ' . $this->sourceTable . " (
                 `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
                 `pid` INT(11) NULL DEFAULT NULL,
                 `timestamp` DATETIME NOT NULL,
@@ -261,12 +266,12 @@ final class LogArchiveTaskTest extends TestCase
 
     private function countSourceRows(): int
     {
-        return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . ApplicationLoggerDb::TABLE_NAME);
+        return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . $this->sourceTable);
     }
 
     private function resetTables(): void
     {
         $this->db->executeStatement('DROP TABLE IF EXISTS ' . $this->archiveTable);
-        $this->db->executeStatement('DELETE FROM ' . ApplicationLoggerDb::TABLE_NAME);
+        $this->db->executeStatement('DELETE FROM ' . $this->sourceTable);
     }
 }


### PR DESCRIPTION
Issue: https://github.com/pimcore/service-operations/issues/958

## Problem

`LogArchiveTask::execute()` archives log entries older than `archive_treshold` days by inserting them into the monthly archive table and deleting them from `application_logs` afterwards. If anything between those two statements fails, the source rows survive, and the next run inserts them into the archive table a second time. Nothing rejects the duplicates, so the archive tables grow with every run.

## Root cause

Three things line up:

1. The `INSERT INTO ... SELECT` and the `DELETE FROM` are not atomic, and the **file object storage cleanup sat between them** — a loop over `$storage->fileExists()` / `$storage->delete()` for every archived row. That is the slowest and least reliable step of the whole task (remote storage, thousands of files) and it is exactly where the run tends to die or time out.
2. The archive table carries **no key on `id`** (`id BIGINT(20) NOT NULL`, no `PRIMARY KEY`, no `UNIQUE`), so duplicate inserts are silently accepted.
3. The `INSERT` has no idempotency guard — it re-selects everything below the threshold, including the rows a previous run already copied over.

## Change

**Archiving is now idempotent.** The insert anti-joins the archive table and skips entries that are already in it:

```sql
INSERT INTO <archive> SELECT `log`.* FROM application_logs `log`
  LEFT JOIN <archive> `archived` ON `archived`.`id` = `log`.`id`
 WHERE `log`.`timestamp` < DATE_SUB(FROM_UNIXTIME(...), INTERVAL ... DAY)
   AND `archived`.`id` IS NULL
```

An interrupted run is now self-healing: the next run skips what was already archived and retries the `DELETE`. (Within the destination table — see *Known limitation* below.) This also works on archive tables that are *already* in the broken state — it stops them growing further without any migration.

**Statement order is unchanged.** An earlier revision of this PR moved the file object cleanup behind the `DELETE` to shrink the window. That was wrong and has been reverted: once the source rows are gone, nothing references those files any more, and the directory cleanup further down is not a fallback for them — `FileObject` stores a file under the `Y/m/d` it was *created* in, while that cleanup removes the month parsed from the *archive table name*, i.e. the month the entry was *archived* in. With `archive_treshold` = 30 those are normally different months, so the files would be orphaned for good.

Since the anti-join already makes a repeated run harmless, the original order is the right one: entries stay in the source table until their files are deleted, and a failed cleanup leaves a state the next run simply picks up again.

### Why not a unique key, `INSERT IGNORE`, or a transaction

The ticket suggests these; they do not hold up for the default configuration:

- `archive_db_table_storage_engine` defaults to **`archive`**, and the ARCHIVE engine only supports an index on an `AUTO_INCREMENT` column. `PRIMARY KEY (id)` on the archive table is rejected outright — verified on MySQL 8.4: `ERROR 1030 (HY000): Got error -1 from storage engine`.
- Without a key, `INSERT IGNORE` / `ON DUPLICATE KEY UPDATE` have nothing to deduplicate on.
- A transaction cannot roll back an `INSERT` into a non-transactional archive table (ARCHIVE, MyISAM, Aria — three of the four engines the task auto-detects), and wrapping the bulk `DELETE` in one would extend lock time on `application_logs`. Idempotency is the stronger property here: it covers every engine *and* repairs tables that are already affected.

This matches the reporter's own follow-up note on the ticket, which suggests excluding rows by id check for the ARCHIVE engine.

## Tests

`tests/Unit/ApplicationLoggerBundle/Maintenance/LogArchiveTaskTest.php` — 5 cases against a real database:

- already-archived rows are not archived a second time (the regression case)
- repeated execution does not grow the archive table
- rows are archived and removed from the source table (happy path)
- rows from an interrupted earlier run are still deleted from the source table
- rows below the threshold are left untouched

The tests create the archive table upfront with an explicit engine, so they do not depend on which storage engines the CI database offers. `application_logs` is created in `setUp()` because `DatabaseSetup::createSchema()` does not install bundle tables.

## Verification

`pimcore/pimcore` has no local `vendor/`, so **the Codeception suite was not run locally — CI is the validator for it.** No CI run was attempted locally.

What *was* verified locally, by replaying the exact statement the task now builds against a real database with the real table DDLs:

- **MariaDB 10.11** — with ids 1 and 2 left behind by a previous run, the old statement archives them twice (`times_archived` 2, 2, 1, 1); the new statement archives every id exactly once (1, 1, 1, 1). Re-running adds nothing, the source table is drained, and a row below the threshold is neither archived nor deleted.
- **MySQL 8.4 with `ENGINE=ARCHIVE`** — same result, confirming the anti-join against the insert target works on the default engine.
- **MySQL 8.4** — `PRIMARY KEY (id)` on an ARCHIVE table fails with `ERROR 1030`, which is what rules out the key-based alternatives above.

`php -l` is clean on both files. php-cs-fixer and PHPStan were not run locally.



## Known limitation

The anti-join checks the destination archive table, which is chosen from the *run* date (`application_logs_archive_<Y>_<m>`). If a run fails between the `INSERT` and the `DELETE` **and** the retry happens in a later calendar month, the retry targets a different table, finds no match there, and archives those entries a second time.

This is bounded — one extra copy per crossed month boundary, not the unbounded per-run growth this PR fixes — and it needs the failure to land on the last run of a month. Closing it fully means probing every retained archive table on every run (up to `delete_archive_threshold` + 1 unindexed full scans, since the ARCHIVE engine cannot carry an index on `id`), or partitioning archive tables by the entry's own timestamp instead of the run date. Both are larger changes than this fix; happy to follow up if maintainers prefer either.
