### PR TITLE
PHPStan workflows: per-leg baseline artifacts and correct lowest-config baseline generation

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/codeception-12x.yaml
+++ b/.github/workflows/codeception-12x.yaml
@@ -9,12 +9,14 @@ on:
         paths-ignore:
             - 'doc/**'
             - 'bundles/**/public/**'
+            - '**.md'
     push:
         branches:
             - "12.*"
         paths-ignore:
             - 'doc/**'
             - 'bundles/**/public/**'
+            - '**.md'
 permissions:
   contents: read
 concurrency:

--- a/.github/workflows/codeception-12x.yaml
+++ b/.github/workflows/codeception-12x.yaml
@@ -11,12 +11,17 @@ on:
             - 'bundles/**/public/**'
     push:
         branches:
-            - "12.*"
+            - "[0-9]+.[0-9]+"
+            - "[0-9]+.x"
         paths-ignore:
             - 'doc/**'
             - 'bundles/**/public/**'
 permissions:
   contents: read
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+    cancel-in-progress: true
+
 jobs:
     codeception-tests:
         uses: pimcore/workflows-collection-public/.github/workflows/reusable-codeception-public.yaml@main

--- a/.github/workflows/codeception-12x.yaml
+++ b/.github/workflows/codeception-12x.yaml
@@ -11,15 +11,14 @@ on:
             - 'bundles/**/public/**'
     push:
         branches:
-            - "[0-9]+.[0-9]+"
-            - "[0-9]+.x"
+            - "12.*"
         paths-ignore:
             - 'doc/**'
             - 'bundles/**/public/**'
 permissions:
   contents: read
 concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codeception.yaml
+++ b/.github/workflows/codeception.yaml
@@ -13,7 +13,8 @@ on:
             - 'bundles/**/public/**'
     push:
         branches:
-            - "2026.*"
+            - "[0-9]+.[0-9]+"
+            - "[0-9]+.x"
             - "*_actions"
         paths-ignore:
             - 'doc/**'
@@ -21,6 +22,10 @@ on:
 permissions:
   contents: read
  
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+    cancel-in-progress: true
+
 jobs:
     codeception-tests:
         uses: pimcore/workflows-collection-public/.github/workflows/reusable-codeception-public.yaml@main

--- a/.github/workflows/codeception.yaml
+++ b/.github/workflows/codeception.yaml
@@ -13,8 +13,7 @@ on:
             - 'bundles/**/public/**'
     push:
         branches:
-            - "[0-9]+.[0-9]+"
-            - "[0-9]+.x"
+            - "2026.*"
             - "*_actions"
         paths-ignore:
             - 'doc/**'
@@ -23,7 +22,7 @@ permissions:
   contents: read
  
 concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codeception.yaml
+++ b/.github/workflows/codeception.yaml
@@ -11,6 +11,7 @@ on:
         paths-ignore:
             - 'doc/**'
             - 'bundles/**/public/**'
+            - '**.md'
     push:
         branches:
             - "2026.*"
@@ -18,6 +19,7 @@ on:
         paths-ignore:
             - 'doc/**'
             - 'bundles/**/public/**'   
+            - '**.md'
 permissions:
   contents: read
  

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -15,6 +15,7 @@ jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     permissions:
       contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,14 +1,14 @@
 name: "Documentation (Reusable)"
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - "[0-9]+.[0-9]+"
       - "[0-9]+.x"
       - "docs_actions"
     paths:
       - "doc/**"
-      - ".github/workflows/new-docs.yml"
+      - ".github/workflows/docs.yml"
       - "README.md"
   push:
     branches:
@@ -17,7 +17,7 @@ on:
       - "docs_actions"
     paths:
       - "doc/**"
-      - ".github/workflows/new-docs.yml"
+      - ".github/workflows/docs.yml"
       - "README.md"
 
 permissions:
@@ -28,5 +28,3 @@ jobs:
     uses: pimcore/workflows-collection-public/.github/workflows/reusable-docs.yaml@main
     with:
       docs_path: "doc"
-    secrets:
-      DOCS_GENERATOR_ACCESS_TOKEN: ${{ secrets.DOCS_GENERATOR_ACCESS_TOKEN }}

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -12,6 +12,7 @@ permissions:
 jobs:
     to_github:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         if: ${{ github.repository == 'pimcore/pimcore' }}
         steps:
             - uses: actions/checkout@v1

--- a/.github/workflows/monthly-recurring-issues.yml
+++ b/.github/workflows/monthly-recurring-issues.yml
@@ -8,6 +8,7 @@ jobs:
     monthly_recurring_issues:
         name: Monthly Recurring Issues
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         if: ${{ github.repository == 'pimcore/pimcore' }}
         steps:
 

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -3,13 +3,7 @@ name: "Psalm Static Analysis"
 
 on:
     pull_request:
-        branches:
-            - "[0-9]+.[0-9]+"
-            - "[0-9]+.x"
     push:
