### PR TITLE
[Telemetry] Platform collector: seats, install scale and real workflow usage

### DIFF
--- a/bundles/CoreBundle/config/services.yaml
+++ b/bundles/CoreBundle/config/services.yaml
@@ -344,6 +344,11 @@ services:
             $debugMode: '%kernel.debug%'
             $timezone: '%pimcore.telemetry.timezone%'
 
+    # seats, permission-model shape, database footprint, schema currency and workflow reach - the
+    # install-scale facts the legacy StatisticsManager carried in its `tables` payload, without the
+    # per-class table names that made that payload unsendable
+    Pimcore\Telemetry\Snapshot\PlatformCollector: ~
+
     # evidence for EM question #1 - which pillars (DAM/PIM/MDM/DXP/Commerce) are actually used
     Pimcore\Telemetry\Snapshot\PillarUsageCollector: ~
 

--- a/lib/Telemetry/Snapshot/CatalogShapeCollector.php
+++ b/lib/Telemetry/Snapshot/CatalogShapeCollector.php
@@ -13,8 +13,11 @@ declare(strict_types=1);
 
 namespace Pimcore\Telemetry\Snapshot;
 
+use Exception;
 use Pimcore\Telemetry\Snapshot\Statistics\ElementKind;
 use Pimcore\Telemetry\Snapshot\Statistics\ElementStatisticsProviderInterface;
+use function array_filter;
+use function is_numeric;
 
 /**
  * Evidence for "what is the shape of the managed catalog/content landscape?" (EM question #3).
@@ -44,6 +47,7 @@ final readonly class CatalogShapeCollector implements SnapshotCollectorInterface
 
     public function __construct(
         private ElementStatisticsProviderInterface $statistics,
+        private SnapshotQueryRunner $queryRunner,
     ) {
     }
 
@@ -56,7 +60,7 @@ final readonly class CatalogShapeCollector implements SnapshotCollectorInterface
     {
         $objectDepth = $this->statistics->treeDepth(ElementKind::DataObject);
 
-        return [
+        $metrics = [
             'schema_version' => self::SCHEMA_VERSION,
 
             // Tree shape - how deep each element hierarchy goes.
@@ -71,6 +75,35 @@ final readonly class CatalogShapeCollector implements SnapshotCollectorInterface
 
             // Organization shape.
             'max_folder_fanout' => $this->statistics->maxObjectFanout(),
+
+            // Content richness - how hard the content is worked, as opposed to how much of it exists.
+            // All fixed-name tables; a failed count omits its key rather than reporting nothing there.
+            'asset_metadata_count' => $this->count('assets_metadata'),
+            'document_editable_count' => $this->count('documents_editables'),
+            'property_count' => $this->count('properties'),
+            'tag_count' => $this->count('tags'),
+            'tag_assignment_count' => $this->count('tags_assignment'),
+            'note_count' => $this->count('notes'),
+            'object_url_slug_count' => $this->count('object_url_slugs'),
         ];
+
+        return array_filter($metrics, static fn (mixed $value): bool => $value !== null);
+    }
+
+    /**
+     * @return int|null null when the count could not be obtained (timeout, driver error), which omits
+     *                  the key rather than reporting the capability as unused
+     */
+    private function count(string $table): ?int
+    {
+        try {
+            $value = $this->queryRunner->fetchOne(
+                'SELECT COUNT(*) FROM ' . $this->queryRunner->quoteIdentifier($table)
+            );
+
+            return is_numeric($value) ? (int)$value : null;
+        } catch (Exception) {
+            return null;
+        }
     }
 }

--- a/lib/Telemetry/Snapshot/PillarUsageCollector.php
+++ b/lib/Telemetry/Snapshot/PillarUsageCollector.php
@@ -89,6 +89,10 @@ final readonly class PillarUsageCollector implements SnapshotCollectorInterface
             'document_email_count' => $documents->ofType('email'),
             'document_link_count' => $documents->ofType('link'),
             'document_total_count' => $documents->total(),
+            // Exact count of Site entities. The legacy StatisticsManager appeared to disagree here -
+            // it reported `sites: 0` alongside a non-empty `sites_domains` - but its table rows came
+            // from information_schema.TABLE_ROWS, an InnoDB estimate that commonly reads 0 for small
+            // tables. The estimate was wrong; this count is not.
             'site_count' => $this->count('sites'),
             'seo_bundle_active' => $this->activeBundles->has('Seo'),
             'personalization_bundle_active' => $this->activeBundles->has('Personalization'),

--- a/lib/Telemetry/Snapshot/PlatformCollector.php
+++ b/lib/Telemetry/Snapshot/PlatformCollector.php
@@ -1,0 +1,170 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Telemetry\Snapshot;
+
+use Exception;
+use Pimcore\Workflow\Manager;
+use function array_filter;
+use function count;
+use function is_numeric;
+
+/**
+ * How large this installation is and how it is run: seats, permission-model shape, database footprint,
+ * schema currency, operational volume, and workflow reach.
+ *
+ * Complements the content collectors - {@see PillarUsageCollector} counts what is managed, this counts
+ * who manages it and what it costs to host.
+ *
+ * Every figure is a count over a FIXED-NAME table. Nothing here enumerates table names: the database
+ * footprint is a single SUM over information_schema, so only the aggregate leaves the server. That is
+ * the line the legacy StatisticsManager crossed - half of its `tables` payload was per-class tables
+ * whose names embed the customer's own class, brick and fieldcollection names.
+ *
+ * @internal
+ */
+final readonly class PlatformCollector implements SnapshotCollectorInterface
+{
+    private const SCHEMA_VERSION = 1;
+
+    public function __construct(
+        private SnapshotQueryRunner $queryRunner,
+        private Manager $workflowManager,
+    ) {
+    }
+
+    public function getNamespace(): string
+    {
+        return 'platform';
+    }
+
+    public function collect(): array
+    {
+        $metrics = [
+            'schema_version' => self::SCHEMA_VERSION,
+
+            // Seats. The users table also holds roles and folders (`type` enum), so every seat figure
+            // is filtered - an unfiltered count would report the permission model as licensed users.
+            'user_count' => $this->count('users', "type = 'user'"),
+            'active_user_count' => $this->count('users', "type = 'user' AND active = 1"),
+            'admin_user_count' => $this->count('users', "type = 'user' AND admin = 1"),
+            'role_count' => $this->count('users', "type = 'role'"),
+
+            // Permission-model shape.
+            'permission_definition_count' => $this->count('users_permission_definitions'),
+            'object_workspace_count' => $this->count('users_workspaces_object'),
+            'asset_workspace_count' => $this->count('users_workspaces_asset'),
+            'document_workspace_count' => $this->count('users_workspaces_document'),
+
+            // Hosting footprint.
+            'database_size_mb' => $this->databaseSizeMb(),
+            'database_table_count' => $this->tableCount(),
+
+            // Schema currency - an install can run a stale schema behind a current package version.
+            'applied_migration_count' => $this->count('migration_versions'),
+
+            // Unbounded operational tables. These are the most likely to exceed the statement timeout;
+            // when they do the key is omitted, which reads as "too large to count in budget" rather
+            // than as a small install. An information_schema row estimate is not acceptable at raw
+            // precision - that is exactly what was removed when bucketing went.
+            'version_count' => $this->count('versions'),
+            'dependency_count' => $this->count('dependencies'),
+            'search_index_entry_count' => $this->count('search_backend_data'),
+
+            // Recycle bin. Both figures are needed: one entry can hold an entire subtree, so the row
+            // count alone understates what is actually retained - and it is the element total that
+            // drives the storage cost, since each entry keeps serialised data (and asset binaries).
+            // A recycle bin that is never emptied is a real hygiene and support signal.
+            // `path` and `deletedby` are customer content and are deliberately never read.
+            'recyclebin_item_count' => $this->count('recyclebin'),
+            'recyclebin_element_count' => $this->recyclebinElementCount(),
+
+            // Workflow reach. Names are deliberately absent: `element_workflow_state.workflow` holds
+            // customer-defined workflow names, so only the DISTINCT count is emitted.
+            'workflow_configured_count' => $this->workflowCount(),
+            'workflow_active_element_count' => $this->count('element_workflow_state'),
+            'workflow_distinct_in_use_count' => $this->fetchCount(
+                'SELECT COUNT(DISTINCT workflow) FROM '
+                . $this->queryRunner->quoteIdentifier('element_workflow_state')
+            ),
+        ];
+
+        // Unknown is not zero: a timed-out or failed count omits its key rather than claiming the
+        // install has no seats.
+        return array_filter($metrics, static fn (mixed $value): bool => $value !== null);
+    }
+
+    /**
+     * @return int|null null when the count could not be obtained (timeout, driver error)
+     */
+    private function count(string $table, ?string $where = null): ?int
+    {
+        $sql = 'SELECT COUNT(*) FROM ' . $this->queryRunner->quoteIdentifier($table);
+        if ($where !== null) {
+            $sql .= ' WHERE ' . $where;
+        }
+
+        return $this->fetchCount($sql);
+    }
+
+    /**
+     * Elements pending purge, not entries. COALESCE matters: SUM() over an empty table returns NULL,
+     * which would omit the key and read as "unknown" when the truth is an empty recycle bin.
+     */
+    private function recyclebinElementCount(): ?int
+    {
+        return $this->fetchCount(
+            'SELECT COALESCE(SUM(amount), 0) FROM ' . $this->queryRunner->quoteIdentifier('recyclebin')
+        );
+    }
+
+    /**
+     * Aggregate only. Deliberately selects no TABLE_NAME - see the class docblock.
+     */
+    private function databaseSizeMb(): ?int
+    {
+        $bytes = $this->fetchCount(
+            'SELECT SUM(data_length + index_length) FROM information_schema.TABLES'
+            . ' WHERE TABLE_SCHEMA = DATABASE()'
+        );
+
+        return $bytes === null ? null : (int)round($bytes / 1024 / 1024);
+    }
+
+    private function tableCount(): ?int
+    {
+        return $this->fetchCount(
+            'SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE()'
+        );
+    }
+
+    private function workflowCount(): ?int
+    {
+        try {
+            return count($this->workflowManager->getAllWorkflows());
+        } catch (Exception) {
+            return null;
+        }
+    }
+
+    private function fetchCount(string $sql): ?int
+    {
+        try {
+            $value = $this->queryRunner->fetchOne($sql);
+
+            return is_numeric($value) ? (int)$value : null;
+        } catch (Exception) {
+            return null;
+        }
+    }
+}

