### PR TITLE
[Bug] Accept "auto" as alias of the SOURCE thumbnail format

### DIFF
--- a/bundles/CoreBundle/src/Command/ThumbnailsImageCommand.php
+++ b/bundles/CoreBundle/src/Command/ThumbnailsImageCommand.php
@@ -18,6 +18,7 @@ use Pimcore\Console\AbstractCommand;
 use Pimcore\Console\Traits\Parallelization;
 use Pimcore\Model\Asset;
 use Pimcore\Model\Asset\Image;
+use Pimcore\Model\Asset\Image\Thumbnail\Config;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -243,7 +244,7 @@ class ThumbnailsImageCommand extends AbstractCommand
                 $resConfig->setHighResolution($resolution);
                 $thumbnailsToGenerate[] = $resConfig;
 
-                if ($resConfig->getFormat() === 'SOURCE') {
+                if (Config::isAutoFormat($resConfig->getFormat())) {
                     foreach ($resConfig->getAutoFormatThumbnailConfigs() as $autoFormat => $autoFormatThumbnailConfig) {
                         if (!$input->getOption('skip-' . $autoFormat)) {
                             $thumbnailsToGenerate[] = $autoFormatThumbnailConfig;

--- a/models/Asset/Document/ImageThumbnail.php
+++ b/models/Asset/Document/ImageThumbnail.php
@@ -23,6 +23,7 @@ use Pimcore\Helper\TemporaryFileHelperTrait;
 use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\Asset\Image;
+use Pimcore\Model\Asset\Image\Thumbnail\Config;
 use Pimcore\Model\Exception\NotFoundException;
 use Pimcore\Model\Exception\ThumbnailFormatNotSupportedException;
 use Pimcore\Tool\Storage;
@@ -199,11 +200,8 @@ final class ImageThumbnail implements ImageThumbnailInterface
             throw new NotFoundException('Thumbnail definition "' . (is_string($selector) ? $selector : '') . '" does not exist');
         }
 
-        if ($config) {
-            $format = strtolower($config->getFormat());
-            if ($format == 'source') {
-                $config->setFormat('PNG');
-            }
+        if ($config && Config::isAutoFormat($config->getFormat())) {
+            $config->setFormat('PNG');
         }
 
         return $config;

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -234,7 +234,7 @@ final class Thumbnail implements ThumbnailInterface
             $options['previewDataUri'] =  $image->getLowQualityPreviewDataUri() ?: $emptyGif;
         }
 
-        $isAutoFormat = $thumbConfig instanceof Config && strtolower($thumbConfig->getFormat()) === 'source';
+        $isAutoFormat = $thumbConfig instanceof Config && Config::isAutoFormat($thumbConfig->getFormat());
 
         if ($isAutoFormat) {
             // ensure the default image is not WebP

--- a/models/Asset/Image/Thumbnail/Config.php
+++ b/models/Asset/Image/Thumbnail/Config.php
@@ -29,6 +29,8 @@ final class Config extends Model\AbstractModel
 {
     use Model\Asset\Thumbnail\ClearTempFilesTrait;
 
+    private const AUTO_FORMAT_ALIASES = ['source', 'auto'];
+
     /**
      * @internal
      */
@@ -806,6 +808,17 @@ final class Config extends Model\AbstractModel
                 }
             }
         }
+    }
+
+    /**
+     * Checks whether the given format name stands for the automatic, web-optimized format selection.
+     * "SOURCE" is the historic name used by the classic admin UI, "auto" is the name used by Pimcore Studio.
+     *
+     * @internal
+     */
+    public static function isAutoFormat(string $format): bool
+    {
+        return in_array(strtolower($format), self::AUTO_FORMAT_ALIASES, true);
     }
 
     /**

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -108,7 +108,7 @@ class Processor
         $fileExt = pathinfo($asset->getFilename(), PATHINFO_EXTENSION);
 
         // simple detection for source type if SOURCE is selected
-        if ($format == 'source' || empty($format)) {
+        if ($format === '' || Config::isAutoFormat($format)) {
             $optimizedFormat = true;
             $format = self::getAllowedFormat($fileExt, ['pjpeg', 'jpeg', 'gif', 'png'], 'png');
             if ($format === 'jpeg') {

--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -399,7 +399,7 @@ class Service extends Model\Element\Service
                 return null;
             }
 
-            if ($config['type'] === 'image' && strcasecmp($thumbnailConfig->getFormat(), 'SOURCE') === 0) {
+            if ($config['type'] === 'image' && ThumbnailConfig::isAutoFormat($thumbnailConfig->getFormat())) {
                 $formatOverride = $config['file_extension'];
                 if (in_array($config['file_extension'], ['jpg', 'jpeg'])) {
                     $formatOverride = 'pjpeg';

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -469,10 +469,7 @@ trait ImageThumbnailTrait
     {
         $format = strtolower($format);
         if ($asset) {
-            if (
-                $format === 'original' ||
-                $format === 'source'
-            ) {
+            if ($format === 'original' || Config::isAutoFormat($format)) {
                 return true;
             }
 

--- a/tests/Model/Asset/AssetThumbnailAutoFormatTest.php
+++ b/tests/Model/Asset/AssetThumbnailAutoFormatTest.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Model\Asset;
 
+use Pimcore\Bundle\CoreBundle\Controller\PublicServicesController;
 use Pimcore\Model\Asset\Image;
 use Pimcore\Model\Asset\Image\Thumbnail\Config;
 use Pimcore\Tests\Support\Test\TestCase;
 use Pimcore\Tests\Support\Util\TestHelper;
 use Pimcore\Tool\Storage;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
  * The web-optimized ("Auto") thumbnail format is stored as "SOURCE" by the classic admin UI
@@ -26,6 +29,11 @@ use Pimcore\Tool\Storage;
 final class AssetThumbnailAutoFormatTest extends TestCase
 {
     private Image $testAsset;
+
+    /**
+     * @var string[]
+     */
+    private array $configNames = [];
 
     protected function setUp(): void
     {
@@ -37,7 +45,9 @@ final class AssetThumbnailAutoFormatTest extends TestCase
     protected function tearDown(): void
     {
         $this->testAsset->clearThumbnails(true);
-        TestHelper::clearThumbnailConfigurations();
+        foreach ($this->configNames as $name) {
+            TestHelper::clearThumbnailConfiguration($name);
+        }
 
         parent::tearDown();
     }
@@ -73,12 +83,43 @@ final class AssetThumbnailAutoFormatTest extends TestCase
         $this->assertSame(substr_count($sourceHtml, '<source'), substr_count($autoHtml, '<source'));
     }
 
+    public function testDeferredAutoFormatVariantRequestDeliversRequestedFormat(): void
+    {
+        $config = $this->createConfig('auto');
+        $autoFormatConfigs = $config->getAutoFormatThumbnailConfigs();
+        if (!isset($autoFormatConfigs['webp'])) {
+            $this->markTestSkipped('WebP is not supported by the image adapter of this environment');
+        }
+
+        $webpThumbnail = $this->testAsset->getThumbnail($autoFormatConfigs['webp']);
+        $webpStoragePath = $webpThumbnail->getPathReference(true)['storagePath'];
+        $this->assertFalse(Storage::get('thumbnail')->fileExists($webpStoragePath));
+
+        $request = new Request(attributes: [
+            'assetId' => $this->testAsset->getId(),
+            'thumbnailName' => $config->getName(),
+            'filename' => $webpThumbnail->getFilename(),
+            'type' => 'image',
+            'prefix' => '',
+        ]);
+        $response = (new PublicServicesController())->thumbnailAction($request);
+
+        $this->assertInstanceOf(StreamedResponse::class, $response);
+        $this->assertSame('image/webp', $response->headers->get('Content-Type'));
+        $this->assertTrue(Storage::get('thumbnail')->fileExists($webpStoragePath));
+    }
+
     private function createConfig(string $format): Config
     {
+        $name = 'assettest_format_' . strtolower($format);
+        TestHelper::clearThumbnailConfiguration($name);
+
         $config = new Config();
-        $config->setName('assettest_format_' . strtolower($format));
+        $config->setName($name);
         $config->setFormat($format);
         $config->addItem('scaleByWidth', ['width' => 100], 'default');
+        $config->save(true);
+        $this->configNames[] = $name;
 
         return $config;
     }

--- a/tests/Model/Asset/AssetThumbnailAutoFormatTest.php
+++ b/tests/Model/Asset/AssetThumbnailAutoFormatTest.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\Asset;
+
+use Pimcore\Model\Asset\Image;
+use Pimcore\Model\Asset\Image\Thumbnail\Config;
+use Pimcore\Tests\Support\Test\TestCase;
+use Pimcore\Tests\Support\Util\TestHelper;
+use Pimcore\Tool\Storage;
+
+/**
+ * The web-optimized ("Auto") thumbnail format is stored as "SOURCE" by the classic admin UI
+ * and as "auto" by Pimcore Studio. Both spellings must produce the same thumbnails.
+ */
+final class AssetThumbnailAutoFormatTest extends TestCase
+{
+    private Image $testAsset;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->testAsset = TestHelper::createImageAsset('', null, true, 'assets/images/image1.jpg');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->testAsset->clearThumbnails(true);
+        TestHelper::clearThumbnailConfigurations();
+
+        parent::tearDown();
+    }
+
+    protected function needsDb(): bool
+    {
+        return true;
+    }
+
+    public function testAutoFormatGeneratesWebOptimizedThumbnail(): void
+    {
+        $thumbnail = $this->testAsset->getThumbnail($this->createConfig('auto'), false);
+
+        $path = $thumbnail->getPath(['deferredAllowed' => false]);
+
+        $this->assertStringEndsWith('.jpg', $path);
+        $this->assertTrue(Storage::get('thumbnail')->fileExists($thumbnail->getPathReference()['storagePath']));
+    }
+
+    public function testAutoFormatIsCaseInsensitive(): void
+    {
+        $thumbnail = $this->testAsset->getThumbnail($this->createConfig('AUTO'), false);
+
+        $this->assertStringEndsWith('.jpg', $thumbnail->getPath(['deferredAllowed' => false]));
+    }
+
+    public function testAutoFormatRendersTheSamePictureSourcesAsSourceFormat(): void
+    {
+        $sourceHtml = $this->testAsset->getThumbnail($this->createConfig('SOURCE'), false)->getHtml();
+        $autoHtml = $this->testAsset->getThumbnail($this->createConfig('auto'), false)->getHtml();
+
+        $this->assertGreaterThan(0, substr_count($sourceHtml, '<source'));
+        $this->assertSame(substr_count($sourceHtml, '<source'), substr_count($autoHtml, '<source'));
+    }
+
+    private function createConfig(string $format): Config
+    {
+        $config = new Config();
+        $config->setName('assettest_format_' . strtolower($format));
+        $config->setFormat($format);
+        $config->addItem('scaleByWidth', ['width' => 100], 'default');
+
+        return $config;
+    }
+}