-        branches:
-            - "[0-9]+.[0-9]+"
-            - "[0-9]+.x"
             - "*_actions"
 
 jobs:

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -4,6 +4,10 @@ name: "Psalm Static Analysis"
 on:
     pull_request:
     push:
+            branches:
+            - "[0-9]+.[0-9]+"
+            - "[0-9]+.x"
+            - "*_actions"
             - "*_actions"
 
 jobs:

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -7,6 +7,10 @@ on:
             - "[0-9]+.[0-9]+"
             - "[0-9]+.x"
     push:
+        paths-ignore:
+            - 'doc/**'
+            - 'bundles/**/public/**'
+            - '**.md'
         branches:
             - "[0-9]+.[0-9]+"
             - "[0-9]+.x"

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -10,10 +10,15 @@ on:
             - "*_actions"
             - "*_actions"
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 jobs:
     psalm:
         name: Psalm
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         steps:
             - name: Checkout code
               uses: actions/checkout@v2

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -3,11 +3,13 @@ name: "Psalm Static Analysis"
 
 on:
     pull_request:
-    push:
-            branches:
+        branches:
             - "[0-9]+.[0-9]+"
             - "[0-9]+.x"
-            - "*_actions"
+    push:
+        branches:
+            - "[0-9]+.[0-9]+"
+            - "[0-9]+.x"
             - "*_actions"
 
 concurrency:

--- a/.github/workflows/pull-request-checklist.yaml
+++ b/.github/workflows/pull-request-checklist.yaml
@@ -11,6 +11,7 @@ permissions:
 jobs:
     comment:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         steps:
             - uses: actions/github-script@v6
               env:

--- a/.github/workflows/static-analyisis-12x.yaml
+++ b/.github/workflows/static-analyisis-12x.yaml
@@ -11,8 +11,7 @@ on:
             - 'bundles/**/public/**'
     push:
         branches:
-            - "[0-9]+.[0-9]+"
-            - "[0-9]+.x"
+            - "12.*"
         paths-ignore:
             - 'doc/**'
             - 'bundles/**/public/**'
@@ -30,7 +29,7 @@ permissions:
   contents: read
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/static-analyisis-12x.yaml
+++ b/.github/workflows/static-analyisis-12x.yaml
@@ -36,7 +36,7 @@ jobs:
     static-analysis-phpstan:
         name: "Static Analysis with PHPStan"
         runs-on: "ubuntu-22.04"
-        timeout-minutes: 30
+        timeout-minutes: 60
         continue-on-error: ${{ matrix.experimental }}
         strategy:
             matrix:

--- a/.github/workflows/static-analyisis-12x.yaml
+++ b/.github/workflows/static-analyisis-12x.yaml
@@ -36,7 +36,7 @@ jobs:
     static-analysis-phpstan:
         name: "Static Analysis with PHPStan"
         runs-on: "ubuntu-22.04"
-        timeout-minutes: 60
+        timeout-minutes: 30
         continue-on-error: ${{ matrix.experimental }}
         strategy:
             matrix:

--- a/.github/workflows/static-analyisis-12x.yaml
+++ b/.github/workflows/static-analyisis-12x.yaml
@@ -11,7 +11,8 @@ on:
             - 'bundles/**/public/**'
     push:
         branches:
-            - "12.*"
+            - "[0-9]+.[0-9]+"
+            - "[0-9]+.x"
         paths-ignore:
             - 'doc/**'
             - 'bundles/**/public/**'
@@ -28,10 +29,15 @@ env:
 permissions:
   contents: read
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+    cancel-in-progress: true
+
 jobs:
     static-analysis-phpstan:
         name: "Static Analysis with PHPStan"
         runs-on: "ubuntu-22.04"
+        timeout-minutes: 30
         continue-on-error: ${{ matrix.experimental }}
         strategy:
             matrix:

--- a/.github/workflows/static-analyisis-12x.yaml
+++ b/.github/workflows/static-analyisis-12x.yaml
@@ -89,13 +89,17 @@ jobs:
               if: ${{ matrix.dependencies == 'lowest' }}
               run: "vendor/bin/phpstan analyse --memory-limit=-1 -c phpstan-lowest.neon"
 
-            - name: "Generate baseline file"
-              if: ${{ failure() }}
+            - name: "Generate baseline file (highest)"
+              if: ${{ failure() && matrix.dependencies != 'lowest' }}
               run: "vendor/bin/phpstan analyse --memory-limit=-1 --generate-baseline"
+
+            - name: "Generate baseline file (lowest)"
+              if: ${{ failure() && matrix.dependencies == 'lowest' }}
+              run: "vendor/bin/phpstan analyse --memory-limit=-1 -c phpstan-lowest.neon --generate-baseline"
 
             - name: "Upload baseline file"
               if: ${{ failure() }}
               uses: actions/upload-artifact@v4
               with:
-                  name: phpstan-baseline.neon
+                  name: phpstan-baseline-${{ matrix.php-version }}-${{ matrix.dependencies }}
                   path: phpstan-baseline.neon

