### PR TITLE
[security] GHSA-x347-3h85-7jh8: escape backslash in generated SelectOptions enum literals

### DIFF
--- a/lib/DataObject/ClassBuilder/SelectOptionsEnumBuilder.php
+++ b/lib/DataObject/ClassBuilder/SelectOptionsEnumBuilder.php
@@ -177,7 +177,10 @@ class SelectOptionsEnumBuilder implements SelectOptionsEnumBuilderInterface
 
     protected function escapeSingleQuote(string $value): string
     {
-        return str_replace("'", "\\'", $value);
+        // Backslash must be escaped first: otherwise a value ending in `\'` produces `\\'` in the
+        // emitted source, an escaped backslash followed by a live, unescaped closing quote, which
+        // breaks out of the single-quoted PHP string literal (GHSA-x347-3h85-7jh8).
+        return str_replace(['\\', "'"], ['\\\\', "\\'"], $value);
     }
 
     protected function generateCaseName(SelectOption $selectOption): string

--- a/tests/Unit/DataObject/ClassBuilder/SelectOptionsEnumBuilderTest.php
+++ b/tests/Unit/DataObject/ClassBuilder/SelectOptionsEnumBuilderTest.php
@@ -1,0 +1,130 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Tests\Unit\DataObject\ClassBuilder;
+
+use PHPUnit\Framework\TestCase;
+use Pimcore\DataObject\ClassBuilder\SelectOptionsEnumBuilder;
+use Pimcore\Model\DataObject\SelectOptions\Config;
+use Pimcore\Model\DataObject\SelectOptions\Data\SelectOption;
+
+/**
+ * The enum generator escapes single quotes in option values/labels before embedding them in a
+ * single-quoted PHP string literal, but previously left backslashes untouched. A value/label
+ * ending in `\'` was therefore emitted as `\\'` in the generated source: an escaped backslash
+ * followed by a live, unescaped closing quote, closing the string (and the enum body) early and
+ * placing attacker-controlled tokens at file scope, where they execute on autoload
+ * (GHSA-x347-3h85-7jh8).
+ *
+ * These tests exercise the real Config/SelectOption/SelectOptionsEnumBuilder::buildEnum() path
+ * and use PHP's own tokenizer (token_get_all) to decode the generated string literals. Tokenizing
+ * is inert (it never executes the generated source), so it safely distinguishes "value round-trips
+ * intact" (fixed) from "value/literal was truncated by an early, unescaped closing quote"
+ * (vulnerable) without ever require()-ing or eval()-ing attacker-controlled generated code.
+ */
+class SelectOptionsEnumBuilderTest extends TestCase
+{
+    public function testMaliciousOptionValueCannotBreakOutOfTheGeneratedCaseLiteral(): void
+    {
+        // Only double quotes are used in the "injected" tail, so a correct single-quote escaper
+        // cannot interfere with it - isolating the missing backslash handling as the sole defect.
+        $payload = '\\\'; } echo "___PIMCORE_RCE_PROOF___"; //';
+
+        $source = $this->buildEnumSource(new SelectOption($payload, 'Safe label', 'MaliciousValue'));
+        $strings = $this->extractConstantStrings($source);
+
+        $this->assertSame(
+            $payload,
+            $strings[0] ?? null,
+            'Option value must round-trip intact through the generated enum case literal'
+        );
+    }
+
+    public function testMaliciousOptionLabelCannotBreakOutOfTheGeneratedLabelMatchLiteral(): void
+    {
+        $payload = '\\\'; } echo "___PIMCORE_RCE_PROOF___"; //';
+
+        $source = $this->buildEnumSource(new SelectOption('safe-value', $payload, 'MaliciousLabel'));
+        $strings = $this->extractConstantStrings($source);
+
+        $this->assertSame(
+            $payload,
+            $strings[1] ?? null,
+            'Option label must round-trip intact through the generated label match literal'
+        );
+    }
+
+    /**
+     * @dataProvider legitimateValueProvider
+     */
+    public function testLegitimateOptionValuesRoundTripUnchanged(string $value): void
+    {
+        $source = $this->buildEnumSource(new SelectOption($value, 'Some label', 'SomeName'));
+        $strings = $this->extractConstantStrings($source);
+
+        $this->assertSame($value, $strings[0] ?? null);
+    }
+
+    public static function legitimateValueProvider(): array
+    {
+        return [
+            'plain value' => ['plain'],
+            'single quote' => ["O'Brien"],
+            'backslash not at the end' => ['C:\\Users\\test'],
+            'trailing single backslash' => ['trailing\\'],
+        ];
+    }
+
+    private function buildEnumSource(SelectOption $selectOption): string
+    {
+        $config = (new Config())
+            ->setId('EnumBuilderTest')
+            ->setSelectOptions($selectOption);
+
+        return (new SelectOptionsEnumBuilder())->buildEnum($config);
+    }
+
+    /**
+     * Tokenizes (never executes) the generated source and returns the decoded value of every
+     * single-quoted string literal, in source order.
+     *
+     * @return string[]
+     */
+    private function extractConstantStrings(string $source): array
+    {
+        $values = [];
+        foreach (token_get_all($source) as $token) {
+            if (is_array($token) && $token[0] === T_CONSTANT_ENCAPSED_STRING && str_starts_with($token[1], "'")) {
+                $values[] = $this->decodeSingleQuotedLiteral(substr($token[1], 1, -1));
+            }
+        }
+
+        return $values;
+    }
+
+    private function decodeSingleQuotedLiteral(string $inner): string
+    {
+        $decoded = '';
+        $length = strlen($inner);
+        for ($i = 0; $i < $length; $i++) {
+            if ($inner[$i] === '\\' && $i + 1 < $length && ($inner[$i + 1] === '\\' || $inner[$i + 1] === "'")) {
+                $decoded .= $inner[$i + 1];
+                $i++;
+            } else {
+                $decoded .= $inner[$i];
+            }
+        }
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## Vulnerability and root cause

`SelectOptionsEnumBuilder` generates a PHP enum file on disk from a `SelectOptions` definition's option values/labels. The only transform applied to those attacker-controlled strings before embedding them in a single-quoted PHP string literal was `escapeSingleQuote()` (`lib/DataObject/ClassBuilder/SelectOptionsEnumBuilder.php:178-181`):

```php
return str_replace("'", "\\'", $value);
```

This escapes `'` but leaves `\` untouched. An option value/label ending in `\'` is therefore emitted as `\\'` in the generated source: an escaped backslash followed by a **live, unescaped closing quote**. That closes the string literal (and the enclosing enum body) early, placing attacker-controlled tokens at file scope in the generated, autoloaded enum class — arbitrary PHP execution on autoload, persistent on disk.

A backend user only needs the granular SelectOptions edit permission (not admin) to reach `Config::save()` → `generateEnumFiles()` → `SelectOptionsEnumBuilder::generateCases()` / `generateLabelMatches()`, both of which share the defective escaper. Only the option's case `name` is constrained by an identifier regex; `value` and `label` are unconstrained.

## The fix

Escape the backslash before the single quote, mirroring PHP's own single-quoted-string escaping rules (only `\\` and `\'` are meaningful escapes in that context):

```php
return str_replace(['\\', "'"], ['\\\\', "\\'"], $value);
```

`str_replace()` with array search/replace processes pairs sequentially left-to-right, so the backslash pass runs first and its output (doubled backslashes) is not itself re-matched by the quote pass. This makes every option value/label round-trip through the generated enum as inert string data, regardless of content — a value ending in `\'` (or any other combination of quotes/backslashes) can no longer terminate the literal early. The change applies to both `generateCases()` and `generateLabelMatches()`, since both call the shared `escapeSingleQuote()`.

## Backward compatibility

Checked against the BC-decision process: `escapeSingleQuote()` is a `protected` implementation-detail method (not `@internal`-annotated, but not part of the public `SelectOptionsEnumBuilderInterface` contract either); no signature, default argument, return type/shape, or visibility changed.

The only thing that changes is the *content* of previously-mis-escaped generated files. For every value that isn't a code-injection payload, the round-tripped runtime value is identical before and after the fix:
- Values with no backslash: identical output (only the quote-escaping path is exercised, unchanged).
- Values with a backslash **not** immediately preceding a quote (e.g. `C:\Users\test`): under the old code, `\U` in a single-quoted string is not a recognized escape sequence, so it was already emitted/parsed back as the literal two characters `\U` — same result the fixed code produces (doubled backslash decodes back to one literal backslash). No observable change for legitimate data.
- Values ending in a lone backslash, or a backslash immediately before a quote: this was already broken *before* this fix (not just for the crafted RCE payload — any legitimate value that happened to end in `\` would already have silently corrupted the generated case, since `\'` was interpreted as an escaped quote). The fix makes these round-trip correctly for the first time; there is no legitimate prior behavior being changed, only a latent code-injection/corruption bug being closed.

No configuration/behavioral flag is introduced or removed, so no deprecation path is needed.

## Verification

Tests could not be executed in this sandbox (no Composer/network access), but were written and added:

**Tests added:** `tests/Unit/DataObject/ClassBuilder/SelectOptionsEnumBuilderTest.php`

The test exercises the real `Config` → `SelectOption` → `SelectOptionsEnumBuilder::buildEnum()` path (no mocking of the vulnerable logic) and uses PHP's own tokenizer (`token_get_all()`) to decode the generated single-quoted string literals. Tokenizing is inert — it never executes the generated source — so it safely distinguishes "value round-trips intact" (fixed) from "literal was truncated by an early, unescaped closing quote" (vulnerable) without `require()`-ing or `eval()`-ing attacker-controlled generated code:

- `testMaliciousOptionValueCannotBreakOutOfTheGeneratedCaseLiteral` — reproduces the advisory's breakout payload in the option **value**; fails against the vulnerable code (decoded literal is truncated to a single backslash instead of the full payload) and passes against the fix.
- `testMaliciousOptionLabelCannotBreakOutOfTheGeneratedLabelMatchLiteral` — same payload in the option **label**, covering `generateLabelMatches()`.
- `testLegitimateOptionValuesRoundTripUnchanged` (data provider) — plain values, a value with a single quote, a value with a non-trailing backslash, and a value with a trailing single backslash all round-trip to their original content, confirming the fix doesn't change legitimate behavior.

Security-Advisory: pimcore/pimcore/GHSA-x347-3h85-7jh8

> [!WARNING]
> <details>
> <summary>Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `api.anthropic.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "api.anthropic.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>

> Generated by [Draft a security-advisory fix](https://github.com/pimcore/workflows-centralized/actions/runs/34732838658) · claude · sonnet50 · 189.4 AIC · ⌖ 22.9 AIC · ⊞ 7.5K · [◷](https://github.com/search?q=repo%3Apimcore%2Fpimcore+%22gh-aw-workflow-id%3A+advisory-fix%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Draft a security-advisory fix, engine: claude, model: claude-sonnet-5, id: 34732838658, workflow_id: advisory-fix, run: https://github.com/pimcore/workflows-centralized/actions/runs/34732838658 -->

<!-- gh-aw-workflow-id: advisory-fix -->
<!-- gh-aw-workflow-call-id: pimcore/workflows-centralized/advisory-fix -->