### PR TITLE
[Bug] Asset folder move silently strands files on storages exposing directory marker objects

### DIFF
--- a/lib/Asset/StorageQueue/QueueAwareStorageAdapter.php
+++ b/lib/Asset/StorageQueue/QueueAwareStorageAdapter.php
@@ -303,7 +303,11 @@ final class QueueAwareStorageAdapter implements FilesystemAdapter, PublicUrlGene
         }
 
         $resolvedSource = $this->resolveFilePath($source);
-        if ($this->inner->fileExists($resolvedSource)) {
+        // A path that answers fileExists() can still be a directory: marker-materializing
+        // backends expose an explicitly created directory as a zero-byte object at its bare
+        // key, and moving only that object would silently strand the whole subtree - such a
+        // path must take the directory branch below.
+        if ($this->inner->fileExists($resolvedSource) && !$this->inner->directoryExists($source)) {
             // single file: normal move, source possibly at its legacy location
             $this->materializeShadowedSource($destination);
             $this->inner->move($resolvedSource, $destination, $config);
@@ -331,7 +335,10 @@ final class QueueAwareStorageAdapter implements FilesystemAdapter, PublicUrlGene
         if ($literalDirectoryExists) {
             try {
                 $this->inner->move($source, $destination, $config);
-                $movedNatively = true;
+                // Trust the native rename only if it actually emptied the source: a marker-
+                // materializing backend "succeeds" after moving just the zero-byte object at
+                // the bare key while the subtree stays behind - that must queue instead.
+                $movedNatively = !$this->inner->directoryExists($source);
             } catch (UnableToMoveFile) {
                 // backend cannot rename directories - fall through to queueing
             }

--- a/lib/Asset/StorageQueue/QueueAwareStorageAdapter.php
+++ b/lib/Asset/StorageQueue/QueueAwareStorageAdapter.php
@@ -306,8 +306,10 @@ final class QueueAwareStorageAdapter implements FilesystemAdapter, PublicUrlGene
         // A path that answers fileExists() can still be a directory: marker-materializing
         // backends expose an explicitly created directory as a zero-byte object at its bare
         // key, and moving only that object would silently strand the whole subtree - such a
-        // path must take the directory branch below.
-        if ($this->inner->fileExists($resolvedSource) && !$this->inner->directoryExists($source)) {
+        // path must take the directory branch below. The check uses the resolved directory
+        // view (own directoryExists()), so a source that exists purely through a pending
+        // move mapping repoints instead of moving its relocated marker as a single file.
+        if ($this->inner->fileExists($resolvedSource) && !$this->directoryExists($source)) {
             // single file: normal move, source possibly at its legacy location
             $this->materializeShadowedSource($destination);
             $this->inner->move($resolvedSource, $destination, $config);

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -547,12 +547,7 @@ class Asset extends Element\AbstractElement
                     // finally move the actual assets themselves
                     // We do this last so that any prior errors don't require a rollback
                     // on potentially a remote service.
-                    try {
-                        $storage->move($oldPath, $this->getRealFullPath());
-                    } catch (UnableToMoveFile $e) {
-                        //update children, if unable to move parent
-                        $this->updateChildPaths($storage, $oldPath);
-                    }
+                    $this->moveDirectoryOnStorage($storage, $oldPath);
                 }
 
                 // lastly create a new version if necessary
@@ -1683,6 +1678,45 @@ class Asset extends Element\AbstractElement
     }
 
     /**
+     * Moves a directory (a folder's subtree) on the given storage: attempts the native
+     * move first (atomic and cheap where the adapter supports it, e.g. on the local
+     * filesystem) and falls back to relocating the contents file by file.
+     *
+     * Whether the fallback is needed is decided by what is actually left at the old
+     * path, never by the move() outcome alone: on some S3-compatible storages a
+     * directory is exposed as a copyable zero-byte object at its bare key, so move()
+     * reports success after relocating just that object while the entire subtree
+     * stays at the old prefix.
+     *
+     * @throws FilesystemException
+     */
+    private function moveDirectoryOnStorage(FilesystemOperator $storage, string $oldPath): void
+    {
+        try {
+            $storage->move($oldPath, $this->getRealFullPath());
+        } catch (UnableToMoveFile) {
+            // expected on storages without native directory rename - covered by the fallback below
+        }
+
+        if ($this->isStorageOperationQueueEnabled()) {
+            // the queue-aware adapter owns the move: a returned move() is either a real native
+            // rename or a queued operation whose source content must stay in place until the
+            // processor drains it - the fallback must not touch it
+            return;
+        }
+
+        if ($storage->directoryExists($oldPath)) {
+            //update children, if the parent move did not (fully) relocate them
+            $this->updateChildPaths($storage, $oldPath);
+        }
+    }
+
+    private function isStorageOperationQueueEnabled(): bool
+    {
+        return (bool) Pimcore::getContainer()->getParameter('pimcore.assets.storage_operation_queue.enabled');
+    }
+
+    /**
      * @throws FilesystemException
      */
     private function updateChildPaths(
@@ -1770,13 +1804,21 @@ class Asset extends Element\AbstractElement
             //remove target parent folder preview thumbnails
             $this->clearFolderThumbnails($this);
 
+            $queueEnabled = $this->isStorageOperationQueueEnabled();
             foreach (['thumbnail', 'asset_cache'] as $storageName) {
                 $storage = Storage::get($storageName);
 
                 try {
                     $this->moveThumbnailPath($storage, $oldThumbnailsPath, $newThumbnailsPath);
-                } catch (UnableToMoveFile $e) {
-                    //update children, if unable to move parent
+                } catch (UnableToMoveFile) {
+                    // expected on storages without native directory rename - covered by the fallback below
+                }
+
+                // same post-condition as in moveDirectoryOnStorage(): run the per-file fallback
+                // based on what is left at the old path, not on the move() outcome; with the
+                // storage operation queue enabled the adapter owns the operation instead
+                if (!$queueEnabled && $storage->directoryExists($oldThumbnailsPath)) {
+                    //update children, if the parent move did not (fully) relocate them
                     //if there is an error, we can ignore it
                     $this->updateChildPaths($storage, $oldPath, null, true);
                 }

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1804,25 +1804,35 @@ class Asset extends Element\AbstractElement
             //remove target parent folder preview thumbnails
             $this->clearFolderThumbnails($this);
 
-            $queueEnabled = $this->isStorageOperationQueueEnabled();
             foreach (['thumbnail', 'asset_cache'] as $storageName) {
-                $storage = Storage::get($storageName);
-
-                try {
-                    $this->moveThumbnailPath($storage, $oldThumbnailsPath, $newThumbnailsPath);
-                } catch (UnableToMoveFile) {
-                    // expected on storages without native directory rename - covered by the fallback below
-                }
-
-                // same post-condition as in moveDirectoryOnStorage(): run the per-file fallback
-                // based on what is left at the old path, not on the move() outcome; with the
-                // storage operation queue enabled the adapter owns the operation instead
-                if (!$queueEnabled && $storage->directoryExists($oldThumbnailsPath)) {
-                    //update children, if the parent move did not (fully) relocate them
-                    //if there is an error, we can ignore it
-                    $this->updateChildPaths($storage, $oldPath, null, true);
-                }
+                $this->moveThumbnailDirectoryOnStorage(Storage::get($storageName), $oldThumbnailsPath, $newThumbnailsPath);
             }
+        }
+    }
+
+    /**
+     * Moves one asset's (or folder's) thumbnail directory on the given storage - same
+     * post-condition approach as moveDirectoryOnStorage(): the per-file fallback runs
+     * based on what is left at the old path, not on the move() outcome; with the storage
+     * operation queue enabled the adapter owns the operation instead.
+     *
+     * @throws FilesystemException
+     */
+    private function moveThumbnailDirectoryOnStorage(
+        FilesystemOperator $storage,
+        string $oldThumbnailsPath,
+        string $newThumbnailsPath
+    ): void {
+        try {
+            $this->moveThumbnailPath($storage, $oldThumbnailsPath, $newThumbnailsPath);
+        } catch (UnableToMoveFile) {
+            // expected on storages without native directory rename - covered by the fallback below
+        }
+
+        if (!$this->isStorageOperationQueueEnabled() && $storage->directoryExists($oldThumbnailsPath)) {
+            //update children, if the parent move did not (fully) relocate them
+            //if there is an error, we can ignore it
+            $this->updateChildPaths($storage, $oldThumbnailsPath, $newThumbnailsPath, true);
         }
     }
 

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1713,7 +1713,7 @@ class Asset extends Element\AbstractElement
 
     private function isStorageOperationQueueEnabled(): bool
     {
-        return (bool) Pimcore::getContainer()->getParameter('pimcore.assets.storage_operation_queue.enabled');
+        return (bool) (Config::getSystemConfiguration('assets')['storage_operation_queue']['enabled'] ?? false);
     }
 
     /**

--- a/tests/Unit/Asset/StorageQueue/MarkerSemanticsAdapterDecorator.php
+++ b/tests/Unit/Asset/StorageQueue/MarkerSemanticsAdapterDecorator.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Asset\StorageQueue;
+
+use League\Flysystem\Config;
+use League\Flysystem\FileAttributes;
+use League\Flysystem\FilesystemAdapter;
+use League\Flysystem\UnableToMoveFile;
+
+/**
+ * Decorates a real adapter but simulates an S3-compatible backend that materializes an
+ * explicitly created directory as a zero-byte object at the BARE key (no trailing slash)
+ * and lets a single-object copy/move of that key succeed. Observed in the wild on such
+ * gateways (e.g. Upsun blob-storage, s3fs-created markers): moving a directory path
+ * "succeeds" by relocating only the marker object while every child stays at the old
+ * prefix. A directory/prefix move without a marker throws, like any object storage.
+ */
+final class MarkerSemanticsAdapterDecorator implements FilesystemAdapter
+{
+    /**
+     * @var array<string, true>
+     */
+    private array $markers = [];
+
+    public function __construct(private readonly FilesystemAdapter $inner)
+    {
+    }
+
+    public function addMarker(string $path): void
+    {
+        $this->markers[trim($path, '/')] = true;
+    }
+
+    public function hasMarker(string $path): bool
+    {
+        return isset($this->markers[trim($path, '/')]);
+    }
+
+    public function fileExists(string $path): bool
+    {
+        return $this->hasMarker($path) || $this->inner->fileExists($path);
+    }
+
+    public function directoryExists(string $path): bool
+    {
+        return $this->inner->directoryExists($path);
+    }
+
+    public function write(string $path, string $contents, Config $config): void
+    {
+        $this->inner->write($path, $contents, $config);
+    }
+
+    public function writeStream(string $path, $contents, Config $config): void
+    {
+        $this->inner->writeStream($path, $contents, $config);
+    }
+
+    public function read(string $path): string
+    {
+        return $this->inner->read($path);
+    }
+
+    public function readStream(string $path)
+    {
+        return $this->inner->readStream($path);
+    }
+
+    public function delete(string $path): void
+    {
+        unset($this->markers[trim($path, '/')]);
+        if ($this->inner->fileExists($path)) {
+            $this->inner->delete($path);
+        }
+    }
+
+    public function deleteDirectory(string $path): void
+    {
+        $this->inner->deleteDirectory($path);
+    }
+
+    public function createDirectory(string $path, Config $config): void
+    {
+        // this is the backend divergence: an explicit createDirectory() materializes a
+        // plain object at the bare key
+        $this->addMarker($path);
+        $this->inner->createDirectory($path, $config);
+    }
+
+    public function setVisibility(string $path, string $visibility): void
+    {
+        $this->inner->setVisibility($path, $visibility);
+    }
+
+    public function visibility(string $path): FileAttributes
+    {
+        return $this->inner->visibility($path);
+    }
+
+    public function mimeType(string $path): FileAttributes
+    {
+        return $this->inner->mimeType($path);
+    }
+
+    public function lastModified(string $path): FileAttributes
+    {
+        return $this->inner->lastModified($path);
+    }
+
+    public function fileSize(string $path): FileAttributes
+    {
+        return $this->inner->fileSize($path);
+    }
+
+    public function listContents(string $path, bool $deep): iterable
+    {
+        return $this->inner->listContents($path, $deep);
+    }
+
+    public function move(string $source, string $destination, Config $config): void
+    {
+        if ($this->hasMarker($source)) {
+            // the spurious "success": the marker object moves, the subtree does not
+            unset($this->markers[trim($source, '/')]);
+            $this->addMarker($destination);
+
+            return;
+        }
+
+        if (!$this->inner->fileExists($source)) {
+            throw UnableToMoveFile::fromLocationTo($source, $destination);
+        }
+
+        $this->inner->move($source, $destination, $config);
+    }
+
+    public function copy(string $source, string $destination, Config $config): void
+    {
+        if ($this->hasMarker($source)) {
+            $this->addMarker($destination);
+
+            return;
+        }
+
+        $this->inner->copy($source, $destination, $config);
+    }
+}

--- a/tests/Unit/Asset/StorageQueue/QueueAwareStorageAdapterTest.php
+++ b/tests/Unit/Asset/StorageQueue/QueueAwareStorageAdapterTest.php
@@ -446,6 +446,44 @@ class QueueAwareStorageAdapterTest extends Unit
         $this->assertSame('bytes', $adapter->read('Archive/Campaigns/img.jpg'));
     }
 
+    public function testPrefixMoveOnMarkerBackendQueuesARowInsteadOfMovingOnlyTheMarker(): void
+    {
+        // Backend divergence observed on marker-materializing gateways (PEES-1617): a
+        // zero-byte object sits at the bare directory key, so a native move() "succeeds"
+        // by relocating just that object. The adapter must not mistake that for a moved
+        // subtree - the operation has to be queued like on any non-renaming backend.
+        $marker = new MarkerSemanticsAdapterDecorator(new LocalFilesystemAdapter($this->tmpDir));
+        $adapter = new QueueAwareStorageAdapter($marker, $this->repository, 'asset');
+        $adapter->write('Campaigns/img.jpg', 'bytes', new Config());
+        $marker->addMarker('Campaigns');
+
+        $adapter->move('Campaigns', 'Archive/Campaigns', new Config());
+
+        $this->assertTrue($marker->fileExists('Campaigns/img.jpg'), 'physical object untouched until the processor runs');
+        $operations = $this->repository->all();
+        $this->assertCount(1, $operations);
+        $this->assertSame('move', $operations[0]->getType()->value);
+        $this->assertSame('Campaigns', $operations[0]->getSourcePrefix());
+        $this->assertSame('Archive/Campaigns', $operations[0]->getTargetPrefix());
+        // and the logical view is already correct:
+        $this->assertSame('bytes', $adapter->read('Archive/Campaigns/img.jpg'));
+    }
+
+    public function testMarkerWithoutChildrenMovesAsASingleObject(): void
+    {
+        // a bare marker with no subtree behind it is just a zero-byte object - a plain
+        // single-object move, no queue row
+        $marker = new MarkerSemanticsAdapterDecorator(new LocalFilesystemAdapter($this->tmpDir));
+        $adapter = new QueueAwareStorageAdapter($marker, $this->repository, 'asset');
+        $marker->addMarker('Empty');
+
+        $adapter->move('Empty', 'Renamed', new Config());
+
+        $this->assertFalse($marker->hasMarker('Empty'));
+        $this->assertTrue($marker->hasMarker('Renamed'));
+        $this->assertSame([], $this->repository->all(), 'no queue row for a single-object move');
+    }
+
     public function testMovingAnEmptyFolderThrowsAndQueuesNothing(): void
     {
         $adapter = $this->nonRenamingAdapter();

--- a/tests/Unit/Asset/StorageQueue/QueueAwareStorageAdapterTest.php
+++ b/tests/Unit/Asset/StorageQueue/QueueAwareStorageAdapterTest.php
@@ -469,6 +469,27 @@ class QueueAwareStorageAdapterTest extends Unit
         $this->assertSame('bytes', $adapter->read('Archive/Campaigns/img.jpg'));
     }
 
+    public function testReMoveOfPendingSubtreeOnMarkerBackendRepointsInsteadOfMovingTheMarker(): void
+    {
+        // After a first queued move A -> B on a marker backend, the marker object sits
+        // physically at B while the children still sit under A. A second move B -> C must
+        // repoint the pending row (the mapped-directory branch), not treat B as a single
+        // file just because the relocated marker answers fileExists().
+        $marker = new MarkerSemanticsAdapterDecorator(new LocalFilesystemAdapter($this->tmpDir));
+        $adapter = new QueueAwareStorageAdapter($marker, $this->repository, 'asset');
+        $adapter->write('A/img.jpg', 'bytes', new Config());
+        $marker->addMarker('A');
+        $adapter->move('A', 'B', new Config());
+
+        $adapter->move('B', 'C', new Config());
+
+        $operations = $this->repository->all();
+        $this->assertCount(1, $operations);
+        $this->assertSame('A', $operations[0]->getSourcePrefix());
+        $this->assertSame('C', $operations[0]->getTargetPrefix());
+        $this->assertSame('bytes', $adapter->read('C/img.jpg'));
+    }
+
     public function testMarkerWithoutChildrenMovesAsASingleObject(): void
     {
         // a bare marker with no subtree behind it is just a zero-byte object - a plain

--- a/tests/Unit/Models/Asset/FolderStorageMoveTest.php
+++ b/tests/Unit/Models/Asset/FolderStorageMoveTest.php
@@ -90,6 +90,29 @@ class FolderStorageMoveTest extends Unit
         self::assertFalse($storage->directoryExists('/old-folder'));
     }
 
+    public function testThumbnailFallbackOfANonFolderAssetRelocatesTheThumbnailDirectory(): void
+    {
+        // For a non-folder asset the thumbnail directory (".../<id>") differs from the
+        // asset's own old path (".../<filename>") - the fallback must operate on the
+        // thumbnail paths, not on the asset path.
+        $decorator = new NonRenamingAdapterDecorator(new LocalFilesystemAdapter($this->tmpDir));
+        $storage = new Filesystem($decorator);
+        $storage->write('old-dir/123/image-thumb__123__preview/img.jpg', 'thumb-bytes');
+
+        $image = new Asset\Image();
+        $image->setPath('/new-dir/');
+        $image->setFilename('img.jpg');
+
+        $method = new ReflectionMethod(Asset::class, 'moveThumbnailDirectoryOnStorage');
+        $method->invoke($image, $storage, '/old-dir/123', '/new-dir/123');
+
+        self::assertTrue(
+            $storage->fileExists('/new-dir/123/image-thumb__123__preview/img.jpg'),
+            'thumbnails must be relocated to the new thumbnail directory'
+        );
+        self::assertFalse($storage->directoryExists('/old-dir/123'), 'nothing may stay at the old thumbnail directory');
+    }
+
     private function moveDirectoryOnStorage(Filesystem $storage, string $oldPath, string $newFilename): void
     {
         $folder = new Asset\Folder();

--- a/tests/Unit/Models/Asset/FolderStorageMoveTest.php
+++ b/tests/Unit/Models/Asset/FolderStorageMoveTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Models\Asset;
+
+use Codeception\Test\Unit;
+use FilesystemIterator;
+use League\Flysystem\Filesystem;
+use League\Flysystem\Local\LocalFilesystemAdapter;
+use Pimcore\Model\Asset;
+use Pimcore\Tests\Unit\Asset\StorageQueue\MarkerSemanticsAdapterDecorator;
+use Pimcore\Tests\Unit\Asset\StorageQueue\NonRenamingAdapterDecorator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionMethod;
+
+/**
+ * Covers Asset::moveDirectoryOnStorage(): the physical part of a folder rename/move.
+ * Whether the per-file fallback runs must be decided by what is actually left at the
+ * old path, not by whether the native move threw - on marker-materializing backends
+ * (PEES-1617) the native move "succeeds" while the whole subtree stays behind.
+ */
+class FolderStorageMoveTest extends Unit
+{
+    private string $tmpDir;
+
+    protected function _before(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/folder-storage-move-test-' . uniqid();
+        mkdir($this->tmpDir, 0777, true);
+    }
+
+    protected function _after(): void
+    {
+        $it = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($this->tmpDir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $file) {
+            $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+        }
+        rmdir($this->tmpDir);
+    }
+
+    public function testDirectoryMoveFallsBackWhenNativeMoveRelocatesOnlyAMarkerObject(): void
+    {
+        $decorator = new MarkerSemanticsAdapterDecorator(new LocalFilesystemAdapter($this->tmpDir));
+        $storage = new Filesystem($decorator);
+        $storage->write('old-folder/sub/image.jpg', 'payload');
+        $decorator->addMarker('old-folder');
+
+        $this->moveDirectoryOnStorage($storage, '/old-folder', 'new-folder');
+
+        self::assertTrue($storage->fileExists('/new-folder/sub/image.jpg'), 'children must be relocated');
+        self::assertSame('payload', $storage->read('/new-folder/sub/image.jpg'));
+        self::assertFalse($storage->directoryExists('/old-folder'), 'nothing may stay at the old prefix');
+    }
+
+    public function testDirectoryMoveFallsBackWhenNativeMoveIsNotSupported(): void
+    {
+        $decorator = new NonRenamingAdapterDecorator(new LocalFilesystemAdapter($this->tmpDir));
+        $storage = new Filesystem($decorator);
+        $storage->write('old-folder/sub/image.jpg', 'payload');
+
+        $this->moveDirectoryOnStorage($storage, '/old-folder', 'new-folder');
+
+        self::assertTrue($storage->fileExists('/new-folder/sub/image.jpg'));
+        self::assertFalse($storage->directoryExists('/old-folder'));
+    }
+
+    public function testDirectoryMoveUsesTheNativeMoveWhereSupported(): void
+    {
+        $storage = new Filesystem(new LocalFilesystemAdapter($this->tmpDir));
+        $storage->write('old-folder/sub/image.jpg', 'payload');
+
+        $this->moveDirectoryOnStorage($storage, '/old-folder', 'new-folder');
+
+        self::assertTrue($storage->fileExists('/new-folder/sub/image.jpg'));
+        self::assertFalse($storage->directoryExists('/old-folder'));
+    }
+
+    private function moveDirectoryOnStorage(Filesystem $storage, string $oldPath, string $newFilename): void
+    {
+        $folder = new Asset\Folder();
+        $folder->setPath('/');
+        $folder->setFilename($newFilename);
+
+        $method = new ReflectionMethod(Asset::class, 'moveDirectoryOnStorage');
+        $method->invoke($folder, $storage, $oldPath);
+    }
+}


### PR DESCRIPTION
## Changes in this pull request

Resolves https://github.com/pimcore/service-operations/issues/1304

Renaming/moving an asset folder can **silently strand every file at the old storage path** on S3-compatible storages that expose an explicitly created directory as a copyable **zero-byte object at its bare key** (no trailing slash). Observed in production on Upsun blob-storage (PEES-1617); the same marker objects can be planted on any backend, including AWS S3, by external tools such as s3fs mounts.

**Mechanism:** `Asset::update()` creates a directory on the asset storage for every folder save, which such backends materialize as a bare-key marker object. On a folder rename, the native `$storage->move($oldPath, $newPath)` then *succeeds* by relocating just that one marker object — so the `UnableToMoveFile` catch that normally triggers the per-file fallback never fires. The DB commits, the UI reports success, and the whole subtree stays at the old prefix (downloads keep working off temp/CDN caches until those expire, so the stranding surfaces weeks later). The thumbnail storage never receives `createDirectory`, so thumbnails *did* get moved by the fallback — the confusing "thumbnails moved, originals didn't" symptom from the report.

**Fix — decide by post-condition, not by exception:** whether the per-file fallback runs is now determined by what is actually left at the old path (`directoryExists($oldPath)`) after the native move attempt, instead of by the presence of an `UnableToMoveFile` exception alone. Applied to the originals move (extracted into `Asset::moveDirectoryOnStorage()`) and to the thumbnail relocation.

The storage operation queue adapter had the same blind trust in two places and is hardened accordingly:
- a source path that answers `fileExists()` but is *also* a directory takes the directory branch instead of being moved as a single object;
- a native rename is only trusted when it actually emptied the source — otherwise the operation is queued as on any non-renaming backend.

With the queue enabled, the fallback in `Asset` intentionally stays out of the way: an enqueued move legitimately leaves the source physically populated until the processor drains it.

### How to reproduce

On stock AWS S3/MinIO the bug is not reproducible (the bare-key copy 404s, which routes into the working fallback). Against an affected backend, or by planting the marker manually:

1. Use a flysystem S3 storage for `pimcore.asset.storage`; create asset folder `A` with children (Pimcore's folder save creates the directory placeholder — on marker-materializing backends this is a plain object at key `…/A`). On conforming S3 you can simulate it with `aws s3api put-object --key "assets/A"` (zero bytes, no trailing slash).
2. Rename folder `A` to `B` in the UI.
3. Before: rename succeeds, DB updated, but every original stays under `assets/A/…`; nothing is logged. After: children are relocated to `assets/B/…`.

The regression tests encode the backend divergence in `MarkerSemanticsAdapterDecorator` and cover the model fallback (`FolderStorageMoveTest`, red before the fix) and the queue adapter (`QueueAwareStorageAdapterTest::testPrefixMoveOnMarkerBackendQueuesARowInsteadOfMovingOnlyTheMarker`, red before the fix), plus a guard that a marker *without* a subtree still moves as a plain single object.

## Additional info

- Root-cause analysis for PEES-1617 (forensics against the affected environment: marker objects with `mtime` equal to the rename moment, subtree fully intact at the old prefix).
- Verified locally: full `Unit` suite green in the tests/bin Docker harness (1063 tests, 2335 assertions); the three new/changed test files red-before/green-after; php-cs-fixer clean on the changed files. Functional/Model suites beyond Unit not run locally — CI validates those.
- Cost note: one additional `directoryExists()` (a `MaxKeys=1` listing on S3 adapters) per path-changing save and per queue-adapter move — these are admin-rate operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
