### PR TITLE
[security] GHSA-8c9h-28x3-9f9f: SQL injection via classificationstore QuantityValue grid-filter value in HAVING clause

### DIFF
--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -406,7 +406,11 @@ class QuantityValue extends AbstractQuantityValue
             $key = $params['brickPrefix'].$key;
         }
         if (str_starts_with($name, 'cskey_')) {
-            return $key .'.'. $db->quoteIdentifier('value') . ' ' . $operator . ' ' . $value[0][0].' ';
+            if (!is_numeric($value[0][0]) || !in_array($operator, self::$validFilterOperators)) {
+                return '';
+            }
+
+            return $key .'.'. $db->quoteIdentifier('value') . ' ' . $operator . ' ' . (float) $value[0][0] . ' ';
         }
 
         return $key . ' ' . $operator . ' ' . (is_string($value) ? $db->quote($value) : $value) . ' ';

--- a/tests/Unit/Models/DataObject/ClassDefinition/Data/QuantityValueFilterConditionTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/Data/QuantityValueFilterConditionTest.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\DataObject\ClassDefinition\Data;
+
+use Pimcore\Model\DataObject\ClassDefinition\Data\QuantityValue;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * Regression test for GHSA-8c9h-28x3-9f9f: classificationstore QuantityValue grid
+ * filters must not allow raw SQL to be injected into the HAVING clause via
+ * $value[0][0].
+ */
+class QuantityValueFilterConditionTest extends TestCase
+{
+    public function testLegitimateNumericValueIsFiltered(): void
+    {
+        $field = new QuantityValue();
+
+        $condition = $field->getFilterConditionExt(
+            [['12.5', '1']],
+            '=',
+            ['name' => 'cskey_1-2']
+        );
+
+        $this->assertStringContainsString('12.5', $condition);
+        $this->assertStringNotContainsString(',1', $condition, 'unit value must not leak into the value comparison');
+    }
+
+    public function testSqlInjectionPayloadIsRejected(): void
+    {
+        $field = new QuantityValue();
+
+        $payload = '0 OR (SELECT 1 FROM users) -- ';
+
+        $condition = $field->getFilterConditionExt(
+            [[$payload, '0']],
+            '=',
+            ['name' => 'cskey_1-2']
+        );
+
+        $this->assertSame('', $condition);
+        $this->assertStringNotContainsString('SELECT', $condition);
+    }
+
+    public function testNonAllowlistedOperatorIsRejected(): void
+    {
+        $field = new QuantityValue();
+
+        $condition = $field->getFilterConditionExt(
+            [['5', '0']],
+            '1=1; DROP TABLE users; --',
+            ['name' => 'cskey_1-2']
+        );
+
+        $this->assertSame('', $condition);
+    }
+}


### PR DESCRIPTION
## Vulnerability

`models/DataObject/ClassDefinition/Data/QuantityValue.php:408-409`, the classificationstore (`cskey_`) branch of `QuantityValue::getFilterConditionExt()`, concatenated the attacker-controlled grid-filter value (`$value[0][0]`) **raw** into a SQL `HAVING` clause fragment:

```php
if (str_starts_with($name, 'cskey_')) {
    return $key .'.'. $db->quoteIdentifier('value') . ' ' . $operator . ' ' . $value[0][0].' ';
}
```

Neither of the two guards present elsewhere were applied here: the base `(redacted) applies `$db->quote((string)$value)`, and `Data\Numeric` requires `is_numeric()`. An authenticated, low-privilege backend user with DataObject grid access (`/admin/object/grid-proxy`) could submit a grid filter of type `quantityValue` against a classificationstore field and inject arbitrary SQL into the listing's `HAVING` clause — enabling blind boolean/time-based extraction of arbitrary DB content, analogous to the sibling CVE-2023-47637 (Multiselect grid filter).

## Fix

The `cskey_` branch now rejects the filter (returns an empty condition, same as the base class does for other invalid/empty filters) unless:
- `$value[0][0]` is `is_numeric()` (the underlying column is a numeric/decimal quantity value, so legitimate filters are always numeric), in which case it is cast to `float` before being inlined, and
- `$operator` is one of the existing `(redacted) allowlist entries.

This mirrors the pattern already used by `Data\Numeric::getFilterConditionExt()` for the same numeric-column scenario, and the guard added to `Multiselect::getFilterConditionExt()` for the sibling CVE-2023-47637.

## Backward compatibility

Checked against the BC promise (`pimcore-backward-compatibility`): `getFilterConditionExt()`'s signature, return type and default arguments are unchanged. The only behavior change is for **non-numeric** `value[0][0]` or a **non-allowlisted** operator on a classificationstore QuantityValue filter — inputs that never occur in legitimate use, since the underlying `value` column is numeric and the operator is normally constrained by the calling grid code. These inputs previously produced broken/injectable SQL, not a meaningful result, so no legitimate caller's behavior changes. This is the same shape of fix already accepted for the sibling CVE-2023-47637 fix in `Multiselect::getFilterConditionExt()`.

## Verification

Tests added: `tests/Unit/Models/DataObject/ClassDefinition/Data/QuantityValueFilterConditionTest.php`

- `testLegitimateNumericValueIsFiltered` — confirms a normal numeric quantity-value filter still produces the expected `HAVING`-fragment condition.
- `testSqlInjectionPayloadIsRejected` — feeds the advisory's PoC-style payload (`0 OR (SELECT 1 FROM users) -- `) as `value[0][0]`; asserts the returned condition is empty and contains no `SELECT`. This fails against the vulnerable code (which would return the raw payload embedded in the condition) and passes with the fix.
- `testNonAllowlistedOperatorIsRejected` — feeds a non-allowlisted operator string; asserts the condition is empty.

This suite (`tests/Unit`) connects to a real DB (`connect_db: true` in `tests/Unit.suite.dist.yml`), so `QuantityValue::getFilterConditionExt()`'s `\Pimcore\Db::get()` call is exercisable. I could not execute Composer/PHPUnit in this sandbox (no network/Composer access), so these were verified by manual trace against both the vulnerable and fixed code paths, not by a live test run.

Security-Advisory: pimcore/pimcore/GHSA-8c9h-28x3-9f9f

> [!WARNING]
> <details>
> <summary>Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `api.anthropic.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "api.anthropic.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>

> Generated by [Draft a security-advisory fix](https://github.com/pimcore/workflows-centralized/actions/runs/34554395060) · claude · sonnet50 · 125.7 AIC · ⌖ 36 AIC · ⊞ 7.5K · [◷](https://github.com/search?q=repo%3Apimcore%2Fpimcore+%22gh-aw-workflow-id%3A+advisory-fix%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Draft a security-advisory fix, engine: claude, model: claude-sonnet-5, id: 34554395060, workflow_id: advisory-fix, run: https://github.com/pimcore/workflows-centralized/actions/runs/34554395060 -->

<!-- gh-aw-workflow-id: advisory-fix -->
<!-- gh-aw-workflow-call-id: pimcore/workflows-centralized/advisory-fix -->