### PR TITLE
[Layout] Default typed string properties to empty string to avoid uninitialized access

### DIFF
--- a/models/DataObject/ClassDefinition/Layout/Fieldcontainer.php
+++ b/models/DataObject/ClassDefinition/Layout/Fieldcontainer.php
@@ -35,7 +35,7 @@ class Fieldcontainer extends Model\DataObject\ClassDefinition\Layout
     /**
      * @internal
      */
-    public string $fieldLabel;
+    public string $fieldLabel = '';
 
     /**
      * @return $this

--- a/models/DataObject/ClassDefinition/Layout/Iframe.php
+++ b/models/DataObject/ClassDefinition/Layout/Iframe.php
@@ -31,13 +31,13 @@ class Iframe extends Model\DataObject\ClassDefinition\Layout implements LayoutDe
      * @internal
      *
      */
-    public string $iframeUrl;
+    public string $iframeUrl = '';
 
     /**
      * @internal
      *
      */
-    public string $renderingData;
+    public string $renderingData = '';
 
     public function getIframeUrl(): string
     {

--- a/models/DataObject/ClassDefinition/Layout/Text.php
+++ b/models/DataObject/ClassDefinition/Layout/Text.php
@@ -45,7 +45,7 @@ class Text extends Model\DataObject\ClassDefinition\Layout implements Model\Data
      * @internal
      *
      */
-    public string $renderingData;
+    public string $renderingData = '';
 
     /**
      * @internal

--- a/tests/Unit/Models/DataObject/ClassDefinition/LayoutOptionalStringDefaultsTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/LayoutOptionalStringDefaultsTest.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\DataObject\ClassDefinition;
+
+use PHPUnit\Framework\TestCase;
+use Pimcore\Model\DataObject\ClassDefinition\Layout\Fieldcontainer;
+use Pimcore\Model\DataObject\ClassDefinition\Layout\Iframe;
+use Pimcore\Model\DataObject\ClassDefinition\Layout\Text;
+
+/**
+ * These layout fields are optional in the class editor, so setValues() never calls their setter
+ * when they are left empty. Without a declared default the typed properties stay uninitialized and
+ * the getters raise "must not be accessed before initialization" instead of returning ''.
+ */
+class LayoutOptionalStringDefaultsTest extends TestCase
+{
+    public function testTextRenderingDataDefaultsToEmptyString(): void
+    {
+        $this->assertSame('', (new Text())->getRenderingData());
+    }
+
+    public function testIframeUrlDefaultsToEmptyString(): void
+    {
+        $this->assertSame('', (new Iframe())->getIframeUrl());
+    }
+
+    public function testIframeRenderingDataDefaultsToEmptyString(): void
+    {
+        $this->assertSame('', (new Iframe())->getRenderingData());
+    }
+
+    public function testFieldcontainerFieldLabelDefaultsToEmptyString(): void
+    {
+        $this->assertSame('', (new Fieldcontainer())->getFieldLabel());
+    }
+}


### PR DESCRIPTION
Fixes pimcore/platform-version#468

### Changes in this pull request

Four typed `string` properties in `DataObject\ClassDefinition\Layout` are declared without a default value, while their siblings in the same classes are defaulted. Any read before a setter runs raises `Error: Typed property ... must not be accessed before initialization`.

- `Layout\Text::$renderingData`
- `Layout\Iframe::$iframeUrl`
- `Layout\Iframe::$renderingData`
- `Layout\Fieldcontainer::$fieldLabel`

This PR defaults all four to `''`, mirroring `Layout\Text::$renderingClass = ''` and `Layout\Text::$html = ''` right next to them.

### Reproduction (the case we hit)

1. Edit a class definition, add a **Text** layout component
2. Set a **Custom Renderer Class** implementing `DynamicTextLabelInterface`, leave **Rendering Data** empty
3. Save the class, then open any object of that class

The object fails to load with a 500:

```
Uncaught PHP Exception Error: "Typed property
Pimcore\Model\DataObject\ClassDefinition\Layout\Text::$renderingData
must not be accessed before initialization"
at models/DataObject/ClassDefinition/Layout/Text.php:115
```

`enrichLayoutDefinition()` reads `$this->renderingData` unconditionally once a renderer is resolved, so an empty **Rendering Data** field makes the object unopenable in the backend. Since the value is never persisted when empty, the property stays uninitialized after `setValues()`.

`Iframe` and `Fieldcontainer` expose the same defect through their getters (`getIframeUrl()`, `getRenderingData()`, `getFieldLabel()`). An empty Preview/Iframe component was already reported as breaking in #7649 (closed as not planned); that report predates the typed properties, so the error message differs, but the empty-value case it describes is still broken today.

### Additional info

- Verified on 2026.2.3, 2026.2.4 and 2026.2.5; the four declarations are identical on the `2026.x` and `2026.2` branches
- Behaviour is unchanged for every already-working configuration: an empty saved field already yields `''` anyway