--- a/tests/Model/Asset/ThumbnailsImageCommandAutoFormatTest.php
+++ b/tests/Model/Asset/ThumbnailsImageCommandAutoFormatTest.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Model\Asset;
+
+use Pimcore\Bundle\CoreBundle\Command\ThumbnailsImageCommand;
+use Pimcore\Model\Asset\Image\Thumbnail\Config;
+use Pimcore\Tests\Support\Test\TestCase;
+use Pimcore\Tests\Support\Util\TestHelper;
+use ReflectionMethod;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * pimcore:thumbnails:image pre-generates the WebP/AVIF variants of web-optimized thumbnail
+ * configurations. This must work for both spellings of the format ("SOURCE" and "auto").
+ */
+final class ThumbnailsImageCommandAutoFormatTest extends TestCase
+{
+    /**
+     * @var string[]
+     */
+    private array $configNames = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->configNames as $name) {
+            TestHelper::clearThumbnailConfiguration($name);
+        }
+
+        parent::tearDown();
+    }
+
+    protected function needsDb(): bool
+    {
+        return true;
+    }
+
+    public function testAutoFormatIsExpandedToTheSameVariantsAsSourceFormat(): void
+    {
+        $sourceFormats = $this->fetchGeneratedFormats($this->createConfig('SOURCE'));
+        $autoFormats = $this->fetchGeneratedFormats($this->createConfig('auto'));
+
+        $this->assertContains('webp', $sourceFormats);
+        $this->assertSame(
+            str_replace('source', 'auto', $sourceFormats),
+            $autoFormats
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    private function fetchGeneratedFormats(Config $config): array
+    {
+        $input = $this->createMock(InputInterface::class);
+        $input->method('getOption')->willReturn(false);
+
+        $method = new ReflectionMethod(ThumbnailsImageCommand::class, 'fetchThumbnailConfigs');
+        $configs = $method->invoke(new ThumbnailsImageCommand(), $input, $config->getName());
+
+        return array_map(
+            static fn (Config $config): string => strtolower($config->getFormat()),
+            $configs
+        );
+    }
+
+    private function createConfig(string $format): Config
+    {
+        $name = 'assettest_command_format_' . strtolower($format);
+        TestHelper::clearThumbnailConfiguration($name);
+
+        $config = new Config();
+        $config->setName($name);
+        $config->setFormat($format);
+        $config->addItem('scaleByWidth', ['width' => 100], 'default');
+        $config->save(true);
+        $this->configNames[] = $name;
+
+        return $config;
+    }
+}

--- a/tests/Unit/Models/Asset/Document/ImageThumbnailAutoFormatTest.php
+++ b/tests/Unit/Models/Asset/Document/ImageThumbnailAutoFormatTest.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Models\Asset\Document;
+
+use Pimcore\Model\Asset\Document\ImageThumbnail;
+use Pimcore\Model\Asset\Image\Thumbnail\Config;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * Document page thumbnails have no meaningful "source" image format, so a web-optimized
+ * configuration is rendered as PNG - regardless of whether it is stored as "SOURCE" or "auto".
+ */
+final class ImageThumbnailAutoFormatTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function autoFormatProvider(): iterable
+    {
+        yield 'classic admin spelling' => ['SOURCE'];
+        yield 'studio spelling' => ['auto'];
+    }
+
+    /**
+     * @dataProvider autoFormatProvider
+     */
+    public function testAutoFormatIsRenderedAsPng(string $format): void
+    {
+        $config = new Config();
+        $config->setName('documenttest_format_' . strtolower($format));
+        $config->setFormat($format);
+
+        $thumbnail = new ImageThumbnail(null, $config);
+
+        $this->assertSame('PNG', $thumbnail->getConfig()->getFormat());
+    }
+
+    public function testExplicitFormatIsKept(): void
+    {
+        $config = new Config();
+        $config->setName('documenttest_format_jpeg');
+        $config->setFormat('JPEG');
+
+        $thumbnail = new ImageThumbnail(null, $config);
+
+        $this->assertSame('JPEG', $thumbnail->getConfig()->getFormat());
+    }
+}