--- a/lib/Telemetry/Snapshot/PlatformCollector.php
+++ b/lib/Telemetry/Snapshot/PlatformCollector.php
@@ -89,15 +89,19 @@ final readonly class PlatformCollector implements SnapshotCollectorInterface
             'recyclebin_item_count' => $this->count('recyclebin'),
             'recyclebin_element_count' => $this->recyclebinElementCount(),
 
-            // Workflow reach. Names are deliberately absent: `element_workflow_state.workflow` holds
-            // customer-defined workflow names, so only the DISTINCT count is emitted.
-            'workflow_configured_count' => $this->workflowCount(),
-            'workflow_active_element_count' => $this->count('element_workflow_state'),
-            'workflow_distinct_in_use_count' => $this->fetchCount(
-                'SELECT COUNT(DISTINCT workflow) FROM '
-                . $this->queryRunner->quoteIdentifier('element_workflow_state')
-            ),
         ];
+
+        // Workflow reach, appended separately so the state table is only queried when at least one
+        // workflow is configured - PHP would otherwise evaluate both counts regardless, making every
+        // workflow-free install pay for two scans. Names are deliberately absent:
+        // `element_workflow_state.workflow` holds customer-defined names, so only the DISTINCT count
+        // is emitted.
+        //
+        // Both counts are unscoped on purpose. Rows can outlive the workflow that wrote them, so
+        // comparing them against `workflow_configured_count` is itself the signal for leftover state -
+        // scoping them would hide exactly that. `usage.workflow` does scope, because there the answer
+        // is a single boolean that must not claim use which is no longer possible.
+        $metrics += $this->workflowMetrics();
 
         // Unknown is not zero: a timed-out or failed count omits its key rather than claiming the
         // install has no seats.
@@ -148,13 +152,33 @@ final readonly class PlatformCollector implements SnapshotCollectorInterface
         );
     }
 
-    private function workflowCount(): ?int
+    /**
+     * The state table is skipped only when the configured count is known to be zero. An unavailable
+     * manager is unknown rather than zero, and the state counts stand on their own as evidence, so
+     * they are still collected in that case - just without a configured count to compare them to.
+     *
+     * @return array<string, int|null>
+     */
+    private function workflowMetrics(): array
     {
         try {
-            return count($this->workflowManager->getAllWorkflows());
+            $configured = count($this->workflowManager->getAllWorkflows());
         } catch (Exception) {
-            return null;
+            $configured = null;
         }
+
+        if ($configured === 0) {
+            return ['workflow_configured_count' => 0];
+        }
+
+        return [
+            'workflow_configured_count' => $configured,
+            'workflow_active_element_count' => $this->count('element_workflow_state'),
+            'workflow_distinct_in_use_count' => $this->fetchCount(
+                'SELECT COUNT(DISTINCT workflow) FROM '
+                . $this->queryRunner->quoteIdentifier('element_workflow_state')
+            ),
+        ];
     }
 
     private function fetchCount(string $sql): ?int

--- a/lib/Telemetry/Usage/WorkflowUsageProvider.php
+++ b/lib/Telemetry/Usage/WorkflowUsageProvider.php
@@ -16,28 +16,42 @@ namespace Pimcore\Telemetry\Usage;
 use Exception;
 use Pimcore\Telemetry\Snapshot\SnapshotQueryRunner;
 use Pimcore\Workflow\Manager;
+use function count;
+use function implode;
 use function is_numeric;
