### PR TITLE
[security] GHSA-f4jp-qhv6-g8gq: sanitize generated getter/setter PHPDoc types

### DIFF
--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -496,7 +496,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
         $code = '/**' . "\n";
         $code .= '* Get ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
-        $code .= '* @return ' . $this->getPhpdocReturnType() . "\n";
+        $code .= '* @return ' . str_replace(['/**', '*/', '//'], '', (string) $this->getPhpdocReturnType()) . "\n";
         $code .= '*/' . "\n";
         $code .= 'public function get' . ucfirst($key) . '()' . $typeDeclaration . "\n";
         $code .= '{' . "\n";
@@ -545,7 +545,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
         $code = '/**' . "\n";
         $code .= '* Set ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
-        $code .= '* @param ' . $this->getPhpdocInputType() . ' $' . $key . "\n";
+        $code .= '* @param ' . str_replace(['/**', '*/', '//'], '', (string) $this->getPhpdocInputType()) . ' $' . $key . "\n";
         $code .= '* @return $this' . "\n";
         $code .= '*/' . "\n";
         $code .= 'public function set' . ucfirst($key) . '(' . $typeDeclaration . '$' . $key . '): static' . "\n";
@@ -624,7 +624,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         $code = '';
         $code .= '/**' . "\n";
         $code .= '* Get ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
-        $code .= '* @return ' . $this->getPhpdocReturnType() . "\n";
+        $code .= '* @return ' . str_replace(['/**', '*/', '//'], '', (string) $this->getPhpdocReturnType()) . "\n";
         $code .= '*/' . "\n";
         $code .= 'public function get' . ucfirst($key) . '()' . $typeDeclaration . "\n";
         $code .= '{' . "\n";
@@ -670,7 +670,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
         $code = '/**' . "\n";
         $code .= '* Set ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
-        $code .= '* @param ' . $this->getPhpdocInputType() . ' $' . $key . "\n";
+        $code .= '* @param ' . str_replace(['/**', '*/', '//'], '', (string) $this->getPhpdocInputType()) . ' $' . $key . "\n";
         $code .= '* @return $this' . "\n";
         $code .= '*/' . "\n";
         $code .= 'public function set' . ucfirst($key) . ' (' . $typeDeclaration . '$' . $key . '): static' . "\n";
@@ -751,7 +751,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
         $code = '/**' . "\n";
         $code .= '* Get ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
-        $code .= '* @return ' . $this->getPhpdocReturnType() . "\n";
+        $code .= '* @return ' . str_replace(['/**', '*/', '//'], '', (string) $this->getPhpdocReturnType()) . "\n";
         $code .= '*/' . "\n";
         $code .= 'public function get' . ucfirst($key) . '()' . $typeDeclaration . "\n";
         $code .= '{' . "\n";
@@ -790,7 +790,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
         $code = '/**' . "\n";
         $code .= '* Set ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
-        $code .= '* @param ' . $this->getPhpdocInputType() . ' $' . $key . "\n";
+        $code .= '* @param ' . str_replace(['/**', '*/', '//'], '', (string) $this->getPhpdocInputType()) . ' $' . $key . "\n";
         $code .= '* @return $this' . "\n";
         $code .= '*/' . "\n";
         $code .= 'public function set' . ucfirst($key) . '(' . $typeDeclaration . '$' . $key . '): static' . "\n";
@@ -860,7 +860,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
         $code = '/**' . "\n";
         $code .= '* Get ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
-        $code .= '* @return ' . $this->getPhpdocReturnType() . "\n";
+        $code .= '* @return ' . str_replace(['/**', '*/', '//'], '', (string) $this->getPhpdocReturnType()) . "\n";
         $code .= '*/' . "\n";
         $code .= 'public function get' . ucfirst($key) . '(?string $language = null)' . $typeDeclaration . "\n";
         $code .= '{' . "\n";
@@ -905,7 +905,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
         $code = '/**' . "\n";
         $code .= '* Set ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
