### PR TITLE
Fix uncaught TypeError in IncludeRenderer when include is a numeric string

### DIFF
--- a/lib/Templating/Renderer/IncludeRenderer.php
+++ b/lib/Templating/Renderer/IncludeRenderer.php
@@ -25,6 +25,7 @@ use Pimcore\Tool\DeviceDetector;
 use Pimcore\Tool\DomCrawler;
 use Pimcore\Tool\Frontend;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Throwable;
 
 /**
  * @internal
@@ -53,8 +54,8 @@ class IncludeRenderer
 
         if (is_numeric($include)) {
             try {
-                $include = Model\Document::getById($include);
-            } catch (Exception $e) {
+                $include = Model\Document::getById((int) $include);
+            } catch (Throwable $e) {
                 $include = $originalInclude;
             }
         } elseif (is_string($include)) {

--- a/tests/Unit/Templating/Renderer/IncludeRendererTest.php
+++ b/tests/Unit/Templating/Renderer/IncludeRendererTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Templating\Renderer;
+
+use PHPUnit\Framework\TestCase;
+use Pimcore\Templating\Renderer\ActionRenderer;
+use Pimcore\Templating\Renderer\IncludeRenderer;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+final class IncludeRendererTest extends TestCase
+{
+    public function testRenderReturnsEmptyContentForMissingNumericStringDocument(): void
+    {
+        $renderer = new IncludeRenderer(
+            $this->createStub(ActionRenderer::class),
+            $this->createStub(EventDispatcherInterface::class),
+        );
+
+        self::assertSame('', $renderer->render('0', cacheEnabled: false));
+    }
+}


### PR DESCRIPTION
## Changes in this pull request
Resolves pimcore/platform-version#473

`IncludeRenderer::render()` checks `is_numeric($include)` and then calls `Document::getById($include)`, but `getById()` declares a strict `int $id` parameter. `is_numeric()` accepts numeric strings, so passing one straight through throws a `TypeError` — which the surrounding `catch (Exception $e)` doesn't catch, since `TypeError` extends `Error`, not `Exception`. The render call fails hard instead of falling back to the original include value like it's supposed to for a missing/invalid document.

Cast `$include` to `(int)` before the lookup so it actually satisfies the type hint, and broadened the catch to `Throwable` so any other genuine lookup failure still falls back gracefully instead of only `Exception` subclasses.

To reproduce: call `IncludeRenderer::render('0')` (or any numeric-string include for a document that doesn't exist) — before this fix it throws `TypeError: Document::getById(): Argument #1 ($id) must be of type int, string given`; after the fix it returns an empty string like the missing-document fallback path already does everywhere else.

Added a unit test (`tests/Unit/Templating/Renderer/IncludeRendererTest.php`) covering exactly this case.

## Additional info
No vendor/ install available in the environment I worked in, so I verified the before/after behavior with a standalone PHP reproduction (via php-wasm) against the actual method rather than through PHPUnit directly — confirmed the exact `TypeError` message pre-fix and empty-string output post-fix.
