### PR TITLE
Fix link() warning when hardlinking asset version binary from an in-memory stream

### DIFF
--- a/models/Version/Adapter/FileSystemVersionStorageAdapter.php
+++ b/models/Version/Adapter/FileSystemVersionStorageAdapter.php
@@ -96,10 +96,13 @@ class FileSystemVersionStorageAdapter implements VersionStorageAdapterInterface
             // old file first before opening a new stream -> see Asset::update()
             $useHardlinks = Config::getSystemConfiguration('assets')['versions']['use_hardlinks'];
             $this->storage->write($binaryStoragePath, '1'); // temp file to determine if stream is local or not
-            if ($useHardlinks && stream_is_local($this->getBinaryFileStream($version)) && stream_is_local($binaryDataStream)) {
-                $linkPath = stream_get_meta_data($this->getBinaryFileStream($version))['uri'];
+
+            $existingFilePath = $this->resolveLocalFilePath($this->getBinaryFileStream($version));
+            $dataFilePath = $this->resolveLocalFilePath($binaryDataStream);
+
+            if ($useHardlinks && $existingFilePath !== null && $dataFilePath !== null) {
                 $this->storage->delete($binaryStoragePath);
-                $linked = @link(stream_get_meta_data($binaryDataStream)['uri'], $linkPath);
+                $linked = @link($dataFilePath, $existingFilePath);
             }
 
             if (!$linked) {
@@ -121,6 +124,23 @@ class FileSystemVersionStorageAdapter implements VersionStorageAdapterInterface
         if (!$isBinaryHashInUse) {
             $this->deleteFileIfExists($binaryStoragePath);
         }
+    }
+
+    /**
+     * resolveLocalFilePath returns the real filesystem path backing the given stream, or null when the
+     * stream isn't backed by an actual file. stream_is_local() alone isn't enough here: it also returns
+     * true for in-memory wrappers like php://temp, which have no real path on disk and make link() fail
+     * with "No such file or directory".
+     */
+    private function resolveLocalFilePath(mixed $stream): ?string
+    {
+        if (!is_resource($stream) || !stream_is_local($stream)) {
+            return null;
+        }
+
+        $uri = stream_get_meta_data($stream)['uri'] ?? null;
+
+        return $uri !== null && is_file($uri) ? $uri : null;
     }
 
     private function deleteFileIfExists(string $path): void

--- a/models/Version/Adapter/FileSystemVersionStorageAdapter.php
+++ b/models/Version/Adapter/FileSystemVersionStorageAdapter.php
@@ -97,12 +97,14 @@ class FileSystemVersionStorageAdapter implements VersionStorageAdapterInterface
             $useHardlinks = Config::getSystemConfiguration('assets')['versions']['use_hardlinks'];
             $this->storage->write($binaryStoragePath, '1'); // temp file to determine if stream is local or not
 
-            $existingFilePath = $this->resolveLocalFilePath($this->getBinaryFileStream($version));
-            $dataFilePath = $this->resolveLocalFilePath($binaryDataStream);
+            if ($useHardlinks) {
+                $existingFilePath = $this->resolveLocalFilePath($this->getBinaryFileStream($version));
+                $dataFilePath = $this->resolveLocalFilePath($binaryDataStream);
 
-            if ($useHardlinks && $existingFilePath !== null && $dataFilePath !== null) {
-                $this->storage->delete($binaryStoragePath);
-                $linked = @link($dataFilePath, $existingFilePath);
+                if ($existingFilePath !== null && $dataFilePath !== null) {
+                    $this->storage->delete($binaryStoragePath);
+                    $linked = @link($dataFilePath, $existingFilePath);
+                }
             }
 
             if (!$linked) {

--- a/tests/Unit/Models/Version/Adapter/FileSystemVersionStorageAdapterTest.php
+++ b/tests/Unit/Models/Version/Adapter/FileSystemVersionStorageAdapterTest.php
@@ -23,6 +23,7 @@ use Pimcore\Model\Version;
 use Pimcore\Model\Version\Adapter\FileSystemVersionStorageAdapter;
 use Pimcore\Tests\Support\Test\TestCase;
 use ReflectionClass;
+use ReflectionMethod;
 
 class FileSystemVersionStorageAdapterTest extends TestCase
 {
@@ -86,6 +87,39 @@ class FileSystemVersionStorageAdapterTest extends TestCase
 
         $this->expectException(UnableToDeleteFile::class);
         $adapter->delete($version, false);
+    }
+
+    public function testResolveLocalFilePathReturnsNullForInMemoryStream(): void
+    {
+        $adapter = $this->createAdapterWithStorage($this->createMock(FilesystemOperator::class));
+        $stream = fopen('php://temp', 'r+');
+
+        try {
+            $this->assertNull($this->callResolveLocalFilePath($adapter, $stream));
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    public function testResolveLocalFilePathReturnsPathForRealFile(): void
+    {
+        $adapter = $this->createAdapterWithStorage($this->createMock(FilesystemOperator::class));
+        $tmpFile = tmpfile();
+        $tmpFilePath = stream_get_meta_data($tmpFile)['uri'];
+
+        try {
+            $this->assertSame($tmpFilePath, $this->callResolveLocalFilePath($adapter, $tmpFile));
+        } finally {
+            fclose($tmpFile);
+        }
+    }
+
+    private function callResolveLocalFilePath(FileSystemVersionStorageAdapter $adapter, mixed $stream): ?string
+    {
+        $method = new ReflectionMethod(FileSystemVersionStorageAdapter::class, 'resolveLocalFilePath');
+        $method->setAccessible(true);
+
+        return $method->invoke($adapter, $stream);
     }
 
     private function createAdapterWithStorage(FilesystemOperator $storage): FileSystemVersionStorageAdapter

--- a/tests/Unit/Models/Version/Adapter/FileSystemVersionStorageAdapterTest.php
+++ b/tests/Unit/Models/Version/Adapter/FileSystemVersionStorageAdapterTest.php
@@ -19,6 +19,7 @@ use League\Flysystem\DirectoryListing;
 use League\Flysystem\FileAttributes;
 use League\Flysystem\FilesystemOperator;
 use League\Flysystem\UnableToDeleteFile;
+use Pimcore\Config;
 use Pimcore\Model\Version;
 use Pimcore\Model\Version\Adapter\FileSystemVersionStorageAdapter;
 use Pimcore\Tests\Support\Test\TestCase;
@@ -112,6 +113,66 @@ class FileSystemVersionStorageAdapterTest extends TestCase
         } finally {
             fclose($tmpFile);
         }
+    }
+
+    public function testSaveFallsBackToWriteStreamWhenBinaryDataStreamIsInMemory(): void
+    {
+        $version = $this->createVersion(100, 12345, 'asset');
+        $metadataFilePath = 'asset/g10000/12345/100';
+        $binaryFilePath = 'asset/g10000/12345/100.bin';
+
+        $binaryDataStream = fopen('php://temp', 'r+');
+        fwrite($binaryDataStream, 'version binary data');
+        rewind($binaryDataStream);
+
+        // the freshly written .bin temp file resolves to a real local file, so
+        // only the in-memory source stream prevents the hardlink
+        $existingFileStream = tmpfile();
+
+        $writtenPaths = [];
+        $storage = $this->createMock(FilesystemOperator::class);
+        $storage
+            ->expects($this->exactly(2))
+            ->method('write')
+            ->willReturnCallback(function (string $path) use (&$writtenPaths): void {
+                $writtenPaths[] = $path;
+            });
+        $storage
+            ->expects($this->once())
+            ->method('fileExists')
+            ->with($binaryFilePath)
+            ->willReturn(false);
+        $storage
+            ->expects($this->once())
+            ->method('readStream')
+            ->with($binaryFilePath)
+            ->willReturn($existingFileStream);
+        // the hardlink must not be attempted, so the .bin temp file may never
+        // be deleted before the fallback writes the actual stream content
+        $storage
+            ->expects($this->never())
+            ->method('delete');
+        $storage
+            ->expects($this->once())
+            ->method('writeStream')
+            ->with($binaryFilePath, $this->identicalTo($binaryDataStream));
+
+        $adapter = $this->createAdapterWithStorage($storage);
+
+        $originalAssetsConfig = Config::getSystemConfiguration('assets');
+        $assetsConfig = $originalAssetsConfig ?? [];
+        $assetsConfig['versions']['use_hardlinks'] = true;
+        Config::setSystemConfiguration($assetsConfig, 'assets');
+
+        try {
+            $adapter->save($version, 'metadata', $binaryDataStream);
+        } finally {
+            Config::setSystemConfiguration($originalAssetsConfig, 'assets');
+            fclose($binaryDataStream);
+            fclose($existingFileStream);
+        }
+
+        $this->assertSame([$metadataFilePath, $binaryFilePath], $writtenPaths);
     }
 
     private function callResolveLocalFilePath(FileSystemVersionStorageAdapter $adapter, mixed $stream): ?string


### PR DESCRIPTION
## Changes in this pull request
Resolves pimcore/platform-version#452
Related to #19069

`FileSystemVersionStorageAdapter::save()` decides whether to hardlink an asset's version binary by checking `stream_is_local()` on both streams. That check also returns true for in-memory wrappers like `php://temp`, whose `stream_get_meta_data()['uri']` is the literal string `php://temp` rather than a real path, so `link()` fails with "No such file or directory" every time an asset's binary content comes from an in-memory stream (e.g. a REST import) with hardlinks enabled. Added a `resolveLocalFilePath()` helper that additionally checks `is_file()` on the resolved URI and only attempts the hardlink when both streams genuinely point at a file, otherwise it falls through to the existing `writeStream()` fallback.

Verified the root cause directly (`stream_is_local('php://temp')` returns `true`, its URI is the literal string `php://temp`) and added unit tests for the new helper following this file's existing reflection-based test pattern. I don't have the DB/Redis/MinIO stack this repo's Codeception suite needs locally, so I ran php-cs-fixer against the changed files and exercised the helper's logic against real and in-memory streams in an isolated PHP script instead of through the full suite.

## Additional info
Used AI assistance (Claude) to investigate and write this fix.
