### PR TITLE
[Bug] Translate areabrick names and descriptions via the studio domain in editmode

### DIFF
--- a/doc/13_Upgrade_Notes/README.md
+++ b/doc/13_Upgrade_Notes/README.md
@@ -1,5 +1,10 @@
 # Upgrade Notes
 
+## Pimcore 2026.2.12
+
+### [Documents]
+- [Areabricks] In editmode, areabrick names and descriptions are now translated via the `studio` translation domain whenever that domain is registered (i.e. Pimcore Studio is installed), so these UI labels show up in Studio's translations instead of the website's `messages` domain. Labels that were already translated in the `messages` domain keep working as a read-only fallback, but missing keys are no longer auto-created there - they are created in the `studio` domain instead. Installations without the `studio` domain keep translating them via `messages` as before.
+
 ## Pimcore 2026.2.5
 
 ### [Custom Reports]

--- a/lib/Document/Editable/EditableHandler.php
+++ b/lib/Document/Editable/EditableHandler.php
@@ -176,6 +176,8 @@ class EditableHandler implements LoggerAwareInterface
 
     private function translateAreabrickLabel(string $label): string
     {
+        // the translator trims message ids as well
+        $label = trim($label);
         if ($label === '') {
             return $label;
         }
@@ -216,14 +218,31 @@ class EditableHandler implements LoggerAwareInterface
         }
 
         // same lookup order as the translator: the locale itself, then its configured fallback languages
+        $translation = null;
         foreach ([$locale, ...Tool::getFallbackLanguagesFor($locale)] as $lookupLocale) {
             $translation = $this->getCatalogueTranslation($label, Translation::DOMAIN_DEFAULT, $lookupLocale);
             if ($translation !== null) {
-                return $translation;
+                break;
             }
         }
 
-        return null;
+        if ($translation === null || $translation === $label) {
+            return $translation;
+        }
+
+        // the translator only creates keys that are unknown to the catalogue of the locale, so once the key is
+        // known there, translating is safe and yields the translator's complete pipeline (link updates, ...)
+        if ($this->isKnownToCatalogue($label, Translation::DOMAIN_DEFAULT, $locale)) {
+            return $this->translator->trans($label, [], Translation::DOMAIN_DEFAULT);
+        }
+
+        return $translation;
+    }
+
+    private function isKnownToCatalogue(string $label, string $domain, string $locale): bool
+    {
+        return $this->translator instanceof TranslatorBagInterface
+            && $this->translator->getCatalogue($locale)->has($label, $domain);
     }
 
     private function getTranslatorLocale(): ?string

--- a/lib/Document/Editable/EditableHandler.php
+++ b/lib/Document/Editable/EditableHandler.php
@@ -73,6 +73,11 @@ class EditableHandler implements LoggerAwareInterface
      */
     protected array $brickTemplateCache = [];
 
+    /**
+     * @var array<string, string> areabrick labels resolved during this request
+     */
+    private array $translatedAreabrickLabels = [];
+
     protected EditmodeResolver $editmodeResolver;
 
     protected HttpKernelRuntime $httpKernelRuntime;
@@ -182,6 +187,13 @@ class EditableHandler implements LoggerAwareInterface
             return $label;
         }
 
+        // translating a label unknown to the Studio domain puts it into the in-memory catalogue as its own
+        // translation, so a label is resolved only once per request to keep repeated occurrences consistent
+        return $this->translatedAreabrickLabels[$label] ??= $this->resolveAreabrickLabel($label);
+    }
+
+    private function resolveAreabrickLabel(string $label): string
+    {
         if (!Translation::isAValidDomain(self::AREABRICK_LABEL_TRANSLATION_DOMAIN)) {
             // without the Studio UI domain, the default domain is the only place to translate with
             return $this->translator->trans($label, [], Translation::DOMAIN_DEFAULT);
@@ -218,31 +230,23 @@ class EditableHandler implements LoggerAwareInterface
         }
 
         // same lookup order as the translator: the locale itself, then its configured fallback languages
-        $translation = null;
         foreach ([$locale, ...Tool::getFallbackLanguagesFor($locale)] as $lookupLocale) {
             $translation = $this->getCatalogueTranslation($label, Translation::DOMAIN_DEFAULT, $lookupLocale);
-            if ($translation !== null) {
-                break;
+            if ($translation === null) {
+                continue;
             }
+
+            if ($translation === $label) {
+                return $translation;
+            }
+
+            // the translator only creates keys that are unknown to the catalogue of the locale it translates
+            // in, so translating explicitly in the locale that knows the key is safe and yields the complete
+            // translator pipeline (link updates, disabled translations, ...) instead of the raw catalogue text
+            return $this->translator->trans($label, [], Translation::DOMAIN_DEFAULT, $lookupLocale);
         }
 
-        if ($translation === null || $translation === $label) {
-            return $translation;
-        }
-
-        // the translator only creates keys that are unknown to the catalogue of the locale, so once the key is
-        // known there, translating is safe and yields the translator's complete pipeline (link updates, ...)
-        if ($this->isKnownToCatalogue($label, Translation::DOMAIN_DEFAULT, $locale)) {
-            return $this->translator->trans($label, [], Translation::DOMAIN_DEFAULT);
-        }
-
-        return $translation;
-    }
-
-    private function isKnownToCatalogue(string $label, string $domain, string $locale): bool
-    {
-        return $this->translator instanceof TranslatorBagInterface
-            && $this->translator->getCatalogue($locale)->has($label, $domain);
+        return null;
     }
 
     private function getTranslatorLocale(): ?string

--- a/lib/Document/Editable/EditableHandler.php
+++ b/lib/Document/Editable/EditableHandler.php
@@ -29,6 +29,7 @@ use Pimcore\Model\Document\Editable;
 use Pimcore\Model\Document\Editable\Area\Info;
 use Pimcore\Model\Document\PageSnippet;
 use Pimcore\Model\Translation;
+use Pimcore\Tool;
 use Pimcore\Translation\Translator;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
@@ -184,6 +185,12 @@ class EditableHandler implements LoggerAwareInterface
             return $this->translator->trans($label, [], Translation::DOMAIN_DEFAULT);
         }
 