--- a/tests/Unit/Models/Asset/Image/Thumbnail/ConfigAutoFormatTest.php
+++ b/tests/Unit/Models/Asset/Image/Thumbnail/ConfigAutoFormatTest.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Models\Asset\Image\Thumbnail;
+
+use Pimcore\Model\Asset\Image\Thumbnail\Config;
+use Pimcore\Tests\Support\Test\TestCase;
+
+final class ConfigAutoFormatTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function autoFormatProvider(): iterable
+    {
+        yield 'classic admin spelling' => ['SOURCE'];
+        yield 'classic admin spelling, lower case' => ['source'];
+        yield 'studio spelling' => ['auto'];
+        yield 'studio spelling, upper case' => ['AUTO'];
+    }
+
+    /**
+     * @dataProvider autoFormatProvider
+     */
+    public function testRecognizesAutoFormatAliases(string $format): void
+    {
+        $this->assertTrue(Config::isAutoFormat($format));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function explicitFormatProvider(): iterable
+    {
+        yield 'original' => ['ORIGINAL'];
+        yield 'png' => ['png'];
+        yield 'webp' => ['webp'];
+        yield 'print' => ['print'];
+        yield 'empty' => [''];
+    }
+
+    /**
+     * @dataProvider explicitFormatProvider
+     */
+    public function testDoesNotTreatExplicitFormatsAsAuto(string $format): void
+    {
+        $this->assertFalse(Config::isAutoFormat($format));
+    }
+}


