### PR TITLE
Fix TypeError when filtering object grid by Image field

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Image.php
+++ b/models/DataObject/ClassDefinition/Data/Image.php
@@ -292,7 +292,7 @@ class Image extends Data implements ResourcePersistenceAwareInterface, QueryReso
     {
         $name = $params['name'] ?: $this->name;
 
-        return $this->getRelationFilterCondition($value, $operator, $name);
+        return $this->getRelationFilterCondition($value !== null ? (string) $value : null, $operator, $name);
     }
 
     public function getColumnType(): string

--- a/tests/Unit/Models/DataObject/ClassDefinition/Data/ImageTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/Data/ImageTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * This source file is available under the terms of the

--- a/tests/Unit/Models/DataObject/ClassDefinition/Data/ImageTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/Data/ImageTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\DataObject\ClassDefinition\Data;
+
+use Pimcore\Model\DataObject\ClassDefinition\Data\Image;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * @group unit.model.datatype.image
+ */
+class ImageTest extends TestCase
+{
+    /**
+     * Regression test for #18939: the object grid's relation filter for an Image field
+     * submits the asset id as an int. getFilterConditionExt() forwarded it straight to
+     * getRelationFilterCondition(?string $value, ...), which threw a TypeError under
+     * strict_types before the filter condition was ever built.
+     */
+    public function testGetFilterConditionExtAcceptsIntValue(): void
+    {
+        $field = new Image();
+        $field->setName('image');
+
+        $condition = $field->getFilterConditionExt(123, '=', ['name' => 'image']);
+
+        $this->assertStringContainsString('123', $condition);
+    }
+
+    public function testGetFilterConditionExtAcceptsNullValue(): void
+    {
+        $field = new Image();
+        $field->setName('image');
+
+        $condition = $field->getFilterConditionExt(null, '=', ['name' => 'image']);
+
+        $this->assertStringContainsString('IS NULL', $condition);
+    }
+}


### PR DESCRIPTION
## Changes in this pull request
Resolves pimcore/platform-version#453
Related to #18939

`Image::getFilterConditionExt()` forwards the object grid's filter value straight to `RelationFilterConditionParser::getRelationFilterCondition(?string $value, ...)`. The Image field's filter value is an asset id, which the grid sends as an int, so under `strict_types` that throw a `TypeError` before any SQL condition got built — filtering an object grid by an Image field failed outright. Other relation fields going through the same trait (`ManyToOneRelation`, `Hotspotimage`) already handle this correctly, so I just brought Image in line: cast the value to string before forwarding it, keeping `null` as `null` so the existing "IS NULL" branch still works.

Added a regression test in `tests/Unit/Models/DataObject/ClassDefinition/Data/ImageTest.php` covering both the int and null cases. I don't have the MySQL/Redis/MinIO stack this repo's Codeception suite needs locally, so I verified the fix by reproducing the exact signature contract (a `?string`-typed method called through a `mixed`-typed forwarder) in an isolated PHP script — confirmed the unfixed version throws `TypeError` on an int and the fixed version builds the expected condition for int, string and null values.

## Additional info
Used AI assistance (Claude) to investigate and write this fix.