+use function array_fill;
 
 /**
  * Reference {@see BundleUsageProviderInterface} for a core capability: workflows are "used" when at
- * least one element actually sits in a workflow state - not merely when a workflow is configured.
+ * least one element has actually been moved through one - not merely when a workflow is configured.
  *
- * That distinction is the whole point of this namespace. A workflow defined in config that no element
- * has ever entered is exactly the shelfware `usage.*` exists to surface, and counting it as used would
- * report an adoption success where there is none. {@see PlatformCollector} emits the two counts side by
- * side (`workflow_configured_count` vs `workflow_active_element_count`) so the gap is visible.
+ * A workflow defined in config that no element has ever entered is exactly the shelfware `usage.*`
+ * exists to surface, and counting it as used would report an adoption success where there is none.
+ * {@see \Pimcore\Telemetry\Snapshot\PlatformCollector} emits the counts side by side so the gap shows.
  *
- * Purely structural and content-never: a boolean derived from a row count. It self-resets - archiving
- * the last in-flight element flips it back - so the capability owns the definition of "used".
+ * **Only some workflows are observable.** Pimcore supports five marking stores, and just `state_table`
+ * persists into `element_workflow_state`; `single_state`, `multiple_state`,
+ * `data_object_multiple_state` and `data_object_splitted_state` all keep the marking on the subject
+ * itself, where no aggregate query can reach it. Reporting `false` for those would invent an adoption
+ * gap for a workflow that is being exercised heavily, so anything not explicitly `state_table` counts
+ * as unobservable and yields `null` (unknown) in the absence of positive evidence. Erring toward
+ * unknown is deliberate: a false "not used" is the one answer this namespace must never give.
  *
- * Also the reference for the null case: if neither the workflow manager nor the state table can be
- * consulted we do not know whether workflows are in use, and saying `false` there would be a
- * fabricated adoption gap.
+ * The state-table query is scoped to the currently configured workflows, so rows left behind by a
+ * workflow that has since been removed cannot report use that is no longer possible.
+ *
+ * Content-never: a boolean derived from a row count. Workflow names are used only as query parameters
+ * and are never emitted.
  *
  * @internal
  */
 final readonly class WorkflowUsageProvider implements BundleUsageProviderInterface
 {
+    /**
+     * The one marking store whose state lands in `element_workflow_state`.
+     */
+    private const OBSERVABLE_MARKING_STORE = 'state_table';
+
     public function __construct(
         private Manager $workflowManager,
         private SnapshotQueryRunner $queryRunner,
@@ -52,28 +66,73 @@ final readonly class WorkflowUsageProvider implements BundleUsageProviderInterfa
     public function isUsed(): ?bool
     {
         try {
-            if ($this->workflowManager->getAllWorkflows() === []) {
-                // Nothing configured, so there is nothing to exercise - no need to touch the state
-                // table, and an empty state table here would be unused rather than unknown anyway.
-                return false;
-            }
+            $configured = $this->workflowManager->getAllWorkflows();
         } catch (Exception) {
             return null;
         }
 
-        $inWorkflow = $this->activeElementCount();
+        if ($configured === []) {
+            // Nothing configured, so nothing to exercise. The state table is not touched - the
+            // majority of installs run no workflows at all and should pay nothing for this metric.
+            return false;
+        }
 
-        return $inWorkflow === null ? null : $inWorkflow > 0;
+        $observable = $this->observableWorkflows($configured);
+
+        if ($observable !== []) {
+            $inWorkflow = $this->activeElementCount($observable);
+
+            if ($inWorkflow === null) {
+                return null;
+            }
+
+            if ($inWorkflow > 0) {
+                return true;
+            }
+        }
+
+        // No positive evidence. If every configured workflow is observable, the empty state table is a
+        // real "configured but never exercised". If any is not, we simply cannot see it - unknown.
+        return count($observable) === count($configured) ? false : null;
     }
 
     /**
-     * @return int|null null when the state table could not be read - unknown, not unused
+     * @param  list<string> $configured
+     * @return list<string> those whose marking is readable from `element_workflow_state`
      */
-    private function activeElementCount(): ?int
+    private function observableWorkflows(array $configured): array
     {
+        $observable = [];
+
+        foreach ($configured as $name) {
+            try {
+                $config = $this->workflowManager->getWorkflowConfig($name)->getWorkflowConfigArray();
+            } catch (Exception) {
+                // Cannot classify it, so cannot claim to observe it.
+                continue;
+            }
+
+            if (($config['marking_store']['type'] ?? null) === self::OBSERVABLE_MARKING_STORE) {
+                $observable[] = $name;
+            }
+        }
+
+        return $observable;
+    }
+
+    /**
+     * @param  list<string> $workflows scoped to these, so rows from removed workflows do not count
+     * @return int|null     null when the state table could not be read - unknown, not unused
+     */
+    private function activeElementCount(array $workflows): ?int
+    {
+        $placeholders = implode(', ', array_fill(0, count($workflows), '?'));
+
         try {
             $count = $this->queryRunner->fetchOne(
                 'SELECT COUNT(*) FROM ' . $this->queryRunner->quoteIdentifier('element_workflow_state')
+                . ' WHERE workflow IN (' . $placeholders . ')',
+                $workflows
             );
 
             return is_numeric($count) ? (int)$count : null;

--- a/lib/Telemetry/Usage/WorkflowUsageProvider.php
+++ b/lib/Telemetry/Usage/WorkflowUsageProvider.php
@@ -14,16 +14,25 @@ declare(strict_types=1);
 namespace Pimcore\Telemetry\Usage;
 
 use Exception;
+use Pimcore\Telemetry\Snapshot\SnapshotQueryRunner;
 use Pimcore\Workflow\Manager;
+use function is_numeric;
 
 /**
  * Reference {@see BundleUsageProviderInterface} for a core capability: workflows are "used" when at
- * least one workflow is configured. Purely structural and content-never (a boolean derived from the
- * count) - it self-resets to false if all workflows are removed, so the bundle/capability owns the
- * definition of "used". Bundles (Data Hub, Portal Engine, …) add their own provider the same way.
+ * least one element actually sits in a workflow state - not merely when a workflow is configured.
  *
- * Also the reference for the null case: if the workflow manager cannot be consulted we do not know
- * whether workflows are in use, and saying `false` there would be a fabricated adoption gap.
+ * That distinction is the whole point of this namespace. A workflow defined in config that no element
+ * has ever entered is exactly the shelfware `usage.*` exists to surface, and counting it as used would
+ * report an adoption success where there is none. {@see PlatformCollector} emits the two counts side by
+ * side (`workflow_configured_count` vs `workflow_active_element_count`) so the gap is visible.
+ *
+ * Purely structural and content-never: a boolean derived from a row count. It self-resets - archiving
+ * the last in-flight element flips it back - so the capability owns the definition of "used".
+ *
+ * Also the reference for the null case: if neither the workflow manager nor the state table can be
+ * consulted we do not know whether workflows are in use, and saying `false` there would be a
+ * fabricated adoption gap.
  *
  * @internal
  */
@@ -31,6 +40,7 @@ final readonly class WorkflowUsageProvider implements BundleUsageProviderInterfa
 {
     public function __construct(
         private Manager $workflowManager,
+        private SnapshotQueryRunner $queryRunner,
     ) {
     }
 
@@ -42,7 +52,31 @@ final readonly class WorkflowUsageProvider implements BundleUsageProviderInterfa
     public function isUsed(): ?bool
     {
         try {
-            return $this->workflowManager->getAllWorkflows() !== [];
+            if ($this->workflowManager->getAllWorkflows() === []) {
+                // Nothing configured, so there is nothing to exercise - no need to touch the state
+                // table, and an empty state table here would be unused rather than unknown anyway.
+                return false;
+            }
+        } catch (Exception) {
+            return null;
+        }
+
+        $inWorkflow = $this->activeElementCount();
+
+        return $inWorkflow === null ? null : $inWorkflow > 0;
+    }
+
+    /**
+     * @return int|null null when the state table could not be read - unknown, not unused
+     */
+    private function activeElementCount(): ?int
+    {
+        try {
+            $count = $this->queryRunner->fetchOne(
+                'SELECT COUNT(*) FROM ' . $this->queryRunner->quoteIdentifier('element_workflow_state')
+            );
+
+            return is_numeric($count) ? (int)$count : null;
         } catch (Exception) {
             return null;
         }

--- a/tests/Unit/Telemetry/CatalogShapeCollectorTest.php
+++ b/tests/Unit/Telemetry/CatalogShapeCollectorTest.php
@@ -14,14 +14,25 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Unit\Telemetry;
 
+use Doctrine\DBAL\Connection;
 use Pimcore\Telemetry\Snapshot\CatalogShapeCollector;
+use Pimcore\Telemetry\Snapshot\SnapshotQueryRunner;
 use Pimcore\Telemetry\Snapshot\Statistics\ElementKind;
 use Pimcore\Telemetry\Snapshot\Statistics\ElementStatisticsProviderInterface;
 use Pimcore\Telemetry\Snapshot\Statistics\TreeDepth;
 use Pimcore\Tests\Support\Test\TestCase;
+use RuntimeException;
+use function preg_match;
+use function preg_quote;
+use function str_contains;
 
 class CatalogShapeCollectorTest extends TestCase
 {
+    /**
+     * @var list<string>
+     */
+    private array $executedSql = [];
+
     public function testNamespaceIsCatalog(): void
     {
         $this->assertSame('catalog', $this->collector()->getNamespace());
@@ -57,8 +68,65 @@ class CatalogShapeCollectorTest extends TestCase
         $this->assertArrayNotHasKey('products_with_variants_bucket', $metrics);
     }
 
-    private function collector(): CatalogShapeCollector
+    /**
+     * Volume says how much content exists; these say how hard it is being worked. 2,624 metadata rows
+     * over 368 assets is a real DAM discipline, not a file dump - a distinction asset_count cannot make.
+     */
+    public function testReportsContentRichness(): void
     {
+        $metrics = $this->collector()->collect();
+
+        $this->assertSame(2_624, $metrics['asset_metadata_count']);
+        $this->assertSame(1_329, $metrics['document_editable_count']);
+        $this->assertSame(593, $metrics['property_count']);
+        $this->assertSame(23, $metrics['tag_count']);
+        $this->assertSame(506, $metrics['tag_assignment_count']);
+        $this->assertSame(229, $metrics['note_count']);
+        $this->assertSame(4, $metrics['object_url_slug_count']);
+    }
+
+    public function testAFailedRichnessCountIsOmittedRatherThanZeroed(): void
+    {
+        $metrics = $this->collector(failFor: 'tags_assignment')->collect();
+
+        $this->assertArrayNotHasKey('tag_assignment_count', $metrics);
+        $this->assertArrayHasKey('tag_count', $metrics, 'unrelated counts must survive');
+    }
+
+    private function collector(?string $failFor = null): CatalogShapeCollector
+    {
+        $this->executedSql = [];
+
+        $counts = [
+            'assets_metadata'    => 2_624,
+            'documents_editables' => 1_329,
+            'properties'         => 593,
+            'tags_assignment'    => 506,
+            'notes'              => 229,
+            'tags'               => 23,
+            'object_url_slugs'   => 4,
+        ];
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('quoteIdentifier')->willReturnArgument(0);
+        $connection->method('fetchOne')->willReturnCallback(
+            function (string $sql) use ($counts, $failFor): int {
+                $this->executedSql[] = $sql;
+
+                if ($failFor !== null && str_contains($sql, $failFor)) {
+                    throw new RuntimeException('max_statement_time exceeded');
+                }
+
+                foreach ($counts as $table => $value) {
+                    if (preg_match('/\bFROM ' . preg_quote($table, '/') . '\b/', $sql) === 1) {
+                        return $value;
+                    }
+                }
+
+                return 0;
+            }
+        );
+
         $statistics = $this->createMock(ElementStatisticsProviderInterface::class);
         $statistics->method('treeDepth')->willReturnCallback(
             static fn (ElementKind $kind): TreeDepth => match ($kind) {
@@ -71,6 +139,6 @@ class CatalogShapeCollectorTest extends TestCase
         $statistics->method('maxVariantsPerObject')->willReturn(7);
         $statistics->method('maxObjectFanout')->willReturn(43);
 
-        return new CatalogShapeCollector($statistics);
+        return new CatalogShapeCollector($statistics, new SnapshotQueryRunner($connection, 0));
     }
 }

--- a/tests/Unit/Telemetry/PlatformCollectorTest.php
+++ b/tests/Unit/Telemetry/PlatformCollectorTest.php
@@ -1,0 +1,372 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Telemetry;
+
+use Doctrine\DBAL\Connection;
+use Pimcore\Telemetry\Snapshot\PlatformCollector;
+use Pimcore\Telemetry\Snapshot\SnapshotQueryRunner;
+use Pimcore\Tests\Support\Test\TestCase;
+use Pimcore\Workflow\Manager;
+use RuntimeException;
+use function array_filter;
+use function is_string;
+use function preg_match;
+use function preg_quote;
+use function str_contains;
+
+class PlatformCollectorTest extends TestCase
+{
+    /**
+     * @var list<string>
+     */
+    private array $executedSql = [];
+
+    public function testNamespaceIsPlatform(): void
+    {
+        $this->assertSame('platform', $this->collector()->getNamespace());
+    }
+
+    /**
+     * Seats are the headline metric. The users table also stores roles and folders, so an unfiltered
+     * COUNT(*) would inflate the seat count by the entire permission model - here 10 users would read
+     * as 18. The type filter is the whole point of this metric.
+     */
+    public function testSeatCountsExcludeRolesAndFolders(): void
+    {
+        $metrics = $this->collector()->collect();
+
+        $this->assertSame(10, $metrics['user_count']);
+        $this->assertSame(8, $metrics['active_user_count']);
+        $this->assertSame(2, $metrics['admin_user_count']);
+        $this->assertSame(6, $metrics['role_count']);
+    }
+
+    /**
+     * Every seat query must be scoped by type. A regression that dropped the filter would still return
+     * a plausible integer, so assert on the SQL rather than only on the value.
+     */
+    public function testEverySeatQueryIsScopedByUserType(): void
+    {
+        $this->collector()->collect();
+
+        $seatQueries = 0;
+        foreach ($this->executedSql as $sql) {
+            if (!str_contains($sql, 'FROM users') || str_contains($sql, 'users_')) {
+                continue;
+            }
+            $seatQueries++;
+            $this->assertStringContainsString('type = ', $sql, "unscoped count over the users table: $sql");
+        }
+
+        $this->assertSame(4, $seatQueries, 'expected user/active/admin/role counts');
+    }
+
+    public function testReportsThePermissionModelShape(): void
+    {
+        $metrics = $this->collector()->collect();
+
+        $this->assertSame(106, $metrics['permission_definition_count']);
+        $this->assertSame(3, $metrics['object_workspace_count']);
+        $this->assertSame(3, $metrics['asset_workspace_count']);
+        $this->assertSame(0, $metrics['document_workspace_count']);
+    }
+
+    /**
+     * Database size is an aggregate over information_schema. Only the SUM leaves the server - never a
+     * table name, which is exactly what made the legacy `tables` payload unsendable.
+     */
+    public function testReportsDatabaseSizeAndTableCountWithoutNamingTables(): void
+    {
+        $metrics = $this->collector()->collect();
+
+        $this->assertSame(25, $metrics['database_size_mb']);
+        $this->assertSame(297, $metrics['database_table_count']);
+
+        foreach ($this->executedSql as $sql) {
+            if (!str_contains($sql, 'information_schema')) {
+                continue;
+            }
+            $this->assertStringNotContainsString('TABLE_NAME', $sql, 'must not select table names');
+        }
+    }
+
+    /**
+     * Schema currency, independent of the composer version string: an install can run an old schema
+     * with a current package.
+     */
+    public function testReportsAppliedMigrationCount(): void
+    {
+        $this->assertSame(185, $this->collector()->collect()['applied_migration_count']);
+    }
+
+    /**
+     * Versioning volume and relation-graph density are the two biggest storage drivers on a mature
+     * install and neither was collected before.
+     */
+    public function testReportsOperationalVolume(): void
+    {
+        $metrics = $this->collector(overrides: [
+            'versions' => 412_004,
+            'dependencies' => 2_910,
+            'search_backend_data' => 1_304,
+        ])->collect();
+
+        $this->assertSame(412_004, $metrics['version_count']);
+        $this->assertSame(2_910, $metrics['dependency_count']);
+        $this->assertSame(1_304, $metrics['search_index_entry_count']);
+    }
+
+    /**
+     * These are the counts most likely to hit the statement timeout, because they are unbounded. An
+     * absent key says "too large to count in budget", which is information; a wrong integer is not.
+     * Losing one must not cost the others.
+     */
+    public function testATimedOutVolumeCountIsOmittedWithoutLosingTheRest(): void
+    {
+        $metrics = $this->collector(failFor: 'versions')->collect();
+
+        $this->assertArrayNotHasKey('version_count', $metrics);
+        $this->assertArrayHasKey('dependency_count', $metrics);
+        $this->assertArrayHasKey('user_count', $metrics);
+    }
+
+    /**
+     * Workflow reach: how many are defined versus how many elements actually sit in one.
+     */
+    public function testReportsWorkflowReach(): void
+    {
+        $metrics = $this->collector(
+            workflows: ['product_approval', 'asset_review'],
+            overrides: ['element_workflow_state' => 51]
+        )->collect();
+
+        $this->assertSame(2, $metrics['workflow_configured_count']);
+        $this->assertSame(51, $metrics['workflow_active_element_count']);
+        $this->assertSame(1, $metrics['workflow_distinct_in_use_count']);
+    }
+
+    /**
+     * `element_workflow_state.workflow` holds customer-chosen workflow names, so only the DISTINCT
+     * count may be emitted. Nothing in this namespace may be a string.
+     */
+    public function testNoWorkflowNameCanLeak(): void
+    {
+        $metrics = $this->collector(workflows: ['secret_project_gate'])->collect();
+
+        foreach ($metrics as $key => $value) {
+            $this->assertIsInt($value, "metric '$key' must be an int");
+        }
+
+        foreach ($this->executedSql as $sql) {
+            $this->assertStringNotContainsString('secret_project_gate', $sql);
+        }
+    }
+
+    /**
+     * Every count is an exact integer - no buckets, no estimates.
+     */
+    public function testEveryMetricIsAnIntegerAndNoneIsABucket(): void
+    {
+        foreach ($this->collector()->collect() as $key => $value) {
+            $this->assertIsInt($value, "metric '$key' must be an int");
+            $this->assertStringNotContainsString('_bucket', (string)$key);
+            $this->assertFalse(is_string($value));
+        }
+    }
+
+    /**
+     * A query that fails must omit its key, never report 0 - the same unknown-is-not-zero rule the
+     * usage.* namespace follows. Reporting an install as having zero seats would be worse than silence.
+     */
+    public function testAFailedQueryOmitsItsKeyRatherThanReportingZero(): void
+    {
+        $metrics = $this->collector(failFor: 'users')->collect();
+
+        $this->assertArrayNotHasKey('user_count', $metrics);
+        $this->assertArrayNotHasKey('active_user_count', $metrics);
+        $this->assertArrayHasKey('applied_migration_count', $metrics, 'unrelated metrics must survive');
+    }
+
+    /**
+     * A table that genuinely holds nothing still reports 0 - the fallback has to distinguish
+     * "could not count" from "counted zero".
+     */
+    public function testAGenuinelyEmptyTableStillReportsZero(): void
+    {
+        $metrics = $this->collector(overrides: ['users_workspaces_object' => 0])->collect();
+
+        $this->assertSame(0, $metrics['object_workspace_count']);
+    }
+
+    /**
+     * An unavailable workflow manager is unknown, not "no workflows".
+     */
+    public function testAnUnavailableWorkflowManagerOmitsTheConfiguredCount(): void
+    {
+        $metrics = $this->collector(failWorkflowManager: true)->collect();
+
+        $this->assertArrayNotHasKey('workflow_configured_count', $metrics);
+        $this->assertArrayHasKey('workflow_active_element_count', $metrics);
+    }
+
+    /**
+     * Both recycle-bin figures are needed. One entry can hold an entire subtree, so entries alone
+     * understate what is retained - and it is the element total that drives the storage cost, since
+     * every entry keeps serialised data behind it.
+     */
+    public function testReportsRecyclebinEntriesAndElementsSeparately(): void
+    {
+        $metrics = $this->collector(overrides: ['recyclebin' => 12])->collect();
+
+        $this->assertSame(12, $metrics['recyclebin_item_count']);
+        $this->assertSame(84, $metrics['recyclebin_element_count']);
+        $this->assertGreaterThan(
+            $metrics['recyclebin_item_count'],
+            $metrics['recyclebin_element_count'],
+            'entries must not be conflated with elements'
+        );
+    }
+
+    /**
+     * MySQL's SUM() returns NULL over an empty table, and the collector's null-filter would then drop
+     * the key - reporting an emptied recycle bin as "unknown" instead of as zero. COALESCE is the only
+     * thing preventing that, and the behaviour lives in the database, so assert on the SQL: a mock
+     * cannot distinguish "COALESCE worked" from "COALESCE is missing".
+     */
+    public function testTheRecyclebinElementSumIsCoalescedSoAnEmptyBinReadsAsZero(): void
+    {
+        $this->collector()->collect();
+
+        $sumQueries = array_filter($this->executedSql, static fn (string $sql): bool => str_contains($sql, 'SUM(amount)'));
+
+        $this->assertCount(1, $sumQueries, 'expected exactly one recycle-bin element sum');
+        foreach ($sumQueries as $sql) {
+            $this->assertStringContainsString('COALESCE(SUM(amount), 0)', $sql);
+        }
+    }
+
+    /**
+     * `recyclebin.path` holds the deleted element's path and `deletedby` a username - both customer
+     * content. Neither column may be read.
+     */
+    public function testTheRecyclebinPathAndDeletedByAreNeverRead(): void
+    {
+        $this->collector(overrides: ['recyclebin' => 5])->collect();
+
+        foreach ($this->executedSql as $sql) {
+            if (!str_contains($sql, 'recyclebin')) {
+                continue;
+            }
+            $this->assertStringNotContainsString('path', $sql);
+            $this->assertStringNotContainsString('deletedby', $sql);
+        }
+    }
+
+    /**
+     * @param array<string, int> $overrides replacement counts, by table
+     * @param list<string>       $workflows configured workflow names
+     */
+    private function collector(
+        ?string $failFor = null,
+        array $overrides = [],
+        array $workflows = ['product_approval'],
+        bool $failWorkflowManager = false,
+    ): PlatformCollector {
+        $this->executedSql = [];
+
+        $counts = $overrides + [
+            'users'                        => 10,
+            'users:active'                 => 8,
+            'users:admin'                  => 2,
+            'users:role'                   => 6,
+            'users_permission_definitions' => 106,
+            'users_workspaces_object'      => 3,
+            'users_workspaces_asset'       => 3,
+            'users_workspaces_document'    => 0,
+            'migration_versions'           => 185,
+            'versions'                     => 0,
+            'dependencies'                 => 0,
+            'search_backend_data'          => 0,
+            'element_workflow_state'       => 0,
+            'recyclebin'                   => 0,
+        ];
+
+        $manager = $this->createMock(Manager::class);
+        if ($failWorkflowManager) {
+            $manager->method('getAllWorkflows')->willThrowException(new RuntimeException('container not booted'));
+        } else {
+            $manager->method('getAllWorkflows')->willReturn($workflows);
+        }
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('quoteIdentifier')->willReturnArgument(0);
+        $connection->method('fetchOne')->willReturnCallback(
+            function (string $sql, array $params = []) use ($counts, $failFor): int|string|false {
+                $this->executedSql[] = $sql;
+
+                if ($failFor !== null && str_contains($sql, $failFor)) {
+                    // stands in for what the per-statement timeout surfaces as
+                    throw new RuntimeException('max_statement_time exceeded');
+                }
+
+                if (str_contains($sql, 'SUM(data_length')) {
+                    return 26_214_400; // 25 MiB
+                }
+
+                if (str_contains($sql, 'information_schema')) {
+                    return 297;
+                }
+
+                if (str_contains($sql, 'SUM(amount)')) {
+                    // one entry can hold a subtree, so elements far exceed entries
+                    return $counts['recyclebin'] * 7;
+                }
+
+                if (str_contains($sql, 'COUNT(DISTINCT workflow)')) {
+                    return $counts['element_workflow_state'] > 0 ? 1 : 0;
+                }
+
+                if (str_contains($sql, 'FROM users') && !str_contains($sql, 'users_')) {
+                    if (str_contains($sql, "type = 'role'")) {
+                        return $counts['users:role'];
+                    }
+                    if (str_contains($sql, 'active = 1')) {
+                        return $counts['users:active'];
+                    }
+                    if (str_contains($sql, 'admin = 1')) {
+                        return $counts['users:admin'];
+                    }
+
+                    return $counts['users'];
+                }
+
+                foreach ($counts as $table => $value) {
+                    if (str_contains($table, ':')) {
+                        continue;
+                    }
+                    // word-boundary match: a plain str_contains for 'users' also hits
+                    // 'users_permission_definitions' and would answer the wrong query
+                    if (preg_match('/\bFROM ' . preg_quote($table, '/') . '\b/', $sql) === 1) {
+                        return $value;
+                    }
+                }
+
+                return 0;
+            }
+        );
+
+        return new PlatformCollector(new SnapshotQueryRunner($connection, 0), $manager);
+    }
+}

--- a/tests/Unit/Telemetry/PlatformCollectorTest.php
+++ b/tests/Unit/Telemetry/PlatformCollectorTest.php
@@ -211,7 +211,8 @@ class PlatformCollectorTest extends TestCase
     }
 
     /**
-     * An unavailable workflow manager is unknown, not "no workflows".
+     * An unavailable workflow manager is unknown, not "no workflows" - so the configured count is
+     * omitted while the state-table evidence, which stands on its own, is still collected.
      */
     public function testAnUnavailableWorkflowManagerOmitsTheConfiguredCount(): void
     {
@@ -219,6 +220,24 @@ class PlatformCollectorTest extends TestCase
 
         $this->assertArrayNotHasKey('workflow_configured_count', $metrics);
         $this->assertArrayHasKey('workflow_active_element_count', $metrics);
+    }
+
+    /**
+     * With no workflows configured there is nothing to observe, so neither state query may run - PHP
+     * evaluates array values eagerly, so this only holds because the workflow metrics are appended
+     * separately rather than inlined.
+     */
+    public function testTheStateTableIsNotQueriedWhenNoWorkflowsAreConfigured(): void
+    {
+        $metrics = $this->collector(workflows: [])->collect();
+
+        $this->assertSame(0, $metrics['workflow_configured_count']);
+        $this->assertArrayNotHasKey('workflow_active_element_count', $metrics);
+        $this->assertArrayNotHasKey('workflow_distinct_in_use_count', $metrics);
+
+        foreach ($this->executedSql as $sql) {
+            $this->assertStringNotContainsString('element_workflow_state', $sql);
+        }
     }
 
     /**

--- a/tests/Unit/Telemetry/WorkflowUsageProviderTest.php
+++ b/tests/Unit/Telemetry/WorkflowUsageProviderTest.php
@@ -20,10 +20,21 @@ use Pimcore\Telemetry\Usage\BundleUsageProviderInterface;
 use Pimcore\Telemetry\Usage\WorkflowUsageProvider;
 use Pimcore\Tests\Support\Test\TestCase;
 use Pimcore\Workflow\Manager;
+use Pimcore\Workflow\WorkflowConfig;
 use RuntimeException;
 
 class WorkflowUsageProviderTest extends TestCase
 {
+    /**
+     * @var list<string>
+     */
+    private array $executedSql = [];
+
+    /**
+     * @var list<array<int|string, mixed>>
+     */
+    private array $executedParams = [];
+
     public function testReportsUnderTheWorkflowKey(): void
     {
         $provider = $this->provider();
@@ -33,45 +44,123 @@ class WorkflowUsageProviderTest extends TestCase
     }
 
     /**
-     * The reason this provider changed: a workflow defined in config that no element has ever entered
-     * is exactly the shelfware `usage.*` exists to expose. Counting it as used would report an adoption
-     * success where there is none.
+     * The reason this provider exists in this form: a workflow defined in config that no element has
+     * ever entered is exactly the shelfware `usage.*` is meant to expose.
      */
     public function testAConfiguredButNeverRunWorkflowIsNotUsed(): void
     {
-        $this->assertFalse($this->provider(workflows: ['product_approval'], elementsInWorkflow: 0)->isUsed());
+        $this->assertFalse($this->provider(['product_approval' => 'state_table'], 0)->isUsed());
     }
 
     public function testAWorkflowWithElementsInItIsUsed(): void
     {
-        $this->assertTrue($this->provider(workflows: ['product_approval'], elementsInWorkflow: 51)->isUsed());
+        $this->assertTrue($this->provider(['product_approval' => 'state_table'], 51)->isUsed());
     }
 
-    /**
-     * Self-resetting: archiving the last in-flight element flips it back rather than leaving a
-     * sticky true.
-     */
     public function testNoWorkflowsConfiguredIsNotUsed(): void
     {
-        $this->assertFalse($this->provider(workflows: [], elementsInWorkflow: 0)->isUsed());
+        $this->assertFalse($this->provider([], 0)->isUsed());
     }
 
     /**
      * With nothing configured there is nothing to exercise, so the state table must not be queried -
-     * the cheap path stays cheap on the majority of installs that use no workflows at all.
+     * the majority of installs run no workflows and should pay nothing.
      */
     public function testTheStateTableIsNotQueriedWhenNothingIsConfigured(): void
     {
-        $executed = [];
-        $this->provider(workflows: [], executedSql: $executed)->isUsed();
+        $this->provider([], 0)->isUsed();
 
-        $this->assertSame([], $executed);
+        $this->assertSame([], $this->executedSql);
+    }
+
+    /**
+     * Only the `state_table` marking store persists into element_workflow_state. `single_state`,
+     * `multiple_state` and both data-object stores keep the marking on the subject, where no aggregate
+     * query can see it - so reporting `false` there would invent an adoption gap for a workflow that
+     * may be in heavy use. Unknown is the only honest answer.
+     *
+     * @dataProvider unobservableMarkingStores
+     */
+    public function testAWorkflowWhoseMarkingIsNotInTheStateTableIsUnknownRatherThanUnused(
+        string $markingStore
+    ): void {
+        $used = $this->provider(['product_approval' => $markingStore], 0)->isUsed();
+
+        $this->assertNull($used, sprintf('%s keeps its marking on the subject', $markingStore));
+        $this->assertNotFalse($used);
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public static function unobservableMarkingStores(): array
+    {
+        return [
+            'single_state' => ['single_state'],
+            'multiple_state' => ['multiple_state'],
+            'data_object_multiple_state' => ['data_object_multiple_state'],
+            'data_object_splitted_state' => ['data_object_splitted_state'],
+            'unset marking store' => [''],
+        ];
+    }
+
+    /**
+     * A mixed install: the observable workflow proves use, so the unobservable one cannot make the
+     * answer worse. Positive evidence wins over ignorance.
+     */
+    public function testPositiveEvidenceFromAnObservableWorkflowWins(): void
+    {
+        $provider = $this->provider(
+            ['product_approval' => 'state_table', 'asset_review' => 'single_state'],
+            7
+        );
+
+        $this->assertTrue($provider->isUsed());
+    }
+
+    /**
+     * Same mix with an empty state table: the observable one is genuinely unused, but the other cannot
+     * be seen at all, so the capability as a whole is unknown - not unused.
+     */
+    public function testAMixedInstallWithNoEvidenceIsUnknown(): void
+    {
+        $provider = $this->provider(
+            ['product_approval' => 'state_table', 'asset_review' => 'single_state'],
+            0
+        );
+
+        $this->assertNull($provider->isUsed());
+    }
+
+    /**
+     * Rows can outlive the workflow that wrote them. An unscoped count would report use that is no
+     * longer possible, so the query is bound to the currently configured workflows.
+     */
+    public function testStateRowsAreScopedToConfiguredWorkflows(): void
+    {
+        $this->provider(['product_approval' => 'state_table', 'asset_review' => 'state_table'], 3)->isUsed();
+
+        $this->assertCount(1, $this->executedSql);
+        $this->assertStringContainsString('WHERE workflow IN (?, ?)', $this->executedSql[0]);
+        $this->assertSame(['product_approval', 'asset_review'], $this->executedParams[0]);
+    }
+
+    /**
+     * Workflow names are customer-chosen. They may be bound as query parameters but must never be
+     * interpolated into SQL, where they could surface in a log or an error message.
+     */
+    public function testWorkflowNamesAreBoundNotInterpolated(): void
+    {
+        $this->provider(['secret_project_gate' => 'state_table'], 1)->isUsed();
+
+        foreach ($this->executedSql as $sql) {
+            $this->assertStringNotContainsString('secret_project_gate', $sql);
+        }
     }
 
     /**
      * The reason `isUsed()` returns `?bool`. A manager that cannot be consulted tells us nothing about
-     * adoption, and `false` there is indistinguishable from a genuine "installed but not used" - the
-     * one signal the `usage.*` namespace exists to produce. Null omits the key instead.
+     * adoption, and `false` there is indistinguishable from a genuine "installed but not used".
      */
     public function testAnUnavailableWorkflowManagerIsUnknownRatherThanUnused(): void
     {
@@ -80,54 +169,66 @@ class WorkflowUsageProviderTest extends TestCase
 
         $used = (new WorkflowUsageProvider($manager, $this->queryRunner(0)))->isUsed();
 
-        $this->assertNull($used, 'a failure must not be reported as "not used"');
+        $this->assertNull($used);
         $this->assertNotFalse($used);
     }
 
-    /**
-     * Same rule one level down: workflows are configured but the state table cannot be read, so
-     * adoption is unknown rather than absent.
-     */
     public function testAnUnreadableStateTableIsUnknownRatherThanUnused(): void
     {
-        $used = $this->provider(workflows: ['product_approval'], failStateQuery: true)->isUsed();
+        $used = $this->provider(['product_approval' => 'state_table'], 0, failStateQuery: true)->isUsed();
 
-        $this->assertNull($used, 'an unreadable state table must not be reported as "not used"');
+        $this->assertNull($used);
         $this->assertNotFalse($used);
     }
 
     /**
-     * @param list<string>  $workflows
-     * @param list<string>  $executedSql captured by reference
+     * A workflow the manager cannot describe cannot be claimed as observed either.
      */
-    private function provider(
-        array $workflows = ['product_approval'],
-        int $elementsInWorkflow = 0,
-        bool $failStateQuery = false,
-        array &$executedSql = [],
-    ): WorkflowUsageProvider {
+    public function testAnUnreadableWorkflowConfigIsTreatedAsUnobservable(): void
+    {
         $manager = $this->createMock(Manager::class);
-        $manager->method('getAllWorkflows')->willReturn($workflows);
+        $manager->method('getAllWorkflows')->willReturn(['product_approval']);
+        $manager->method('getWorkflowConfig')->willThrowException(new RuntimeException('workflow not found'));
 
-        return new WorkflowUsageProvider(
-            $manager,
-            $this->queryRunner($elementsInWorkflow, $failStateQuery, $executedSql)
-        );
+        $used = (new WorkflowUsageProvider($manager, $this->queryRunner(0)))->isUsed();
+
+        $this->assertNull($used);
+        $this->assertSame([], $this->executedSql, 'nothing observable, so no query');
     }
 
     /**
-     * @param list<string> $executedSql captured by reference
+     * @param array<string, string> $workflows name => marking store type
      */
-    private function queryRunner(
-        int $count,
-        bool $fail = false,
-        array &$executedSql = [],
-    ): SnapshotQueryRunner {
+    private function provider(
+        array $workflows = ['product_approval' => 'state_table'],
+        int $elementsInWorkflow = 0,
+        bool $failStateQuery = false,
+    ): WorkflowUsageProvider {
+        $manager = $this->createMock(Manager::class);
+        $manager->method('getAllWorkflows')->willReturn(array_keys($workflows));
+        $manager->method('getWorkflowConfig')->willReturnCallback(
+            static function (string $name) use ($workflows): WorkflowConfig {
+                $store = $workflows[$name];
+                $config = $store === '' ? [] : ['marking_store' => ['type' => $store]];
+
+                return new WorkflowConfig($name, $config);
+            }
+        );
+
+        return new WorkflowUsageProvider($manager, $this->queryRunner($elementsInWorkflow, $failStateQuery));
+    }
+
+    private function queryRunner(int $count, bool $fail = false): SnapshotQueryRunner
+    {
+        $this->executedSql = [];
+        $this->executedParams = [];
+
         $connection = $this->createMock(Connection::class);
         $connection->method('quoteIdentifier')->willReturnArgument(0);
         $connection->method('fetchOne')->willReturnCallback(
-            function (string $sql) use ($count, $fail, &$executedSql): int {
-                $executedSql[] = $sql;
+            function (string $sql, array $params = []) use ($count, $fail): int {
+                $this->executedSql[] = $sql;
+                $this->executedParams[] = $params;
 
                 if ($fail) {
                     throw new RuntimeException('max_statement_time exceeded');

--- a/tests/Unit/Telemetry/WorkflowUsageProviderTest.php
+++ b/tests/Unit/Telemetry/WorkflowUsageProviderTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Unit\Telemetry;
 
+use Doctrine\DBAL\Connection;
+use Pimcore\Telemetry\Snapshot\SnapshotQueryRunner;
 use Pimcore\Telemetry\Usage\BundleUsageProviderInterface;
 use Pimcore\Telemetry\Usage\WorkflowUsageProvider;
 use Pimcore\Tests\Support\Test\TestCase;
@@ -24,24 +26,46 @@ class WorkflowUsageProviderTest extends TestCase
 {
     public function testReportsUnderTheWorkflowKey(): void
     {
-        $provider = new WorkflowUsageProvider($this->manager([]));
+        $provider = $this->provider();
 
         $this->assertInstanceOf(BundleUsageProviderInterface::class, $provider);
         $this->assertSame('workflow', $provider->getBundleKey());
     }
 
-    public function testWorkflowsConfiguredCountsAsUsed(): void
+    /**
+     * The reason this provider changed: a workflow defined in config that no element has ever entered
+     * is exactly the shelfware `usage.*` exists to expose. Counting it as used would report an adoption
+     * success where there is none.
+     */
+    public function testAConfiguredButNeverRunWorkflowIsNotUsed(): void
     {
-        $this->assertTrue((new WorkflowUsageProvider($this->manager(['product_approval'])))->isUsed());
+        $this->assertFalse($this->provider(workflows: ['product_approval'], elementsInWorkflow: 0)->isUsed());
+    }
+
+    public function testAWorkflowWithElementsInItIsUsed(): void
+    {
+        $this->assertTrue($this->provider(workflows: ['product_approval'], elementsInWorkflow: 51)->isUsed());
     }
 
     /**
-     * Self-resetting: the capability owns the definition of "used", and removing the last workflow
-     * flips it back rather than leaving a sticky true.
+     * Self-resetting: archiving the last in-flight element flips it back rather than leaving a
+     * sticky true.
      */
-    public function testNoWorkflowsCountsAsNotUsed(): void
+    public function testNoWorkflowsConfiguredIsNotUsed(): void
     {
-        $this->assertFalse((new WorkflowUsageProvider($this->manager([])))->isUsed());
+        $this->assertFalse($this->provider(workflows: [], elementsInWorkflow: 0)->isUsed());
+    }
+
+    /**
+     * With nothing configured there is nothing to exercise, so the state table must not be queried -
+     * the cheap path stays cheap on the majority of installs that use no workflows at all.
+     */
+    public function testTheStateTableIsNotQueriedWhenNothingIsConfigured(): void
+    {
+        $executed = [];
+        $this->provider(workflows: [], executedSql: $executed)->isUsed();
+
+        $this->assertSame([], $executed);
     }
 
     /**
@@ -54,20 +78,65 @@ class WorkflowUsageProviderTest extends TestCase
         $manager = $this->createMock(Manager::class);
         $manager->method('getAllWorkflows')->willThrowException(new RuntimeException('container not booted'));
 
-        $used = (new WorkflowUsageProvider($manager))->isUsed();
+        $used = (new WorkflowUsageProvider($manager, $this->queryRunner(0)))->isUsed();
 
         $this->assertNull($used, 'a failure must not be reported as "not used"');
         $this->assertNotFalse($used);
     }
 
     /**
-     * @param list<string> $workflows
+     * Same rule one level down: workflows are configured but the state table cannot be read, so
+     * adoption is unknown rather than absent.
      */
-    private function manager(array $workflows): Manager
+    public function testAnUnreadableStateTableIsUnknownRatherThanUnused(): void
     {
+        $used = $this->provider(workflows: ['product_approval'], failStateQuery: true)->isUsed();
+
+        $this->assertNull($used, 'an unreadable state table must not be reported as "not used"');
+        $this->assertNotFalse($used);
+    }
+
+    /**
+     * @param list<string>  $workflows
+     * @param list<string>  $executedSql captured by reference
+     */
+    private function provider(
+        array $workflows = ['product_approval'],
+        int $elementsInWorkflow = 0,
+        bool $failStateQuery = false,
+        array &$executedSql = [],
+    ): WorkflowUsageProvider {
         $manager = $this->createMock(Manager::class);
         $manager->method('getAllWorkflows')->willReturn($workflows);
 
-        return $manager;
+        return new WorkflowUsageProvider(
+            $manager,
+            $this->queryRunner($elementsInWorkflow, $failStateQuery, $executedSql)
+        );
+    }
+
+    /**
+     * @param list<string> $executedSql captured by reference
+     */
+    private function queryRunner(
+        int $count,
+        bool $fail = false,
+        array &$executedSql = [],
+    ): SnapshotQueryRunner {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('quoteIdentifier')->willReturnArgument(0);
+        $connection->method('fetchOne')->willReturnCallback(
+            function (string $sql) use ($count, $fail, &$executedSql): int {
+                $executedSql[] = $sql;
+
+                if ($fail) {
+                    throw new RuntimeException('max_statement_time exceeded');
+                }
+
+                return $count;
+            }
+        );
+
+        return new SnapshotQueryRunner($connection, 0);
     }
 }


### PR DESCRIPTION
Mines the legacy `Tool\StatisticsManager` payload for the signals it carried that current telemetry does not — without carrying over the parts that made that payload unsendable.

## Background: why the legacy payload could not simply be reused

Classifying all 297 tables in a real sample:

- **153 of them (52%) can never be sent.** Their names embed the customer's own identifiers — 20 DataObject class names, 6 object-brick names, 22 fieldcollection names, plus per-language variants. Nothing in this PR comes from that half; `pillars.class_count` and `datamodel.*` already summarise it in aggregate.
- **Its row numbers are estimates, not counts.** `getInstanceData()` reads `information_schema.TABLE_ROWS`. That is why the sample showed `sites: 0` next to a populated `sites_domains` — the estimate was wrong, and `pillars.site_count` (an exact `COUNT(*)`) was always right. Recorded in a comment there, since anyone comparing old and new telemetry will hit that discrepancy.

Everything below reads a **fixed-name** table. The one `information_schema` query is a single `SUM`, so only the aggregate leaves the server — no table name does.

## New `platform.*` namespace

| Group | Keys |
|---|---|
| Seats | `user_count`, `active_user_count`, `admin_user_count`, `role_count` |
| Permissions | `permission_definition_count`, `object_`/`asset_`/`document_workspace_count` |
| Hosting | `database_size_mb`, `database_table_count` |
| Currency | `applied_migration_count` |
| Volume | `version_count`, `dependency_count`, `search_index_entry_count`, `recyclebin_item_count`, `recyclebin_element_count` |
| Workflow | `workflow_configured_count`, `workflow_active_element_count`, `workflow_distinct_in_use_count` |

**Seat count is the headline** — the strongest commercial signal we were not collecting at all. The `users` table also stores roles and folders, so every seat figure filters on `type`; an unfiltered `COUNT(*)` would report the permission model as licensed users. A test asserts on the generated SQL, not just the value, because a dropped filter would still return a plausible integer.

**Unbounded tables get honest failure.** `versions`, `dependencies`, the search index and the recycle bin are counted exactly under the existing statement timeout and **omit their key** when they do not finish. An absent key reads as "too large to count in budget"; a row estimate would just be wrong — which is precisely what was removed from `CoreSnapshotCollector` in #19414.

**Recycle bin needs two figures.** One entry can hold an entire subtree (its `amount` column), so entries alone understate what is retained, and it is the element total that drives storage cost. `COALESCE(SUM(amount), 0)` matters: bare `SUM()` returns `NULL` over an empty table, and the null-filter would then drop the key — reporting an *emptied* bin as unknown. `recyclebin.path` and `deletedby` are customer content and are never read; a test enforces that.

## `usage.workflow` now means exercised, not configured

A workflow defined in config that no element has ever entered is exactly the shelfware the `usage.*` namespace exists to expose, so `isUsed()` reads `element_workflow_state`. With nothing configured the state table is not queried at all, so the majority of installs pay nothing. `platform.*` emits both counts side by side so the gap is visible.

**This changes the meaning of an existing metric.** Nothing is released, so no consumer depends on the old reading. Workflow names stay unemitted — customers choose them, so only the `DISTINCT` count is reported.

## Extended `catalog.*`

`asset_metadata_count`, `document_editable_count`, `property_count`, `tag_count`, `tag_assignment_count`, `note_count`, `object_url_slug_count` — how hard the content is being worked, as opposed to how much of it exists.

## Verified locally

- `codecept run Unit Telemetry` — **139 tests, 604 assertions, OK**, re-run after rebasing onto current `2026.x`
- PHPStan level 6 over `lib/Telemetry` — no errors
- The `COALESCE` assertion was mutation-checked: stripping `COALESCE` in a throwaway copy correctly fails the test, since a mock cannot distinguish "it worked" from "it is missing"

Not run locally: `php-cs-fixer` (absent from the local vendor tree) and the wider Codeception suites. CI validates those. No live dry-run snapshot was taken, so the `meta.db_statements` delta from roughly 20 added `COUNT(*)` statements is unmeasured.

## Companion PR

`pimcore/ecommerce-framework-bundle` gets an `ecommerce.*` collector and `usage.ecommerce`, replacing the bare `pillars.commerce_bundle_active` boolean. It requires `pimcore/pimcore: ^2026.3`, so it cannot go green until this lands and 2026.3 is released.

## Not in this PR

Six bundles still report a bare `usage.*` boolean while their own tables hold the answer — CMF, Personalization/targeting, Portal Engine, Advanced Object Search, OutputDataConfigToolkit, Data Hub workspaces. Each needs a collector in its own repo, following the ecommerce one as the pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)