### PR DESCRIPTION
## Changes in this pull request
Resolves https://github.com/pimcore/platform-version/issues/267

Pimcore Studio stores the web-optimized thumbnail format ("Auto (Web-optimized - recommended)") as `auto`, while the classic admin UI and the core default use `SOURCE`. Core only recognised `SOURCE`, so an image thumbnail configuration saved with `auto` was rejected by the allowed-format check (`ThumbnailFormatNotSupportedException`) and the thumbnail preview in Studio failed with *An exception has been thrown during the rendering of a template*.

- Add `Config::isAutoFormat()` which resolves both spellings (case-insensitive) in one place.
- Use it wherever the format decides whether the automatic format selection applies: the allowed-format validation in `ImageThumbnailTrait`, the format resolution in `Processor` and the `<picture>` auto-format `<source>` generation in `Thumbnail`.

Purely additive; `SOURCE` keeps working unchanged and thumbnail configurations already saved with `auto` start working without being re-saved.

### How to reproduce
1. In Studio, create an image thumbnail configuration and select *Auto (Web-optimized - recommended)* as format.
2. Open the preview of the thumbnail (or call `$image->getThumbnail('<name>')->getPath()`).
3. Before this change the thumbnail generation throws `ThumbnailFormatNotSupportedException`; after it a web-optimized thumbnail (jpg/png) is generated like with `SOURCE`.

### Tests
- `tests/Model/Asset/AssetThumbnailAutoFormatTest.php`: generates thumbnails with `auto` / `AUTO` and asserts the `<picture>` sources match the `SOURCE` variant (fails before the fix with `ThumbnailFormatNotSupportedException`).
- `tests/Unit/Models/Asset/Image/Thumbnail/ConfigAutoFormatTest.php`: covers the alias resolution.

Verified locally: both new tests plus `tests/Model/Asset/` (61 tests) pass, PHPStan and php-cs-fixer report no issues on the changed files.

## Additional info
Follow-up idea (not part of this PR): Studio UI could map `SOURCE` from configurations created in the classic UI onto its *Auto* option so the select does not show the raw value.
