### PR TITLE
[DataObject] Do not evaluate calculated values or load reverse relations for consumers that discard them

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Fieldcollections.php
+++ b/models/DataObject/ClassDefinition/Data/Fieldcollections.php
@@ -329,6 +329,14 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
 
                 if ($collectionDef = DataObject\Fieldcollection\Definition::getByKey($item->getType())) {
                     foreach ($collectionDef->getFieldDefinitions() as $fd) {
+                        if ($fd instanceof CalculatedValue) {
+                            // a calculated value cannot own a dependency: it is computed on read and
+                            // CalculatedValue does not override Data::resolveDependencies(), which
+                            // returns an empty array. Calling the getter would run the calculator
+                            // for nothing.
+                            continue;
+                        }
+
                         $getter = 'get' . ucfirst($fd->getName());
                         $dependencies = array_merge($dependencies, $fd->resolveDependencies($item->$getter()));
                     }

--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -728,6 +728,16 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
         foreach ($languages as $language) {
             $data[$language] = [];
             foreach ($this->getFieldDefinitions() as $fd) {
+                if ($fd instanceof CalculatedValue) {
+                    // getLocalizedValue() runs the calculator for a calculated value, and the only
+                    // consumer of this array is checkValidity(), where CalculatedValue::checkValidity()
+                    // is a no-op. The non-variant branch above already yields null for these fields,
+                    // because Localizedfield::getInternalData() nulls them out.
+                    $data[$language][$fd->getName()] = null;
+
+                    continue;
+                }
+
                 $data[$language][$fd->getName()] = $localizedObject->getLocalizedValue($fd->getName(), $language);
             }
         }

--- a/models/DataObject/ClassDefinition/Data/Objectbricks.php
+++ b/models/DataObject/ClassDefinition/Data/Objectbricks.php
@@ -415,6 +415,14 @@ class Objectbricks extends Data implements CustomResourcePersistingInterface, Ty
 
                 if ($collectionDef = DataObject\Objectbrick\Definition::getByKey($item->getType())) {
                     foreach ($collectionDef->getFieldDefinitions() as $fd) {
+                        if ($fd instanceof CalculatedValue) {
+                            // a calculated value cannot own a dependency: it is computed on read and
+                            // CalculatedValue does not override Data::resolveDependencies(), which
+                            // returns an empty array. Calling the getter would run the calculator
+                            // for nothing.
+                            continue;
+                        }
+
                         $key = $fd->getName();
                         $getter = 'get' . ucfirst($key);
                         $dependencies = array_merge($dependencies, $fd->resolveDependencies($item->$getter()));
@@ -525,6 +533,15 @@ class Objectbricks extends Data implements CustomResourcePersistingInterface, Ty
 
                     if (!$omitMandatoryCheck) {
                         foreach ($collectionDef->getFieldDefinitions() as $fd) {
+                            if ($fd instanceof CalculatedValue) {
+                                // a calculated value is computed on read and never persisted from
+                                // user input, and CalculatedValue::checkValidity() is a no-op for
+                                // that reason. Calling the getter here would run the calculator
+                                // only to discard the result. Fieldcollections::checkValidity()
+                                // has skipped calculated values the same way since #3962.
+                                continue;
+                            }
+
                             $key = $fd->getName();
                             $getter = 'get' . ucfirst($key);
 

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -363,6 +363,13 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
 
         // check in fields
         foreach ($this->getClass()->getFieldDefinitions() as $field) {
+            if ($field instanceof DataObject\ClassDefinition\Data\CalculatedValue) {
+                // a calculated value cannot own a dependency: it is computed on read and
+                // CalculatedValue does not override Data::resolveDependencies(), which returns
+                // an empty array. Calling the getter would run the calculator for nothing.
+                continue;
+            }
+
             $key = $field->getName();
             $getter = 'get' . ucfirst($key);
             $dependencies[] = $field->resolveDependencies($this->$getter());

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -112,6 +112,14 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
                     $this->__objectAwareFields['localizedfields'] = true;
                 }
 
+                if ($fd instanceof DataObject\ClassDefinition\Data\CalculatedValue) {
+                    // a calculated value is computed on read and never persisted from user input,
+                    // and CalculatedValue::checkValidity() is a no-op for that reason - including
+                    // for the mandatory check. Calling the getter here would run the calculator
+                    // for every calculated field on every save, only to discard the result.
+                    continue;
+                }
+
                 $getter = 'get' . ucfirst($fd->getName());
 
                 if (method_exists($this, $getter)) {

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -370,6 +370,14 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
                 continue;
             }
 
+            if ($field instanceof DataObject\ClassDefinition\Data\ReverseObjectRelation) {
+                // a reverse relation cannot own a dependency either - the relation is recorded
+                // on the owning object - and ReverseObjectRelation::resolveDependencies() says so
+                // by returning an empty array. Its getter is never memoised, so calling it here
+                // would query the relation table and load every owning object for nothing.
+                continue;
+            }
+
             $key = $field->getName();
             $getter = 'get' . ucfirst($key);
             $dependencies[] = $field->resolveDependencies($this->$getter());

--- a/tests/Model/DataObject/CalculatedValueEvaluationTest.php
+++ b/tests/Model/DataObject/CalculatedValueEvaluationTest.php
@@ -1,0 +1,192 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\DataObject;
+
+use Pimcore;
+use Pimcore\Cache\RuntimeCache;
+use Pimcore\Db;
+use Pimcore\Event\DataObjectEvents;
+use Pimcore\Model\DataObject;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Objectbricks;
+use Pimcore\Model\DataObject\Inheritance;
+use Pimcore\Tests\Support\Helper\DataType\Calculator;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+use Pimcore\Tests\Support\Util\TestHelper;
+
+/**
+ * A calculated value is computed on read and never persisted from user input, and both
+ * CalculatedValue::checkValidity() and the inherited Data::resolveDependencies() ignore
+ * the value they are handed. Save validation and dependency resolution must therefore not
+ * run the calculator at all - neither for a field on the class itself nor for one owned by
+ * a container such as an object brick.
+ *
+ * @group model.dataobject.calculatedvalue
+ */
+class CalculatedValueEvaluationTest extends ModelTestCase
+{
+    private const CALCULATED = 'computed-value';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        TestHelper::cleanUp();
+
+        // the test calculator returns this runtime-cache value for every calculated field
+        RuntimeCache::set('modeltest.testCalculatedValue.value', self::CALCULATED);
+        Calculator::$computeCount = 0;
+    }
+
+    protected function tearDown(): void
+    {
+        TestHelper::cleanUp();
+
+        parent::tearDown();
+    }
+
+    /**
+     * The inheritance class carries a calculated value of its own and one inside its
+     * localized fields, and its unittestBrick carries a third one - so a single object
+     * exercises the class-level loop in Concrete::update() as well as the container-owned
+     * loops in Objectbricks and Localizedfields.
+     */
+    private function createObjectWithCalculatedValues(): Inheritance
+    {
+        $object = new Inheritance();
+        $object->setKey('calculated-value-evaluation');
+        $object->setParentId(1);
+        $object->setPublished(true);
+        $object->setNormalInput('some text');
+
+        $brick = new DataObject\Objectbrick\Data\UnittestBrick($object);
+        $brick->setBrickInput('brick-input');
+        $object->getMybricks()->setUnittestBrick($brick);
+
+        return $object;
+    }
+
+    public function testSaveValidationDoesNotEvaluateCalculators(): void
+    {
+        $object = $this->createObjectWithCalculatedValues();
+
+        $dispatcher = Pimcore::getEventDispatcher();
+
+        // PRE_ADD/PRE_UPDATE are dispatched before Concrete::update() runs its validation
+        // loop and PRE_UPDATE_VALIDATION_EXCEPTION immediately after it, so the difference
+        // between the two isolates exactly the calculator evaluations made while validating.
+        $countWhenValidationStarted = null;
+        $countWhenValidationFinished = null;
+
+        $start = static function () use (&$countWhenValidationStarted): void {
+            $countWhenValidationStarted = Calculator::$computeCount;
+        };
+        $finish = static function () use (&$countWhenValidationFinished): void {
+            $countWhenValidationFinished = Calculator::$computeCount;
+        };
+
+        $dispatcher->addListener(DataObjectEvents::PRE_ADD, $start);
+        $dispatcher->addListener(DataObjectEvents::PRE_UPDATE, $start);
+        $dispatcher->addListener(DataObjectEvents::PRE_UPDATE_VALIDATION_EXCEPTION, $finish);
+
+        try {
+            $object->save();
+        } finally {
+            $dispatcher->removeListener(DataObjectEvents::PRE_ADD, $start);
+            $dispatcher->removeListener(DataObjectEvents::PRE_UPDATE, $start);
+            $dispatcher->removeListener(DataObjectEvents::PRE_UPDATE_VALIDATION_EXCEPTION, $finish);
+        }
+
+        $this->assertNotNull($countWhenValidationStarted, 'the save dispatched a pre-save event');
+        $this->assertNotNull($countWhenValidationFinished, 'the save dispatched the validation event');
+        $this->assertSame(
+            0,
+            $countWhenValidationFinished - $countWhenValidationStarted,
+            'save validation must not evaluate calculated values, neither on the class nor in a brick'
+        );
+    }
+
+    public function testResolveDependenciesDoesNotEvaluateCalculators(): void
+    {
+        $object = $this->createObjectWithCalculatedValues();
+        $object->save();
+
+        Calculator::$computeCount = 0;
+        $object->resolveDependencies();
+
+        $this->assertSame(
+            0,
+            Calculator::$computeCount,
+            'dependency resolution must not evaluate calculated values, neither on the class nor in a brick'
+        );
+    }
+
+    /**
+     * The object brick container on its own, so that a regression is attributed to the
+     * container rather than to the object save as a whole.
+     */
+    public function testObjectbrickContainerDoesNotEvaluateCalculators(): void
+    {
+        $object = $this->createObjectWithCalculatedValues();
+        $object->save();
+
+        $fieldDefinition = $object->getClass()->getFieldDefinition('mybricks');
+        $this->assertInstanceOf(Objectbricks::class, $fieldDefinition);
+
+        $bricks = $object->getMybricks();
+
+        Calculator::$computeCount = 0;
+        $fieldDefinition->checkValidity($bricks, false, []);
+        $this->assertSame(0, Calculator::$computeCount, 'Objectbricks::checkValidity() must not evaluate calculated values');
+
+        Calculator::$computeCount = 0;
+        $fieldDefinition->resolveDependencies($bricks);
+        $this->assertSame(0, Calculator::$computeCount, 'Objectbricks::resolveDependencies() must not evaluate calculated values');
+    }
+
+    /**
+     * Skipping the two consumers that discard the value must not change what is persisted:
+     * the query tables are still filled from the calculator during the save.
+     */
+    public function testCalculatedValuesAreStillPersisted(): void
+    {
+        $object = $this->createObjectWithCalculatedValues();
+        $object->save();
+
+        $db = Db::get();
+        $classId = $object->getClassId();
+
+        $row = $db->fetchAssociative(
+            'SELECT * FROM object_query_' . $classId . ' WHERE oo_id = ?',
+            [$object->getId()]
+        );
+        $this->assertSame(self::CALCULATED, $row['calculatedinherited']);
+
+        $localizedRow = $db->fetchAssociative(
+            'SELECT * FROM object_localized_query_' . $classId . '_en WHERE ooo_id = ?',
+            [$object->getId()]
+        );
+        $this->assertSame(self::CALCULATED, $localizedRow['lcalculatedinherited']);
+
+        $brickRow = $db->fetchAssociative(
+            'SELECT * FROM object_brick_query_unittestBrick_' . $classId . ' WHERE id = ?',
+            [$object->getId()]
+        );
+        $this->assertSame(self::CALCULATED, $brickRow['brickcalculated']);
+
+        // and the getters keep working after the save
+        $reloaded = Inheritance::getById($object->getId(), ['force' => true]);
+        $this->assertSame(self::CALCULATED, $reloaded->getCalculatedinherited());
+        $this->assertSame(self::CALCULATED, $reloaded->getMybricks()->getUnittestBrick()->getBrickcalculated());
+    }
+}

--- a/tests/Model/DataObject/ReverseObjectRelationDependencyTest.php
+++ b/tests/Model/DataObject/ReverseObjectRelationDependencyTest.php
@@ -1,0 +1,108 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\DataObject;
+
+use Pimcore\Model\DataObject\Unittest;
+use Pimcore\Tests\Support\Helper\Pimcore;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+use Pimcore\Tests\Support\Util\TestHelper;
+use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
+
+/**
+ * A reverse relation is the read-only mirror of a relation that is stored - and whose
+ * dependency is recorded - on the owning object, which is why
+ * ReverseObjectRelation::resolveDependencies() returns an empty array. Dependency resolution
+ * must therefore not read the reverse relation at all: its getter is not memoised, so every
+ * call queries the relation table and loads every owning object.
+ *
+ * @group model.dataobject.reverseobjectrelation
+ */
+class ReverseObjectRelationDependencyTest extends ModelTestCase
+{
+    private DebugDataHolder $debugDataHolder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        TestHelper::cleanUp();
+
+        $container = $this->getModule('\\'.Pimcore::class)->_getContainer();
+        if (!$container->has('doctrine.debug_data_holder')) {
+            $this->markTestSkipped('The Doctrine debug data holder is only registered when the kernel runs in debug mode.');
+        }
+
+        $this->debugDataHolder = $container->get('doctrine.debug_data_holder');
+    }
+
+    protected function tearDown(): void
+    {
+        TestHelper::cleanUp();
+
+        parent::tearDown();
+    }
+
+    /**
+     * The unittest class relates to itself: `objects` is the owning side and `nonowner` is
+     * its reverse relation, so one owner and one target of the same class are enough.
+     */
+    public function testResolveDependenciesDoesNotLoadTheReverseRelation(): void
+    {
+        $target = TestHelper::createEmptyObject('reverse-relation-target-');
+        $owner = TestHelper::createEmptyObject('reverse-relation-owner-', false);
+        $owner->setObjects([$target]);
+        $owner->save();
+
+        $target = Unittest::getById($target->getId(), ['force' => true]);
+
+        // precondition: reading the reverse relation is what issues the query this test
+        // guards against, so the pattern below has to catch it
+        $this->debugDataHolder->reset();
+        $related = $target->getNonowner();
+        $this->assertCount(1, $related);
+        $this->assertSame($owner->getId(), $related[0]->getId());
+        $this->assertNotEmpty($this->grabReverseRelationReads(), 'precondition: the getter reads the reverse relation');
+
+        $this->debugDataHolder->reset();
+        $dependencies = $target->resolveDependencies();
+
+        $this->assertSame(
+            [],
+            $this->grabReverseRelationReads(),
+            'resolving the dependencies of the target must not read the reverse relation'
+        );
+
+        // the dependency belongs to the owning side of the relation, which still records it
+        $this->assertArrayNotHasKey('object_'.$owner->getId(), $dependencies);
+        $this->assertArrayHasKey('object_'.$target->getId(), $owner->resolveDependencies());
+    }
+
+    /**
+     * @return string[]
+     */
+    private function grabReverseRelationReads(): array
+    {
+        $reads = [];
+        foreach ($this->debugDataHolder->getData() as $queries) {
+            foreach ($queries as $query) {
+                $sql = preg_replace('/\s+/', ' ', (string)$query['sql']);
+                if (preg_match('/^SELECT \* FROM object_relations_\S+ WHERE dest_id = \?/i', $sql)) {
+                    $reads[] = $sql;
+                }
+            }
+        }
+
+        return $reads;
+    }
+}

--- a/tests/Support/Helper/DataType/Calculator.php
+++ b/tests/Support/Helper/DataType/Calculator.php
@@ -20,8 +20,18 @@ use Pimcore\Model\DataObject\Data\CalculatedValue;
 
 class Calculator implements CalculatorClassInterface
 {
+    /**
+     * Number of times compute() has been called since the last reset.
+     *
+     * Tests asserting that a code path does not evaluate calculated values reset
+     * this counter and check it afterwards.
+     */
+    public static int $computeCount = 0;
+
     public function compute(Concrete $object, CalculatedValue $context): string
     {
+        self::$computeCount++;
+
         $value = '';
         if (RuntimeCache::isRegistered('modeltest.testCalculatedValue.value')) {
             $value = RuntimeCache::get('modeltest.testCalculatedValue.value');


### PR DESCRIPTION
Fixes pimcore/platform-version#440
Fixes pimcore/platform-version#442

Saving a DataObject evaluates every `CalculatedValue` field for two consumers that discard the result, and loads every `ReverseObjectRelation` for one of them. Skipping them is behaviour-preserving and removes a large share of the save cost on classes with many calculated fields or many reverse-related objects.

### 1. The validation loop

`Concrete::update()` calls the getter for every field definition and hands the value to `$fd->checkValidity()` — but `CalculatedValue::checkValidity()` is `// nothing to do`. The calculator runs on every save purely to produce an argument that is thrown away.

This also skips the `$omitMandatoryCheck` computation for that field type, which sounds alarming and is not: `$omitMandatoryCheck` is only a *suppression* flag, and enforcement lives inside `checkValidity()`, which is empty. **A `CalculatedValue` marked mandatory is not enforced today either**, with or without this change, so there is no mandatory semantics to preserve.

### 2. Dependency resolution

`Concrete::resolveDependencies()` calls the getter for every field and passes it to `$field->resolveDependencies(...)`. `CalculatedValue` does not override `resolveDependencies()`, so it inherits `Data::resolveDependencies()`, which is `return [];`.

### 2b. Reverse relations, in the same loop

`ReverseObjectRelation::resolveDependencies()` is an explicit `return [];` — the relation, and its dependency, are recorded on the owning object. But the class-level loop still calls its getter, and that getter is never memoised: every call runs `ReverseObjectRelation::load()` (`SELECT … FROM object_relations_<ownerClassId> WHERE dest_id = ?`) and then `getById()` on every owning object it finds, only to hand the list to a method that discards it. The cost scales with the number of owners, so it is largest exactly where a reverse relation is used — the "many" side. Measured on a real installation: ~0.7 ms and ~7 SELECTs per owner not already in the runtime cache, ~22 ms / ~210 SELECTs for an object with 30 owners, on every save.

Only `resolveDependencies()` is guarded. `ReverseObjectRelation::checkValidity()` genuinely validates (mandatory check, owner-class check), so the validation loop keeps calling the getter. And the class-level loop is the only site: `reverseObjectRelation` is only allowed directly on a class, not in bricks, field collections or localized fields.

### 3. The container-owned paths

A field definition on the class is only one of the ways a calculated value is reached. A container walks its own children, so the same two consumers pay the same cost for a calculated value inside an object brick or a field collection:

| call site | evaluates the calculator | now |
|---|---|---|
| `Objectbricks::checkValidity()` | `$fd->checkValidity($item->$getter(), …)` | skipped |
| `Objectbricks::resolveDependencies()` | `$fd->resolveDependencies($item->$getter())` | skipped |
| `Fieldcollections::resolveDependencies()` | `$fd->resolveDependencies($item->$getter())` | skipped |
| `Fieldcollections::checkValidity()` | — | already skipped since #3962 (2019) |
| `Localizedfields::checkValidity()` / `::resolveDependencies()` | non-variant: no — `Localizedfield::getInternalData()` nulls calculated values | unchanged |
| `Localizedfields::getDataForValidity()`, variant branch | yes — it builds its array from `getLocalizedValue()` | nulled, matching the non-variant branch |

`Block` and `Classificationstore` were checked too and need nothing: they validate from stored data, never through a getter.

### Impact

Measured on a real application with `XDEBUG_MODE=off`, plain `$object->save()` before vs after, with the first two guards only:

| class | calculated fields | SQL statements per save | wall time |
|---|---|---|---|
| A | 13 | **130 → 98** (−25%) | 26.0 → 18.2 ms (−30%) |
| B | 62 | **124 → 84** (−32%) | 20.6 → 13.3 ms (−35%) |

The statement counts are what generalises. Those calculators issue queries, so on a remote database each saved round trip is worth more than the local millisecond figures suggest; an installation whose calculators are pure computation would see the CPU saving without the query saving. A class with brick or fieldcollection calculated values saves proportionally more again.

### Why `instanceof` and not an exact-class check or a new capability

`CalculatedValue` is not `final`, so in principle a subclass could override `checkValidity()` or `resolveDependencies()` and would now be skipped. I kept `instanceof` deliberately:

* Core already decides "is this a calculated value" with `instanceof` in ~18 places, and several of them already skip per-field work in the very same machinery: `Fieldcollections::checkValidity()` (since #3962), `Fieldcollections::getDataForEditmode()`, `Objectbricks::doGetDataForEditmode()`, `FieldDefinitionPropertiesBuilder`. A subclass of `CalculatedValue` is *already* treated as a calculated value by every one of them.
* So an exact-class check here would not give a subclass its `checkValidity()` back — it would still be skipped inside a fieldcollection. It would only make these guards disagree with the rest of core: an inconsistency, not extra safety.
* A new capability method (an interface, or `Data::isValidationNoOp()`) would have to be honoured by those existing sites too to mean anything, which is a much larger API change than this performance fix warrants. If you want that contract, it deserves its own PR covering every site at once, and I am happy to write it.

The same reasoning applies to both guards and to the container ones.

### The validation event

`PRE_UPDATE_VALIDATION_EXCEPTION` is dispatched right after the validation loop, and a listener may remove exceptions from it. So: does skipping the getter remove a calculator-thrown `ValidationException` that a listener could previously have suppressed, turning an accepted save into a failure?

No — that save was never accepted. `Concrete\Dao::update()` calls the same getter a few lines later for the query table (`CalculatedValue` is `QueryResourcePersistenceAwareInterface`), the getter is not memoised, and nothing catches an exception there. A listener that dropped the calculator's exception from the event today simply got the same failure a few lines further on. What changes is where the exception surfaces from, and that it is no longer aggregated with the other fields' messages — flagging it rather than burying it, but no save changes outcome.

### Tests

`tests/Model/DataObject/CalculatedValueEvaluationTest.php`, with a counter added to the shared test calculator. The fixture is the `inheritance` class, which carries a calculated value on the class, one in its localized fields and a third in `unittestBrick`, so one object covers the class-level loop and the container-owned ones.

Save validation is isolated with events rather than by counting a whole save: `PRE_ADD`/`PRE_UPDATE` fire immediately before `Concrete::update()`'s validation loop and `PRE_UPDATE_VALIDATION_EXCEPTION` immediately after it, so the difference between the counter at those two points is exactly the evaluations made while validating — independent of how many the rest of the save legitimately makes for the query tables. `resolveDependencies()` and the brick container's `checkValidity()` / `resolveDependencies()` are called directly. A fourth test asserts the values are still written to the object, localized and brick query tables and still readable from the getters.

`tests/Model/DataObject/ReverseObjectRelationDependencyTest.php` covers the reverse relation with the `unittest` class, which relates to itself (`objects` owning, `nonowner` reverse). It records SQL through the Doctrine debug data holder, the way `LocalizedFieldQueryTableTest` does: first it asserts that the getter does issue the relation read (so the pattern is known to catch it), then that `resolveDependencies()` issues none — and that the dependency is still recorded on the owning side.

Not covered: the fieldcollection paths, because no test fieldcollection defines a calculated value, and the variant branch of `Localizedfields::getDataForValidity()`.