+        // a label maintained in the Studio domain always wins, also when its translation equals the key
+        if ($this->hasTranslation($label, self::AREABRICK_LABEL_TRANSLATION_DOMAIN)) {
+            return $this->translator->trans($label, [], self::AREABRICK_LABEL_TRANSLATION_DOMAIN);
+        }
+
+        // translating creates the missing key in the Studio domain, where the label is meant to be maintained
         $translated = $this->translator->trans($label, [], self::AREABRICK_LABEL_TRANSLATION_DOMAIN);
         if ($translated !== $label) {
             return $translated;
@@ -194,24 +201,60 @@ class EditableHandler implements LoggerAwareInterface
         return $this->getExistingDefaultDomainTranslation($label) ?? $label;
     }
 
+    private function hasTranslation(string $label, string $domain): bool
+    {
+        $locale = $this->getTranslatorLocale();
+
+        return $locale !== null && $this->getCatalogueTranslation($label, $domain, $locale) !== null;
+    }
+
     private function getExistingDefaultDomainTranslation(string $label): ?string
+    {
+        $locale = $this->getTranslatorLocale();
+        if ($locale === null) {
+            return null;
+        }
+
+        // same lookup order as the translator: the locale itself, then its configured fallback languages
+        foreach ([$locale, ...Tool::getFallbackLanguagesFor($locale)] as $lookupLocale) {
+            $translation = $this->getCatalogueTranslation($label, Translation::DOMAIN_DEFAULT, $lookupLocale);
+            if ($translation !== null) {
+                return $translation;
+            }
+        }
+
+        return null;
+    }
+
+    private function getTranslatorLocale(): ?string
+    {
+        if ($this->translator instanceof TranslatorBagInterface && $this->translator instanceof LocaleAwareInterface) {
+            return $this->translator->getLocale();
+        }
+
+        return null;
+    }
+
+    /**
+     * Reads a translation from the catalogue without translating, so that no missing key gets created.
+     */
+    private function getCatalogueTranslation(string $label, string $domain, string $locale): ?string
     {
         if (!$this->translator instanceof TranslatorBagInterface) {
             return null;
         }
 
-        $locale = $this->translator instanceof LocaleAwareInterface ? $this->translator->getLocale() : null;
-        if ($this->translator instanceof Translator && $locale !== null) {
-            // makes sure the database translations of the default domain are part of the catalogue
-            $this->translator->lazyInitialize(Translation::DOMAIN_DEFAULT, $locale);
+        if ($this->translator instanceof Translator) {
+            // makes sure the database translations of the domain are part of the catalogue
+            $this->translator->lazyInitialize($domain, $locale);
         }
 
         $catalogue = $this->translator->getCatalogue($locale);
-        if (!$catalogue->has($label, Translation::DOMAIN_DEFAULT)) {
+        if (!$catalogue->has($label, $domain)) {
             return null;
         }
 
-        $translation = $catalogue->get($label, Translation::DOMAIN_DEFAULT);
+        $translation = $catalogue->get($label, $domain);
 
         return $translation !== '' ? $translation : null;
     }

--- a/lib/Document/Editable/EditableHandler.php
+++ b/lib/Document/Editable/EditableHandler.php
@@ -28,6 +28,8 @@ use Pimcore\HttpKernel\WebPathResolver;
 use Pimcore\Model\Document\Editable;
 use Pimcore\Model\Document\Editable\Area\Info;
 use Pimcore\Model\Document\PageSnippet;
+use Pimcore\Model\Translation;
+use Pimcore\Translation\Translator;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Bridge\Twig\Extension\HttpKernelRuntime;
@@ -37,6 +39,8 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface;
 use Symfony\Component\Templating\EngineInterface;
+use Symfony\Component\Translation\TranslatorBagInterface;
+use Symfony\Contracts\Translation\LocaleAwareInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -77,6 +81,13 @@ class EditableHandler implements LoggerAwareInterface
     protected RequestStack $requestStack;
 
     public const ATTRIBUTE_AREABRICK_INFO = '_pimcore_areabrick_info';
+
+    /**
+     * Areabrick names and descriptions are labels of the editing UI, so they are resolved via the
+     * translation domain of the Studio UI when that domain is registered, instead of the website's
+     * default domain.
+     */
+    private const AREABRICK_LABEL_TRANSLATION_DOMAIN = 'studio';
 
     public function __construct(
         AreabrickManagerInterface $brickManager,
@@ -143,8 +154,8 @@ class EditableHandler implements LoggerAwareInterface
                 : null;
 
             if ($this->editmodeResolver->isEditmode()) {
-                $name = $this->translator->trans($name);
-                $desc = $this->translator->trans($desc);
+                $name = $this->translateAreabrickLabel($name);
+                $desc = $this->translateAreabrickLabel($desc);
             }
 
             $areas[$brick->getId()] = [
@@ -160,6 +171,49 @@ class EditableHandler implements LoggerAwareInterface
         }
 
         return $areas;
+    }
+
+    private function translateAreabrickLabel(string $label): string
+    {
+        if ($label === '') {
+            return $label;
+        }
+
+        if (!Translation::isAValidDomain(self::AREABRICK_LABEL_TRANSLATION_DOMAIN)) {
+            // without the Studio UI domain, the default domain is the only place to translate with
+            return $this->translator->trans($label, [], Translation::DOMAIN_DEFAULT);
+        }
+
+        $translated = $this->translator->trans($label, [], self::AREABRICK_LABEL_TRANSLATION_DOMAIN);
+        if ($translated !== $label) {
+            return $translated;
+        }
+
+        // labels that were translated in the default domain before must keep working, but they are
+        // only looked up there: translating via the default domain would auto-create the missing keys
+        return $this->getExistingDefaultDomainTranslation($label) ?? $label;
+    }
+
+    private function getExistingDefaultDomainTranslation(string $label): ?string
+    {
+        if (!$this->translator instanceof TranslatorBagInterface) {
+            return null;
+        }
+
+        $locale = $this->translator instanceof LocaleAwareInterface ? $this->translator->getLocale() : null;
+        if ($this->translator instanceof Translator && $locale !== null) {
+            // makes sure the database translations of the default domain are part of the catalogue
+            $this->translator->lazyInitialize(Translation::DOMAIN_DEFAULT, $locale);
+        }
+
+        $catalogue = $this->translator->getCatalogue($locale);
+        if (!$catalogue->has($label, Translation::DOMAIN_DEFAULT)) {
+            return null;
+        }
+
+        $translation = $catalogue->get($label, Translation::DOMAIN_DEFAULT);
+
+        return $translation !== '' ? $translation : null;
     }
 
     public function renderAreaFrontend(Info $info, array $templateParams = []): string

--- a/lib/Document/Editable/EditableHandler.php
+++ b/lib/Document/Editable/EditableHandler.php
@@ -74,7 +74,7 @@ class EditableHandler implements LoggerAwareInterface
     protected array $brickTemplateCache = [];
 
     /**
-     * @var array<string, string> areabrick labels resolved during this request
+     * @var array<string, array<string, string>> areabrick labels resolved during this request, per locale
      */
     private array $translatedAreabrickLabels = [];
 
@@ -188,8 +188,10 @@ class EditableHandler implements LoggerAwareInterface
         }
 
         // translating a label unknown to the Studio domain puts it into the in-memory catalogue as its own
-        // translation, so a label is resolved only once per request to keep repeated occurrences consistent
-        return $this->translatedAreabrickLabels[$label] ??= $this->resolveAreabrickLabel($label);
+        // translation, so a label is resolved only once per locale to keep repeated occurrences consistent
+        $locale = $this->translator instanceof LocaleAwareInterface ? $this->translator->getLocale() : '';
+
+        return $this->translatedAreabrickLabels[$locale][$label] ??= $this->resolveAreabrickLabel($label);
     }
 
     private function resolveAreabrickLabel(string $label): string

