### PR TITLE
[security] GHSA-qfg9-rq74-hp35: DDL injection via unvalidated Date/Datetime/DateRange columnType

### DIFF
--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -182,6 +182,18 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
     }
 
     /**
+     * Column/query column types (Date, Datetime, DateRange) are emitted verbatim into
+     * ALTER TABLE DDL, so they must be restricted to a plain SQL type expression instead
+     * of accepting arbitrary strings.
+     */
+    protected function validateColumnType(string $columnType): void
+    {
+        if (!preg_match('/^[a-zA-Z][a-zA-Z0-9_]*(\(\s*\d+\s*(,\s*\d+\s*)?\))?(\s+(?:unsigned|zerofill))*\z/i', $columnType)) {
+            throw new InvalidArgumentException(sprintf('Invalid column type "%s"', $columnType));
+        }
+    }
+
+    /**
      * @return $this
      */
     public function setTitle(string $title): static

--- a/models/DataObject/ClassDefinition/Data/Date.php
+++ b/models/DataObject/ClassDefinition/Data/Date.php
@@ -401,6 +401,7 @@ class Date extends Data implements ResourcePersistenceAwareInterface, QueryResou
 
     public function setColumnType(string $columnType): void
     {
+        $this->validateColumnType($columnType);
         $this->columnType = $columnType;
     }
 

--- a/models/DataObject/ClassDefinition/Data/DateRange.php
+++ b/models/DataObject/ClassDefinition/Data/DateRange.php
@@ -358,8 +358,12 @@ class DateRange extends Data implements
     public function setColumnType(string|array $columnType): void
     {
         if (is_array($columnType)) {
+            foreach ($columnType as $singleColumnType) {
+                $this->validateColumnType($singleColumnType);
+            }
             $this->columnType = $columnType;
         } else {
+            $this->validateColumnType($columnType);
             $this->columnType = [
                 'start_date' => $columnType,
                 'end_date' => $columnType,

--- a/models/DataObject/ClassDefinition/Data/Datetime.php
+++ b/models/DataObject/ClassDefinition/Data/Datetime.php
@@ -421,6 +421,7 @@ class Datetime extends Data implements ResourcePersistenceAwareInterface, QueryR
 
     public function setColumnType(string $columnType): void
     {
+        $this->validateColumnType($columnType);
         $this->columnType = $columnType;
     }
 

--- a/tests/Unit/Models/DataObject/ClassDefinition/Data/ColumnTypeValidationTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/Data/ColumnTypeValidationTest.php
@@ -1,0 +1,103 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\Model\DataObject\ClassDefinition\Data;
+
+use InvalidArgumentException;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Date;
+use Pimcore\Model\DataObject\ClassDefinition\Data\DateRange;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Datetime;
+use Pimcore\Tests\Support\Test\TestCase;
+
+/**
+ * Regression test for GHSA-qfg9-rq74-hp35: columnType/queryColumnType of Date, Datetime
+ * and DateRange fields are concatenated verbatim into ALTER TABLE DDL, so setColumnType()
+ * must reject anything that is not a plain SQL type expression.
+ */
+class ColumnTypeValidationTest extends TestCase
+{
+    private const INJECTION_PAYLOAD = 'bigint(20), DROP COLUMN `oo_id`, ADD INDEX `pwn`(`o_published`) -- ';
+
+    public function testDateRejectsInjectedColumnType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new Date())->setColumnType(self::INJECTION_PAYLOAD);
+    }
+
+    public function testDateAcceptsLegitimateColumnTypes(): void
+    {
+        $field = new Date();
+
+        $field->setColumnType('bigint(20)');
+        $this->assertSame('bigint(20)', $field->getColumnType());
+
+        $field->setColumnType('date');
+        $this->assertSame('date', $field->getColumnType());
+    }
+
+    public function testDatetimeRejectsInjectedColumnType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new Datetime())->setColumnType(self::INJECTION_PAYLOAD);
+    }
+
+    public function testDatetimeAcceptsLegitimateColumnTypes(): void
+    {
+        $field = new Datetime();
+
+        $field->setColumnType('bigint(20)');
+        $this->assertSame('bigint(20)', $field->getColumnType());
+
+        $field->setColumnType('datetime');
+        $this->assertSame('datetime', $field->getColumnType());
+    }
+
+    public function testDateRangeRejectsInjectedScalarColumnType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new DateRange())->setColumnType(self::INJECTION_PAYLOAD);
+    }
+
+    public function testDateRangeRejectsInjectedArrayColumnType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new DateRange())->setColumnType([
+            'start_date' => 'bigint(20)',
+            'end_date' => self::INJECTION_PAYLOAD,
+        ]);
+    }
+
+    public function testDateRangeAcceptsLegitimateColumnTypes(): void
+    {
+        $field = new DateRange();
+
+        $field->setColumnType('bigint(20)');
+        $this->assertSame([
+            'start_date' => 'bigint(20)',
+            'end_date' => 'bigint(20)',
+        ], $field->getColumnType());
+
+        $field->setColumnType([
+            'start_date' => 'date',
+            'end_date' => 'datetime',
+        ]);
+        $this->assertSame([
+            'start_date' => 'date',
+            'end_date' => 'datetime',
+        ], $field->getColumnType());
+    }
+}