-        $code .= '* @param ' . $this->getPhpdocInputType() . ' $' . $key . "\n";
+        $code .= '* @param ' . str_replace(['/**', '*/', '//'], '', (string) $this->getPhpdocInputType()) . ' $' . $key . "\n";
         $code .= '* @return $this' . "\n";
         $code .= '*/' . "\n";
         $code .= 'public function set' . ucfirst($key) . ' (' . $typeDeclaration . '$' . $key . ', ?string $language = null): static' . "\n";

--- a/tests/Model/DataObject/ClassDefinitionTest.php
+++ b/tests/Model/DataObject/ClassDefinitionTest.php
@@ -17,6 +17,7 @@ use Exception;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Fieldcollections;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Input;
+use Pimcore\Model\DataObject\ClassDefinition\Data\ManyToManyObjectRelation;
 use Pimcore\Tests\Support\Test\ModelTestCase;
 
 /**
@@ -323,6 +324,41 @@ public function getMybricks(): ?\Pimcore\Model\DataObject\Objectbrick
 
 ';
         $this->testGetterCode('mybricks', $expectedGetterCode);
+    }
+
+    /**
+     * An allowed-classes entry on an object-relation field is attacker-controlled (any backend
+     * user with class-edit rights). Its value is embedded raw into the generated model class'
+     * getter/setter PHPDoc type, so a comment-terminator in the entry used to close the docblock
+     * early and inject arbitrary PHP into the generated, autoloaded class (GHSA-f4jp-qhv6-g8gq).
+     * The getter and setter generators must scrub the PHPDoc type the same way they already
+     * scrub the field name and title, so the malicious sequence never reaches the emitted
+     * docblock intact.
+     */
+    public function testGetterSetterCodeSanitizesMaliciousAllowedClassPhpDocType(): void
+    {
+        $field = new ManyToManyObjectRelation();
+        $field->setName('vulnRelation');
+        $field->setTitle('vulnRelation');
+        $field->setClasses([
+            ['classes' => "Foo */ } echo 'INJECTED'; /*"],
+        ]);
+
+        $class = new ClassDefinition();
+
+        $getterCode = $field->getGetterCode($class);
+        $setterCode = $field->getSetterCode($class);
+
+        // Exactly one '*/' may appear in each snippet: the generator's own docblock terminator.
+        // A malicious allowed-class entry must not be able to introduce an earlier one that
+        // closes the docblock (and, in the full generated file, the enclosing class body) early.
+        $this->assertSame(1, substr_count($getterCode, '*/'));
+        $this->assertSame(1, substr_count($setterCode, '*/'));
+
+        // The payload text itself is left in place (it is now inert comment content) — only the
+        // comment-terminator sequence that would let it escape the docblock is stripped.
+        $this->assertStringContainsString("echo 'INJECTED'", $getterCode);
+        $this->assertStringContainsString("echo 'INJECTED'", $setterCode);
     }
 
     public function testInputEmptyDefaultValueIsNormalizedToNullAfterImportAndReload(): void


### PR DESCRIPTION
## Vulnerability

A backend user with the granular DataObject class-edit permission can achieve remote code execution through an object-relation field's `classes` (allowed-classes) list. `ManyToManyObjectRelation` always has this enabled (`getObjectsAllowed()` hardcoded to `true`), so no non-default configuration is required; `ManyToManyRelation` and `ManyToOneRelation` are reachable whenever object relations are permitted.

### Root cause

When a class definition is saved, Pimcore generates a PHP model class whose getter/setter carry a PHPDoc type built from the field's resolved type (`models/DataObject/ClassDefinition/Data.php`, `getGetterCode()`/`getSetterCode()` and their objectbrick/fieldcollection/localizedfields variants). The field name and title are scrubbed of comment terminators before being emitted, but the adjacent `@return`/`@param` type line is concatenated **raw**.

For relation fields, that type comes from `Extension/Relation::getPhpDocClassString()`, which builds each allowed-class entry via `sprintf('Pimcore\Model\DataObject\%s', ucfirst($item['classes']))` and — to avoid loading the class during a rebuild — falls back to the **raw, unvalidated string** whenever the class isn't in the class map. `Element\Service::fixAllowedTypes()` only restructures the array; it performs no identifier or comment-terminator validation either.