--- a/tests/Unit/Document/Editable/EditableHandlerTest.php
+++ b/tests/Unit/Document/Editable/EditableHandlerTest.php
@@ -26,6 +26,7 @@ use Pimcore\HttpKernel\WebPathResolver;
 use Pimcore\Model\Document\Editable\Areablock;
 use Pimcore\Model\Translation;
 use Pimcore\Tests\Support\Test\TestCase;
+use Pimcore\Tool;
 use Pimcore\Translation\Translator;
 use ReflectionClassConstant;
 use Symfony\Bridge\Twig\Extension\HttpKernelRuntime;
@@ -53,20 +54,39 @@ final class EditableHandlerTest extends TestCase
 
     private EditmodeResolver&MockObject $editmodeResolver;
 
-    private MessageCatalogue $catalogue;
+    /**
+     * @var array<string, MessageCatalogue>
+     */
+    private array $catalogues = [];
+
+    /**
+     * @var list<string> "<domain>/<locale>" pairs the handler asked the translator to initialize
+     */
+    private array $initializedCatalogues = [];
+
+    private string $locale = self::LOCALE;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->catalogue = new MessageCatalogue(self::LOCALE);
+        $this->catalogues = [];
+        $this->initializedCatalogues = [];
+        $this->locale = self::LOCALE;
 
         $this->translator = $this->getMockBuilder(Translator::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['trans', 'getCatalogue', 'lazyInitialize', 'getLocale'])
             ->getMock();
-        $this->translator->method('getLocale')->willReturn(self::LOCALE);
-        $this->translator->method('getCatalogue')->willReturn($this->catalogue);
+        $this->translator->method('getLocale')->willReturnCallback(fn (): string => $this->locale);
+        $this->translator->method('getCatalogue')->willReturnCallback(
+            fn (?string $locale = null): MessageCatalogue => $this->catalogue($locale ?? $this->locale)
+        );
+        $this->translator->method('lazyInitialize')->willReturnCallback(
+            function (string $domain, string $locale): void {
+                $this->initializedCatalogues[] = $domain . '/' . $locale;
+            }
+        );
 
         $this->editmodeResolver = $this->createMock(EditmodeResolver::class);
         $this->editmodeResolver->method('isEditmode')->willReturn(true);
@@ -97,13 +117,31 @@ final class EditableHandlerTest extends TestCase
         self::assertSame('Ein Teaser-Baustein', $areas['teaser']['description']);
     }
 