--- a/.github/workflows/static-analyisis-12x.yaml
+++ b/.github/workflows/static-analyisis-12x.yaml
@@ -9,12 +9,14 @@ on:
         paths-ignore:
             - 'doc/**'
             - 'bundles/**/public/**'
+            - '**.md'
     push:
         branches:
             - "12.*"
         paths-ignore:
             - 'doc/**'
             - 'bundles/**/public/**'
+            - '**.md'
 
 env:
     PIMCORE_INSTANCE_IDENTIFIER: ${{ secrets.PIMCORE_CI_INSTANCE_IDENTIFIER }}

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -13,7 +13,8 @@ on:
             - 'bundles/**/public/**'
     push:
         branches:
-            - "2026.*"
+            - "[0-9]+.[0-9]+"
+            - "[0-9]+.x"
             - "*_actions"
         paths-ignore:
             - 'doc/**'
@@ -31,10 +32,15 @@ env:
 permissions:
   contents: read
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+    cancel-in-progress: true
+
 jobs:
     static-analysis-phpstan:
         name: "Static Analysis with PHPStan"
         runs-on: "ubuntu-latest"
+        timeout-minutes: 30
         continue-on-error: ${{ matrix.experimental }}
         strategy:
             matrix:

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -87,13 +87,17 @@ jobs:
               if: ${{ matrix.dependencies == 'lowest' }}
               run: "vendor/bin/phpstan analyse --memory-limit=-1 -c phpstan-lowest.neon"
 
-            - name: "Generate baseline file"
-              if: ${{ failure() }}
+            - name: "Generate baseline file (highest)"
+              if: ${{ failure() && matrix.dependencies != 'lowest' }}
               run: "vendor/bin/phpstan analyse --memory-limit=-1 --generate-baseline"
+
+            - name: "Generate baseline file (lowest)"
+              if: ${{ failure() && matrix.dependencies == 'lowest' }}
+              run: "vendor/bin/phpstan analyse --memory-limit=-1 -c phpstan-lowest.neon --generate-baseline"
 
             - name: "Upload baseline file"
               if: ${{ failure() }}
               uses: actions/upload-artifact@v4
               with:
-                  name: phpstan-baseline.neon
+                  name: phpstan-baseline-${{ matrix.php-version }}-${{ matrix.dependencies }}
                   path: phpstan-baseline.neon

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -39,7 +39,7 @@ jobs:
     static-analysis-phpstan:
         name: "Static Analysis with PHPStan"
         runs-on: "ubuntu-latest"
-        timeout-minutes: 30
+        timeout-minutes: 60
         continue-on-error: ${{ matrix.experimental }}
         strategy:
             matrix:

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -13,8 +13,7 @@ on:
             - 'bundles/**/public/**'
     push:
         branches:
-            - "[0-9]+.[0-9]+"
-            - "[0-9]+.x"
+            - "2026.*"
             - "*_actions"
         paths-ignore:
             - 'doc/**'
@@ -33,7 +32,7 @@ permissions:
   contents: read
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -39,7 +39,7 @@ jobs:
     static-analysis-phpstan:
         name: "Static Analysis with PHPStan"
         runs-on: "ubuntu-latest"
-        timeout-minutes: 60
+        timeout-minutes: 30
         continue-on-error: ${{ matrix.experimental }}
         strategy:
             matrix:

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -11,6 +11,7 @@ on:
         paths-ignore:
             - 'doc/**'
             - 'bundles/**/public/**'
+            - '**.md'
     push:
         branches:
             - "2026.*"
@@ -18,6 +19,7 @@ on:
         paths-ignore:
             - 'doc/**'
             - 'bundles/**/public/**'
+            - '**.md'
 
 env:
     PIMCORE_INSTANCE_IDENTIFIER: ${{ secrets.PIMCORE_CI_INSTANCE_IDENTIFIER }}


### PR DESCRIPTION
Fixes pimcore/DevOps-Tasks#33 — both defects are diagnostic-only (no false pass/fail), confirmed in every copy:

1. **Baseline artifact name collision**: every matrix leg uploaded `phpstan-baseline.neon`; `upload-artifact@v4` artifacts are immutable, so when several legs fail in one run only the first upload survives — exactly the multi-leg case where comparing baselines matters. Now `phpstan-baseline-${{ matrix.php-version }}-${{ matrix.dependencies }}`, mirroring `reusable-static-analysis-unified`.
2. **`lowest` legs generated the baseline with the wrong config**: analyse ran `-c phpstan-lowest.neon`, generate re-ran with the default config. The generate step now mirrors the analyse conditional (`highest`/`lowest` variants).

Files on `2026.2`: `static-analysis.yaml`, `static-analyisis-12x.yaml`. `static-analysis-11x.yaml` exists only on `2026.x` and receives the same fix during the forward merge. EE `2026.2`/`2026.x` arrive via the nightly CE→EE sync; EE `11.5`/`12.3` are outside the sync and get direct PRs (per DevOps-Tasks#33 discussion).

Verification: YAML parses; both files diff only in the two steps; naming byte-matches the unified reusable's scheme.