### PR TITLE
[security] GHSA-g2vm-g4vq-qhwj: Anchor SelectOptions Config identifier validation to prevent codegen RCE

### DIFF
--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -1150,14 +1150,15 @@ final class ClassDefinition extends Model\AbstractModel implements ClassDefiniti
             $this->setId((string) $maxId);
         }
 
-        if (!preg_match('/^[a-zA-Z]\w+$/', $this->getName())) {
+        // `\z` rather than `$` in these checks: PCRE `$` also matches before a trailing newline.
+        if (!preg_match('/^[a-zA-Z]\w+\z/', $this->getName())) {
             throw new Exception(sprintf(
                 'Invalid name for class definition: %s',
                 $this->getName()
             ));
         }
 
-        if (!preg_match('/^[a-zA-Z0-9][a-zA-Z0-9_]*$/', $this->getId())) {
+        if (!preg_match('/^[a-zA-Z0-9][a-zA-Z0-9_]*\z/', $this->getId())) {
             throw new Exception(sprintf(
                 'Invalid ID `%s` for class definition %s',
                 $this->getId(),
@@ -1167,7 +1168,7 @@ final class ClassDefinition extends Model\AbstractModel implements ClassDefiniti
 
         foreach (['parentClass', 'listingParentClass', 'useTraits', 'listingUseTraits'] as $propertyName) {
             $propertyValue = $this->{'get'.ucfirst($propertyName)}();
-            if ($propertyValue && !preg_match('/^[a-zA-Z_\x7f-\xff\\\][a-zA-Z0-9_\x7f-\xff\\\ ,]*$/', $propertyValue)) {
+            if ($propertyValue && !preg_match('/^[a-zA-Z_\x7f-\xff\\\][a-zA-Z0-9_\x7f-\xff\\\ ,]*\z/', $propertyValue)) {
                 throw new Exception(sprintf('Invalid %s value for class definition: %s', $propertyName,
                     $this->getParentClass()));
             }

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -171,7 +171,8 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         // getter/setter and constant) and into ALTER TABLE DDL, so it must be a valid identifier.
         // The length is capped at 63 characters to bound it; note that generated index and
         // multi-column identifiers add prefixes/suffixes and may still exceed the DB identifier limit.
-        if ($name !== '' && !preg_match('/^[a-zA-Z_][a-zA-Z0-9_]{0,62}$/', $name)) {
+        // `\z` rather than `$`: PCRE `$` also matches before a trailing newline.
+        if ($name !== '' && !preg_match('/^[a-zA-Z_][a-zA-Z0-9_]{0,62}\z/', $name)) {
             throw new InvalidArgumentException(sprintf('Invalid field name "%s"', $name));
         }
 

--- a/models/DataObject/SelectOptions/Config.php
+++ b/models/DataObject/SelectOptions/Config.php
@@ -85,6 +85,16 @@ final class Config extends AbstractModel implements JsonSerializable
             );
         }
 
+        // The ID is emitted verbatim into the generated PHP enum file (as the enum name) and used
+        // to build the on-disk class file path, so it must be a valid identifier. Anchored so it
+        // cannot merely contain a valid substring alongside injected PHP (GHSA-g2vm-g4vq-qhwj).
+        if ($id !== '' && !preg_match('/^[A-Z][a-zA-Z0-9]+$/', $id)) {
+            throw new InvalidArgumentException(
+                'Invalid ID: Must start with capital letter, followed by alphanumeric characters',
+                1676639634486
+            );
+        }
+
         $this->id = $id;
 
         return $this;

--- a/models/DataObject/SelectOptions/Config.php
+++ b/models/DataObject/SelectOptions/Config.php
@@ -88,7 +88,8 @@ final class Config extends AbstractModel implements JsonSerializable
         // The ID is emitted verbatim into the generated PHP enum file (as the enum name) and used
         // to build the on-disk class file path, so it must be a valid identifier. Anchored so it
         // cannot merely contain a valid substring alongside injected PHP (GHSA-g2vm-g4vq-qhwj).
-        if ($id !== '' && !preg_match('/^[A-Z][a-zA-Z0-9]+$/', $id)) {
+        // `\z` rather than `$`: PCRE `$` also matches before a trailing newline.
+        if ($id !== '' && !preg_match('/^[A-Z][a-zA-Z0-9]+\z/', $id)) {
             throw new InvalidArgumentException(
                 'Invalid ID: Must start with capital letter, followed by alphanumeric characters',
                 1676639634486

--- a/models/DataObject/SelectOptions/Config/Dao.php
+++ b/models/DataObject/SelectOptions/Config/Dao.php
@@ -111,7 +111,7 @@ class Dao extends Model\Dao\PimcoreLocationAwareConfigDao
             throw new InvalidArgumentException('A select options definition needs an ID to be saved!', 1676639722696);
         }
 
-        if (!preg_match('/[A-Z][a-zA-Z0-9]+/', $id)) {
+        if (!preg_match('/^[A-Z][a-zA-Z0-9]+$/', $id)) {
             throw new InvalidArgumentException('Invalid ID: Must start with capital letter, followed by alphanumeric characters', 1676639634486);
         }
     }

--- a/models/DataObject/SelectOptions/Config/Dao.php
+++ b/models/DataObject/SelectOptions/Config/Dao.php
@@ -111,7 +111,7 @@ class Dao extends Model\Dao\PimcoreLocationAwareConfigDao
             throw new InvalidArgumentException('A select options definition needs an ID to be saved!', 1676639722696);
         }
 
-        if (!preg_match('/^[A-Z][a-zA-Z0-9]+$/', $id)) {
+        if (!preg_match('/^[A-Z][a-zA-Z0-9]+\z/', $id)) {
             throw new InvalidArgumentException('Invalid ID: Must start with capital letter, followed by alphanumeric characters', 1676639634486);
         }
     }

--- a/tests/Model/DataObject/ClassDefinitionTest.php
+++ b/tests/Model/DataObject/ClassDefinitionTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Model\DataObject;
 
+use Exception;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Fieldcollections;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Input;
@@ -62,6 +63,35 @@ class ClassDefinitionTest extends ModelTestCase
 
         $renamedClass = ClassDefinition::getByName('unittest_renamed');
         $renamedClass->rename('unittest');
+    }
+
+    /**
+     * PCRE `$` also matches immediately before a trailing newline, so a class name, id or parent
+     * class ending in "\n" passed the identifier checks in save() and reached the class-file
+     * generator, which emits them verbatim into PHP source and file paths (GHSA-g2vm-g4vq-qhwj).
+     *
+     * @dataProvider trailingNewlineIdentifierProvider
+     */
+    public function testSaveRejectsIdentifiersWithTrailingNewline(string $name, string $id, string $parentClass): void
+    {
+        $class = new ClassDefinition();
+        $class->setName($name);
+        $class->setId($id);
+        $class->setParentClass($parentClass);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('for class definition');
+
+        $class->save();
+    }
+
+    public static function trailingNewlineIdentifierProvider(): array
+    {
+        return [
+            'name' => ["TrailingNewlineName\n", 'TrailingNewlineName', ''],
+            'id' => ['TrailingNewlineId', "TrailingNewlineId\n", ''],
+            'parentClass' => ['TrailingNewlineParent', 'TrailingNewlineParent', "\\Pimcore\\Model\\DataObject\\Concrete\n"],
+        ];
     }
 
     /**

--- a/tests/Unit/Models/DataObject/ClassDefinition/SetNameValidationTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/SetNameValidationTest.php
@@ -76,6 +76,8 @@ class SetNameValidationTest extends TestCase
             'contains space' => ['my field'],
             'contains dash' => ['my-field'],
             'too long (64)' => [str_repeat('a', 64)],
+            // PCRE `$` also matches before a final newline; only `\z` is an absolute end anchor.
+            'trailing newline' => ["myField\n"],
         ];
     }
 

--- a/tests/Unit/Models/DataObject/SelectOptions/SetIdValidationTest.php
+++ b/tests/Unit/Models/DataObject/SelectOptions/SetIdValidationTest.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\DataObject\SelectOptions;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Pimcore\Model\DataObject\SelectOptions\Config;
+
+/**
+ * Ensures Config::setId() only accepts valid identifiers. The ID is emitted verbatim into the
+ * generated PHP enum file (as the enum name) and used to build the on-disk class file path, so it
+ * must be a valid identifier. Without an anchored check here, an ID containing a valid identifier
+ * substring anywhere (e.g. alongside injected PHP) previously passed, achieving RCE on autoload
+ * (GHSA-g2vm-g4vq-qhwj, residual of GHSA-9x44-4gxf-8c25).
+ */
+class SetIdValidationTest extends TestCase
+{
+    /**
+     * @dataProvider validIdProvider
+     */
+    public function testValidIdsAreAccepted(string $id): void
+    {
+        $config = new Config();
+        $config->setId($id);
+
+        $this->assertSame($id, $config->getId());
+    }
+
+    public static function validIdProvider(): array
+    {
+        return [
+            'simple' => ['MyOption'],
+            'with digits' => ['Option123'],
+            'single letter followed by digit' => ['A1'],
+        ];
+    }
+
+    public function testEmptyIdIsAccepted(): void
+    {
+        // An empty id is set transiently by the framework and must not throw.
+        $config = new Config();
+        $config->setId('');
+
+        $this->assertSame('', $config->getId());
+    }
+
+    /**
+     * @dataProvider invalidIdProvider
+     */
+    public function testInvalidIdsAreRejected(string $id): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new Config())->setId($id);
+    }
+
+    public static function invalidIdProvider(): array
+    {
+        return [
+            'GHSA-g2vm-g4vq-qhwj codegen injection payload' => [
+                'Xa{};echo "___PIMCORE_RCE_PROOF___";file_put_contents("pimcore_rce_proof.txt","RCE_CONFIRMED");__halt_compiler();',
+            ],
+            'contains semicolon and braces' => ['Xa{};function __construct(){}//'],
+            'leading digit' => ['1Option'],
+            'lowercase start' => ['myOption'],
+            'contains space' => ['My Option'],
+            'contains dash' => ['My-Option'],
+            'single capital letter (too short)' => ['A'],
+        ];
+    }
+}

--- a/tests/Unit/Models/DataObject/SelectOptions/SetIdValidationTest.php
+++ b/tests/Unit/Models/DataObject/SelectOptions/SetIdValidationTest.php
@@ -77,6 +77,10 @@ class SetIdValidationTest extends TestCase
             'contains space' => ['My Option'],
             'contains dash' => ['My-Option'],
             'single capital letter (too short)' => ['A'],
+            // PCRE `$` also matches before a final newline; only `\z` is an absolute end anchor.
+            'trailing newline' => ["MyOption\n"],
+            'trailing CRLF' => ["MyOption\r\n"],
+            'embedded newline' => ["My\nOption"],
         ];
     }
 }


### PR DESCRIPTION
## Vulnerability

`SelectOptionsConfig`'s ID is interpolated verbatim into the PHP enum source that Pimcore generates and autoloads for every Select-Options definition (`enum %enumName%: string implements ...`, `lib/DataObject/ClassBuilder/SelectOptionsEnumBuilder.php`). Any authenticated user holding only the `selectoptions` permission (not admin) can create/update a Select-Options definition whose ID closes the enum declaration early and injects arbitrary top-level PHP, which executes on file inclusion/autoload — full RCE, no constructor/instantiation required.

This is a residual of GHSA-9x44-4gxf-8c25 ("RCE via DataObject Class-Definition Field Name"): that fix anchored `(redacted) identifier regex, but never touched `SelectOptionsConfig`, which has its own, separate identifier path.

### Root cause

- `Config::setId()` (`models/DataObject/SelectOptions/Config.php`) only called `ReservedWordsHelper::isReservedWord()`, a whole-string check — it applied no identifier-pattern validation at all.
- `Config\Dao::validateId()` (`models/DataObject/SelectOptions/Config/Dao.php`), the only pattern check on this path, used `preg_match('/[A-Z][a-zA-Z0-9]+/', $id)` — **unanchored**, so it matches if the ID merely *contains* a valid-looking substring anywhere, even alongside injected PHP (e.g. `Xa{};echo "...";file_put_contents(...);__halt_compiler();` contains `Xa` and passes).

The generated file is written to Pimcore's DataObject autoload directory and reached via a single authenticated `POST` to the Studio API's SelectOptions create endpoint (`pimcore/studio-backend-bundle`), or via the admin class-rebuild commands.

## Fix

Anchor the identifier validation in both places, mirroring the anchored regex already used by `(redacted) for the parent GHSA-9x44 fix:

- `models/DataObject/SelectOptions/Config/Dao.php`: `'/[A-Z][a-zA-Z0-9]+/'` → `'/^[A-Z][a-zA-Z0-9]+$/'`.
- `models/DataObject/SelectOptions/Config.php` (`setId()`): added the same anchored check, so an invalid ID is rejected before it's ever stored — defense in depth against any other save path reaching codegen, not just the primary UI/API save flow. Empty string is still permitted through, consistent with how `(redacted) treats a transiently-unset value.

## Follow-up hardening: absolute end anchors (`\z`)

Copilot review pointed out that PCRE `$` also matches immediately before a trailing newline, so an id like `MyOption\n` still passed the anchored check above. Both SelectOptions checks now use `\z`.

The same `$` weakness existed in the sibling class-definition identifier validation, so this PR closes it there as well:

- `models/DataObject/ClassDefinition.php` (`save()`): the class `name`, `id` and `parentClass`/`listingParentClass`/`useTraits`/`listingUseTraits` checks. Verified in the Model suite that `TrailingNewlineName\n` previously saved a class whose name contained the newline, and `TrailingNewlineId\n` reached `CREATE TABLE` DDL with the newline in the table name.
- `models/DataObject/ClassDefinition/Data.php` (`setName()`): the field-name check introduced for GHSA-9x44-4gxf-8c25.

No legitimate identifier is affected; `\z` only rejects values that end in a newline, which `$` silently tolerated.

## Backward compatibility

`Config::setId()` is public API with no `@internal` marker, so this is evaluated as a real BC-sensitive change (tightening validation on an existing public setter). However:

- Legitimate IDs created through the normal save flow already had to pass `Dao::validateId()`'s existing (unanchored) pattern, which already required starting with a capital letter followed by alphanumerics — every real-world ID already satisfies the stricter anchored form. Only a string that is *not* a valid identifier on its own (i.e. an injection payload) is newly rejected.
- `setId()` is also invoked when loading a persisted config (`Dao::getById()` → `setValues()` → `setId()`), so a config whose stored ID fails the anchored check will now fail to load. This can only affect a record whose ID was never a valid identifier to begin with — which is the exact malicious/corrupt state this fix is meant to make unusable, not a legitimate configuration.
- This mirrors the precedent already established in this codebase: the sibling fix for GHSA-9x44-4gxf-8c25 added the identical anchored-regex validation directly to `(redacted) (a comparably public setter) without a deprecation cycle, on the same reasoning — an unrestricted identifier was never a supported value, only a validation gap.

No signature, return type, or default value changes; this only narrows what was already documented as required input ("must start with capital letter, followed by alphanumeric characters").

## Tests

**Tests added:** `tests/Unit/Models/DataObject/SelectOptions/SetIdValidationTest.php`

This is a plain PHPUnit test (mirrors the existing `tests/Unit/Models/DataObject/ClassDefinition/SetNameValidationTest.php` pattern for the sibling fix — no framework bootstrap needed since `Config::setId()` has no external dependencies). It:
- Reproduces the advisory's exact RCE payload (`Xa{};echo "___PIMCORE_RCE_PROOF___";...__halt_compiler();`) as an ID and asserts `setId()` now throws `InvalidArgumentException` for it (fails against the vulnerable code, passes against the fix).
- Covers other injection-shaped and malformed IDs (semicolons/braces, leading digit, lowercase start, spaces, dashes, too-short).
- Confirms legitimate IDs (`MyOption`, `Option123`, `A1`) are still accepted, and that an empty ID is still tolerated transiently.

Trailing-newline regression cases were added for every hardened check:
- `SetIdValidationTest` (SelectOptions): trailing `\n`, trailing `\r\n`, embedded `\n`.
- `tests/Unit/Models/DataObject/ClassDefinition/SetNameValidationTest.php`: trailing `\n` for `Data::setName()`.
- `tests/Model/DataObject/ClassDefinitionTest.php::testSaveRejectsIdentifiersWithTrailingNewline`: trailing `\n` in class name, id and parent class, asserting `save()` throws before any file or DDL is written.

The original draft could not run the suite in its sandbox. The follow-up commits were verified locally in the `tests/bin` Docker Codeception harness: each new case fails against `$` and passes against `\z` (SelectOptions 14/14, SetNameValidation 26/26, ClassDefinitionTest 14/14).

Security-Advisory: pimcore/pimcore/GHSA-g2vm-g4vq-qhwj




> Generated by [Draft a security-advisory fix](https://github.com/pimcore/workflows-centralized/actions/runs/33462410211) · sonnet50 · 104.7 AIC · ⌖ 20.2 AIC · ⊞ 6.2K · [◷](https://github.com/search?q=repo%3Apimcore%2Fpimcore+%22gh-aw-workflow-id%3A+advisory-fix%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Draft a security-advisory fix, engine: claude, model: claude-sonnet-5, id: 33462410211, workflow_id: advisory-fix, run: https://github.com/pimcore/workflows-centralized/actions/runs/33462410211 -->

<!-- gh-aw-workflow-id: advisory-fix -->
<!-- gh-aw-workflow-call-id: pimcore/workflows-centralized/advisory-fix -->