+    public function testStudioTranslationEqualToItsKeyTakesPrecedenceOverDefaultDomain(): void
+    {
+        $this->markStudioDomainAsRegistered(true);
+
+        // a Studio translation that intentionally equals the key must not be mistaken for a missing one
+        $this->catalogue(self::LOCALE)->set('Teaser', 'Teaser', self::STUDIO_DOMAIN);
+        $this->catalogue(self::LOCALE)->set('Teaser', 'Vorspann', Translation::DOMAIN_DEFAULT);
+
+        $this->translator->expects($this->exactly(2))
+            ->method('trans')
+            ->with($this->anything(), [], self::STUDIO_DOMAIN)
+            ->willReturnArgument(0);
+
+        $areas = $this->createHandler()->getAvailableAreablockAreas(new Areablock(), []);
+
+        self::assertSame('Teaser', $areas['teaser']['name']);
+    }
+
     public function testExistingDefaultDomainTranslationIsUsedWithoutCreatingKeysThere(): void
     {
         $this->markStudioDomainAsRegistered(true);
 
         // an installation that already maintains the labels in "messages" (e.g. a classic install
         // that later added Studio) must keep its translations ...
-        $this->catalogue->set('Teaser', 'Teaser (messages)', Translation::DOMAIN_DEFAULT);
+        $this->catalogue(self::LOCALE)->set('Teaser', 'Teaser (messages)', Translation::DOMAIN_DEFAULT);
 
         // ... but the lookup must never go through trans() with the default domain, because that
         // is what auto-creates the missing keys in the "messages" domain.
@@ -111,14 +149,39 @@ final class EditableHandlerTest extends TestCase
             ->method('trans')
             ->with($this->anything(), [], self::STUDIO_DOMAIN)
             ->willReturnArgument(0);
-        $this->translator->expects($this->atLeastOnce())
-            ->method('lazyInitialize')
-            ->with(Translation::DOMAIN_DEFAULT, self::LOCALE);
 
         $areas = $this->createHandler()->getAvailableAreablockAreas(new Areablock(), []);
 
         self::assertSame('Teaser (messages)', $areas['teaser']['name']);
         self::assertSame('A teaser brick', $areas['teaser']['description']);
+        self::assertContains(
+            Translation::DOMAIN_DEFAULT . '/' . self::LOCALE,
+            $this->initializedCatalogues,
+            'The database translations of the default domain must be loaded before looking the label up.'
+        );
+    }
+
+    public function testConfiguredFallbackLanguageOfDefaultDomainIsUsed(): void
+    {
+        $this->markStudioDomainAsRegistered(true);
+
+        // the test system settings configure "de" as fallback language of "de_AT"
+        self::assertSame(['de'], Tool::getFallbackLanguagesFor('de_AT'));
+        $this->locale = 'de_AT';
+
+        // an empty "de_AT" value falls back to the configured "de" translation, like trans() does
+        $this->catalogue('de_AT')->set('Teaser', '', Translation::DOMAIN_DEFAULT);
+        $this->catalogue('de')->set('Teaser', 'Vorspann', Translation::DOMAIN_DEFAULT);
+
+        $this->translator->expects($this->exactly(2))
+            ->method('trans')
+            ->with($this->anything(), [], self::STUDIO_DOMAIN)
+            ->willReturnArgument(0);
+
+        $areas = $this->createHandler()->getAvailableAreablockAreas(new Areablock(), []);
+
+        self::assertSame('Vorspann', $areas['teaser']['name']);
+        self::assertContains(Translation::DOMAIN_DEFAULT . '/de', $this->initializedCatalogues);
     }
 
     public function testEmptyDefaultDomainTranslationFallsBackToTheLabel(): void
@@ -126,7 +189,7 @@ final class EditableHandlerTest extends TestCase
         $this->markStudioDomainAsRegistered(true);
 
         // an auto-created key without a text must not blank out the label
-        $this->catalogue->set('Teaser', '', Translation::DOMAIN_DEFAULT);
+        $this->catalogue(self::LOCALE)->set('Teaser', '', Translation::DOMAIN_DEFAULT);
 
         $this->translator->method('trans')->willReturnArgument(0);
 
@@ -146,12 +209,12 @@ final class EditableHandlerTest extends TestCase
                 ['Teaser', [], Translation::DOMAIN_DEFAULT, null, 'Teaser (messages)'],
                 ['A teaser brick', [], Translation::DOMAIN_DEFAULT, null, 'Ein Teaser-Baustein'],
             ]);
-        $this->translator->expects($this->never())->method('lazyInitialize');
 
         $areas = $this->createHandler()->getAvailableAreablockAreas(new Areablock(), []);
 
         self::assertSame('Teaser (messages)', $areas['teaser']['name']);
         self::assertSame('Ein Teaser-Baustein', $areas['teaser']['description']);
+        self::assertSame([], $this->initializedCatalogues);
     }
 
     public function testLabelsAreNotTranslatedOutsideOfEditmode(): void
@@ -182,6 +245,11 @@ final class EditableHandlerTest extends TestCase
 
         self::assertSame('Teaser (Studio)', $areas['teaser']['name']);
         self::assertSame('', $areas['teaser']['description']);
+    }
+
+    private function catalogue(string $locale): MessageCatalogue
+    {
+        return $this->catalogues[$locale] ??= new MessageCatalogue($locale);
     }
 
     private function createHandler(

--- a/tests/Unit/Document/Editable/EditableHandlerTest.php
+++ b/tests/Unit/Document/Editable/EditableHandlerTest.php
@@ -64,6 +64,11 @@ final class EditableHandlerTest extends TestCase
      */
     private array $initializedCatalogues = [];
 
+    /**
+     * @var list<string> "<domain>/<id>" pairs the handler translated via trans()
+     */
+    private array $translated = [];
+
     private string $locale = self::LOCALE;
 
     protected function setUp(): void
@@ -72,6 +77,7 @@ final class EditableHandlerTest extends TestCase
 
         $this->catalogues = [];
         $this->initializedCatalogues = [];
+        $this->translated = [];
         $this->locale = self::LOCALE;
 
         $this->translator = $this->getMockBuilder(Translator::class)
@@ -143,22 +149,42 @@ final class EditableHandlerTest extends TestCase
         // that later added Studio) must keep its translations ...
         $this->catalogue(self::LOCALE)->set('Teaser', 'Teaser (messages)', Translation::DOMAIN_DEFAULT);
 
-        // ... but the lookup must never go through trans() with the default domain, because that
-        // is what auto-creates the missing keys in the "messages" domain.
-        $this->translator->expects($this->exactly(2))
-            ->method('trans')
-            ->with($this->anything(), [], self::STUDIO_DOMAIN)
-            ->willReturnArgument(0);
+        // ... but a label that is unknown to the default domain must never go through trans() with
+        // that domain, because that is what auto-creates the missing keys in "messages".
+        $this->translator->method('trans')->willReturnCallback($this->translateFromCatalogues(...));
 
         $areas = $this->createHandler()->getAvailableAreablockAreas(new Areablock(), []);
 
-        self::assertSame('Teaser (messages)', $areas['teaser']['name']);
+        self::assertSame('Teaser (messages) (via trans)', $areas['teaser']['name']);
         self::assertSame('A teaser brick', $areas['teaser']['description']);
         self::assertContains(
             Translation::DOMAIN_DEFAULT . '/' . self::LOCALE,
             $this->initializedCatalogues,
             'The database translations of the default domain must be loaded before looking the label up.'
         );
+        self::assertSame(
+            [
+                self::STUDIO_DOMAIN . '/Teaser',
+                Translation::DOMAIN_DEFAULT . '/Teaser',
+                self::STUDIO_DOMAIN . '/A teaser brick',
+            ],
+            $this->translated,
+            'Only the label known to the default domain may be translated through it.'
+        );
+    }
+
+    public function testLabelWithSurroundingWhitespaceIsLookedUpTrimmed(): void
+    {
+        $this->markStudioDomainAsRegistered(true);
+
+        $this->catalogue(self::LOCALE)->set('Teaser', 'Teaser (messages)', Translation::DOMAIN_DEFAULT);
+
+        $this->translator->method('trans')->willReturnCallback($this->translateFromCatalogues(...));
+
+        $areas = $this->createHandler(null, 'A teaser brick', ' Teaser ')
+            ->getAvailableAreablockAreas(new Areablock(), []);
+
+        self::assertSame('Teaser (messages) (via trans)', $areas['teaser']['name']);
     }
 
     public function testConfiguredFallbackLanguageOfDefaultDomainIsUsed(): void
