### PR TITLE
[Docs] Clarify context-dependent default of Localizedfield::setGetFallbackValues()

### DIFF
--- a/doc/03_Objects/01_Object_Classes/01_Data_Types/50_Localized_Fields.md
+++ b/doc/03_Objects/01_Object_Classes/01_Data_Types/50_Localized_Fields.md
@@ -61,12 +61,44 @@ The following code will create an array containing the available languages for t
 $languages = \Pimcore\Tool::getValidLanguages();
 ```
 
-### Disable Fallback languages ###
+### Enable / Disable Fallback languages ###
 
-You can disable the Fallback languages
+Whether getters return the value of the fallback language when the requested language has no value is controlled by
+the static flag `\Pimcore\Model\DataObject\Localizedfield::setGetFallbackValues()`.
+
+Its default depends on the context Pimcore is running in:
+
+| Context | Fallback values |
+|---------|-----------------|
+| Frontend requests (website) | enabled |
+| CLI scripts / commands | enabled |
+| Admin requests (backend UI, admin API) | disabled |
+
+Note that in admin context (or in any other context where fallback values are disabled) getters will return an empty
+value for languages without a value, even if a fallback language is configured.
+
+You can change the behavior at any time:
 
 ```php
+// disable fallback values, e.g. in the frontend
 \Pimcore\Model\DataObject\Localizedfield::setGetFallbackValues(false);
+
+// enable fallback values, e.g. in the admin context
+\Pimcore\Model\DataObject\Localizedfield::setGetFallbackValues(true);
+
+// check the current state
+$fallbackEnabled = \Pimcore\Model\DataObject\Localizedfield::getGetFallbackValues();
+```
+
+As the flag is global, remember to restore the previous value after you are done:
+
+```php
+$fallbackEnabled = \Pimcore\Model\DataObject\Localizedfield::getGetFallbackValues();
+\Pimcore\Model\DataObject\Localizedfield::setGetFallbackValues(true);
+
+// ... code that relies on fallback values ...
+
+\Pimcore\Model\DataObject\Localizedfield::setGetFallbackValues($fallbackEnabled);
 ```
 
 ### Accessing the data


### PR DESCRIPTION
## Changes in this pull request
Resolves pimcore/pimcore#18382
Resolves: pimcore/platform-version#460

The localized fields docs only showed how to *disable* fallback values, which implied they are always enabled. In fact the default depends on the context Pimcore runs in:

- Frontend requests: enabled (`PimcoreContextListener`)
- CLI scripts / commands: enabled (`Bootstrap`)
- Admin requests: disabled (`PimcoreContextListener`)

This PR updates `doc/03_Objects/01_Object_Classes/01_Data_Types/50_Localized_Fields.md`:

- Renames the section to "Enable / Disable Fallback languages"
- Adds a table with the default per context
- Notes that with fallback disabled, getters return an empty value for a language without data even if a fallback language is configured
- Shows how to enable, disable and read the flag (`getGetFallbackValues()`)
- Shows how to save and restore the flag, since it is global state

## Additional info
Documentation only, no code changes.