### PR TITLE
[Bug] Fix orphaned rel="noopener" fragment leaking into WYSIWYG text for broken links

### DIFF
--- a/lib/Tool/Text.php
+++ b/lib/Tool/Text.php
@@ -190,7 +190,7 @@ class Text
                         $text = str_replace($oldTag, '', $text);
                     } elseif ($matches[1][$i] == 'a') {
                         // just display the text for links
-                        $text = preg_replace('@' . preg_quote($oldTag, '@') . '([^\<]+)\</a\>@i', '$1', $text);
+                        $text = preg_replace('@' . preg_quote($oldTag, '@') . '[^>]*>(.*?)\</a\>@is', '$1', $text);
                     }
                 }
             }

--- a/models/DataObject/ClassDefinition/Data/Wysiwyg.php
+++ b/models/DataObject/ClassDefinition/Data/Wysiwyg.php
@@ -318,6 +318,11 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
      */
     public function getVersionPreview(mixed $data, ?DataObject\Concrete $object = null, array $params = []): string
     {
-        return self::getWysiwygSanitizer()->sanitizeFor('body', (string) $data);
+        $sanitized = self::getWysiwygSanitizer()->sanitizeFor('body', (string) $data);
+
+        return Text::wysiwygText($sanitized, array_merge($params, [
+            'object' => $object,
+            'context' => $this,
+        ])) ?? '';
     }
 }

--- a/tests/Model/DataObject/ClassDefinition/Data/WysiwygTest.php
+++ b/tests/Model/DataObject/ClassDefinition/Data/WysiwygTest.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\DataObject\ClassDefinition\Data;
+
+use Pimcore\Cache\RuntimeCache;
+use Pimcore\Model\Document;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Wysiwyg;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+
+class WysiwygTest extends ModelTestCase
+{
+    protected function needsDb(): bool
+    {
+        return true;
+    }
+
+    public function testGetVersionPreviewStripsBrokenLinkWithExtraAttributes(): void
+    {
+        RuntimeCache::clear();
+
+        $unpublishedDocument = new Document\Page();
+        $unpublishedDocument->setKey('unpublished-version-preview-testing');
+        $unpublishedDocument->setPublished(false);
+        $unpublishedDocument->setParentId(1);
+        $unpublishedDocument->setUserOwner(1);
+        $unpublishedDocument->setUserModification(1);
+        $unpublishedDocument->setCreationDate(time());
+        $unpublishedDocument->save();
+
+        $data = sprintf(
+            'Link to a document <a href="/some/path" target="_blank" pimcore_id="%s" pimcore_type="document" rel="noopener">Link text</a>',
+            $unpublishedDocument->getId()
+        );
+
+        $field = new Wysiwyg();
+        $field->setName('description');
+
+        $this->assertEquals('Link to a document Link text', $field->getVersionPreview($data));
+    }
+}

--- a/tests/Model/Tool/TextTest.php
+++ b/tests/Model/Tool/TextTest.php
@@ -54,11 +54,56 @@ class TextTest extends ModelTestCase
         $this->assertEquals($expected, Text::wysiwygText($text));
     }
 
-    private function createDocument(string $key, int $parentId): Document\Page
+    public function testWysiwygTextWithBrokenLinkAndExtraAttributes(): void
+    {
+        RuntimeCache::clear();
+
+        $unpublishedDocument = $this->createDocument('unpublished-testing', $this->testingDocument->getParentId(), false);
+
+        $text = sprintf(
+            'Link to a document <a href="/some/path" target="_blank" pimcore_id="%s" pimcore_type="document" rel="noopener">Link text</a>',
+            $unpublishedDocument->getId()
+        );
+        $expected = 'Link to a document Link text';
+
+        $this->assertEquals($expected, Text::wysiwygText($text));
+    }
+
+    public function testWysiwygTextWithBrokenLinkAndNestedMarkup(): void
+    {
+        RuntimeCache::clear();
+
+        $unpublishedDocument = $this->createDocument('unpublished-testing-nested', $this->testingDocument->getParentId(), false);
+
+        $text = sprintf(
+            'Link to a document <a href="/some/path" target="_blank" pimcore_id="%s" pimcore_type="document" rel="noopener"><strong>Link text</strong></a>',
+            $unpublishedDocument->getId()
+        );
+        $expected = 'Link to a document <strong>Link text</strong>';
+
+        $this->assertEquals($expected, Text::wysiwygText($text));
+    }
+
+    public function testWysiwygTextWithBrokenLinkAndEmptyLabel(): void
+    {
+        RuntimeCache::clear();
+
+        $unpublishedDocument = $this->createDocument('unpublished-testing-empty', $this->testingDocument->getParentId(), false);
+
+        $text = sprintf(
+            'Link to a document <a href="/some/path" target="_blank" pimcore_id="%s" pimcore_type="document" rel="noopener"></a>',
+            $unpublishedDocument->getId()
+        );
+        $expected = 'Link to a document ';
+
+        $this->assertEquals($expected, Text::wysiwygText($text));
+    }
+
+    private function createDocument(string $key, int $parentId, bool $published = true): Document\Page
     {
         $document = new Document\Page();
         $document->setKey($key);
-        $document->setPublished(true);
+        $document->setPublished($published);
         $document->setParentId($parentId);
         $document->setUserOwner(1);
         $document->setUserModification(1);


### PR DESCRIPTION
Resolves https://github.com/pimcore/service-operations/issues/823

## Summary
- `Text::wysiwygText()` used an ungreedy tag match for broken/unpublished links, so when the link's opening tag had trailing attributes after the point the match ended (e.g. `rel="noopener"` added by TinyMCE for `target="_blank"` links), the leftover attribute fragment was re-emitted as visible text instead of being discarded.
- `Wysiwyg::getVersionPreview()` (used by the Data Object version-history / diff-versions screen) only ran stored HTML through the WYSIWYG sanitizer and never called `Text::wysiwygText()`, so it never benefited from the fix and kept showing the raw fragment regardless of when the content was saved.
- Switched the broken-link capture group to a non-greedy dotall pattern so nested markup (e.g. `<strong>`) and empty labels are also handled correctly.

Ported from https://github.com/pimcore/ee-pimcore/pull/1008 (merged on ee-pimcore's `12.3` LTS line, PEES-1127). Verified the same bug is present on `2026.2` (unfixed) before porting.

## Test plan
- [x] Added `tests/Model/DataObject/ClassDefinition/Data/WysiwygTest.php` covering `getVersionPreview()` stripping a broken link with extra attributes.
- [x] Extended `tests/Model/Tool/TextTest.php` with regression cases: extra attributes, nested markup, empty label.
- [ ] CI (no local PHP/Codeception environment available to run the suite locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)