@@ -173,15 +199,35 @@ final class EditableHandlerTest extends TestCase
         $this->catalogue('de_AT')->set('Teaser', '', Translation::DOMAIN_DEFAULT);
         $this->catalogue('de')->set('Teaser', 'Vorspann', Translation::DOMAIN_DEFAULT);
 
-        $this->translator->expects($this->exactly(2))
-            ->method('trans')
-            ->with($this->anything(), [], self::STUDIO_DOMAIN)
-            ->willReturnArgument(0);
+        $this->translator->method('trans')->willReturnCallback($this->translateFromCatalogues(...));
+
+        $areas = $this->createHandler()->getAvailableAreablockAreas(new Areablock(), []);
+
+        self::assertSame('Vorspann (via trans)', $areas['teaser']['name']);
+        self::assertContains(Translation::DOMAIN_DEFAULT . '/de', $this->initializedCatalogues);
+        self::assertNotContains(
+            Translation::DOMAIN_DEFAULT . '/A teaser brick',
+            $this->translated,
+            'A label unknown to the default domain must not be translated through it.'
+        );
+    }
+
+    public function testTranslationOnlyKnownToAFallbackLanguageIsReturnedWithoutTranslating(): void
+    {
+        $this->markStudioDomainAsRegistered(true);
+
+        $this->locale = 'de_AT';
+
+        // no "de_AT" entry at all (e.g. a translation file only for "de"): translating via the
+        // default domain would create the "de_AT" key, so the fallback value is used as it is
+        $this->catalogue('de')->set('Teaser', 'Vorspann', Translation::DOMAIN_DEFAULT);
+
+        $this->translator->method('trans')->willReturnCallback($this->translateFromCatalogues(...));
 
         $areas = $this->createHandler()->getAvailableAreablockAreas(new Areablock(), []);
 
         self::assertSame('Vorspann', $areas['teaser']['name']);
-        self::assertContains(Translation::DOMAIN_DEFAULT . '/de', $this->initializedCatalogues);
+        self::assertNotContains(Translation::DOMAIN_DEFAULT . '/Teaser', $this->translated);
     }
 
     public function testEmptyDefaultDomainTranslationFallsBackToTheLabel(): void
@@ -191,11 +237,15 @@ final class EditableHandlerTest extends TestCase
         // an auto-created key without a text must not blank out the label
         $this->catalogue(self::LOCALE)->set('Teaser', '', Translation::DOMAIN_DEFAULT);
 
-        $this->translator->method('trans')->willReturnArgument(0);
+        $this->translator->method('trans')->willReturnCallback($this->translateFromCatalogues(...));
 
         $areas = $this->createHandler()->getAvailableAreablockAreas(new Areablock(), []);
 
         self::assertSame('Teaser', $areas['teaser']['name']);
+        self::assertSame(
+            [self::STUDIO_DOMAIN . '/Teaser', self::STUDIO_DOMAIN . '/A teaser brick'],
+            $this->translated
+        );
     }
 
     public function testClassicOnlyInstallationKeepsTranslatingViaDefaultDomain(): void
@@ -252,13 +302,33 @@ final class EditableHandlerTest extends TestCase
         return $this->catalogues[$locale] ??= new MessageCatalogue($locale);
     }
 
+    /**
+     * Stand-in for Translator::trans(): records the call and resolves the id from the catalogues of
+     * the locale and its configured fallback languages, marking the result as post-processed.
+     */
+    private function translateFromCatalogues(string $id, array $parameters = [], ?string $domain = null): string
+    {
+        $domain ??= Translation::DOMAIN_DEFAULT;
+        $this->translated[] = $domain . '/' . $id;
+
+        foreach ([$this->locale, ...Tool::getFallbackLanguagesFor($this->locale)] as $locale) {
+            $catalogue = $this->catalogue($locale);
+            if ($catalogue->has($id, $domain) && $catalogue->get($id, $domain) !== '') {
+                return $catalogue->get($id, $domain) . ' (via trans)';
+            }
+        }
+
+        return $id;
+    }
+
     private function createHandler(
         ?EditmodeResolver $editmodeResolver = null,
-        string $description = 'A teaser brick'
+        string $description = 'A teaser brick',
+        string $name = 'Teaser'
     ): EditableHandler {
         $brick = $this->createMock(AreabrickInterface::class);
         $brick->method('getId')->willReturn('teaser');
-        $brick->method('getName')->willReturn('Teaser');
+        $brick->method('getName')->willReturn($name);
         $brick->method('getDescription')->willReturn($description);
         $brick->method('getIcon')->willReturn('/bundles/app/areas/teaser/icon.png');
         $brick->method('needsReload')->willReturn(false);

--- a/tests/Unit/Document/Editable/EditableHandlerTest.php
+++ b/tests/Unit/Document/Editable/EditableHandlerTest.php
@@ -202,6 +202,27 @@ final class EditableHandlerTest extends TestCase
         self::assertSame('Teaser (messages) (via trans)', $areas['teaser']['description']);
     }
 
