### PR TITLE
docs(upgrade-notes): note Custom Reports enabled_adapters config option

### DIFF
--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -94,6 +94,15 @@ Pass an explicit value: `false` to forbid object deserialization (the safe choic
 or an array of allowed class names when a trusted stored object graph must be reconstructed.
 The default changes from `true` to `false` (object deserialization disabled) in Pimcore 2027.1.
 
+### [Custom Reports]
+- Added a `pimcore_custom_reports.enabled_adapters` config option to enable/disable individual Custom Report data-source adapters (e.g. the built-in `sql` adapter) per project. Adapters not listed default to enabled; a disabled adapter is removed from the shared `pimcore.custom_report.adapter.factories` service locator, so it becomes unavailable to every consumer (the classic admin controller and the Studio backend bundle alike).
+    ```yaml
+    pimcore_custom_reports:
+        enabled_adapters:
+            sql: false
+    ```
+  We recommend disabling the built-in `sql` adapter unless specifically needed: any user with the `reports_config` permission can otherwise define arbitrary `SELECT` statements against the application's database, including tables never intended to be exposed. See [Custom Reports](../../06_Reporting/01_Custom_Reports.md) for details.
+
 ## Pimcore 12.3.10
 
 ### Deprecations


### PR DESCRIPTION
## Summary
- The restructured `doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md` was missing the Custom Reports `enabled_adapters` upgrade note that #19365 added only to the legacy `doc/13_Upgrade_Notes/README.md`.
- Ported the entry (with the already-correct doc link) so both upgrade-notes files stay in sync, matching what ee-pimcore carries under 12.3.12 (see [ee-pimcore@415e49b](https://github.com/pimcore/ee-pimcore/commit/415e49ba8a82f2a3e705d1cc3537ed53f495bc6a), a link-only fix for the same paragraph, and the original addition [ee-pimcore@624ce6a](https://github.com/pimcore/ee-pimcore/commit/624ce6a656)).

## Test plan
- [x] Doc-only change; verified the link target `doc/06_Reporting/01_Custom_Reports.md` exists.
- [ ] No functional code changed, no test suite run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)