### PR TITLE
Normalize empty language permission strings to null in DataObject workspace

### DIFF
--- a/models/User/Workspace/DataObject.php
+++ b/models/User/Workspace/DataObject.php
@@ -73,7 +73,7 @@ class DataObject extends AbstractWorkspace
     public function setLEdit(?string $lEdit): void
     {
         //@TODO - at the moment disallowing all languages is not possible - the empty lEdit value means that every language is allowed to edit...
-        $this->lEdit = $lEdit;
+        $this->lEdit = $lEdit === '' ? null : $lEdit;
     }
 
     public function getLEdit(): ?string
@@ -83,7 +83,7 @@ class DataObject extends AbstractWorkspace
 
     public function setLView(?string $lView): void
     {
-        $this->lView = $lView;
+        $this->lView = $lView === '' ? null : $lView;
     }
 
     public function getLView(): ?string

--- a/tests/Unit/Models/User/Workspace/DataObjectTest.php
+++ b/tests/Unit/Models/User/Workspace/DataObjectTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * This source file is available under the terms of the

--- a/tests/Unit/Models/User/Workspace/DataObjectTest.php
+++ b/tests/Unit/Models/User/Workspace/DataObjectTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\User\Workspace;
+
+use Pimcore\Model\User\Workspace\DataObject;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * An empty lEdit/lView value is documented to mean "every language is allowed", the same as
+ * NULL. Some callers (e.g. a MultiSelect widget with nothing selected) submit '' rather than
+ * NULL, so the setters must normalize '' to NULL to keep that contract intact for every reader.
+ *
+ * @group model.user.workspace.dataobject
+ */
+class DataObjectTest extends TestCase
+{
+    public function testSetLEditNormalizesEmptyStringToNull(): void
+    {
+        $workspace = new DataObject();
+        $workspace->setLEdit('');
+
+        self::assertNull($workspace->getLEdit());
+    }
+
+    public function testSetLViewNormalizesEmptyStringToNull(): void
+    {
+        $workspace = new DataObject();
+        $workspace->setLView('');
+
+        self::assertNull($workspace->getLView());
+    }
+
+    public function testSetLEditKeepsNullAsNull(): void
+    {
+        $workspace = new DataObject();
+        $workspace->setLEdit(null);
+
+        self::assertNull($workspace->getLEdit());
+    }
+
+    public function testSetLViewKeepsNullAsNull(): void
+    {
+        $workspace = new DataObject();
+        $workspace->setLView(null);
+
+        self::assertNull($workspace->getLView());
+    }
+
+    public function testSetLEditKeepsNonEmptyValueUnchanged(): void
+    {
+        $workspace = new DataObject();
+        $workspace->setLEdit('en,de');
+
+        self::assertSame('en,de', $workspace->getLEdit());
+    }
+
+    public function testSetLViewKeepsNonEmptyValueUnchanged(): void
+    {
+        $workspace = new DataObject();
+        $workspace->setLView('en,de');
+
+        self::assertSame('en,de', $workspace->getLView());
+    }
+}


### PR DESCRIPTION
## Summary

An empty `lEdit`/`lView` value on `Pimcore\Model\User\Workspace\DataObject` is documented to mean "every language is allowed", the same as `NULL`. Some callers submit an empty string instead of `NULL` (e.g. a MultiSelect widget with nothing selected). Readers that only check for a strict `NULL` then treat that empty string as "no language allowed" instead of "all languages allowed", producing inconsistent behavior depending on which code path last wrote the value.

This normalizes the empty string to `NULL` in the `setLEdit()`/`setLView()` setters, so the "all languages allowed" contract holds regardless of which caller writes the value.

Related: https://github.com/pimcore/service-operations/issues/961

## Test plan

- [x] Added `tests/Unit/Models/User/Workspace/DataObjectTest.php` covering: empty string → `null`, `null` stays `null`, non-empty value passes through unchanged, for both `lEdit` and `lView`.
- [ ] CI (Codeception) — not run locally, will validate in CI.