+    public function testResolvedLabelsAreCachedPerLocale(): void
+    {
+        $this->markStudioDomainAsRegistered(true);
+
+        $this->catalogue('de')->set('Teaser', 'Teaser (de)', Translation::DOMAIN_DEFAULT);
+        $this->catalogue('en')->set('Teaser', 'Teaser (en)', Translation::DOMAIN_DEFAULT);
+
+        $this->translator->method('trans')->willReturnCallback($this->translateFromCatalogues(...));
+
+        // the handler is a shared service and the translator locale is switched while rendering
+        // documents of different languages, so a resolved label must not leak into another locale
+        $handler = $this->createHandler();
+        $this->locale = 'de';
+        $german = $handler->getAvailableAreablockAreas(new Areablock(), []);
+        $this->locale = 'en';
+        $english = $handler->getAvailableAreablockAreas(new Areablock(), []);
+
+        self::assertSame('Teaser (de) (via trans)', $german['teaser']['name']);
+        self::assertSame('Teaser (en) (via trans)', $english['teaser']['name']);
+    }
+
     public function testLabelWithSurroundingWhitespaceIsLookedUpTrimmed(): void
     {
         $this->markStudioDomainAsRegistered(true);

--- a/tests/Unit/Document/Editable/EditableHandlerTest.php
+++ b/tests/Unit/Document/Editable/EditableHandlerTest.php
@@ -1,0 +1,233 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Document\Editable;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Pimcore\Cache\RuntimeCache;
+use Pimcore\Document\Editable\EditableHandler;
+use Pimcore\Extension\Document\Areabrick\AreabrickInterface;
+use Pimcore\Extension\Document\Areabrick\AreabrickManagerInterface;
+use Pimcore\Http\Request\Resolver\EditmodeResolver;
+use Pimcore\Http\RequestHelper;
+use Pimcore\Http\ResponseStack;
+use Pimcore\HttpKernel\BundleLocator\BundleLocatorInterface;
+use Pimcore\HttpKernel\WebPathResolver;
+use Pimcore\Model\Document\Editable\Areablock;
+use Pimcore\Model\Translation;
+use Pimcore\Tests\Support\Test\TestCase;
+use Pimcore\Translation\Translator;
+use ReflectionClassConstant;
+use Symfony\Bridge\Twig\Extension\HttpKernelRuntime;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
+use Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface;
+use Symfony\Component\Templating\EngineInterface;
+use Symfony\Component\Translation\MessageCatalogue;
+
+/**
+ * Areabrick names and descriptions are labels of the editing UI. In editmode they used to be
+ * translated through the default ("messages") domain, which also auto-creates every missing key
+ * there - so opening a document with an areablock polluted the website translations with UI
+ * strings. These tests pin down that the labels are now resolved via the Studio UI domain when
+ * it is available, that already existing "messages" translations keep working as a read-only
+ * fallback, and that classic-only installations keep their previous behavior.
+ */
+final class EditableHandlerTest extends TestCase
+{
+    private const STUDIO_DOMAIN = 'studio';
+
+    private const LOCALE = 'de';
+
+    private Translator&MockObject $translator;
+
+    private EditmodeResolver&MockObject $editmodeResolver;
+
+    private MessageCatalogue $catalogue;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->catalogue = new MessageCatalogue(self::LOCALE);
+
+        $this->translator = $this->getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['trans', 'getCatalogue', 'lazyInitialize', 'getLocale'])
+            ->getMock();
+        $this->translator->method('getLocale')->willReturn(self::LOCALE);
+        $this->translator->method('getCatalogue')->willReturn($this->catalogue);
+
+        $this->editmodeResolver = $this->createMock(EditmodeResolver::class);
+        $this->editmodeResolver->method('isEditmode')->willReturn(true);
+    }
+
+    protected function tearDown(): void
+    {
+        RuntimeCache::set($this->getValidDomainsCacheKey(), []);
+
+        parent::tearDown();
+    }
+
+    public function testLabelsAreTranslatedViaStudioDomainWhenAvailable(): void
+    {
+        $this->markStudioDomainAsRegistered(true);
+
+        $this->translator->expects($this->exactly(2))
+            ->method('trans')
+            ->with($this->anything(), [], self::STUDIO_DOMAIN)
+            ->willReturnMap([
+                ['Teaser', [], self::STUDIO_DOMAIN, null, 'Teaser (Studio)'],
+                ['A teaser brick', [], self::STUDIO_DOMAIN, null, 'Ein Teaser-Baustein'],
+            ]);
+
+        $areas = $this->createHandler()->getAvailableAreablockAreas(new Areablock(), []);
+
+        self::assertSame('Teaser (Studio)', $areas['teaser']['name']);
+        self::assertSame('Ein Teaser-Baustein', $areas['teaser']['description']);
+    }
+
+    public function testExistingDefaultDomainTranslationIsUsedWithoutCreatingKeysThere(): void
+    {
+        $this->markStudioDomainAsRegistered(true);
+
+        // an installation that already maintains the labels in "messages" (e.g. a classic install
+        // that later added Studio) must keep its translations ...
+        $this->catalogue->set('Teaser', 'Teaser (messages)', Translation::DOMAIN_DEFAULT);
+
+        // ... but the lookup must never go through trans() with the default domain, because that
+        // is what auto-creates the missing keys in the "messages" domain.
+        $this->translator->expects($this->exactly(2))
+            ->method('trans')
+            ->with($this->anything(), [], self::STUDIO_DOMAIN)
+            ->willReturnArgument(0);
+        $this->translator->expects($this->atLeastOnce())
+            ->method('lazyInitialize')
+            ->with(Translation::DOMAIN_DEFAULT, self::LOCALE);
+
+        $areas = $this->createHandler()->getAvailableAreablockAreas(new Areablock(), []);
+
+        self::assertSame('Teaser (messages)', $areas['teaser']['name']);
+        self::assertSame('A teaser brick', $areas['teaser']['description']);
+    }
+
+    public function testEmptyDefaultDomainTranslationFallsBackToTheLabel(): void
+    {
+        $this->markStudioDomainAsRegistered(true);
+
+        // an auto-created key without a text must not blank out the label
+        $this->catalogue->set('Teaser', '', Translation::DOMAIN_DEFAULT);
+
+        $this->translator->method('trans')->willReturnArgument(0);
+
+        $areas = $this->createHandler()->getAvailableAreablockAreas(new Areablock(), []);
+
+        self::assertSame('Teaser', $areas['teaser']['name']);
+    }
+
+    public function testClassicOnlyInstallationKeepsTranslatingViaDefaultDomain(): void
+    {
+        $this->markStudioDomainAsRegistered(false);
+
+        $this->translator->expects($this->exactly(2))
+            ->method('trans')
+            ->with($this->anything(), [], Translation::DOMAIN_DEFAULT)
+            ->willReturnMap([
+                ['Teaser', [], Translation::DOMAIN_DEFAULT, null, 'Teaser (messages)'],
+                ['A teaser brick', [], Translation::DOMAIN_DEFAULT, null, 'Ein Teaser-Baustein'],
+            ]);
+        $this->translator->expects($this->never())->method('lazyInitialize');
+
+        $areas = $this->createHandler()->getAvailableAreablockAreas(new Areablock(), []);
+
+        self::assertSame('Teaser (messages)', $areas['teaser']['name']);
+        self::assertSame('Ein Teaser-Baustein', $areas['teaser']['description']);
+    }
+
+    public function testLabelsAreNotTranslatedOutsideOfEditmode(): void
+    {
+        $this->markStudioDomainAsRegistered(true);
+
+        $editmodeResolver = $this->createMock(EditmodeResolver::class);
+        $editmodeResolver->method('isEditmode')->willReturn(false);
+
+        $this->translator->expects($this->never())->method('trans');
+
+        $areas = $this->createHandler($editmodeResolver)->getAvailableAreablockAreas(new Areablock(), []);
+
+        self::assertSame('Teaser', $areas['teaser']['name']);
+        self::assertSame('A teaser brick', $areas['teaser']['description']);
+    }
+
+    public function testEmptyDescriptionIsNotTranslated(): void
+    {
+        $this->markStudioDomainAsRegistered(true);
+
+        $this->translator->expects($this->once())
+            ->method('trans')
+            ->with('Teaser', [], self::STUDIO_DOMAIN)
+            ->willReturn('Teaser (Studio)');
+
+        $areas = $this->createHandler(null, '')->getAvailableAreablockAreas(new Areablock(), []);
+
+        self::assertSame('Teaser (Studio)', $areas['teaser']['name']);
+        self::assertSame('', $areas['teaser']['description']);
+    }
+
+    private function createHandler(
+        ?EditmodeResolver $editmodeResolver = null,
+        string $description = 'A teaser brick'
+    ): EditableHandler {
+        $brick = $this->createMock(AreabrickInterface::class);
+        $brick->method('getId')->willReturn('teaser');
+        $brick->method('getName')->willReturn('Teaser');
+        $brick->method('getDescription')->willReturn($description);
+        $brick->method('getIcon')->willReturn('/bundles/app/areas/teaser/icon.png');
+        $brick->method('needsReload')->willReturn(false);
+
+        $brickManager = $this->createMock(AreabrickManagerInterface::class);
+        $brickManager->method('getBricks')->willReturn([$brick]);
+
+        return new EditableHandler(
+            $brickManager,
+            $this->createMock(EngineInterface::class),
+            $this->createMock(BundleLocatorInterface::class),
+            $this->createMock(WebPathResolver::class),
+            $this->createMock(RequestHelper::class),
+            $this->translator,
+            $this->createMock(ResponseStack::class),
+            $editmodeResolver ?? $this->editmodeResolver,
+            new HttpKernelRuntime(new FragmentHandler(new RequestStack())),
+            $this->createMock(FragmentRendererInterface::class),
+            new RequestStack()
+        );
+    }
+
+    /**
+     * Translation::isAValidDomain() memoizes its result per request, so seeding the memo is the
+     * way to simulate an installation with or without the Studio translation domain without
+     * touching the database or the system configuration.
+     */
+    private function markStudioDomainAsRegistered(bool $registered): void
+    {
+        RuntimeCache::set($this->getValidDomainsCacheKey(), [
+            self::STUDIO_DOMAIN => $registered,
+            Translation::DOMAIN_DEFAULT => true,
+        ]);
+    }
+
+    private function getValidDomainsCacheKey(): string
+    {
+        return (new ReflectionClassConstant(Translation\Dao::class, 'VALID_DOMAINS_CACHE_KEY'))->getValue();
+    }
+}

