### PR TITLE
Fix getDataFromEditmode() to accept associative UrlSlug edit-mode data

### DIFF
--- a/models/DataObject/ClassDefinition/Data/UrlSlug.php
+++ b/models/DataObject/ClassDefinition/Data/UrlSlug.php
@@ -90,13 +90,14 @@ class UrlSlug extends Data implements CustomResourcePersistingInterface, LazyLoa
     {
         $result = [];
         if (is_array($data)) {
-            foreach ($data as $siteId => $item) {
-                $siteId = $item[0];
-                $slug = $item[1];
-                $slug = new Model\DataObject\Data\UrlSlug($slug, (int) $siteId);
+            foreach ($data as $item) {
+                $siteId = $item['siteId'] ?? $item[0] ?? 0;
+                $slugStr = $item['slug'] ?? $item[1] ?? '';
+                $slug = new Model\DataObject\Data\UrlSlug($slugStr, (int) $siteId);
 
-                if ($item[2]) {
-                    $slug->setPreviousSlug($item[2]);
+                $previousSlug = $item['previousSlug'] ?? $item[2] ?? null;
+                if ($previousSlug) {
+                    $slug->setPreviousSlug($previousSlug);
                 }
 
                 $result[] = $slug;

--- a/tests/Unit/Models/DataObject/ClassDefinition/Data/UrlSlugTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/Data/UrlSlugTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\DataObject\ClassDefinition\Data;
+
+use Pimcore\Model\DataObject\ClassDefinition\Data\UrlSlug;
+use Pimcore\Model\DataObject\Data\UrlSlug as UrlSlugValue;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * @group unit.model.datatype.urlslug
+ */
+class UrlSlugTest extends TestCase
+{
+    /**
+     * Regression test: getDataForEditmode() emits an associative array
+     * (['slug' => ..., 'siteId' => ..., 'domain' => ...]), but getDataFromEditmode()
+     * used to read it back positionally ($item[0]/$item[1]/$item[2]), silently producing
+     * a UrlSlug with a null slug and siteId 0 for any associative payload
+     * (e.g. from Pimcore Studio's dependent-select-options flow).
+     */
+    public function testGetDataFromEditmodeAcceptsAssociativeArray(): void
+    {
+        $data = [
+            ['siteId' => 3, 'slug' => '/foo', 'previousSlug' => '/old-foo'],
+        ];
+
+        $result = (new UrlSlug())->getDataFromEditmode($data);
+
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf(UrlSlugValue::class, $result[0]);
+        $this->assertSame('/foo', $result[0]->getSlug());
+        $this->assertSame(3, $result[0]->getSiteId());
+        $this->assertSame('/old-foo', $result[0]->getPreviousSlug());
+    }
+
+    /**
+     * Legacy Admin UI Classic still sends positional tuples ([siteId, slug, previousSlug]);
+     * this shape must keep working unchanged.
+     */
+    public function testGetDataFromEditmodeAcceptsPositionalArray(): void
+    {
+        $data = [
+            [3, '/foo', '/old-foo'],
+        ];
+
+        $result = (new UrlSlug())->getDataFromEditmode($data);
+
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf(UrlSlugValue::class, $result[0]);
+        $this->assertSame('/foo', $result[0]->getSlug());
+        $this->assertSame(3, $result[0]->getSiteId());
+        $this->assertSame('/old-foo', $result[0]->getPreviousSlug());
+    }
+
+    public function testGetDataFromEditmodeReturnsEmptyArrayForNonArrayData(): void
+    {
+        $result = (new UrlSlug())->getDataFromEditmode(null);
+
+        $this->assertSame([], $result);
+    }
+}


### PR DESCRIPTION
## Summary
- `UrlSlug::getDataForEditmode()` emits an associative array (`slug`/`siteId`/`domain`) but `getDataFromEditmode()` read it back positionally (`$item[0]`/`[1]`/`[2]`), so any associative edit-mode payload silently produced a `UrlSlug` with a null slug and `siteId` 0 instead of the real values.
- Reads `siteId`/`slug`/`previousSlug` by associative key first, falling back to the old positional indices, so the legacy Admin UI Classic tuples (`[siteId, slug, previousSlug]`) keep working unchanged.
- Ports the fix from pimcore/ee-pimcore#1165 back to pimcore/pimcore (originally proposed in #19203, which was closed for inactivity).

## Test plan
- [ ] CI green (Codeception unit suite)
- Added `tests/Unit/Models/DataObject/ClassDefinition/Data/UrlSlugTest.php` covering the associative shape, the legacy positional shape, and non-array input.