### PR DESCRIPTION
## Vulnerability

`Date`, `Datetime` and `DateRange` field definitions override the default `resolveBlockedVars()` export block list so that `columnType`/`queryColumnType` round-trip from the class-definition JSON to `setColumnType()` unvalidated (`Date::resolveBlockedVars()`, `Datetime::resolveBlockedVars()`, `DateRange::resolveBlockedVars()`).

`ClassDefinition\Dao::update()` later passes `getColumnType()`/`getQueryColumnType()` into `ClassDefinition\Helper\Dao::addModifyColumn()`, which builds:

```php
'ALTER TABLE ' . quoteIdentifier($table) . ' ADD COLUMN ' . quoteIdentifier($colName) . ' ' . $type . $default . ' ' . $null . ';'
```

Only the table and column identifiers are quoted; `$type` is concatenated raw. Since the three date types allow `columnType` to be set to an arbitrary string via the class editor, a backend user with the granular class-edit permission can inject extra DDL clauses (e.g. `bigint(20), DROP COLUMN \`oo_id\`, ADD INDEX ...`) into the `ALTER TABLE` statement issued against the class's own `object_store`/`object_query` tables — corrupting the table structure, including dropping protected system columns.

This is distinct from the field-name hardening fix (CVE-2026-55634 / GHSA-9x44-4gxf-8c25), which only quotes the column-name argument of the same helper; the type argument was a separate, unvalidated parameter.

## Fix

Added `(redacted) in the shared base class (`models/DataObject/ClassDefinition/Data.php`), following the exact pattern already used by `(redacted) for the sibling field-name fix: a strict allowlist regex for plain SQL type expressions (`type_name`, optional `(length)` / `(precision,scale)`, optional `unsigned`/`zerofill` modifiers), anchored at both ends, throwing `InvalidArgumentException` on anything else.

`setColumnType()` in `Date`, `Datetime` and `DateRange` now calls this validator before storing the value (for `DateRange`, each element when an array is passed). This closes the injection path at the model layer, where it applies regardless of how the value was set (class editor import, API, or programmatic construction), while continuing to accept all values the admin UI legitimately produces (`bigint(20)`, `date`, `datetime`, and similar length/precision/modifier variants).

Protected-column enforcement in `removeUnusedColumns()`/`addModifyColumn()` is untouched — the fix is scoped purely to constraining the type string, per the advisory's suggested remediation.

## Backward compatibility

`columnType`/`queryColumnType`/`setColumnType()` are marked `@internal` on the property and are framework-internal configuration written by the class editor, not part of the public API contract data-object consumers rely on. The change tightens validation on this internal setter only: legitimate values used by the shipped editor (`bigint(20)`, `date`, `datetime`, and other standard SQL type expressions with optional length/precision/`unsigned`/`zerofill`) continue to work unchanged; only strings that are not valid standalone SQL type expressions (i.e., ones that could only serve to inject additional DDL) now throw `InvalidArgumentException`. This mirrors the precedent already established for the sibling field-name injection fix in `(redacted)

## Verification

Tests added: `tests/Unit/Models/DataObject/ClassDefinition/Data/ColumnTypeValidationTest.php`

This new test file covers: the exact PoC injection payload from the advisory rejected for `Date`, `Datetime`, and both scalar and array forms of `DateRange::setColumnType()`; and legitimate values (`bigint(20)`, `date`, `datetime`) still accepted and correctly stored/round-tripped through `getColumnType()`. These are plain, DB-independent unit tests in the same style as the existing `DateRangeTest`/`QuantityValueColumnTypeTest` in that directory.

The sandbox has no Composer/network access, so the suite could not be executed here (`vendor/` is absent); the tests are written to run via `vendor/bin/codecept run Unit` in CI.

Security-Advisory: pimcore/pimcore/GHSA-qfg9-rq74-hp35

> [!WARNING]
> <details>
> <summary>Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `api.anthropic.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "api.anthropic.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>

> Generated by [Draft a security-advisory fix](https://github.com/pimcore/workflows-centralized/actions/runs/34732896587) · claude · sonnet50 · 210.2 AIC · ⌖ 36.3 AIC · ⊞ 7.5K · [◷](https://github.com/search?q=repo%3Apimcore%2Fpimcore+%22gh-aw-workflow-id%3A+advisory-fix%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Draft a security-advisory fix, engine: claude, model: claude-sonnet-5, id: 34732896587, workflow_id: advisory-fix, run: https://github.com/pimcore/workflows-centralized/actions/runs/34732896587 -->

<!-- gh-aw-workflow-id: advisory-fix -->
<!-- gh-aw-workflow-call-id: pimcore/workflows-centralized/advisory-fix -->