--- a/tests/Unit/Document/Editable/EditableHandlerTest.php
+++ b/tests/Unit/Document/Editable/EditableHandlerTest.php
@@ -69,6 +69,11 @@ final class EditableHandlerTest extends TestCase
      */
     private array $translated = [];
 
+    /**
+     * @var list<string> "<domain>/<id>@<locale>" keys the translator stand-in had to create
+     */
+    private array $createdKeys = [];
+
     private string $locale = self::LOCALE;
 
     protected function setUp(): void
@@ -78,6 +83,7 @@ final class EditableHandlerTest extends TestCase
         $this->catalogues = [];
         $this->initializedCatalogues = [];
         $this->translated = [];
+        $this->createdKeys = [];
         $this->locale = self::LOCALE;
 
         $this->translator = $this->getMockBuilder(Translator::class)
@@ -171,6 +177,29 @@ final class EditableHandlerTest extends TestCase
             $this->translated,
             'Only the label known to the default domain may be translated through it.'
         );
+        self::assertSame(
+            [self::STUDIO_DOMAIN . '/Teaser@de', self::STUDIO_DOMAIN . '/A teaser brick@de'],
+            $this->createdKeys,
+            'Missing keys are created in the Studio domain only.'
+        );
+    }
+
+    public function testRepeatedLabelKeepsUsingTheDefaultDomainFallback(): void
+    {
+        $this->markStudioDomainAsRegistered(true);
+
+        $this->catalogue(self::LOCALE)->set('Teaser', 'Teaser (messages)', Translation::DOMAIN_DEFAULT);
+
+        $this->translator->method('trans')->willReturnCallback($this->translateFromCatalogues(...));
+
+        // the same label twice (name and description) and the whole lookup twice (two areablocks): the
+        // key the first translation created in the Studio catalogue must not shadow the fallback
+        $handler = $this->createHandler(null, 'Teaser');
+        $handler->getAvailableAreablockAreas(new Areablock(), []);
+        $areas = $handler->getAvailableAreablockAreas(new Areablock(), []);
+
+        self::assertSame('Teaser (messages) (via trans)', $areas['teaser']['name']);
+        self::assertSame('Teaser (messages) (via trans)', $areas['teaser']['description']);
     }
 
     public function testLabelWithSurroundingWhitespaceIsLookedUpTrimmed(): void