A `*/` inside an allowed-class entry therefore closes the docblock early. Combined with a `}` and `__halt_compiler()`, the attacker's tokens land at class/file scope in the generated, autoloaded model class, giving persistent RCE on any load of an object of that class or on a class rebuild.

## Fix

Apply the same comment-terminator scrubbing already used for the field name/title (`str_replace(['/**', '*/', '//'], '', ...)`) to the PHPDoc type emitted on the `@return`/`@param` lines, in all four getter/setter generator methods in `models/DataObject/ClassDefinition/Data.php` (`getGetterCode`, `getSetterCode`, `getGetterCodeObjectbrick`, `getSetterCodeObjectbrick`, `getGetterCodeFieldcollection`, `getSetterCodeFieldcollection`, `getGetterCodeLocalizedfields`, `getSetterCodeLocalizedfields`).

This is a single sink-level fix: since every relation type identified in the advisory (`ManyToOneRelation`, `ManyToManyRelation`, `ManyToManyObjectRelation`, `AdvancedManyToManyRelation`, `AdvancedManyToManyObjectRelation`) shares this same base code generator (none of them override `getGetterCode`/`getSetterCode`), scrubbing at this single choke point closes the docblock-breakout for all of them regardless of what an allowed-class entry resolves to. For legitimate class names (which never contain `/**`, `*/`, or `//`), the scrub is a no-op, so normal PHPDoc output is unchanged.

## Backward compatibility

Checked against the `pimcore-backward-compatibility` guidance: this only strips comment-terminator substrings from a generated **PHPDoc comment string** (not executable code, a signature, a default, or a return type/shape) in an already-`@internal`-flavored code generator (`getGetterCode`/`getSetterCode` are internal code-generation helpers, not part of the object's runtime API). For every legitimate class name, the string is unchanged, so there is no observable behavior change for any well-formed input — only malformed/malicious input that could never have produced valid PHP before is affected. Not a BC break.

## Testing

Tests already present: none of the tests in `tests/Model/DataObject/ClassDefinitionTest.php` exercised a malicious/adversarial allowed-classes entry, so:

Tests added: `tests/Model/DataObject/ClassDefinitionTest.php` (`testGetterSetterCodeSanitizesMaliciousAllowedClassPhpDocType`). It builds a `ManyToManyObjectRelation` field with an allowed-class entry containing a comment terminator and inline PHP (mirroring the advisory's PoC payload), then asserts:
- exactly one `*/` appears in the generated getter/setter code (the generator's own docblock terminator) — this assertion fails against the vulnerable code (two-plus terminators, i.e. an early break-out) and passes with the fix;
- the payload text is still present (now as inert comment content), confirming the fix sanitizes rather than drops the field.

I could not execute the test suite in this sandbox (no Composer/network access, no Docker-based Codeception environment) — the test is written to CI's standard for this file (an existing `ModelTestCase`-based Codeception Model-suite test) and should run via `vendor/bin/codecept run Model`.

Security-Advisory: pimcore/pimcore/GHSA-f4jp-qhv6-g8gq

> [!WARNING]
> <details>
> <summary>Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `api.anthropic.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "api.anthropic.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>

> Generated by [Draft a security-advisory fix](https://github.com/pimcore/workflows-centralized/actions/runs/34732862273) · claude · sonnet50 · 261.7 AIC · ⌖ 23.1 AIC · ⊞ 7.5K · [◷](https://github.com/search?q=repo%3Apimcore%2Fpimcore+%22gh-aw-workflow-id%3A+advisory-fix%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Draft a security-advisory fix, engine: claude, model: claude-sonnet-5, id: 34732862273, workflow_id: advisory-fix, run: https://github.com/pimcore/workflows-centralized/actions/runs/34732862273 -->

<!-- gh-aw-workflow-id: advisory-fix -->
<!-- gh-aw-workflow-call-id: pimcore/workflows-centralized/advisory-fix -->