@@ -205,29 +234,32 @@ final class EditableHandlerTest extends TestCase
 
         self::assertSame('Vorspann (via trans)', $areas['teaser']['name']);
         self::assertContains(Translation::DOMAIN_DEFAULT . '/de', $this->initializedCatalogues);
-        self::assertNotContains(
-            Translation::DOMAIN_DEFAULT . '/A teaser brick',
-            $this->translated,
-            'A label unknown to the default domain must not be translated through it.'
+        self::assertSame(
+            [self::STUDIO_DOMAIN . '/Teaser@de_AT', self::STUDIO_DOMAIN . '/A teaser brick@de_AT'],
+            $this->createdKeys,
+            'No key may be created in the default domain.'
         );
     }
 
-    public function testTranslationOnlyKnownToAFallbackLanguageIsReturnedWithoutTranslating(): void
+    public function testTranslationOnlyKnownToAFallbackLanguageIsTranslatedInThatLanguage(): void
     {
         $this->markStudioDomainAsRegistered(true);
 
         $this->locale = 'de_AT';
 
-        // no "de_AT" entry at all (e.g. a translation file only for "de"): translating via the
-        // default domain would create the "de_AT" key, so the fallback value is used as it is
+        // no "de_AT" entry at all (e.g. a translation file only for "de"): translating in "de_AT"
+        // would create the key there, so the label is translated explicitly in "de"
         $this->catalogue('de')->set('Teaser', 'Vorspann', Translation::DOMAIN_DEFAULT);
 
         $this->translator->method('trans')->willReturnCallback($this->translateFromCatalogues(...));
 
         $areas = $this->createHandler()->getAvailableAreablockAreas(new Areablock(), []);
 
-        self::assertSame('Vorspann', $areas['teaser']['name']);
-        self::assertNotContains(Translation::DOMAIN_DEFAULT . '/Teaser', $this->translated);
+        self::assertSame('Vorspann (via trans)', $areas['teaser']['name']);
+        self::assertSame(
+            [self::STUDIO_DOMAIN . '/Teaser@de_AT', self::STUDIO_DOMAIN . '/A teaser brick@de_AT'],
+            $this->createdKeys
+        );
     }
 
     public function testEmptyDefaultDomainTranslationFallsBackToTheLabel(): void
@@ -303,19 +335,31 @@ final class EditableHandlerTest extends TestCase
     }
 
     /**
-     * Stand-in for Translator::trans(): records the call and resolves the id from the catalogues of
-     * the locale and its configured fallback languages, marking the result as post-processed.
+     * Stand-in for Translator::trans(): records the call, resolves the id from the catalogues of the
+     * locale and its configured fallback languages and marks the result as post-processed. Like the
+     * real translator, an unknown id is "created": recorded, and put into the in-memory catalogue of
+     * the locale as its own translation.
      */
-    private function translateFromCatalogues(string $id, array $parameters = [], ?string $domain = null): string
-    {
+    private function translateFromCatalogues(
+        string $id,
+        array $parameters = [],
+        ?string $domain = null,
+        ?string $locale = null
+    ): string {
         $domain ??= Translation::DOMAIN_DEFAULT;
+        $locale ??= $this->locale;
         $this->translated[] = $domain . '/' . $id;
 
-        foreach ([$this->locale, ...Tool::getFallbackLanguagesFor($this->locale)] as $locale) {
-            $catalogue = $this->catalogue($locale);
+        foreach ([$locale, ...Tool::getFallbackLanguagesFor($locale)] as $lookupLocale) {
+            $catalogue = $this->catalogue($lookupLocale);
             if ($catalogue->has($id, $domain) && $catalogue->get($id, $domain) !== '') {
                 return $catalogue->get($id, $domain) . ' (via trans)';
             }
+        }
+
+        if (!$this->catalogue($locale)->has($id, $domain)) {
+            $this->createdKeys[] = $domain . '/' . $id . '@' . $locale;
+            $this->catalogue($locale)->set($id, $id, $domain);
         }
 
         return $id;


### PR DESCRIPTION
## Changes in this pull request
Resolves https://github.com/pimcore/platform-version/issues/232

In editmode, `EditableHandler::getAvailableAreablockAreas()` translated areabrick names and descriptions through the default `messages` domain. Pimcore's translator auto-creates missing keys of a registered domain, so opening a document with an areablock filled `translations_messages` (and therefore Studio's translation list for `messages`) with UI labels.

- Areabrick names and descriptions are now translated via the `studio` domain whenever that domain is registered. A label maintained there always wins, also when its translation equals the key.
- Labels that were already translated in `messages` keep working as a fallback: the catalogue of the locale and of its configured fallback languages is consulted first, and the label is only translated through the translator, explicitly in the locale that knows the key, so the complete translator pipeline applies but no key is created in `messages`.
- Labels are trimmed like message ids and resolved once per locale and request, because translating an unknown Studio key puts it into the in-memory catalogue as its own translation.
- Installations without the `studio` domain keep translating via `messages` as before.
- Upgrade note added. `EditableHandler` is `@internal`, so no public API changes.

### How to reproduce
1. Install Pimcore with Studio and create an areabrick with a name and description.
2. Open a document that contains an areablock in the Studio document editor.
3. Open Studio's translations: before this change the name and description show up as keys in the `messages` domain (`translations_messages`); with this change they show up in the `studio` domain only.

## Additional info
Verified locally: the new `tests/Unit/Document/Editable/EditableHandlerTest.php` (12 tests; each behavior was added red-first against the previous code), the whole `tests/Unit/Document/Editable` folder, PHPStan and php-cs-fixer on the changed files. CI validates the remaining suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
